### PR TITLE
feat: treasury-info skill — wallet holdings via Bankr API

### DIFF
--- a/aeon.yml
+++ b/aeon.yml
@@ -28,6 +28,7 @@ skills:
   wallet-digest: { enabled: false, schedule: "0 12 * * *" }
   on-chain-monitor: { enabled: false, schedule: "0 12 * * *" }
   defi-monitor: { enabled: false, schedule: "0 12 * * *" }
+  treasury-info: { enabled: false, schedule: "0 12 * * *" }
   defi-overview: { enabled: false, schedule: "0 12 * * *" }
   polymarket: { enabled: false, schedule: "0 12 * * *" }
   monitor-polymarket: { enabled: false, schedule: "30 12 * * *", model: "claude-sonnet-4-6" } # monitor specific markets for 24h price moves and volume changes

--- a/generate-skills-json
+++ b/generate-skills-json
@@ -57,6 +57,7 @@ declare -A CATEGORIES=(
   [on-chain-monitor]="crypto"
   [defi-monitor]="crypto"
   [defi-overview]="crypto"
+  [treasury-info]="crypto"
   [polymarket]="crypto"
   [polymarket-comments]="crypto"
   [monitor-runners]="crypto"

--- a/skills/treasury-info/SKILL.md
+++ b/skills/treasury-info/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: Treasury Info
+description: Show holdings overview for a wallet using Bankr API with block explorer fallback
+var: ""
+tags: [crypto]
+---
+> **${var}** — Wallet label to check. If empty, checks all watched wallets.
+
+If `${var}` is set, only check the wallet with that label.
+
+
+## Config
+
+This skill reads watched addresses from `memory/on-chain-watches.yml`. If the file doesn't exist yet, create it or skip this skill.
+
+```yaml
+# memory/on-chain-watches.yml
+watches:
+  - label: Treasury
+    address: "0x1234...abcd"
+    chain: base
+    rpc_url: https://base.llamarpc.com
+    type: wallet
+```
+
+### Bankr API (preferred)
+
+Set the `BANKR_API_KEY` secret (prefixed `bk_`). The Bankr portfolio endpoint returns token balances, USD values, PnL, and NFTs across chains — one call covers everything.
+
+If `BANKR_API_KEY` is not set, the skill falls back to direct RPC + CoinGecko.
+
+---
+
+Read memory/MEMORY.md and memory/on-chain-watches.yml for watched addresses.
+Read the last 2 days of memory/logs/ to compare against previous snapshots.
+
+Steps:
+
+1. **Load watches** — parse `memory/on-chain-watches.yml`. Filter to `type: wallet` entries. If `${var}` is set, match by label.
+
+2. **Fetch holdings** — for each wallet, try Bankr first, then fall back:
+
+   **Path A — Bankr API** (if `BANKR_API_KEY` is set):
+   ```bash
+   curl -s "https://api.bankr.bot/wallet/portfolio?include=pnl&showLowValueTokens=false" \
+     -H "X-API-Key: ${BANKR_API_KEY}"
+   ```
+   This returns balances grouped by chain with token symbols, amounts, USD values, and PnL.
+
+   If the Bankr wallet address matches a watched address, use the response directly.
+   If querying a different wallet, use the Agent API:
+   ```bash
+   # Submit prompt
+   JOB=$(curl -s -X POST "https://api.bankr.bot/agent/prompt" \
+     -H "X-API-Key: ${BANKR_API_KEY}" \
+     -H "Content-Type: application/json" \
+     -d '{"prompt":"Show full token balances for wallet '"${address}"' on '"${chain}"'"}' \
+     | jq -r '.jobId')
+
+   # Poll for result (max 30s, 3s intervals)
+   for i in $(seq 1 10); do
+     RESULT=$(curl -s "https://api.bankr.bot/agent/job/${JOB}" \
+       -H "X-API-Key: ${BANKR_API_KEY}")
+     STATUS=$(echo "$RESULT" | jq -r '.status')
+     if [ "$STATUS" = "completed" ]; then break; fi
+     sleep 3
+   done
+   ```
+
+   **Path B — RPC + CoinGecko fallback** (no Bankr key):
+   - Get native balance via `eth_getBalance` (EVM) or equivalent RPC call.
+   - For ERC-20 tokens, query known token contracts with `balanceOf(address)` via `eth_call`.
+   - Look up USD prices from CoinGecko:
+     ```bash
+     curl -s "https://api.coingecko.com/api/v3/simple/price?ids=${coin_ids}&vs_currencies=usd&include_24hr_change=true"
+     ```
+   - For Solana wallets, use the Solana RPC `getBalance` and `getTokenAccountsByOwner` methods.
+
+3. **Format treasury overview**:
+   ```
+   *Treasury Overview — ${today}*
+
+   *Label* (chain)
+   Total Value: $X,XXX.XX
+
+   Holdings:
+   - TOKEN1: amount ($value) [+/-% 24h]
+   - TOKEN2: amount ($value) [+/-% 24h]
+   - ...
+
+   Top 5 by value shown. N tokens below $1 hidden.
+
+   Change since last check: +/- $X.XX
+   ```
+   Include PnL data if available from Bankr. Compare total value against the last logged snapshot.
+
+4. **Send** via `./notify`.
+
+5. **Log** current totals and per-token balances to `memory/logs/${today}.md` so future runs can track changes over time.
+
+If no watched wallets configured, send nothing. Log "TREASURY_INFO_OK — no wallets configured" and end.


### PR DESCRIPTION
## Summary
- Adds `treasury-info` skill that shows a wallet holdings overview (token balances, USD values, 24h changes)
- **Primary path**: Bankr API (`/wallet/portfolio`) — single call returns multi-chain balances, PnL, and NFTs
- **Fallback**: Direct RPC + CoinGecko when `BANKR_API_KEY` is not set
- Reads wallet addresses from `memory/on-chain-watches.yml` (consistent with existing crypto skills)
- Scheduled at midday (12 PM UTC) alongside other crypto skills, disabled by default

## Files changed
- `skills/treasury-info/SKILL.md` — new skill
- `aeon.yml` — added schedule entry
- `generate-skills-json` — added category mapping

## Setup
1. Set `BANKR_API_KEY` secret (get one at [bankr.bot/api](https://bankr.bot/api)), or skip for RPC fallback
2. Add wallet addresses to `memory/on-chain-watches.yml`
3. Enable in `aeon.yml`: `treasury-info: { enabled: true, ... }`

Closes HYP-35

## Test plan
- [ ] Run skill manually via `workflow_dispatch` with a configured wallet
- [ ] Verify Bankr API path returns formatted holdings
- [ ] Verify RPC fallback works without `BANKR_API_KEY`
- [ ] Confirm notification is sent and log entry written

🤖 Generated with [Claude Code](https://claude.com/claude-code)