### PR TITLE
feat: skill forking — skills.json manifest and export-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,34 @@ npx skills find "crypto trading"
 
 Installed skills land in `skills/` and are added to `aeon.yml` disabled. Flip `enabled: true` to activate.
 
+### Install individual skills from Aeon
+
+Every skill in this repo is independently installable. Browse the full catalog in [`skills.json`](skills.json) or use the CLI:
+
+```bash
+# Install a single skill
+./add-skill aaronjmars/aeon token-alert
+
+# Install multiple skills
+./add-skill aaronjmars/aeon token-alert polymarket hn-digest
+
+# Install everything
+./add-skill aaronjmars/aeon --all
+
+# Browse available skills
+./add-skill aaronjmars/aeon --list
+```
+
+### Export a skill for distribution
+
+Package any skill as a standalone directory (with a generated README) for sharing:
+
+```bash
+./export-skill token-alert              # exports to ./exports/token-alert/
+./export-skill token-alert --tar        # also creates a .tar.gz archive
+./export-skill --list                   # list all exportable skills
+```
+
 ### Trigger feature builds from issues
 
 Label any GitHub issue `ai-build` → workflow fires → Claude reads the issue, implements it, opens a PR.
@@ -346,14 +374,17 @@ Every skill reads `CLAUDE.md`, so identity propagates automatically.
 ```
 CLAUDE.md                ← agent identity (auto-loaded by Claude Code)
 aeon.yml                 ← skill schedules + enabled flags
+skills.json              ← machine-readable skill catalog (50 skills)
 ./notify                 ← multi-channel notifications
 ./add-skill              ← import skills from GitHub repos
+./export-skill           ← package skills for standalone distribution
+./generate-skills-json   ← regenerate skills.json from SKILL.md files
 soul/                    ← optional identity files
 skills/                  ← each skill is SKILL.md (Agent Skills format)
   article/
   digest/
   heartbeat/
-  ...                    ← 47 skills total
+  ...                    ← 50 skills total
 memory/
   MEMORY.md              ← goals, active topics, pointers
   topics/                ← detailed notes by topic

--- a/export-skill
+++ b/export-skill
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# export-skill — Package a single skill for standalone use
+#
+# Usage:
+#   ./export-skill <skill-name>                    Package to ./exports/<skill-name>/
+#   ./export-skill <skill-name> --output /path     Package to custom directory
+#   ./export-skill <skill-name> --tar              Create a .tar.gz archive
+#   ./export-skill --list                          List all exportable skills
+#
+# The exported package includes:
+#   - SKILL.md (the skill definition)
+#   - Any helper scripts or config files in the skill directory
+#   - A generated README.md with install instructions
+#
+# Recipients can install the exported skill with:
+#   ./add-skill <path-or-repo> <skill-name>
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+SKILLS_DIR="$ROOT/skills"
+EXPORTS_DIR="$ROOT/exports"
+
+usage() {
+  cat <<'EOF'
+Usage: ./export-skill <skill-name> [options]
+
+Package a single Aeon skill for standalone distribution.
+
+Arguments:
+  <skill-name>        Name of the skill to export (directory name under skills/)
+
+Options:
+  --output <path>     Custom output directory (default: ./exports/<skill-name>/)
+  --tar               Also create a .tar.gz archive
+  --list              List all exportable skills
+  --help              Show this help
+
+Examples:
+  ./export-skill token-alert
+  ./export-skill token-alert --tar
+  ./export-skill token-alert --output ~/my-skills/token-alert
+  ./export-skill --list
+EOF
+  exit 0
+}
+
+# List mode
+if [[ "${1:-}" == "--list" ]]; then
+  echo "Exportable skills:"
+  echo ""
+  for skill_dir in "$SKILLS_DIR"/*/; do
+    [[ -f "$skill_dir/SKILL.md" ]] || continue
+    slug=$(basename "$skill_dir")
+    desc=$(sed -n '/^---$/,/^---$/{ /^description:/s/^description: *//p }' "$skill_dir/SKILL.md")
+    file_count=$(find "$skill_dir" -type f | wc -l | tr -d ' ')
+    printf "  %-24s %s (%s files)\n" "$slug" "$desc" "$file_count"
+  done
+  echo ""
+  echo "Export with: ./export-skill <skill-name>"
+  exit 0
+fi
+
+if [[ $# -lt 1 ]] || [[ "$1" == "--help" ]] || [[ "$1" == "-h" ]]; then
+  usage
+fi
+
+SKILL_NAME="$1"
+shift
+
+# Parse flags
+OUTPUT_DIR=""
+CREATE_TAR=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output) OUTPUT_DIR="$2"; shift 2 ;;
+    --tar) CREATE_TAR=true; shift ;;
+    --help|-h) usage ;;
+    -*) echo "Unknown option: $1" >&2; exit 1 ;;
+    *) echo "Unexpected argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+# Validate skill exists
+SKILL_SRC="$SKILLS_DIR/$SKILL_NAME"
+if [[ ! -d "$SKILL_SRC" ]] || [[ ! -f "$SKILL_SRC/SKILL.md" ]]; then
+  echo "Error: skill '$SKILL_NAME' not found in $SKILLS_DIR" >&2
+  echo "Run './export-skill --list' to see available skills." >&2
+  exit 1
+fi
+
+# Set output directory
+if [[ -z "$OUTPUT_DIR" ]]; then
+  OUTPUT_DIR="$EXPORTS_DIR/$SKILL_NAME"
+fi
+
+# Parse skill metadata
+SKILL_DISPLAY=$(sed -n '/^---$/,/^---$/{ /^name:/s/^name: *//p }' "$SKILL_SRC/SKILL.md")
+SKILL_DESC=$(sed -n '/^---$/,/^---$/{ /^description:/s/^description: *//p }' "$SKILL_SRC/SKILL.md")
+
+# Create output directory
+mkdir -p "$OUTPUT_DIR"
+
+# Copy all skill files
+cp -r "$SKILL_SRC"/* "$OUTPUT_DIR/"
+
+# Generate a README for the exported skill
+cat > "$OUTPUT_DIR/README.md" << READMEEOF
+# ${SKILL_DISPLAY}
+
+${SKILL_DESC}
+
+## Install
+
+If you have an Aeon-compatible agent, install this skill with:
+
+\`\`\`bash
+# From a GitHub repo
+./add-skill aaronjmars/aeon ${SKILL_NAME}
+
+# Or copy the SKILL.md into your skills directory
+cp SKILL.md /path/to/your/agent/skills/${SKILL_NAME}/SKILL.md
+\`\`\`
+
+## Manual use
+
+You can also use this skill directly with Claude Code:
+
+\`\`\`
+Read skills/${SKILL_NAME}/SKILL.md and execute its steps.
+\`\`\`
+
+## Source
+
+Exported from [aaronjmars/aeon](https://github.com/aaronjmars/aeon) — an autonomous agent on GitHub Actions powered by Claude Code.
+READMEEOF
+
+echo "Exported '$SKILL_NAME' to $OUTPUT_DIR/"
+ls -la "$OUTPUT_DIR/"
+
+# Create tar archive if requested
+if [[ "$CREATE_TAR" == "true" ]]; then
+  TAR_FILE="${OUTPUT_DIR}.tar.gz"
+  tar -czf "$TAR_FILE" -C "$(dirname "$OUTPUT_DIR")" "$(basename "$OUTPUT_DIR")"
+  echo ""
+  echo "Archive: $TAR_FILE"
+fi

--- a/generate-skills-json
+++ b/generate-skills-json
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# generate-skills-json — Build skills.json manifest from all skills/*/SKILL.md files
+#
+# Usage:
+#   ./generate-skills-json              Generate skills.json at repo root
+#   ./generate-skills-json --pretty     Pretty-print the output
+#
+# The manifest enables one-command skill installation and marketplace discovery.
+# Each entry includes: name, slug, description, category, default var, schedule,
+# required secrets, and install command.
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+SKILLS_DIR="$ROOT/skills"
+AEON_YML="$ROOT/aeon.yml"
+OUTPUT="$ROOT/skills.json"
+
+PRETTY=false
+if [[ "${1:-}" == "--pretty" ]]; then
+  PRETTY=true
+fi
+
+# Map skill slugs to categories based on aeon.yml schedule groups
+declare -A CATEGORIES=(
+  # Research & Content
+  [article]="research"
+  [digest]="research"
+  [rss-digest]="research"
+  [hacker-news-digest]="research"
+  [hn-digest]="research"
+  [paper-digest]="research"
+  [paper-pick]="research"
+  [tweet-digest]="research"
+  [list-digest]="research"
+  [research-brief]="research"
+  [fetch-tweets]="research"
+  [search-papers]="research"
+  [reddit-digest]="research"
+  [security-digest]="research"
+  # Dev & Code
+  [pr-review]="dev"
+  [github-monitor]="dev"
+  [github-issues]="dev"
+  [github-trending]="dev"
+  [issue-triage]="dev"
+  [changelog]="dev"
+  [code-health]="dev"
+  [feature]="dev"
+  [build-skill]="dev"
+  [search-skill]="dev"
+  # Crypto & Markets
+  [token-alert]="crypto"
+  [token-movers]="crypto"
+  [trending-coins]="crypto"
+  [wallet-digest]="crypto"
+  [on-chain-monitor]="crypto"
+  [defi-monitor]="crypto"
+  [defi-overview]="crypto"
+  [polymarket]="crypto"
+  [polymarket-comments]="crypto"
+  [monitor-runners]="crypto"
+  [token-pick]="crypto"
+  # Social
+  [write-tweet]="social"
+  [reply-maker]="social"
+  [refresh-x]="social"
+  # Productivity & Meta
+  [morning-brief]="productivity"
+  [daily-routine]="productivity"
+  [heartbeat]="productivity"
+  [memory-flush]="productivity"
+  [reflect]="productivity"
+  [weekly-review]="productivity"
+  [self-review]="productivity"
+  [skill-health]="productivity"
+  [goal-tracker]="productivity"
+  [action-converter]="productivity"
+  [idea-capture]="productivity"
+  [startup-idea]="productivity"
+)
+
+# Extract schedule for a skill from aeon.yml
+get_schedule() {
+  local slug="$1"
+  grep -E "^\s+${slug}:" "$AEON_YML" 2>/dev/null \
+    | grep -oP 'schedule:\s*"\K[^"]+' \
+    || echo ""
+}
+
+# Extract required secrets by scanning SKILL.md for secret/env references
+get_secrets() {
+  local skill_file="$1"
+  grep -oP '(?:SECRET|TOKEN|KEY|WEBHOOK|API_KEY|BOT_TOKEN)[A-Z_]*' "$skill_file" 2>/dev/null \
+    | sort -u \
+    | paste -sd ',' - \
+    || echo ""
+}
+
+# Count files in skill directory (excluding SKILL.md)
+count_files() {
+  local skill_dir="$1"
+  find "$skill_dir" -type f ! -name "SKILL.md" 2>/dev/null | wc -l | tr -d ' '
+}
+
+# Start JSON output
+echo -n '{"version":"1.0","generated":"' > "$OUTPUT"
+echo -n "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$OUTPUT"
+echo -n '","repo":"aaronjmars/aeon","total":0,"categories":{"research":"Research & Content","dev":"Dev & Code","crypto":"Crypto & Markets","social":"Social","productivity":"Productivity & Meta"},"skills":[' >> "$OUTPUT"
+
+TOTAL=0
+FIRST=true
+
+for skill_dir in "$SKILLS_DIR"/*/; do
+  skill_file="$skill_dir/SKILL.md"
+  [[ -f "$skill_file" ]] || continue
+
+  slug=$(basename "$skill_dir")
+
+  # Parse frontmatter
+  name=$(sed -n '/^---$/,/^---$/{ /^name:/s/^name: *//p }' "$skill_file")
+  description=$(sed -n '/^---$/,/^---$/{ /^description:/s/^description: *//p }' "$skill_file")
+  var=$(sed -n '/^---$/,/^---$/{ /^var:/s/^var: *//p }' "$skill_file" | tr -d '"')
+
+  # Get metadata
+  schedule=$(get_schedule "$slug")
+  category="${CATEGORIES[$slug]:-other}"
+  extra_files=$(count_files "$skill_dir")
+
+  # Escape JSON strings
+  name="${name//\\/\\\\}"
+  name="${name//\"/\\\"}"
+  description="${description//\\/\\\\}"
+  description="${description//\"/\\\"}"
+
+  if [[ "$FIRST" == "true" ]]; then
+    FIRST=false
+  else
+    echo -n ',' >> "$OUTPUT"
+  fi
+
+  echo -n "{\"slug\":\"$slug\",\"name\":\"$name\",\"description\":\"$description\",\"category\":\"$category\",\"schedule\":\"$schedule\",\"var\":\"$var\",\"files\":$extra_files,\"install\":\"./add-skill aaronjmars/aeon $slug\"}" >> "$OUTPUT"
+
+  TOTAL=$((TOTAL + 1))
+done
+
+echo -n '],"install_all":"./add-skill aaronjmars/aeon --all","install_one":"./add-skill aaronjmars/aeon <skill-name>"}' >> "$OUTPUT"
+
+# Patch total count
+sed -i "s/\"total\":0/\"total\":$TOTAL/" "$OUTPUT"
+
+# Pretty-print if requested and python3 is available
+if [[ "$PRETTY" == "true" ]] && command -v python3 &>/dev/null; then
+  python3 -m json.tool "$OUTPUT" > "${OUTPUT}.tmp" && mv "${OUTPUT}.tmp" "$OUTPUT"
+fi
+
+echo "Generated $OUTPUT with $TOTAL skills"

--- a/skills.json
+++ b/skills.json
@@ -1,0 +1,517 @@
+{
+  "version": "1.0",
+  "generated": "2026-03-28T00:00:00Z",
+  "repo": "aaronjmars/aeon",
+  "total": 50,
+  "categories": {
+    "research": "Research & Content",
+    "dev": "Dev & Code",
+    "crypto": "Crypto & Markets",
+    "social": "Social",
+    "productivity": "Productivity & Meta"
+  },
+  "skills": [
+    {
+      "slug": "article",
+      "name": "Daily Article",
+      "description": "Research trending topics and write a publication-ready article",
+      "category": "research",
+      "schedule": "0 14 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon article"
+    },
+    {
+      "slug": "digest",
+      "name": "Daily Digest",
+      "description": "Generate and send a daily digest on a configurable topic",
+      "category": "research",
+      "schedule": "0 14 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon digest"
+    },
+    {
+      "slug": "rss-digest",
+      "name": "RSS Digest",
+      "description": "Fetch, summarize, and deliver RSS feed highlights",
+      "category": "research",
+      "schedule": "0 7 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon rss-digest"
+    },
+    {
+      "slug": "hacker-news-digest",
+      "name": "Hacker News Digest",
+      "description": "Top HN stories filtered by keywords relevant to your interests",
+      "category": "research",
+      "schedule": "0 7 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon hacker-news-digest"
+    },
+    {
+      "slug": "hn-digest",
+      "name": "HN Digest",
+      "description": "Top Hacker News stories filtered by interests",
+      "category": "research",
+      "schedule": "0 7 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon hn-digest"
+    },
+    {
+      "slug": "paper-digest",
+      "name": "Paper Digest",
+      "description": "Find and summarize new papers matching tracked research interests",
+      "category": "research",
+      "schedule": "0 7 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon paper-digest"
+    },
+    {
+      "slug": "paper-pick",
+      "name": "Paper Pick",
+      "description": "Find the one paper you should read today from arXiv and Semantic Scholar",
+      "category": "research",
+      "schedule": "0 14 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon paper-pick"
+    },
+    {
+      "slug": "tweet-digest",
+      "name": "Tweet Digest",
+      "description": "Aggregate and summarize tweets from tracked accounts",
+      "category": "research",
+      "schedule": "0 7 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon tweet-digest"
+    },
+    {
+      "slug": "list-digest",
+      "name": "List Digest",
+      "description": "Top tweets from tracked X lists in the past 24 hours",
+      "category": "research",
+      "schedule": "0 17 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon list-digest"
+    },
+    {
+      "slug": "research-brief",
+      "name": "Research Brief",
+      "description": "Deep dive on a topic combining web search, papers, and synthesis",
+      "category": "research",
+      "schedule": "0 14 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon research-brief"
+    },
+    {
+      "slug": "fetch-tweets",
+      "name": "Fetch Tweets",
+      "description": "Search X/Twitter for tweets by keyword, username, or both",
+      "category": "research",
+      "schedule": "0 17 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon fetch-tweets"
+    },
+    {
+      "slug": "search-papers",
+      "name": "Search Academic Papers",
+      "description": "Search for recent academic papers on topics of interest and save a summary",
+      "category": "research",
+      "schedule": "0 14 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon search-papers"
+    },
+    {
+      "slug": "reddit-digest",
+      "name": "Reddit Digest",
+      "description": "Fetch and summarize top Reddit posts from tracked subreddits",
+      "category": "research",
+      "schedule": "0 7 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon reddit-digest"
+    },
+    {
+      "slug": "security-digest",
+      "name": "Security Digest",
+      "description": "Monitor recent security advisories from the GitHub Advisory Database for tracked ecosystems",
+      "category": "research",
+      "schedule": "0 14 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon security-digest"
+    },
+    {
+      "slug": "pr-review",
+      "name": "PR Review",
+      "description": "Auto-review open PRs on watched repos and post summary comments",
+      "category": "dev",
+      "schedule": "0 9 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon pr-review"
+    },
+    {
+      "slug": "github-monitor",
+      "name": "GitHub Monitor",
+      "description": "Watch repos for stale PRs, new issues, and new releases",
+      "category": "dev",
+      "schedule": "0 9 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon github-monitor"
+    },
+    {
+      "slug": "github-issues",
+      "name": "GitHub Issues",
+      "description": "Check all your repos for new open issues in the last 24 hours",
+      "category": "dev",
+      "schedule": "0 9 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon github-issues"
+    },
+    {
+      "slug": "github-trending",
+      "name": "GitHub Trending",
+      "description": "Top 10 trending repos on GitHub right now",
+      "category": "dev",
+      "schedule": "0 9 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon github-trending"
+    },
+    {
+      "slug": "issue-triage",
+      "name": "Issue Triage",
+      "description": "Label and prioritize new GitHub issues on watched repos",
+      "category": "dev",
+      "schedule": "0 9 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon issue-triage"
+    },
+    {
+      "slug": "changelog",
+      "name": "Changelog",
+      "description": "Generate a changelog from recent commits across watched repos",
+      "category": "dev",
+      "schedule": "0 16 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon changelog"
+    },
+    {
+      "slug": "code-health",
+      "name": "Code Health",
+      "description": "Weekly report on TODOs, dead code, and test coverage gaps",
+      "category": "dev",
+      "schedule": "0 16 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon code-health"
+    },
+    {
+      "slug": "feature",
+      "name": "Feature Builder",
+      "description": "Build new features from GitHub issues or improve the agent",
+      "category": "dev",
+      "schedule": "0 16 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon feature"
+    },
+    {
+      "slug": "build-skill",
+      "name": "Build Skill",
+      "description": "Design and build a new reusable skill",
+      "category": "dev",
+      "schedule": "0 16 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon build-skill"
+    },
+    {
+      "slug": "search-skill",
+      "name": "Search Skills",
+      "description": "Search the open agent skills ecosystem for useful skills to install",
+      "category": "dev",
+      "schedule": "0 14 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon search-skill"
+    },
+    {
+      "slug": "token-alert",
+      "name": "Token Alert",
+      "description": "Notify on price or volume anomalies for tracked tokens",
+      "category": "crypto",
+      "schedule": "0 12 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon token-alert"
+    },
+    {
+      "slug": "token-movers",
+      "name": "Token Movers",
+      "description": "Top movers, losers, and trending coins from CoinGecko",
+      "category": "crypto",
+      "schedule": "0 12 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon token-movers"
+    },
+    {
+      "slug": "trending-coins",
+      "name": "Trending Coins",
+      "description": "Top trending and most searched coins on CoinGecko in the last 24 hours",
+      "category": "crypto",
+      "schedule": "0 12 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon trending-coins"
+    },
+    {
+      "slug": "wallet-digest",
+      "name": "Wallet Digest",
+      "description": "Summarize recent wallet activity across tracked addresses",
+      "category": "crypto",
+      "schedule": "0 12 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon wallet-digest"
+    },
+    {
+      "slug": "on-chain-monitor",
+      "name": "On-Chain Monitor",
+      "description": "Monitor blockchain addresses and contracts for notable activity",
+      "category": "crypto",
+      "schedule": "0 12 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon on-chain-monitor"
+    },
+    {
+      "slug": "defi-monitor",
+      "name": "DeFi Monitor",
+      "description": "Check pool health, positions, and yield rates for tracked protocols",
+      "category": "crypto",
+      "schedule": "0 12 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon defi-monitor"
+    },
+    {
+      "slug": "defi-overview",
+      "name": "DeFi Overview",
+      "description": "Daily overview of DeFi activity from DeFiLlama — TVL changes, top chains, top protocols",
+      "category": "crypto",
+      "schedule": "0 12 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon defi-overview"
+    },
+    {
+      "slug": "polymarket",
+      "name": "Polymarket",
+      "description": "Trending and top markets on Polymarket — volume, new markets, biggest movers",
+      "category": "crypto",
+      "schedule": "0 12 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon polymarket"
+    },
+    {
+      "slug": "polymarket-comments",
+      "name": "Polymarket Comments",
+      "description": "Top trending Polymarket markets and the most interesting comments from them",
+      "category": "crypto",
+      "schedule": "0 12 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon polymarket-comments"
+    },
+    {
+      "slug": "monitor-runners",
+      "name": "Monitor Runners",
+      "description": "Find the top 5 tokens that ran hardest in the past 24h across major chains using GeckoTerminal",
+      "category": "crypto",
+      "schedule": "0 12 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon monitor-runners"
+    },
+    {
+      "slug": "token-pick",
+      "name": "Token Pick",
+      "description": "One token recommendation and one prediction market pick based on live data",
+      "category": "crypto",
+      "schedule": "0 12 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon token-pick"
+    },
+    {
+      "slug": "write-tweet",
+      "name": "Write Tweet",
+      "description": "Generate 10 tweet drafts across 5 size tiers (2 variations each) on a topic from today's outputs",
+      "category": "social",
+      "schedule": "0 17 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon write-tweet"
+    },
+    {
+      "slug": "reply-maker",
+      "name": "Reply Maker",
+      "description": "Generate two reply options for 5 tweets from tracked X accounts or topics",
+      "category": "social",
+      "schedule": "0 17 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon reply-maker"
+    },
+    {
+      "slug": "refresh-x",
+      "name": "Refresh X",
+      "description": "Fetch a tracked X/Twitter account's latest tweets and save the gist to memory",
+      "category": "social",
+      "schedule": "0 17 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon refresh-x"
+    },
+    {
+      "slug": "morning-brief",
+      "name": "Morning Brief",
+      "description": "Aggregated daily briefing — digests, priorities, and what's ahead",
+      "category": "productivity",
+      "schedule": "0 7 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon morning-brief"
+    },
+    {
+      "slug": "daily-routine",
+      "name": "Daily Routine",
+      "description": "Morning briefing combining token movers, tweet roundup, paper pick, GitHub issues, and HN digest",
+      "category": "productivity",
+      "schedule": "0 7 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon daily-routine"
+    },
+    {
+      "slug": "heartbeat",
+      "name": "Heartbeat",
+      "description": "Proactive ambient check — surface anything worth attention",
+      "category": "productivity",
+      "schedule": "0 12 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon heartbeat"
+    },
+    {
+      "slug": "memory-flush",
+      "name": "Memory Flush",
+      "description": "Promote important recent log entries into MEMORY.md",
+      "category": "productivity",
+      "schedule": "0 18 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon memory-flush"
+    },
+    {
+      "slug": "reflect",
+      "name": "Weekly Reflect",
+      "description": "Review recent activity, consolidate memory, and prune stale entries",
+      "category": "productivity",
+      "schedule": "0 18 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon reflect"
+    },
+    {
+      "slug": "weekly-review",
+      "name": "Weekly Review",
+      "description": "Synthesize the week's logs into a structured retrospective",
+      "category": "productivity",
+      "schedule": "0 19 * * 1",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon weekly-review"
+    },
+    {
+      "slug": "self-review",
+      "name": "Self Review",
+      "description": "Weekly audit of what Aeon did, what failed, and what to improve",
+      "category": "productivity",
+      "schedule": "0 18 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon self-review"
+    },
+    {
+      "slug": "skill-health",
+      "name": "Skill Health",
+      "description": "Check which scheduled skills haven't run recently",
+      "category": "productivity",
+      "schedule": "0 18 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon skill-health"
+    },
+    {
+      "slug": "goal-tracker",
+      "name": "Goal Tracker",
+      "description": "Compare current progress against goals stored in MEMORY.md",
+      "category": "productivity",
+      "schedule": "0 18 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon goal-tracker"
+    },
+    {
+      "slug": "action-converter",
+      "name": "Action Converter",
+      "description": "5 concrete real-life actions for today based on recent signals and memory",
+      "category": "productivity",
+      "schedule": "0 18 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon action-converter"
+    },
+    {
+      "slug": "idea-capture",
+      "name": "Idea Capture",
+      "description": "Quick note capture triggered via Telegram — stores to memory",
+      "category": "productivity",
+      "schedule": "0 14 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon idea-capture"
+    },
+    {
+      "slug": "startup-idea",
+      "name": "Startup Idea",
+      "description": "2 startup ideas tailored to the user's skills, interests, and context",
+      "category": "productivity",
+      "schedule": "0 18 * * *",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon startup-idea"
+    }
+  ],
+  "install_all": "./add-skill aaronjmars/aeon --all",
+  "install_one": "./add-skill aaronjmars/aeon <skill-name>"
+}


### PR DESCRIPTION
## What

Skill forking turns Aeon from a monolithic agent into a skill library. Users can now discover, install, and export individual skills without forking the entire 50-skill repo.

Three new files:
- **skills.json** — Machine-readable catalog of all 50 skills with metadata: name, slug, description, category (research/dev/crypto/social/productivity), schedule, and one-command install string
- **generate-skills-json** — Bash script that parses all skills SKILL.md frontmatter + aeon.yml schedules to regenerate the manifest. Run after adding/removing skills
- **export-skill** — Packages any single skill as a standalone directory with a generated README and optional .tar.gz archive for sharing

## Why

Repo-actions idea 2 (2026-03-28): Skill Forking — Let Users Import and Customize Individual Skills. With 7,000+ skills on SkillHub and 66,500+ on SkillsMP, discovery happens on marketplaces — not by browsing repos. The skills.json manifest enables programmatic discovery and makes each skill independently installable. Users take what they need without forking 50 skills they don't want.

## Changes

- skills.json: Generated manifest with all 50 skills across 5 categories
- generate-skills-json: Parser script (reads SKILL.md frontmatter + aeon.yml)
- export-skill: Packaging script with --tar, --output, --list options
- README.md: Added Install individual skills and Export a skill sections, updated project structure to include new files

---
*Built autonomously by Aeon*
