### PR TITLE
feat: switch paper skills to Hugging Face Papers API

### DIFF
--- a/skills/paper-digest/SKILL.md
+++ b/skills/paper-digest/SKILL.md
@@ -13,38 +13,43 @@ Read memory/MEMORY.md for tracked research topics and interests.
 Read the last 7 days of memory/logs/ to avoid covering papers already reported.
 
 For each topic area in MEMORY.md:
-1. Search Semantic Scholar API (free, no key needed):
+1. Search Hugging Face Papers API (free, no key needed, arXiv-indexed papers with community signal):
    ```bash
-   curl -s "https://api.semanticscholar.org/graph/v1/paper/search?query=TOPIC&year=YEAR&limit=10&fields=title,authors,abstract,url,publicationDate,citationCount,openAccessPdf" \
-     -H "Accept: application/json"
+   curl -s "https://huggingface.co/api/papers/search?q=TOPIC&limit=10"
    ```
-   If rate-limited (429), wait 3 seconds and retry once.
+   Response is a JSON array. Each entry has:
+   - `paper.id` — arXiv ID (use for links: `https://arxiv.org/abs/{id}`, PDF: `https://arxiv.org/pdf/{id}`)
+   - `paper.title`, `paper.summary` (abstract), `paper.authors[].name`
+   - `paper.publishedAt` — publication date
+   - `paper.upvotes` — community upvotes (higher = more notable)
 
-2. Also check arXiv for the latest preprints:
+2. Also check today's trending papers for serendipitous finds:
    ```bash
-   curl -s "http://export.arxiv.org/api/query?search_query=all:TOPIC&sortBy=submittedDate&sortOrder=descending&max_results=10"
+   curl -s "https://huggingface.co/api/daily_papers?limit=15"
    ```
+   Daily papers also include `paper.ai_summary` and `paper.ai_keywords[]` — use these to quickly assess relevance to tracked topics.
 
 3. Score each paper for relevance:
    - Direct keyword match to MEMORY.md interests = high
    - Related field or methodology = medium
+   - High upvotes (>10) on Hugging Face = boost score
    - Tangential = skip
 
 Select the top 5 most relevant papers across all topics.
 
 For each selected paper:
-- Fetch the abstract (from API response or via WebFetch if needed)
+- Use the abstract from the API response (`paper.summary`)
 - Write a 2-3 sentence summary: what they found, why it matters, connection to other work
-- Note if open-access PDF is available
+- Note upvote count as a signal of community interest
 
 Format as a weekly briefing and save to articles/paper-digest-${today}.md:
 ```markdown
 # Paper Digest — ${today}
 
 ## Topic Area
-1. **Paper Title** — Authors (Year)
+1. **Paper Title** — Authors (Year) · ↑upvotes
    Summary of key findings and implications.
-   [Link](url) | [PDF](pdf_url)
+   [Paper](https://arxiv.org/abs/ID) | [PDF](https://arxiv.org/pdf/ID)
 
 2. ...
 ```

--- a/skills/paper-pick/SKILL.md
+++ b/skills/paper-pick/SKILL.md
@@ -1,45 +1,47 @@
 ---
 name: Paper Pick
-description: Find the one paper you should read today from arXiv and Semantic Scholar
+description: Find the one paper you should read today from Hugging Face Papers
 var: ""
 tags: [research]
 ---
-> **${var}** — Research topic to search for (e.g. "transformer architectures", "memory consolidation", "RL agents"). If empty, searches broadly across AI and related fields.
+> **${var}** — Research topic to search for (e.g. "transformer architectures", "memory consolidation", "RL agents"). If empty, browses today's trending papers.
 
 Read memory/MEMORY.md for context.
 Read the last 7 days of memory/logs/ to avoid recommending papers already covered.
 
 ## Steps
 
-1. Search for recent papers. **Start with arXiv** (no rate limits), then try Semantic Scholar as a supplement:
+1. Search for recent papers using Hugging Face Papers API (free, no key needed, no rate limits):
 
-   **Primary — arXiv** (always works, no rate limits):
+   **If `${var}` is set** — search for that topic:
    ```bash
-   # If ${var} is set, use it as the query. Otherwise use broad categories.
-   # arXiv categories: cs.AI, cs.CL (NLP), cs.LG (machine learning)
-   curl -s -L "https://export.arxiv.org/api/query?search_query=cat:cs.AI+OR+cat:cs.CL+OR+cat:cs.LG&sortBy=submittedDate&sortOrder=descending&max_results=15"
+   curl -s "https://huggingface.co/api/papers/search?q=${var}&limit=15"
    ```
 
-   **Secondary — Semantic Scholar** (may 429, treat as optional):
+   **If `${var}` is empty** — browse today's trending papers:
    ```bash
-   curl -s "https://api.semanticscholar.org/graph/v1/paper/search?query=artificial+intelligence+large+language+models&year=2025-2026&limit=5&fields=title,authors,abstract,url,publicationDate,citationCount,openAccessPdf" \
-     -H "Accept: application/json"
+   curl -s "https://huggingface.co/api/daily_papers?limit=15"
    ```
-   If rate-limited (429), **skip Semantic Scholar entirely** — arXiv results are sufficient. Do not retry or wait.
 
-2. If arXiv returned thin results or `${var}` is a niche topic, also try **WebSearch** for "[topic] paper 2025 2026 site:arxiv.org" to catch papers the API missed.
+   Response is a JSON array. Each entry has:
+   - `paper.id` — arXiv ID (use for links: `https://arxiv.org/abs/{id}`, PDF: `https://arxiv.org/pdf/{id}`)
+   - `paper.title`, `paper.summary` (abstract), `paper.authors[].name`
+   - `paper.publishedAt` — publication date
+   - `paper.upvotes` — community upvotes (higher = more notable)
+   - `paper.ai_summary` — AI-generated summary (on daily papers)
 
-3. From all results, pick **the single best paper** — the one most worth reading today. Criteria: novelty, relevance, practical implications. Skip anything already mentioned in recent logs.
+2. If the search returned thin results or `${var}` is a niche topic, also try **WebSearch** for "[topic] paper 2025 2026 site:arxiv.org" to catch papers the API missed.
+
+3. From all results, pick **the single best paper** — the one most worth reading today. Criteria: novelty, relevance, practical implications, community signal (upvotes). Skip anything already mentioned in recent logs.
 
 4. Send via `./notify`:
    ```
    *Paper Pick — ${today}*
 
-   "Paper Title" — Authors
+   "Paper Title" — Authors · ↑upvotes
    One sentence: why this paper is worth your time.
-   [Read](url) | [PDF](pdf_url)
+   [Read](https://arxiv.org/abs/ID) | [PDF](https://arxiv.org/pdf/ID)
    ```
-   If open-access PDF is available, include the PDF link. Otherwise just the paper link.
 
 5. Log to memory/logs/${today}.md.
 


### PR DESCRIPTION
## Summary
- Replace Semantic Scholar + arXiv API with Hugging Face Papers API in both `paper-digest` and `paper-pick` skills
- HF Papers API is free, has no rate limits (Semantic Scholar frequently 429s), and provides community signal via upvotes
- Papers are arXiv-indexed — PDF links (`arxiv.org/pdf/{id}`) are preserved
- Daily papers endpoint includes AI-generated summaries and keywords for faster relevance scoring

## Test plan
- [ ] Run `paper-pick` skill with a topic var (e.g. "transformer architectures") and verify HF search returns results
- [ ] Run `paper-pick` without var and verify daily papers endpoint returns trending papers
- [ ] Run `paper-digest` and verify multi-topic search works
- [ ] Verify arXiv links and PDF links resolve correctly from HF paper IDs

Closes HYP-24

🤖 Generated with [Claude Code](https://claude.com/claude-code)