### PR TITLE
feat: skill versioning and upstream sync

### DIFF
--- a/generate-skills-json
+++ b/generate-skills-json
@@ -103,6 +103,18 @@ count_files() {
   find "$skill_dir" -type f ! -name "SKILL.md" 2>/dev/null | wc -l | tr -d ' '
 }
 
+# Get 7-char git SHA of last commit touching a SKILL.md
+get_skill_sha() {
+  local slug="$1"
+  git -C "$ROOT" log --follow --format="%H" -1 -- "skills/$slug/SKILL.md" 2>/dev/null | cut -c1-7 || echo ""
+}
+
+# Get YYYY-MM-DD date of last commit touching a SKILL.md
+get_skill_updated() {
+  local slug="$1"
+  git -C "$ROOT" log --follow --format="%as" -1 -- "skills/$slug/SKILL.md" 2>/dev/null || echo ""
+}
+
 # Start JSON output
 echo -n '{"version":"1.0","generated":"' > "$OUTPUT"
 echo -n "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$OUTPUT"
@@ -126,6 +138,8 @@ for skill_dir in "$SKILLS_DIR"/*/; do
   schedule=$(get_schedule "$slug")
   category="${CATEGORIES[$slug]:-other}"
   extra_files=$(count_files "$skill_dir")
+  sha=$(get_skill_sha "$slug")
+  updated=$(get_skill_updated "$slug")
 
   # Escape JSON strings
   name="${name//\\/\\\\}"
@@ -139,7 +153,7 @@ for skill_dir in "$SKILLS_DIR"/*/; do
     echo -n ',' >> "$OUTPUT"
   fi
 
-  echo -n "{\"slug\":\"$slug\",\"name\":\"$name\",\"description\":\"$description\",\"category\":\"$category\",\"schedule\":\"$schedule\",\"var\":\"$var\",\"files\":$extra_files,\"install\":\"./add-skill aaronjmars/aeon $slug\"}" >> "$OUTPUT"
+  echo -n "{\"slug\":\"$slug\",\"name\":\"$name\",\"description\":\"$description\",\"category\":\"$category\",\"schedule\":\"$schedule\",\"var\":\"$var\",\"files\":$extra_files,\"sha\":\"$sha\",\"updated\":\"$updated\",\"install\":\"./add-skill aaronjmars/aeon $slug\"}" >> "$OUTPUT"
 
   TOTAL=$((TOTAL + 1))
 done

--- a/scripts/sync-upstream.sh
+++ b/scripts/sync-upstream.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# sync-upstream.sh — Update skills from upstream aaronjmars/aeon
+#
+# Usage:
+#   ./scripts/sync-upstream.sh              Interactive sync
+#   ./scripts/sync-upstream.sh --auto       Auto-update all outdated skills
+#   ./scripts/sync-upstream.sh --dry-run    Show what would be updated
+#   ./scripts/sync-upstream.sh --missing    Also install missing skills
+
+UPSTREAM="${UPSTREAM_REPO:-aaronjmars/aeon}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+AUTO=false
+DRY_RUN=false
+INCLUDE_MISSING=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --auto)     AUTO=true; shift ;;
+    --dry-run)  DRY_RUN=true; shift ;;
+    --missing)  INCLUDE_MISSING=true; shift ;;
+    --upstream) UPSTREAM="$2"; shift 2 ;;
+    -h|--help)
+      echo "Usage: ./scripts/sync-upstream.sh [--auto] [--dry-run] [--missing] [--upstream owner/repo]"
+      exit 0 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+if ! command -v jq &>/dev/null; then
+  echo "jq is required. Install with: brew install jq / apt-get install jq" >&2
+  exit 1
+fi
+
+LOCAL_JSON="$ROOT/skills.json"
+if [[ ! -f "$LOCAL_JSON" ]]; then
+  echo "Local skills.json not found. Run ./generate-skills-json first." >&2
+  exit 1
+fi
+
+echo "Checking against upstream: $UPSTREAM"
+echo ""
+
+# Fetch upstream skills.json
+UPSTREAM_TMP=$(mktemp)
+trap 'rm -f "$UPSTREAM_TMP"' EXIT
+
+if ! gh api "repos/$UPSTREAM/contents/skills.json" --jq '.content' | base64 -d > "$UPSTREAM_TMP" 2>/dev/null; then
+  echo "Failed to fetch upstream skills.json from $UPSTREAM" >&2
+  exit 1
+fi
+
+# Find outdated skills (SHA mismatch)
+OUTDATED_SLUGS=()
+OUTDATED_INFO=()
+while IFS=$'\t' read -r slug local_sha upstream_sha updated; do
+  [[ -z "$slug" ]] && continue
+  if [[ -n "$local_sha" && -n "$upstream_sha" && "$local_sha" != "$upstream_sha" ]]; then
+    OUTDATED_SLUGS+=("$slug")
+    OUTDATED_INFO+=("$slug (local: $local_sha → upstream: $upstream_sha, updated: $updated)")
+  fi
+done < <(
+  jq -r --slurpfile local "$LOCAL_JSON" '
+    .skills[] |
+    . as $up |
+    ($local[0].skills // [] | map(select(.slug == $up.slug)) | first) as $loc |
+    if $loc != null and ($up.sha // "") != "" and ($loc.sha // "") != "" then
+      [$up.slug, ($loc.sha // ""), ($up.sha // ""), ($up.updated // "")] | @tsv
+    else empty end
+  ' "$UPSTREAM_TMP"
+)
+
+# Find missing skills
+MISSING_SLUGS=()
+while IFS=$'\t' read -r slug name; do
+  [[ -z "$slug" ]] && continue
+  MISSING_SLUGS+=("$slug")
+done < <(
+  jq -r --slurpfile local "$LOCAL_JSON" '
+    .skills[] |
+    . as $up |
+    ($local[0].skills // [] | map(select(.slug == $up.slug)) | first) as $loc |
+    if $loc == null then [$up.slug, $up.name] | @tsv else empty end
+  ' "$UPSTREAM_TMP"
+)
+
+echo "Local skills: $(jq '.total' "$LOCAL_JSON")"
+echo "Upstream skills: $(jq '.total' "$UPSTREAM_TMP")"
+echo ""
+
+# Report outdated
+if [[ ${#OUTDATED_SLUGS[@]} -eq 0 ]]; then
+  echo "All installed skills are up-to-date with upstream."
+else
+  echo "Outdated skills (${#OUTDATED_SLUGS[@]}):"
+  for info in "${OUTDATED_INFO[@]}"; do
+    echo "  • $info"
+  done
+  echo ""
+
+  if [[ "$DRY_RUN" == "false" ]]; then
+    for slug in "${OUTDATED_SLUGS[@]}"; do
+      if [[ "$AUTO" == "true" ]]; then
+        echo "Updating: $slug"
+        "$ROOT/add-skill" "$UPSTREAM" "$slug"
+      else
+        read -rp "Update $slug from upstream? [y/N] " confirm
+        if [[ "$confirm" =~ ^[Yy] ]]; then
+          "$ROOT/add-skill" "$UPSTREAM" "$slug"
+        else
+          echo "  Skipped: $slug"
+        fi
+      fi
+    done
+  fi
+fi
+
+# Report missing
+if [[ ${#MISSING_SLUGS[@]} -gt 0 ]]; then
+  echo ""
+  echo "Skills available upstream but not installed (${#MISSING_SLUGS[@]}):"
+  for slug in "${MISSING_SLUGS[@]}"; do
+    echo "  • $slug"
+  done
+
+  if [[ "$INCLUDE_MISSING" == "true" && "$DRY_RUN" == "false" ]]; then
+    echo ""
+    for slug in "${MISSING_SLUGS[@]}"; do
+      if [[ "$AUTO" == "true" ]]; then
+        echo "Installing: $slug"
+        "$ROOT/add-skill" "$UPSTREAM" "$slug"
+      else
+        read -rp "Install $slug? [y/N] " confirm
+        if [[ "$confirm" =~ ^[Yy] ]]; then
+          "$ROOT/add-skill" "$UPSTREAM" "$slug"
+        else
+          echo "  Skipped: $slug"
+        fi
+      fi
+    done
+  elif [[ "$INCLUDE_MISSING" == "false" ]]; then
+    echo "Run with --missing to install missing skills."
+  fi
+fi
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo ""
+  echo "(Dry run — no changes made)"
+fi
+
+echo ""
+echo "Done."

--- a/skills/sync-check/SKILL.md
+++ b/skills/sync-check/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: Upstream Sync Check
+description: Compare installed skills against upstream aaronjmars/aeon — find outdated and missing skills
+var: ""
+---
+> **${var}** — Upstream repo to check against (default: aaronjmars/aeon).
+
+Today is ${today}. Check whether this Aeon instance's skills are up-to-date with upstream.
+
+## Steps
+
+1. **Determine upstream repo** — use `${var}` if set, otherwise default to `aaronjmars/aeon`.
+
+2. **Fetch upstream skills.json** from GitHub API:
+   ```bash
+   gh api repos/aaronjmars/aeon/contents/skills.json --jq '.content' | base64 -d > /tmp/upstream-skills.json
+   ```
+
+3. **Read local skills.json** at the repo root. If it doesn't exist, run `./generate-skills-json` first.
+
+4. **Compare local vs upstream:**
+   - For each upstream skill: check if it exists locally (by slug)
+   - If it exists locally and both have `sha` fields: compare SHAs — if different, mark as **outdated**
+   - If it doesn't exist locally: mark as **missing**
+   - Count how many local skills are **current** (SHA matches upstream or no SHA tracking yet)
+
+5. **Generate sync report** — save to `articles/sync-check-${today}.md`:
+
+   ```
+   # Upstream Sync Report — ${today}
+   
+   **Upstream:** aaronjmars/aeon (or ${var})
+   **Local skills:** X | **Upstream skills:** Y
+   
+   ## Missing Skills (not installed locally)
+   | Skill | Description | Install |
+   |-------|-------------|---------|
+   | name | desc | `./add-skill aaronjmars/aeon slug` |
+   
+   ## Outdated Skills (different SHA than upstream)
+   | Skill | Local SHA | Upstream SHA | Last Updated |
+   |-------|-----------|--------------|--------------|
+   | name | abc1234 | def5678 | YYYY-MM-DD |
+   
+   ## Up-to-Date Skills
+   X skills are current.
+   
+   ## How to Sync
+   Run `./scripts/sync-upstream.sh` to interactively update outdated skills, or install missing ones with:
+   `./add-skill aaronjmars/aeon <slug>`
+   ```
+
+6. **Commit the report:**
+   ```bash
+   git add articles/sync-check-${today}.md
+   git commit -m "chore(sync-check): upstream sync report ${today}"
+   ```
+
+7. **Send notification** via `./notify` only if there are missing or outdated skills:
+   ```
+   *Upstream Sync — ${today}*
+   
+   X skills missing, Y skills outdated vs aaronjmars/aeon.
+   
+   Missing: [list skill names]
+   Outdated: [list skill names]
+   
+   Run `./scripts/sync-upstream.sh` to update.
+   ```
+   
+   If everything is up to date: no notification needed, just log "All skills current — no notification sent."


### PR DESCRIPTION
## What
Adds git SHA-based version tracking to all skills and tooling for forkers to stay in sync with upstream.

## Why
Aeon has 15+ forks but no way for forkers to know when upstream skills have been updated. This creates divergence — forkers miss bug fixes and new features silently. This is the #5 most impactful idea from the March 29 repo-actions run.

## Changes
- `generate-skills-json`: adds `sha` (7-char git SHA of last SKILL.md commit) and `updated` (YYYY-MM-DD) to each skill entry in skills.json
- `skills/sync-check/SKILL.md`: new skill that compares local skills against upstream, reports missing/outdated skills, and generates a sync report
- `scripts/sync-upstream.sh`: interactive shell script for forkers to update outdated skills via `./add-skill`, with `--auto`, `--dry-run`, and `--missing` flags

## How it works
`generate-skills-json` now records the git SHA of the last commit touching each `skills/*/SKILL.md` file. Forkers who run this tool get their own SHA fingerprints. The `sync-check` skill fetches upstream's `skills.json`, compares SHAs, and reports which skills have diverged. `sync-upstream.sh` makes it one-command to pull updates.

---
*Built autonomously by Aeon*