### PR TITLE
feat: Bankr Gateway support for LLM routing

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -18,6 +18,11 @@ on:
           - claude-opus-4-6
           - claude-sonnet-4-6
           - claude-haiku-4-5-20251001
+          - gemini-3-pro
+          - gemini-3-flash
+          - gpt-5.2
+          - kimi-k2.5
+          - qwen3-coder
       var:
         description: 'Variable (e.g. AI, bitcoin, owner/repo)'
         required: false
@@ -119,7 +124,7 @@ jobs:
           SECRETS=$(grep -oE '\$\{?[A-Z][A-Z0-9_]{2,}\}?' "$SKILL_FILE" 2>/dev/null | \
             sed 's/[${}]//g' | \
             grep -E '_(API_KEY|KEY|TOKEN|SECRET|WEBHOOK_URL)$' | \
-            grep -vE '^(GITHUB_TOKEN|GH_TOKEN|ANTHROPIC_API_KEY|CLAUDE_CODE_OAUTH_TOKEN|TELEGRAM_|DISCORD_|SLACK_)' | \
+            grep -vE '^(GITHUB_TOKEN|GH_TOKEN|ANTHROPIC_API_KEY|CLAUDE_CODE_OAUTH_TOKEN|BANKR_LLM_KEY|TELEGRAM_|DISCORD_|SLACK_)' | \
             sort -u) || true
 
           [ -z "$SECRETS" ] && exit 0
@@ -146,6 +151,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          BANKR_LLM_KEY: ${{ secrets.BANKR_LLM_KEY }}
           GITHUB_TOKEN: ${{ secrets.GH_GLOBAL || secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GH_GLOBAL || secrets.GITHUB_TOKEN }}
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
@@ -178,6 +184,28 @@ jobs:
           fi
           echo "Using model: $MODEL"
           echo "SKILL_MODEL=$MODEL" >> "$GITHUB_OUTPUT"
+
+          # --- AI Gateway routing ---
+          GATEWAY=$(grep -A1 '^gateway:' aeon.yml | grep 'provider:' | sed 's/.*provider: *//' | tr -d ' "'"'" || echo "direct")
+          GATEWAY="${GATEWAY:-direct}"
+          echo "Gateway: $GATEWAY"
+
+          echo "GATEWAY=$GATEWAY" >> "$GITHUB_OUTPUT"
+
+          if [ "$GATEWAY" = "bankr" ]; then
+            if [ -z "${BANKR_LLM_KEY:-}" ]; then
+              echo "::error::gateway.provider=bankr but BANKR_LLM_KEY secret is not set"
+              exit 1
+            fi
+            export ANTHROPIC_BASE_URL="https://llm.bankr.bot"
+            export ANTHROPIC_AUTH_TOKEN="$BANKR_LLM_KEY"
+            unset ANTHROPIC_API_KEY
+            unset CLAUDE_CODE_OAUTH_TOKEN
+            echo "::notice::Routing through Bankr Gateway (https://llm.bankr.bot)"
+          else
+            echo "::notice::Using direct Anthropic API"
+          fi
+
           # Generate notify script in workspace (Claude calls: ./notify "message")
           cat > ./notify << 'NOTIFY_SCRIPT'
           #!/usr/bin/env bash
@@ -298,7 +326,14 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          BANKR_LLM_KEY: ${{ secrets.BANKR_LLM_KEY }}
         run: |
+          if [ "${{ steps.run.outputs.GATEWAY }}" = "bankr" ] && [ -n "${BANKR_LLM_KEY:-}" ]; then
+            export ANTHROPIC_BASE_URL="https://llm.bankr.bot"
+            export ANTHROPIC_AUTH_TOKEN="$BANKR_LLM_KEY"
+            unset ANTHROPIC_API_KEY
+            unset CLAUDE_CODE_OAUTH_TOKEN
+          fi
           for pending in dashboard/outputs/.pending-*.md; do
             [ -f "$pending" ] || continue
             SKILL=$(basename "$pending" .md | sed 's/^\.pending-//')

--- a/README.md
+++ b/README.md
@@ -221,6 +221,36 @@ model: claude-opus-4-6
 
 You can change it from the dashboard header dropdown. Options: `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-haiku-4-5-20251001`. Per-run overrides are also available via workflow dispatch.
 
+### Bankr Gateway (optional)
+
+Route all Claude Code requests through [Bankr LLM Gateway](https://docs.bankr.bot/llm-gateway/overview) for multi-model access and cost optimization. Bankr routes Claude through Vertex AI (~67% cheaper for Opus) and adds access to Gemini, GPT, Kimi, and Qwen models through a single API.
+
+**Setup:**
+
+1. Get an API key at [bankr.bot/api](https://bankr.bot/api)
+2. Top up credits at [bankr.bot/llm?tab=credits](https://bankr.bot/llm?tab=credits) (USDC, ETH, or BNKR on Base)
+3. Add `BANKR_LLM_KEY` as a repo secret (value: `bk_your_key`)
+4. Set the gateway provider in `aeon.yml`:
+
+```yaml
+gateway:
+  provider: bankr
+```
+
+**Key Permissions:** Your API key must have **LLM Gateway** enabled at [bankr.bot/api](https://bankr.bot/api). The Read Only toggle only affects the Agent API — LLM Gateway access is always available when enabled. A key used only for LLM Gateway doesn't need Agent API enabled. See [Access Control](https://docs.bankr.bot/llm-gateway/overview) for full details.
+
+**Available models (via Bankr):**
+
+| Provider | Models |
+|----------|--------|
+| Anthropic | `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-haiku-4-5-20251001` |
+| Google | `gemini-3-pro`, `gemini-3-flash` |
+| OpenAI | `gpt-5.2` |
+| Moonshot AI | `kimi-k2.5` |
+| Alibaba | `qwen3-coder` |
+
+Non-Claude models are available in the workflow dispatch dropdown and per-skill model overrides when gateway is set to `bankr`. Set `provider: direct` (the default) to use the standard Anthropic API.
+
 ### Changing check frequency
 
 Edit `.github/workflows/messages.yml`:

--- a/aeon.yml
+++ b/aeon.yml
@@ -93,7 +93,14 @@ skills:
 
 # Default model for all skills. Override per-run via workflow_dispatch.
 # Options: claude-opus-4-6, claude-sonnet-4-6, claude-haiku-4-5-20251001
+# Bankr gateway also supports: gemini-3-pro, gemini-3-flash, gpt-5.2, kimi-k2.5, qwen3-coder
 model: claude-opus-4-6
+
+# AI Gateway — route Claude Code requests through an LLM gateway.
+# provider: direct (default, uses ANTHROPIC_API_KEY) | bankr (uses BANKR_LLM_KEY)
+# Bankr docs: https://docs.bankr.bot/llm-gateway/overview
+gateway:
+  provider: direct
 
 # Output channels
 channels:

--- a/dashboard/app/api/secrets/route.ts
+++ b/dashboard/app/api/secrets/route.ts
@@ -4,6 +4,7 @@ import { execSync } from 'child_process'
 const BUILTIN_SECRETS = [
   { name: 'CLAUDE_CODE_OAUTH_TOKEN', group: 'Core', description: 'Claude Code OAuth token (set via Authenticate button)', either: 'auth' },
   { name: 'ANTHROPIC_API_KEY', group: 'Core', description: 'Anthropic API key for Claude Code', either: 'auth' },
+  { name: 'BANKR_LLM_KEY', group: 'Core', description: 'Bankr Gateway API key (bk_...) — enable at bankr.bot/api' },
   { name: 'TELEGRAM_BOT_TOKEN', group: 'Telegram', description: 'Bot token from @BotFather' },
   { name: 'TELEGRAM_CHAT_ID', group: 'Telegram', description: 'Your chat ID' },
   { name: 'DISCORD_BOT_TOKEN', group: 'Discord', description: 'Discord bot token' },

--- a/dashboard/app/api/skills/route.ts
+++ b/dashboard/app/api/skills/route.ts
@@ -80,7 +80,7 @@ export async function GET() {
     })
 
     const repo = getRepoSlug()
-    return NextResponse.json({ skills, model: config.model, repo, jsonrenderEnabled: config.jsonrenderEnabled })
+    return NextResponse.json({ skills, model: config.model, gateway: config.gateway, repo, jsonrenderEnabled: config.jsonrenderEnabled })
   } catch (error: unknown) {
     const msg = error instanceof Error ? error.message : 'Unknown error'
     return NextResponse.json({ error: msg }, { status: 500 })

--- a/dashboard/app/page.tsx
+++ b/dashboard/app/page.tsx
@@ -24,6 +24,7 @@ export default function Dashboard() {
   const [runs, setRuns] = useState<Run[]>([])
   const [secrets, setSecrets] = useState<Secret[]>([])
   const [model, setModel] = useState('claude-sonnet-4-6')
+  const [gateway, setGateway] = useState<'direct' | 'bankr'>('direct')
   const [repo, setRepo] = useState('')
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
@@ -49,7 +50,7 @@ export default function Dashboard() {
 
   // --- API ---
   const fetchData = useCallback(async () => {
-    try { const [sr, rr, secr] = await Promise.all([fetch('/api/skills'), fetch('/api/runs'), fetch('/api/secrets')]); if (sr.ok) { const d = await sr.json(); setSkills(d.skills); if (d.model) setModel(d.model); if (d.repo) setRepo(d.repo) }; if (rr.ok) setRuns((await rr.json()).runs); if (secr.ok) { const d = await secr.json(); if (d.secrets) setSecrets(d.secrets) } } catch (e: unknown) { setError(e instanceof Error ? e.message : 'Failed to connect') } finally { setLoading(false) }
+    try { const [sr, rr, secr] = await Promise.all([fetch('/api/skills'), fetch('/api/runs'), fetch('/api/secrets')]); if (sr.ok) { const d = await sr.json(); setSkills(d.skills); if (d.model) setModel(d.model); if (d.gateway?.provider) setGateway(d.gateway.provider); if (d.repo) setRepo(d.repo) }; if (rr.ok) setRuns((await rr.json()).runs); if (secr.ok) { const d = await secr.json(); if (d.secrets) setSecrets(d.secrets) } } catch (e: unknown) { setError(e instanceof Error ? e.message : 'Failed to connect') } finally { setLoading(false) }
     try { const r = await fetch('/api/sync'); if (r.ok) { const d = await r.json(); setHasChanges(d.hasChanges); if (typeof d.behind === 'number') setBehind(d.behind) } } catch {}
     try { const r = await fetch('/api/auth'); if (r.ok) setAuthStatus(await r.json()) } catch {}
   }, [])
@@ -95,7 +96,7 @@ export default function Dashboard() {
 
       <div className="flex-1 flex flex-col min-w-0">
         <TopBar
-          skill={skill} view={view} repo={repo} model={model}
+          skill={skill} view={view} repo={repo} model={model} gateway={gateway}
           authStatus={authStatus} authLoading={authLoading}
           pulling={pulling} syncing={syncing} hasChanges={hasChanges} behind={behind}
           onSetupAuth={() => setupAuth()} onUpdateModel={updateModel}

--- a/dashboard/lib/config.ts
+++ b/dashboard/lib/config.ts
@@ -7,9 +7,14 @@ export interface SkillConfig {
   model: string
 }
 
+export interface GatewayConfig {
+  provider: 'direct' | 'bankr'
+}
+
 export interface AeonConfig {
   skills: Record<string, SkillConfig>
   model: string
+  gateway: GatewayConfig
   jsonrenderEnabled: boolean
 }
 
@@ -39,6 +44,13 @@ export function parseConfig(raw: string): AeonConfig {
 
   const model = String(doc.get('model') ?? 'claude-sonnet-4-6')
 
+  let gateway: GatewayConfig = { provider: 'direct' }
+  const gatewayNode = doc.get('gateway')
+  if (isMap(gatewayNode)) {
+    const provider = String(getMapValue(gatewayNode, 'provider') ?? 'direct')
+    gateway = { provider: provider === 'bankr' ? 'bankr' : 'direct' }
+  }
+
   let jsonrenderEnabled = false
   const channels = doc.get('channels')
   if (isMap(channels)) {
@@ -48,7 +60,7 @@ export function parseConfig(raw: string): AeonConfig {
     }
   }
 
-  return { skills, model, jsonrenderEnabled }
+  return { skills, model, gateway, jsonrenderEnabled }
 }
 
 /**

--- a/skills/cost-report/SKILL.md
+++ b/skills/cost-report/SKILL.md
@@ -11,7 +11,9 @@ Today is ${today}. Generate a cost report from Aeon's token usage data.
 
 ## Model Pricing (per million tokens)
 
-Use these rates to calculate costs:
+Use these rates to calculate costs. First check `aeon.yml` for the `gateway.provider` value.
+
+### Direct Anthropic (gateway.provider: direct)
 
 | Model | Input | Output | Cache Read | Cache Write |
 |-------|-------|--------|------------|-------------|
@@ -19,7 +21,22 @@ Use these rates to calculate costs:
 | claude-sonnet-4-6 | $3.00 | $15.00 | $0.30 | $3.75 |
 | claude-haiku-4-5-20251001 | $0.80 | $4.00 | $0.08 | $3.75 |
 
-For any model not in this table, default to Opus pricing (conservative estimate).
+### Bankr Gateway (gateway.provider: bankr)
+
+| Model | Input | Output |
+|-------|-------|--------|
+| claude-opus-4-6 | $5.00 | $25.00 |
+| claude-sonnet-4-6 | $3.00 | $15.00 |
+| claude-haiku-4-5-20251001 | $0.80 | $4.00 |
+| gemini-3-pro | $1.25 | $10.00 |
+| gemini-3-flash | $0.15 | $0.60 |
+| gpt-5.2 | $2.50 | $10.00 |
+| kimi-k2.5 | $1.00 | $4.00 |
+| qwen3-coder | $0.50 | $2.00 |
+
+Note: Bankr does not break out cache read/write pricing separately. Treat cache columns as zero cost for Bankr rows.
+
+For any model not in these tables, default to Opus pricing (conservative estimate).
 
 ## Steps
 


### PR DESCRIPTION
## Summary
- Add configurable AI gateway routing via `aeon.yml` — `gateway.provider: direct` (default) or `bankr`
- When `bankr` is selected, Claude Code requests route through `https://llm.bankr.bot` using the `BANKR_LLM_KEY` secret
- Expands available models to include Gemini 3 Pro/Flash, GPT-5.2, Kimi K2.5, Qwen3 Coder (Bankr-only)
- Updates cost-report skill with Bankr pricing tiers (Opus is ~67% cheaper via Bankr's Vertex AI routing)
- Dashboard config parser now exposes `gateway` field

## How to activate
1. Get a Bankr API key at `bankr.bot/api` (enable "LLM Gateway" permission)
2. Add `BANKR_LLM_KEY` as a repo secret (value: `bk_your_key`)
3. Top up credits at `bankr.bot/llm?tab=credits` (USDC/ETH/BNKR on Base)
4. Change `gateway.provider` from `direct` to `bankr` in `aeon.yml`

## Files changed
| File | Change |
|------|--------|
| `aeon.yml` | New `gateway` config block, expanded model comments |
| `.github/workflows/aeon.yml` | Gateway routing logic, `BANKR_LLM_KEY` secret, expanded model dropdown |
| `dashboard/lib/config.ts` | `GatewayConfig` type, parser for `gateway` block |
| `skills/cost-report/SKILL.md` | Bankr pricing table + non-Claude model pricing |

## Risks & testing notes
- **Feature passthrough**: Bankr docs don't explicitly confirm extended thinking or prompt caching. Test with `heartbeat` skill first.
- **Model IDs**: Bankr may expect dots (`claude-opus-4.6`) vs dashes (`claude-opus-4-6`). If skills fail, may need ID mapping.
- **Zero-impact default**: Ships with `gateway.provider: direct` — no behavior change until manually switched.

## Test plan
- [ ] Verify workflow still works with `gateway.provider: direct` (no regression)
- [ ] Set `BANKR_LLM_KEY` and flip to `bankr`, run `heartbeat` skill
- [ ] Confirm tool use and streaming work through Bankr gateway
- [ ] Test a non-Claude model (e.g. `gemini-3-flash`) via workflow dispatch
- [ ] Run `cost-report` and verify it reads gateway config for pricing

Closes HYP-6

🤖 Generated with [Claude Code](https://claude.com/claude-code)