### PR TITLE
feat: skill chaining system

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -22,6 +22,10 @@ on:
         description: 'Variable (e.g. AI, bitcoin, owner/repo)'
         required: false
         type: string
+      chain_context_file:
+        description: 'Path to file with prior chain step outputs (set by chain runner)'
+        required: false
+        type: string
   workflow_call:
     inputs:
       skill:
@@ -30,6 +34,14 @@ on:
         type: string
       model:
         description: 'Model override'
+        required: false
+        type: string
+      var:
+        description: 'Variable'
+        required: false
+        type: string
+      chain_context_file:
+        description: 'Chain context file path'
         required: false
         type: string
   issues:
@@ -233,7 +245,21 @@ jobs:
 
           SKILL_NAME="${{ steps.skill.outputs.name }}"
           VAR="$SKILL_VAR"
-          PROMPT="Today is $TODAY. Read and execute the skill defined in skills/${SKILL_NAME}/SKILL.md"
+
+          # Build prompt — inject chain context if running as part of a chain
+          CHAIN_CTX="${{ inputs.chain_context_file }}"
+          if [ -n "$CHAIN_CTX" ] && [ -f "$CHAIN_CTX" ]; then
+            CONTEXT=$(cat "$CHAIN_CTX")
+            PROMPT="Today is $TODAY.
+
+          ## Context from prior chain steps
+          $CONTEXT
+
+          Read and execute the skill defined in skills/${SKILL_NAME}/SKILL.md
+          Use the chain context above instead of re-running those skills. Synthesize and build on their outputs."
+          else
+            PROMPT="Today is $TODAY. Read and execute the skill defined in skills/${SKILL_NAME}/SKILL.md"
+          fi
           if [ -n "$VAR" ]; then
             PROMPT="$PROMPT
 
@@ -248,7 +274,10 @@ jobs:
           fi
 
           # Extract and print the text result so logs still show skill output
-          echo "$CLAUDE_OUTPUT" | jq -r '.result // empty'
+          RESULT_TEXT=$(echo "$CLAUDE_OUTPUT" | jq -r '.result // empty')
+          echo "$RESULT_TEXT"
+          # Save result for output capture step
+          echo "$RESULT_TEXT" > /tmp/skill-result.txt
 
           # Parse token usage from JSON response
           INPUT_TOKENS=$(echo "$CLAUDE_OUTPUT" | jq '.usage.input_tokens // 0')
@@ -292,6 +321,22 @@ jobs:
             echo "date,skill,model,input_tokens,output_tokens,cache_read,cache_creation" > "$CSV"
           fi
           echo "$(date -u +%Y-%m-%d),${{ steps.skill.outputs.name }},${{ steps.run.outputs.SKILL_MODEL }},${{ steps.run.outputs.SKILL_INPUT_TOKENS }},${{ steps.run.outputs.SKILL_OUTPUT_TOKENS }},${{ steps.run.outputs.SKILL_CACHE_READ_TOKENS }},${{ steps.run.outputs.SKILL_CACHE_CREATION_TOKENS }}" >> "$CSV"
+
+      - name: Capture skill output
+        if: steps.work.outputs.mode != '' && steps.run.outcome == 'success'
+        run: |
+          SKILL="${{ steps.skill.outputs.name }}"
+          mkdir -p .outputs
+          # Save the notification message as a chain artifact
+          PENDING="dashboard/outputs/.pending-${SKILL}.md"
+          if [ -f "$PENDING" ]; then
+            cp "$PENDING" ".outputs/${SKILL}.md"
+          elif [ -f /tmp/skill-result.txt ] && [ -s /tmp/skill-result.txt ]; then
+            cp /tmp/skill-result.txt ".outputs/${SKILL}.md"
+          else
+            echo "_No output captured._" > ".outputs/${SKILL}.md"
+          fi
+          echo "::notice::Skill output captured to .outputs/${SKILL}.md ($(wc -c < ".outputs/${SKILL}.md") bytes)"
 
       - name: Convert feed outputs
         if: steps.work.outputs.mode != '' && vars.JSONRENDER_ENABLED != 'false'
@@ -349,7 +394,7 @@ jobs:
                 CONFLICTED=$(git diff --name-only --diff-filter=U) || true
                 [ -z "$CONFLICTED" ] && break
                 for f in $CONFLICTED; do
-                  if [[ "$f" == memory/logs/* ]] || [[ "$f" == memory/topics/* ]] || [[ "$f" == memory/MEMORY.md ]] || [[ "$f" == dashboard/outputs/* ]]; then
+                  if [[ "$f" == memory/logs/* ]] || [[ "$f" == memory/topics/* ]] || [[ "$f" == memory/MEMORY.md ]] || [[ "$f" == dashboard/outputs/* ]] || [[ "$f" == .outputs/* ]]; then
                     sed -i '/^<<<<<<< /d; /^=======/d; /^>>>>>>> /d' "$f"
                     git add "$f"
                   else

--- a/.github/workflows/chain-runner.yml
+++ b/.github/workflows/chain-runner.yml
@@ -1,0 +1,338 @@
+name: Chain Runner
+run-name: "chain: ${{ inputs.chain }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      chain:
+        description: 'Chain name from aeon.yml chains section'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  actions: write
+
+concurrency:
+  group: aeon-chain-${{ inputs.chain }}
+  cancel-in-progress: false
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v5
+        with:
+          token: ${{ secrets.GH_GLOBAL || secrets.GITHUB_TOKEN }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name "aeonframework"
+          git config user.email "aeonframework@proton.me"
+
+      - name: Run chain
+        env:
+          GH_TOKEN: ${{ secrets.GH_GLOBAL || secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          CHAIN="${{ inputs.chain }}"
+          NOW_ISO=$(date -u +%FT%TZ)
+          echo "Running chain: $CHAIN"
+
+          # --- Helper: dispatch a skill and return its run ID ---
+          dispatch_skill() {
+            local skill="$1" var="${2:-}" ctx_file="${3:-}"
+            local before_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+            local args=(-f skill="$skill")
+            [ -n "$var" ] && args+=(-f var="$var")
+            [ -n "$ctx_file" ] && args+=(-f chain_context_file="$ctx_file")
+
+            echo "  Dispatching: $skill"
+            gh workflow run aeon.yml "${args[@]}"
+
+            # Poll for the run to appear (up to 60s)
+            local run_id=""
+            for i in $(seq 1 12); do
+              sleep 5
+              run_id=$(gh run list --workflow=aeon.yml -L 10 \
+                --json databaseId,displayTitle,createdAt \
+                -q "[.[] | select(.displayTitle | test(\"skill: ${skill}(\"; \"i\")) | select(.createdAt >= \"${before_ts}\")] | .[0].databaseId" \
+                2>/dev/null || true)
+              [ -n "$run_id" ] && [ "$run_id" != "null" ] && break
+              run_id=""
+            done
+
+            if [ -z "$run_id" ]; then
+              echo "::error::Failed to discover run ID for skill: $skill"
+              return 1
+            fi
+            echo "  Run ID: $run_id"
+            echo "$run_id"
+          }
+
+          # --- Helper: wait for a set of run IDs to complete ---
+          wait_for_runs() {
+            local timeout=1800  # 30 min
+            local start=$(date +%s)
+            local run_ids=("$@")
+
+            echo "  Waiting for ${#run_ids[@]} run(s)..."
+            while true; do
+              local all_done=true
+              for id in "${run_ids[@]}"; do
+                local status=$(gh run view "$id" --json status -q '.status' 2>/dev/null || echo "unknown")
+                if [ "$status" != "completed" ]; then
+                  all_done=false
+                  break
+                fi
+              done
+              $all_done && break
+
+              local elapsed=$(( $(date +%s) - start ))
+              if [ "$elapsed" -ge "$timeout" ]; then
+                echo "::error::Chain timed out waiting for runs: ${run_ids[*]}"
+                return 1
+              fi
+              sleep 30
+            done
+
+            # Check conclusions
+            local failed=()
+            for id in "${run_ids[@]}"; do
+              local conclusion=$(gh run view "$id" --json conclusion -q '.conclusion' 2>/dev/null || echo "failure")
+              if [ "$conclusion" != "success" ]; then
+                local name=$(gh run view "$id" --json displayTitle -q '.displayTitle' 2>/dev/null || echo "$id")
+                failed+=("$name")
+                echo "::warning::Run failed: $name (ID: $id, conclusion: $conclusion)"
+              fi
+            done
+
+            if [ ${#failed[@]} -gt 0 ]; then
+              return 1
+            fi
+            return 0
+          }
+
+          # --- Helper: build chain context file from consumed outputs ---
+          build_context() {
+            local target_skill="$1"
+            shift
+            local consume_skills=("$@")
+            local ctx_file=".outputs/.chain-context-${target_skill}.md"
+
+            mkdir -p .outputs
+            echo "" > "$ctx_file"
+            for dep in "${consume_skills[@]}"; do
+              local output_file=".outputs/${dep}.md"
+              if [ -f "$output_file" ] && [ -s "$output_file" ]; then
+                echo "### ${dep}" >> "$ctx_file"
+                echo "" >> "$ctx_file"
+                cat "$output_file" >> "$ctx_file"
+                echo "" >> "$ctx_file"
+                echo "---" >> "$ctx_file"
+                echo "" >> "$ctx_file"
+              else
+                echo "### ${dep}" >> "$ctx_file"
+                echo "" >> "$ctx_file"
+                echo "_Output not available._" >> "$ctx_file"
+                echo "" >> "$ctx_file"
+              fi
+            done
+
+            echo "$ctx_file"
+          }
+
+          # --- Parse chain definition from aeon.yml ---
+          # Extract the chain block using awk
+          CHAIN_BLOCK=$(awk -v chain="$CHAIN" '
+            /^chains:/ { in_chains=1; next }
+            in_chains && /^[^ ]/ { in_chains=0 }
+            in_chains && $0 ~ "^  " chain ":" { in_chain=1; next }
+            in_chain && /^  [^ ]/ && !($0 ~ "^    ") { in_chain=0 }
+            in_chain { print }
+          ' aeon.yml)
+
+          if [ -z "$CHAIN_BLOCK" ]; then
+            echo "::error::Chain '$CHAIN' not found in aeon.yml"
+            exit 1
+          fi
+
+          # Extract on_error mode (default: fail-fast)
+          ON_ERROR=$(echo "$CHAIN_BLOCK" | grep -oP 'on_error:\s*\K[a-z-]+' || echo "fail-fast")
+          echo "Error mode: $ON_ERROR"
+
+          # Parse steps into an ordered array
+          # Each step is either:
+          #   - parallel: [a, b, c]
+          #   - skill: name [, var: "val"] [, consume: [a, b]]
+          STEP_INDEX=0
+          declare -A STEP_TYPE STEP_SKILLS STEP_VAR STEP_CONSUME
+
+          while IFS= read -r line; do
+            # Skip empty lines and non-step lines
+            [[ "$line" =~ ^[[:space:]]*$ ]] && continue
+            [[ "$line" =~ ^[[:space:]]*#  ]] && continue
+
+            if [[ "$line" =~ parallel:\ *\[([^\]]+)\] ]]; then
+              STEP_TYPE[$STEP_INDEX]="parallel"
+              STEP_SKILLS[$STEP_INDEX]=$(echo "${BASH_REMATCH[1]}" | tr -d ' ')
+              STEP_INDEX=$((STEP_INDEX + 1))
+            elif [[ "$line" =~ skill:\ *([a-zA-Z0-9_-]+) ]]; then
+              STEP_TYPE[$STEP_INDEX]="single"
+              STEP_SKILLS[$STEP_INDEX]="${BASH_REMATCH[1]}"
+              # Extract optional var
+              if [[ "$line" =~ var:\ *\"([^\"]+)\" ]]; then
+                STEP_VAR[$STEP_INDEX]="${BASH_REMATCH[1]}"
+              fi
+              # Extract optional consume
+              if [[ "$line" =~ consume:\ *\[([^\]]+)\] ]]; then
+                STEP_CONSUME[$STEP_INDEX]=$(echo "${BASH_REMATCH[1]}" | tr -d ' ')
+              fi
+              STEP_INDEX=$((STEP_INDEX + 1))
+            fi
+          done <<< "$CHAIN_BLOCK"
+
+          TOTAL_STEPS=$STEP_INDEX
+          echo "Chain has $TOTAL_STEPS step(s)"
+          CHAIN_FAILED=false
+
+          # --- Execute steps sequentially ---
+          for ((i=0; i<TOTAL_STEPS; i++)); do
+            TYPE="${STEP_TYPE[$i]}"
+            SKILLS="${STEP_SKILLS[$i]}"
+            VAR="${STEP_VAR[$i]:-}"
+            CONSUME="${STEP_CONSUME[$i]:-}"
+
+            echo ""
+            echo "=== Step $((i+1))/$TOTAL_STEPS: $TYPE [$SKILLS] ==="
+
+            # Check if chain should abort
+            if [ "$CHAIN_FAILED" = "true" ] && [ "$ON_ERROR" = "fail-fast" ]; then
+              echo "Skipping step (chain failed, on_error=fail-fast)"
+              continue
+            fi
+
+            # Build list of skills to dispatch
+            IFS=',' read -ra SKILL_LIST <<< "$SKILLS"
+            RUN_IDS=()
+
+            for skill in "${SKILL_LIST[@]}"; do
+              # Build context file if this step consumes outputs
+              CTX_FILE=""
+              if [ -n "$CONSUME" ]; then
+                IFS=',' read -ra CONSUME_LIST <<< "$CONSUME"
+                CTX_FILE=$(build_context "$skill" "${CONSUME_LIST[@]}")
+                # Commit and push context file so the skill run can access it
+                git add .outputs/ 2>/dev/null || true
+                if ! git diff --staged --quiet 2>/dev/null; then
+                  git commit -m "chore(chain): context for $skill"
+                  for attempt in 1 2 3; do
+                    git pull --rebase origin main 2>/dev/null || true
+                    git push -u origin HEAD 2>/dev/null && break
+                    sleep "$attempt"
+                  done
+                fi
+              fi
+
+              RUN_ID=$(dispatch_skill "$skill" "$VAR" "$CTX_FILE")
+              DISPATCH_EXIT=$?
+              if [ $DISPATCH_EXIT -ne 0 ] || [ -z "$RUN_ID" ]; then
+                echo "::error::Failed to dispatch skill: $skill"
+                CHAIN_FAILED=true
+                [ "$ON_ERROR" = "fail-fast" ] && break
+                continue
+              fi
+              # run_id is the last line of dispatch_skill output
+              RUN_ID=$(echo "$RUN_ID" | tail -1)
+              RUN_IDS+=("$RUN_ID")
+              sleep 2  # Stagger dispatches
+            done
+
+            # Wait for all runs in this step to complete
+            if [ ${#RUN_IDS[@]} -gt 0 ]; then
+              if ! wait_for_runs "${RUN_IDS[@]}"; then
+                echo "::warning::Step $((i+1)) had failures"
+                CHAIN_FAILED=true
+                if [ "$ON_ERROR" = "fail-fast" ]; then
+                  echo "Aborting chain (on_error=fail-fast)"
+                  continue
+                fi
+              fi
+
+              # Pull latest to get committed outputs from completed skills
+              git pull --rebase origin main 2>/dev/null || true
+              echo "  Pulled latest outputs"
+            fi
+          done
+
+          # --- Final status ---
+          echo ""
+          if [ "$CHAIN_FAILED" = "true" ]; then
+            echo "::error::Chain '$CHAIN' completed with failures"
+            echo "CHAIN_STATUS=failed" >> "$GITHUB_ENV"
+          else
+            echo "Chain '$CHAIN' completed successfully"
+            echo "CHAIN_STATUS=success" >> "$GITHUB_ENV"
+          fi
+
+      - name: Update cron state
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GH_GLOBAL || secrets.GITHUB_TOKEN }}
+        run: |
+          CHAIN="${{ inputs.chain }}"
+          NOW_ISO=$(date -u +%FT%TZ)
+          STATUS="${CHAIN_STATUS:-failed}"
+          STATE_FILE="memory/cron-state.json"
+
+          git checkout main 2>/dev/null || true
+          git pull --rebase origin main 2>/dev/null || true
+
+          if [ -f "$STATE_FILE" ] && jq empty "$STATE_FILE" 2>/dev/null; then
+            STATE=$(cat "$STATE_FILE")
+          else
+            STATE='{}'
+          fi
+
+          # Store chain state with "chain:" prefix to distinguish from skills
+          STATE=$(echo "$STATE" | jq --arg s "chain:$CHAIN" --arg st "$STATUS" --arg ts "$NOW_ISO" \
+            '.[$s].last_status = $st | .[$s]["last_" + $st] = $ts')
+
+          mkdir -p memory
+          echo "$STATE" | jq '.' > "$STATE_FILE"
+
+          git add "$STATE_FILE"
+          if git diff --staged --quiet; then
+            echo "No state changes"
+            exit 0
+          fi
+
+          git commit -m "chore(chain): $CHAIN $STATUS"
+          for i in 1 2 3 4 5; do
+            if git pull --rebase origin main 2>/dev/null && git push -u origin HEAD 2>/dev/null; then
+              echo "Chain state updated: $CHAIN=$STATUS"
+              exit 0
+            fi
+            git rebase --abort 2>/dev/null || true
+            git reset --soft HEAD~1 2>/dev/null || true
+            git checkout -- "$STATE_FILE" 2>/dev/null || true
+            git pull origin main 2>/dev/null || true
+
+            if [ -f "$STATE_FILE" ] && jq empty "$STATE_FILE" 2>/dev/null; then
+              STATE=$(cat "$STATE_FILE")
+            else
+              STATE='{}'
+            fi
+            STATE=$(echo "$STATE" | jq --arg s "chain:$CHAIN" --arg st "$STATUS" --arg ts "$NOW_ISO" \
+              '.[$s].last_status = $st | .[$s]["last_" + $st] = $ts')
+            echo "$STATE" | jq '.' > "$STATE_FILE"
+            git add "$STATE_FILE"
+            git diff --staged --quiet && { echo "State already up to date"; exit 0; }
+            git commit -m "chore(chain): $CHAIN $STATUS"
+            sleep "$i"
+          done
+          echo "::warning::Failed to commit chain state (non-fatal)"

--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -211,6 +211,107 @@ jobs:
           done
           ORDERED=("${DEPS_FIRST[@]}" "${DEPS_LAST[@]}")
 
+          # --- Parse chains from aeon.yml ---
+          declare -A CHAIN_SCHEDULE CHAIN_SKILLS
+          CHAIN_ORDER=()
+          CHAIN_COVERED_SKILLS=()  # Skills covered by chains dispatching this cycle
+          IN_CHAINS=false
+          CURRENT_CHAIN=""
+          IN_STEPS=false
+          while IFS= read -r line; do
+            if [[ "$line" =~ ^chains: ]]; then
+              IN_CHAINS=true
+              continue
+            fi
+            # Exit chains section on next top-level key
+            $IN_CHAINS && [[ "$line" =~ ^[a-z] ]] && IN_CHAINS=false
+            $IN_CHAINS || continue
+
+            # Chain name (indented 2 spaces)
+            if [[ "$line" =~ ^\ \ ([a-zA-Z0-9_-]+): ]]; then
+              CURRENT_CHAIN="${BASH_REMATCH[1]}"
+              CHAIN_ORDER+=("$CURRENT_CHAIN")
+              IN_STEPS=false
+              continue
+            fi
+            [ -z "$CURRENT_CHAIN" ] && continue
+            # Schedule
+            if [[ "$line" =~ schedule:\ *\"([^\"]+)\" ]]; then
+              CHAIN_SCHEDULE["$CURRENT_CHAIN"]="${BASH_REMATCH[1]}"
+            fi
+            # Collect all skill names from steps (parallel or single)
+            if [[ "$line" =~ parallel:\ *\[([^\]]+)\] ]]; then
+              CHAIN_SKILLS["$CURRENT_CHAIN"]+="$(echo "${BASH_REMATCH[1]}" | tr -d ' '),"
+            elif [[ "$line" =~ skill:\ *([a-zA-Z0-9_-]+) ]]; then
+              CHAIN_SKILLS["$CURRENT_CHAIN"]+="${BASH_REMATCH[1]},"
+            fi
+          done < aeon.yml
+
+          # Match chains against current time
+          MATCHED_CHAINS=()
+          for CH in "${CHAIN_ORDER[@]}"; do
+            SCHED="${CHAIN_SCHEDULE[$CH]:-}"
+            [ -z "$SCHED" ] && continue
+
+            IFS=' ' read -r C_MIN C_HOUR C_DOM C_MONTH C_DOW <<< "$SCHED"
+            cron_match "$C_DOM" "$DOM" || continue
+            cron_match "$C_MONTH" "$MONTH" || continue
+            cron_match "$C_DOW" "$DOW" || continue
+
+            SHOULD_RUN=false
+            if cron_match "$C_HOUR" "$HOUR"; then
+              if [ "$C_MIN" = "*" ] || [ "$C_MIN" -le "$MINUTE" ]; then
+                SHOULD_RUN=true
+              fi
+            fi
+            if [ "$SHOULD_RUN" = "false" ] && cron_match "$C_HOUR" "$PREV_HOUR"; then
+              SHOULD_RUN=true
+            fi
+            [ "$SHOULD_RUN" = "false" ] && continue
+
+            # Dedup check
+            CHAIN_KEY="chain:$CH"
+            LAST_DISPATCH=$(echo "$STATE" | jq -r --arg s "$CHAIN_KEY" '.[$s].last_dispatch // "1970-01-01T00:00:00Z"')
+            LAST_DISPATCH_EPOCH=$(date -u -d "$LAST_DISPATCH" +%s 2>/dev/null || echo 0)
+            MINUTES_SINCE=$(( (NOW_EPOCH - LAST_DISPATCH_EPOCH) / 60 ))
+            if [ "$MINUTES_SINCE" -lt 90 ]; then
+              echo "Skipping chain $CH (dispatched ${MINUTES_SINCE}m ago)"
+              continue
+            fi
+
+            MATCHED_CHAINS+=("$CH")
+            # Collect skills covered by this chain for dedup
+            IFS=',' read -ra CH_SKILLS <<< "${CHAIN_SKILLS[$CH]}"
+            for s in "${CH_SKILLS[@]}"; do
+              [ -n "$s" ] && CHAIN_COVERED_SKILLS+=("$s")
+            done
+            echo "Matched chain: $CH (schedule: $SCHED)"
+          done
+
+          # --- Dispatch chains ---
+          for CH in "${MATCHED_CHAINS[@]}"; do
+            echo "Dispatching chain: $CH"
+            gh workflow run chain-runner.yml -f chain="$CH"
+            STATE=$(echo "$STATE" | jq --arg s "chain:$CH" --arg ts "$NOW_ISO" \
+              '.[$s].last_dispatch = $ts | .[$s].last_status = "dispatched"')
+            sleep 2
+          done
+
+          # --- Filter standalone skills: skip if covered by a chain dispatching now ---
+          FILTERED_ORDERED=()
+          for SKILL in "${ORDERED[@]}"; do
+            SKIP=false
+            for covered in "${CHAIN_COVERED_SKILLS[@]}"; do
+              if [ "$SKILL" = "$covered" ]; then
+                echo "Skipping standalone $SKILL (covered by chain)"
+                SKIP=true
+                break
+              fi
+            done
+            $SKIP || FILTERED_ORDERED+=("$SKILL")
+          done
+          ORDERED=("${FILTERED_ORDERED[@]}")
+
           # --- Dispatch ---
           DISPATCHED_DEPS=false
           for SKILL in "${ORDERED[@]}"; do

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,17 +27,30 @@ When consolidating memory (reflect, memory-flush), move detail into topic files 
 
   When running `./aeon` locally, use the json-render MCP tool to emit a rendered spec at the end of each skill run. The spec lands in `dashboard/outputs/` and the dashboard feed renders it in real time. This mode only activates locally — the GitHub Actions path uses `./notify-jsonrender` instead.
 
-## Composing Skills
+## Skill Chaining
 
-A skill can reuse another skill by reading its file and following its steps. For example, `morning-brief` can incorporate `rss-digest` and `hacker-news-digest` results in a single run:
+Skills can be chained together using the `chains:` section in `aeon.yml`. Chains run skills as separate workflow steps with outputs passed between them.
 
+### How chains work
+1. Each step runs as a separate GitHub Actions workflow (via `chain-runner.yml`)
+2. After each skill completes, its output is saved to `.outputs/{skill}.md`
+3. Downstream steps with `consume:` get prior outputs injected into context
+4. Steps can run in parallel or sequentially
+
+### Chain definition format
+```yaml
+chains:
+  my-chain:
+    schedule: "0 7 * * *"
+    on_error: fail-fast    # or: continue
+    steps:
+      - parallel: [skill-a, skill-b]     # run concurrently
+      - skill: skill-c                    # run after parallel group
+        consume: [skill-a, skill-b]       # inject their outputs
 ```
-Read skills/rss-digest/SKILL.md and execute its steps to get today's feed highlights.
-Read skills/hacker-news-digest/SKILL.md and execute its steps to get top stories.
-Combine the results into one briefing.
-```
 
-This works because skills are just markdown instructions — there's no API boundary. Use this for aggregation skills that synthesize outputs from multiple sources.
+### Standalone composition (legacy)
+A skill can still inline-execute another skill by reading its SKILL.md. Prefer chains when you need parallelism, output passing, or error handling.
 
 ## Notifications
 

--- a/aeon.yml
+++ b/aeon.yml
@@ -91,6 +91,26 @@ skills:
   # --- Fallback (must be last) ---
   heartbeat: { enabled: true, schedule: "0 8,14,20 * * *" }
 
+# Chains — multi-step skill pipelines with parallel execution and output passing.
+# Steps run sequentially; use parallel: [...] for concurrent execution within a step.
+# Skills with consume: [...] receive prior step outputs injected into their context.
+#
+# Format:
+#   chains:
+#     chain-name:
+#       schedule: "cron expression"
+#       on_error: fail-fast          # fail-fast (default) | continue
+#       steps:
+#         - parallel: [skill-a, skill-b]
+#         - skill: skill-c, consume: [skill-a, skill-b]
+chains:
+  # daily-routine:
+  #   schedule: "0 7 * * *"
+  #   on_error: fail-fast
+  #   steps:
+  #     - parallel: [token-movers, paper-pick, github-issues, hn-digest]
+  #     - skill: daily-routine, consume: [token-movers, paper-pick, github-issues, hn-digest]
+
 # Default model for all skills. Override per-run via workflow_dispatch.
 # Options: claude-opus-4-6, claude-sonnet-4-6, claude-haiku-4-5-20251001
 model: claude-opus-4-6

--- a/skills/daily-routine/SKILL.md
+++ b/skills/daily-routine/SKILL.md
@@ -2,25 +2,24 @@
 name: Daily Routine
 description: Morning briefing combining token movers, tweet roundup, paper pick, GitHub issues, and HN digest
 var: ""
-depends_on: [token-movers, paper-pick, github-issues, hn-digest]
 tags: [news]
 ---
 > **${var}** — Area to emphasize (e.g. "crypto", "AI", "security"). If empty, covers all areas equally.
 
+This skill is designed to run as part of a chain (see `chains:` in `aeon.yml`). When chained, prior step outputs (token-movers, paper-pick, github-issues, hn-digest) are provided in the chain context above. Use those outputs directly — do not re-run the sub-skills.
+
+If running standalone (no chain context provided), fall back to reading each sub-skill and executing it inline:
+- Read `skills/token-movers/SKILL.md` and execute its steps
+- Read `skills/paper-pick/SKILL.md` and execute its steps
+- Read `skills/github-issues/SKILL.md` and execute its steps
+- Read `skills/hn-digest/SKILL.md` and execute its steps
+
 Read memory/MEMORY.md for context.
 Read the last 2 days of memory/logs/ to avoid repeating items.
 
-Run all five sections below by executing the corresponding skill. If `${var}` is set, pass it through to each skill. Combine the results into a single notification at the end.
-
 ---
 
-## 1. Token Movers
-
-Read `skills/token-movers/SKILL.md` and execute its steps. Capture the top 10 winners and losers.
-
----
-
-## 2. Tweet Roundup
+## Tweet Roundup
 
 Search X for the latest chatter across topics relevant to your interests. Use the X.AI API if `XAI_API_KEY` is set:
 
@@ -47,29 +46,9 @@ For each topic, write 2-3 bullet points capturing the gist. Include links.
 
 ---
 
-## 3. Paper Pick
-
-Read `skills/paper-pick/SKILL.md` and execute its steps. Capture the single best paper.
-
-Note: paper-pick requires `var` to be set with research topics. If the daily-routine `${var}` maps to research topics, pass it through. Otherwise, check if paper-pick has a default `var` configured in aeon.yml and use that.
-
----
-
-## 4. GitHub Issues
-
-Read `skills/github-issues/SKILL.md` and execute its steps. Report any new issues from the last 24 hours.
-
----
-
-## 5. HN Digest
-
-Read `skills/hn-digest/SKILL.md` and execute its steps. Capture the top 5-7 stories.
-
----
-
 ## Format & Send
 
-Combine everything into a single notification via `./notify` (keep under 4000 chars):
+Combine everything (chain context outputs + tweet roundup) into a single notification via `./notify` (keep under 4000 chars):
 
 ```
 *Daily Routine — ${today}*


### PR DESCRIPTION
## Summary

- Adds a **chain runner workflow** (`chain-runner.yml`) that orchestrates multi-step skill pipelines with parallel execution, output passing, and error handling
- Skills now write outputs to `.outputs/{skill}.md` after each run, creating artifacts downstream skills can consume
- Chains are defined in `aeon.yml` with `parallel:` and `consume:` directives — zero Claude tokens for orchestration (pure bash)
- Scheduler parses `chains:` section, dispatches `chain-runner.yml`, and dedupes standalone skills covered by active chains
- `daily-routine` converted to chain-aware: uses injected context when chained, falls back to inline execution when standalone

Closes HYP-21

## Files changed

| File | Change |
|------|--------|
| `.github/workflows/aeon.yml` | `chain_context_file` input, context injection, output capture step |
| `.github/workflows/chain-runner.yml` | **New** — chain orchestrator |
| `.github/workflows/scheduler.yml` | Chain schedule matching + dispatch + dedup |
| `aeon.yml` | `chains:` config section |
| `CLAUDE.md` | Skill chaining docs |
| `skills/daily-routine/SKILL.md` | Chain-aware with standalone fallback |
| `.outputs/.gitkeep` | Output artifact directory |

## Test plan

- [ ] Run any skill manually, verify `.outputs/{skill}.md` is committed
- [ ] Run `gh workflow run aeon.yml -f skill=heartbeat -f chain_context_file=".outputs/test.md"` with a test context file, verify Claude receives context
- [ ] Uncomment `daily-routine` chain in `aeon.yml`, run `gh workflow run chain-runner.yml -f chain=daily-routine`, verify parallel dispatch + wait + context passing
- [ ] Verify scheduler dispatches `chain-runner.yml` for matched chain schedules

🤖 Generated with [Claude Code](https://claude.com/claude-code)