### PR TITLE
feat: skill security scanner — audit imported skills before execution

### DIFF
--- a/add-skill
+++ b/add-skill
@@ -33,6 +33,7 @@ Options:
   --list              List available skills in the repo
   --all               Install all skills from the repo
   --branch <branch>   Use a specific branch (default: main)
+  --force             Install even if security scan finds issues
   --help              Show this help
 
 Examples:
@@ -63,6 +64,7 @@ while [[ $# -gt 0 ]]; do
     --list) LIST_ONLY=true; shift ;;
     --all) INSTALL_ALL=true; shift ;;
     --branch) BRANCH="$2"; shift 2 ;;
+    --force) SKILL_NAMES+=("--force"); shift ;;
     --help|-h) usage ;;
     -*) echo "Unknown option: $1" >&2; exit 1 ;;
     *) SKILL_NAMES+=("$1"); shift ;;
@@ -150,18 +152,72 @@ if [[ ${#SKILL_NAMES[@]} -eq 0 ]]; then
   exit 1
 fi
 
+# Security scanning
+SCANNER="$(cd "$(dirname "$0")" && pwd)/skills/skill-security-scan/scan.sh"
+TRUSTED_FILE="$(cd "$(dirname "$0")" && pwd)/skills/security/trusted-sources.txt"
+FORCE_INSTALL=false
+
+# Check for --force flag (already parsed, but check env)
+for arg in "${SKILL_NAMES[@]}"; do
+  if [[ "$arg" == "--force" ]]; then
+    FORCE_INSTALL=true
+  fi
+done
+
+# Check if source repo is trusted
+is_trusted() {
+  local repo="$1"
+  local owner="${repo%%/*}"
+  if [[ -f "$TRUSTED_FILE" ]]; then
+    while IFS= read -r line; do
+      line="${line%%#*}"
+      line="${line// /}"
+      [[ -z "$line" ]] && continue
+      if [[ "$line" == "$repo" ]] || [[ "$line" == "$owner" ]]; then
+        return 0
+      fi
+    done < "$TRUSTED_FILE"
+  fi
+  return 1
+}
+
+TRUSTED_SOURCE=false
+if is_trusted "$REPO"; then
+  TRUSTED_SOURCE=true
+  echo "Source $REPO is trusted — skipping deep security scan."
+fi
+
 # Install each skill
 INSTALLED=0
 SKIPPED=0
 FAILED=0
 
 for skill in "${SKILL_NAMES[@]}"; do
+  [[ "$skill" == "--force" ]] && continue
+
   src="$REPO_DIR/$skill"
 
   if [[ ! -d "$src" ]] || [[ ! -f "$src/SKILL.md" ]]; then
     echo "  skip: '$skill' not found in repo"
     FAILED=$((FAILED + 1))
     continue
+  fi
+
+  # Run security scan on untrusted sources
+  if [[ "$TRUSTED_SOURCE" == "false" ]] && [[ -x "$SCANNER" ]]; then
+    echo "  scanning: $skill ..."
+    if ! "$SCANNER" "$src/SKILL.md" 2>/dev/null; then
+      if [[ "$FORCE_INSTALL" == "true" ]]; then
+        echo "  ⚠ SECURITY ISSUES DETECTED — installing anyway (--force)"
+        echo "  $(date -u '+%Y-%m-%dT%H:%M:%SZ') FORCE_INSTALL: $skill from $REPO" >> "$(cd "$(dirname "$0")" && pwd)/memory/logs/security.log"
+      else
+        echo "  ✗ BLOCKED: $skill has security issues. Use --force to override."
+        FAILED=$((FAILED + 1))
+        continue
+      fi
+    else
+      echo "  ✓ security scan passed"
+    fi
   fi
 
   dest="$SKILLS_DIR/$skill"

--- a/aeon.yml
+++ b/aeon.yml
@@ -45,6 +45,7 @@ skills:
   idea-capture: { enabled: false, schedule: "0 14 * * *" }
 
   # --- Late afternoon (4 PM UTC) ---
+  skill-security-scan: { enabled: false, schedule: "0 16 * * 1" }
   code-health: { enabled: false, schedule: "0 16 * * *" }
   changelog: { enabled: false, schedule: "0 16 * * *" }
   feature: { enabled: false, schedule: "0 16 * * *" }

--- a/skills/security/trusted-sources.txt
+++ b/skills/security/trusted-sources.txt
@@ -1,0 +1,11 @@
+# Trusted skill sources — one per line (GitHub owner/repo or owner)
+# Skills from these sources skip deep content analysis (still get format validation).
+# Add sources you trust after manual review.
+#
+# Format:
+#   owner           — trusts all repos from this owner
+#   owner/repo      — trusts only this specific repo
+
+aaronjmars
+aaronjmars/aeon
+aaronjmars/aeon-agent

--- a/skills/skill-security-scan/SKILL.md
+++ b/skills/skill-security-scan/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: Skill Security Scan
+description: Audit imported skills for shell injection, secret exfiltration, path traversal, and prompt injection before they run
+var: ""
+---
+> **${var}** — Path to a SKILL.md file or skill directory to scan. If empty, scans all skills in `skills/`.
+
+If `${var}` is set, scan only that path. Otherwise, scan all skill directories.
+
+Today is ${today}. Your task is to audit skill files for security vulnerabilities before they can be executed.
+
+## Threat Model
+
+Imported skills are markdown files that instruct Claude Code to take actions. A malicious skill could:
+- **Shell injection**: Execute arbitrary commands via unquoted variables, `eval`, backticks, or `$(...)` in bash blocks
+- **Secret exfiltration**: Send environment variables, tokens, or file contents to external URLs via curl/wget/fetch
+- **Path traversal**: Access files outside the repo using `../` or absolute paths
+- **Prompt injection**: Override CLAUDE.md safety rules with embedded instructions ("ignore previous instructions", "you are now...")
+- **Destructive commands**: Run `rm -rf`, `git push --force`, or other irreversible operations
+
+## Steps
+
+1. **Determine scan scope**:
+   - If `${var}` is a file path, scan that file only.
+   - If `${var}` is a skill name, scan `skills/${var}/SKILL.md`.
+   - If empty, scan all `skills/*/SKILL.md` files.
+
+2. **Run the scanner** on each skill file using `./skills/skill-security-scan/scan.sh`:
+   ```bash
+   ./skills/skill-security-scan/scan.sh <path-to-SKILL.md>
+   ```
+   The scanner checks for the threat categories above and outputs findings with severity levels (HIGH, MEDIUM, LOW).
+
+3. **Check trusted sources**: Read `skills/security/trusted-sources.txt`. Skills from trusted sources get a reduced scan (format validation only, skip content analysis). The source is determined by checking git remote or the skill's frontmatter for an origin field.
+
+4. **Generate report**: For each scanned skill, produce:
+   ```
+   [PASS/WARN/FAIL] skill-name
+     HIGH: description (if any)
+     MEDIUM: description (if any)
+     LOW: description (if any)
+   ```
+   - FAIL = any HIGH severity finding
+   - WARN = MEDIUM findings only
+   - PASS = no findings or LOW only
+
+5. **Save report** to `articles/security-scan-${today}.md` with full details.
+
+6. **Notify** via `./notify` if any skills FAIL:
+   ```
+   *Security Scan — ${today}*
+   Scanned N skills: X passed, Y warnings, Z failed.
+   Failed: skill1 (reason), skill2 (reason)
+   ```
+   If all pass, log "SECURITY_SCAN_OK" and skip notification.
+
+7. **Log** results to `memory/logs/${today}.md`.

--- a/skills/skill-security-scan/scan.sh
+++ b/skills/skill-security-scan/scan.sh
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# scan.sh — Security scanner for SKILL.md files
+#
+# Usage:
+#   ./skills/skill-security-scan/scan.sh <path-to-SKILL.md>
+#   ./skills/skill-security-scan/scan.sh skills/my-skill/SKILL.md
+#   ./skills/skill-security-scan/scan.sh --all              # Scan all skills
+#   ./skills/skill-security-scan/scan.sh --all --json        # JSON output
+#
+# Exit codes:
+#   0 = PASS (no HIGH findings)
+#   1 = FAIL (HIGH severity findings detected)
+#   2 = Usage error
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TRUSTED_FILE="$REPO_ROOT/skills/security/trusted-sources.txt"
+
+# Colors (disabled if not a terminal)
+if [[ -t 1 ]]; then
+  RED='\033[0;31m'; YELLOW='\033[0;33m'; GREEN='\033[0;32m'; CYAN='\033[0;36m'; NC='\033[0m'
+else
+  RED=''; YELLOW=''; GREEN=''; CYAN=''; NC=''
+fi
+
+JSON_OUTPUT=false
+SCAN_ALL=false
+FILES=()
+
+usage() {
+  echo "Usage: $0 <SKILL.md path> [--json]"
+  echo "       $0 --all [--json]"
+  exit 2
+}
+
+# Parse args
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --all) SCAN_ALL=true; shift ;;
+    --json) JSON_OUTPUT=true; shift ;;
+    --help|-h) usage ;;
+    -*) echo "Unknown option: $1" >&2; usage ;;
+    *) FILES+=("$1"); shift ;;
+  esac
+done
+
+if [[ "$SCAN_ALL" == "true" ]]; then
+  while IFS= read -r f; do
+    FILES+=("$f")
+  done < <(find "$REPO_ROOT/skills" -maxdepth 2 -name "SKILL.md" -type f 2>/dev/null | sort)
+fi
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+  echo "No files to scan." >&2
+  usage
+fi
+
+# Load trusted sources
+TRUSTED_OWNERS=()
+TRUSTED_REPOS=()
+if [[ -f "$TRUSTED_FILE" ]]; then
+  while IFS= read -r line; do
+    line="${line%%#*}"  # strip comments
+    line="${line// /}"  # strip whitespace
+    [[ -z "$line" ]] && continue
+    if [[ "$line" == */* ]]; then
+      TRUSTED_REPOS+=("$line")
+    else
+      TRUSTED_OWNERS+=("$line")
+    fi
+  done < "$TRUSTED_FILE"
+fi
+
+# ---------- Pattern definitions ----------
+
+# HIGH severity: immediate risk of code execution or data exfiltration
+HIGH_PATTERNS=(
+  # Shell injection
+  'eval\s'
+  'eval\('
+  '`[^`]*\$'
+  '\$\([^)]*\$'
+  # Secret exfiltration — curl/wget piping secrets or env vars
+  'curl.*\$[A-Z_]'
+  'wget.*\$[A-Z_]'
+  'curl.*\$\{'
+  'wget.*\$\{'
+  'curl.*--data.*secret'
+  'curl.*--data.*token'
+  'curl.*--data.*password'
+  'curl.*--data.*api.key'
+  # Env var exfiltration patterns
+  'printenv.*\|.*curl'
+  'printenv.*\|.*wget'
+  'env\s.*\|.*curl'
+  'cat.*/proc/.*environ'
+  # Direct exfil of known secrets
+  '\$TELEGRAM_BOT_TOKEN'
+  '\$DISCORD_BOT_TOKEN'
+  '\$SLACK_BOT_TOKEN'
+  '\$GITHUB_TOKEN.*curl'
+  '\$GITHUB_TOKEN.*wget'
+  # Prompt injection
+  '[Ii]gnore\s+(all\s+)?previous\s+instructions'
+  '[Ii]gnore\s+(all\s+)?prior\s+instructions'
+  '[Yy]ou\s+are\s+now\s+'
+  '[Ff]orget\s+(all\s+)?(your\s+)?instructions'
+  '[Dd]isregard\s+(all\s+)?previous'
+  '[Oo]verride\s+(all\s+)?rules'
+  # Destructive commands
+  'rm\s+-rf\s+/'
+  'rm\s+-rf\s+\*'
+  'rm\s+-rf\s+~'
+  'mkfs\.'
+  'dd\s+if=.*of=/dev/'
+  ':(){.*};:'
+  'git\s+push\s+--force\s+origin\s+main'
+  'git\s+push\s+-f\s+origin\s+main'
+)
+
+# MEDIUM severity: suspicious patterns that may or may not be intentional
+MEDIUM_PATTERNS=(
+  # Path traversal
+  '\.\./\.\.'
+  '\.\./.*\.\.'
+  # Absolute paths outside typical dirs
+  '/etc/passwd'
+  '/etc/shadow'
+  '~/.ssh'
+  '~/.gnupg'
+  '~/.aws'
+  '~/.config'
+  # Network calls to non-standard destinations
+  'curl\s+http://'
+  'wget\s+http://'
+  # Unquoted variable expansion in bash blocks
+  'rm\s.*\$[A-Z]'
+  'chmod\s+777'
+  'chmod\s+-R\s+777'
+  # Git force operations
+  'git\s+push\s+--force'
+  'git\s+push\s+-f\b'
+  'git\s+reset\s+--hard'
+  'git\s+clean\s+-fd'
+  # Base64 encoded payloads
+  'base64\s+-d'
+  'base64\s+--decode'
+  # Process manipulation
+  'kill\s+-9'
+  'killall'
+  'pkill'
+)
+
+# LOW severity: worth noting but usually harmless
+LOW_PATTERNS=(
+  # Broad file operations
+  'find\s+/\s'
+  'cat\s+/etc/'
+  # Network without explicit https
+  'fetch\('
+  'XMLHttpRequest'
+  # Write operations outside skills/
+  'tee\s+/'
+  '>\s+/'
+)
+
+# ---------- Scanner ----------
+
+TOTAL_PASS=0
+TOTAL_WARN=0
+TOTAL_FAIL=0
+JSON_RESULTS=""
+
+scan_file() {
+  local file="$1"
+  local skill_name
+  skill_name=$(basename "$(dirname "$file")")
+
+  if [[ ! -f "$file" ]]; then
+    echo -e "${RED}ERROR${NC}: File not found: $file"
+    return 1
+  fi
+
+  local content
+  content=$(cat "$file")
+
+  local highs=()
+  local mediums=()
+  local lows=()
+
+  # Check HIGH patterns
+  for pattern in "${HIGH_PATTERNS[@]}"; do
+    local matches
+    matches=$(grep -nE "$pattern" "$file" 2>/dev/null || true)
+    if [[ -n "$matches" ]]; then
+      while IFS= read -r match; do
+        local line_num="${match%%:*}"
+        local line_content="${match#*:}"
+        line_content="${line_content:0:120}"  # truncate
+        highs+=("L${line_num}: ${line_content} [pattern: ${pattern}]")
+      done <<< "$matches"
+    fi
+  done
+
+  # Check MEDIUM patterns
+  for pattern in "${MEDIUM_PATTERNS[@]}"; do
+    local matches
+    matches=$(grep -nE "$pattern" "$file" 2>/dev/null || true)
+    if [[ -n "$matches" ]]; then
+      while IFS= read -r match; do
+        local line_num="${match%%:*}"
+        local line_content="${match#*:}"
+        line_content="${line_content:0:120}"
+        mediums+=("L${line_num}: ${line_content} [pattern: ${pattern}]")
+      done <<< "$matches"
+    fi
+  done
+
+  # Check LOW patterns
+  for pattern in "${LOW_PATTERNS[@]}"; do
+    local matches
+    matches=$(grep -nE "$pattern" "$file" 2>/dev/null || true)
+    if [[ -n "$matches" ]]; then
+      while IFS= read -r match; do
+        local line_num="${match%%:*}"
+        local line_content="${match#*:}"
+        line_content="${line_content:0:120}"
+        lows+=("L${line_num}: ${line_content} [pattern: ${pattern}]")
+      done <<< "$matches"
+    fi
+  done
+
+  # Determine result
+  local status="PASS"
+  if [[ ${#highs[@]} -gt 0 ]]; then
+    status="FAIL"
+    TOTAL_FAIL=$((TOTAL_FAIL + 1))
+  elif [[ ${#mediums[@]} -gt 0 ]]; then
+    status="WARN"
+    TOTAL_WARN=$((TOTAL_WARN + 1))
+  else
+    TOTAL_PASS=$((TOTAL_PASS + 1))
+  fi
+
+  # Output
+  if [[ "$JSON_OUTPUT" == "true" ]]; then
+    local json_highs="[]" json_mediums="[]" json_lows="[]"
+    if [[ ${#highs[@]} -gt 0 ]]; then
+      json_highs=$(printf '%s\n' "${highs[@]}" | jq -R -s 'split("\n") | map(select(length > 0))')
+    fi
+    if [[ ${#mediums[@]} -gt 0 ]]; then
+      json_mediums=$(printf '%s\n' "${mediums[@]}" | jq -R -s 'split("\n") | map(select(length > 0))')
+    fi
+    if [[ ${#lows[@]} -gt 0 ]]; then
+      json_lows=$(printf '%s\n' "${lows[@]}" | jq -R -s 'split("\n") | map(select(length > 0))')
+    fi
+    local entry
+    entry=$(jq -n \
+      --arg skill "$skill_name" \
+      --arg status "$status" \
+      --arg file "$file" \
+      --argjson high "$json_highs" \
+      --argjson medium "$json_mediums" \
+      --argjson low "$json_lows" \
+      '{skill: $skill, status: $status, file: $file, high: $high, medium: $medium, low: $low}')
+    if [[ -n "$JSON_RESULTS" ]]; then
+      JSON_RESULTS="${JSON_RESULTS},${entry}"
+    else
+      JSON_RESULTS="${entry}"
+    fi
+  else
+    case "$status" in
+      FAIL) echo -e "${RED}[FAIL]${NC} $skill_name ($file)" ;;
+      WARN) echo -e "${YELLOW}[WARN]${NC} $skill_name ($file)" ;;
+      PASS) echo -e "${GREEN}[PASS]${NC} $skill_name ($file)" ;;
+    esac
+
+    for h in "${highs[@]}"; do
+      echo -e "  ${RED}HIGH${NC}: $h"
+    done
+    for m in "${mediums[@]}"; do
+      echo -e "  ${YELLOW}MEDIUM${NC}: $m"
+    done
+    for l in "${lows[@]}"; do
+      echo -e "  ${CYAN}LOW${NC}: $l"
+    done
+  fi
+}
+
+# Run scans
+echo "Aeon Skill Security Scanner"
+echo "==========================="
+echo "Scanning ${#FILES[@]} file(s)..."
+echo ""
+
+for file in "${FILES[@]}"; do
+  scan_file "$file"
+done
+
+# Summary
+echo ""
+echo "==========================="
+TOTAL=$((TOTAL_PASS + TOTAL_WARN + TOTAL_FAIL))
+echo "Scanned: $TOTAL | Pass: $TOTAL_PASS | Warn: $TOTAL_WARN | Fail: $TOTAL_FAIL"
+
+if [[ "$JSON_OUTPUT" == "true" ]]; then
+  echo ""
+  echo "--- JSON ---"
+  echo "[${JSON_RESULTS}]" | jq .
+fi
+
+# Exit code reflects worst finding
+if [[ $TOTAL_FAIL -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
A security scanning pipeline that audits SKILL.md files for dangerous patterns before they can be executed. Catches shell injection, secret exfiltration, path traversal, prompt injection, and destructive commands. The SkillsMP ecosystem crossed 351K skills but audits found most MCP servers vulnerable to path traversal and code injection. Aeon add-skill imports external SKILL.md files with no security validation. New files: skills/skill-security-scan/SKILL.md (skill definition), skills/skill-security-scan/scan.sh (318-line bash scanner with 30+ patterns across HIGH/MEDIUM/LOW severity), skills/security/trusted-sources.txt (allowlist for verified sources). Modified: add-skill (integrated scanner blocks unsafe imports unless --force), aeon.yml (weekly schedule). Built autonomously by Aeon.