### PR TITLE
feat: instance fleet skills — spawn, control, and track clones

### DIFF
--- a/aeon.yml
+++ b/aeon.yml
@@ -86,6 +86,8 @@ skills:
 
   # --- Weekly (Monday only) ---
   fork-fleet: { enabled: false, schedule: "0 10 * * 1" } # fork fleet scan — inventory active forks, detect diverged work
+  spawn-instance: { enabled: false, schedule: "workflow_dispatch", var: "" } # on-demand — var: "name: purpose"
+  fleet-control: { enabled: false, schedule: "0 9,15 * * *" } # fleet health checks twice daily, dispatch via var
   weekly-review: { enabled: false, schedule: "0 19 * * 1" }
 
   # --- Fallback (must be last) ---

--- a/generate-skills-json
+++ b/generate-skills-json
@@ -78,6 +78,10 @@ declare -A CATEGORIES=(
   [action-converter]="productivity"
   [idea-capture]="productivity"
   [startup-idea]="productivity"
+  # Fleet & Instances
+  [spawn-instance]="dev"
+  [fleet-control]="dev"
+  [fork-fleet]="dev"
 )
 
 # Extract schedule for a skill from aeon.yml

--- a/skills/fleet-control/SKILL.md
+++ b/skills/fleet-control/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: Fleet Control
+description: Monitor managed Aeon instances — check health, dispatch skills, aggregate status
+var: ""
+tags: [dev]
+cron: "0 9,15 * * *"
+---
+> **${var}** — Command to execute. Format: `dispatch <instance> <skill>` to run a skill on a child, `status` for fleet overview, or empty for default health check. Examples: `dispatch crypto-tracker token-movers`, `status`.
+
+Today is ${today}. Monitor and manage the fleet of Aeon instances registered in `memory/instances.json`.
+
+## Steps
+
+### 0. Load the fleet registry
+
+Read `memory/instances.json`. If it doesn't exist or has no instances, log `FLEET_EMPTY: no managed instances` to `memory/logs/${today}.md` and **stop — do NOT send a notification**.
+
+Parse the var to determine the command:
+- If var starts with `dispatch`: extract instance name and skill, go to **Dispatch Mode**
+- If var is `status`: go to **Status Mode**
+- If var is empty or anything else: go to **Health Check Mode** (default)
+
+---
+
+### Health Check Mode (default)
+
+1. **For each registered instance**, check its health:
+
+   a. **Repo exists and is accessible**:
+   ```bash
+   gh api "repos/${REPO}" --jq '.full_name' 2>/dev/null
+   ```
+
+   b. **GitHub Actions status** — check if workflows are running:
+   ```bash
+   gh api "repos/${REPO}/actions/runs?per_page=5" --jq '[.workflow_runs[] | {name: .name, status: .status, conclusion: .conclusion, created_at: .created_at}]'
+   ```
+
+   c. **Last activity** — check the most recent push:
+   ```bash
+   gh api "repos/${REPO}" --jq '.pushed_at'
+   ```
+
+   d. **Read the child's cron-state** (if accessible):
+   ```bash
+   gh api "repos/${REPO}/contents/memory/cron-state.json" --jq '.content' | base64 -d | jq '.'
+   ```
+
+   e. **Classify instance health**:
+   - **healthy**: Actions running, recent pushes, no failed skills in cron-state
+   - **pending_secrets**: No workflow runs at all (instance is inert)
+   - **degraded**: Some skills failing in cron-state
+   - **stale**: No push in 7+ days but was previously active
+   - **unreachable**: API calls fail (repo deleted or permissions changed)
+
+2. **Update the registry** — write back updated status for each instance to `memory/instances.json`. Add a `last_checked` timestamp and `health` field.
+
+3. **Check for instances that need attention**:
+   - Any `pending_secrets` older than 7 days — nudge the owner
+   - Any `degraded` instances — list which skills are failing
+   - Any `stale` instances — flag for review
+   - Any `unreachable` instances — mark for cleanup
+
+4. **Log to memory** — append to `memory/logs/${today}.md`:
+   ```
+   ## fleet-control (health check)
+   - Fleet size: N instances
+   - Healthy: N | Pending: N | Degraded: N | Stale: N | Unreachable: N
+   - Issues: [list any problems found]
+   ```
+
+5. **Send notification** via `./notify` (only if there are issues OR this is the first check of the day):
+   ```
+   *Fleet Status — ${today}*
+
+   Instances: N total
+   [For each instance, one line]:
+   - {name} ({repo}): {status} — last active {date}, {N} skills running
+   
+   [If issues exist]:
+   Issues:
+   - {instance}: {problem description}
+   ```
+
+   If all instances are healthy and this is not the first check today, skip the notification.
+
+---
+
+### Dispatch Mode
+
+Parse var: `dispatch <instance-name> <skill-name>`
+
+1. **Look up the instance** in `memory/instances.json` by name.
+   If not found, send an error notification and stop.
+
+2. **Check the instance is active** (status is `healthy` or `degraded`).
+   If `pending_secrets`, notify: "Cannot dispatch — instance needs secrets configured first."
+
+3. **Dispatch the skill** on the child repo:
+   ```bash
+   gh workflow run aeon.yml --repo "${REPO}" -f skill="${SKILL_NAME}"
+   ```
+
+4. **Log the dispatch** to `memory/logs/${today}.md`:
+   ```
+   ## fleet-control (dispatch)
+   - Dispatched skill '${SKILL_NAME}' on instance '${INSTANCE_NAME}' (${REPO})
+   ```
+
+5. **Notify** via `./notify`:
+   ```
+   *Fleet Dispatch*
+   Dispatched '${SKILL_NAME}' on ${INSTANCE_NAME} (${REPO})
+   ```
+
+---
+
+### Status Mode
+
+Generate a comprehensive fleet report.
+
+1. **For each instance**, gather:
+   - Repo metadata (stars, forks, open issues)
+   - Last 10 workflow runs with outcomes
+   - Full cron-state.json
+   - List of enabled skills (read their aeon.yml)
+   - Recent commits (last 5)
+
+2. **Read each child's aeon.yml** to see what skills are enabled:
+   ```bash
+   gh api "repos/${REPO}/contents/aeon.yml" --jq '.content' | base64 -d
+   ```
+
+3. **Write a fleet status article** to `articles/fleet-status-${today}.md`:
+   ```markdown
+   # Fleet Status Report — ${today}
+
+   ## Overview
+   Parent: aaronjmars/aeon
+   Managed instances: N
+   Total skills running across fleet: N
+
+   ---
+
+   ## Instance: {name}
+   **Repo:** {owner/repo}
+   **Purpose:** {purpose}
+   **Status:** {health status}
+   **Created:** {date}
+   **Last active:** {pushed_at}
+   **Skills enabled:** {list}
+   **Recent runs:**
+   | Skill | Status | When |
+   |-------|--------|------|
+   | ... | ... | ... |
+
+   ---
+   [repeat for each instance]
+
+   ## Fleet Health Summary
+   | Metric | Value |
+   |--------|-------|
+   | Total instances | N |
+   | Healthy | N |
+   | Degraded | N |
+   | Pending setup | N |
+   | Total skills across fleet | N |
+   | Total runs today | N |
+   ```
+
+4. **Log and notify** with a summary.
+
+Write complete, working code. No TODOs or placeholders.

--- a/skills/fork-fleet/SKILL.md
+++ b/skills/fork-fleet/SKILL.md
@@ -11,6 +11,10 @@ Today is ${today}. Track Aeon's fork fleet: discover active forks, analyze diver
 
 ## Steps
 
+0. **Load managed instance registry** — read `memory/instances.json` (if it exists).
+   Build a set of repo full_names that are managed instances (e.g. `owner/aeon-crypto-tracker`).
+   These will be tagged differently from organic community forks in the report.
+
 1. **Fetch all forks** of `aaronjmars/aeon`:
    ```bash
    gh api repos/aaronjmars/aeon/forks --paginate --jq '[.[] | {owner: .owner.login, full_name: .full_name, pushed_at, stargazers_count, open_issues_count, forks_count, description}]'
@@ -65,13 +69,14 @@ Today is ${today}. Track Aeon's fork fleet: discover active forks, analyze diver
 
    ## Active Forks — Ranked by Divergence
 
-   ### 1. owner/aeon — Score: N
+   ### 1. owner/aeon — Score: N [MANAGED INSTANCE | COMMUNITY FORK]
+   **Type:** Managed instance (spawned {date}, purpose: {purpose}) | Community fork
    **Activity:** Last pushed YYYY-MM-DD | Stars: N | Unique commits: N
    **Divergence signals:** [list of signals: "3 new skills", "custom schedule", "modified dashboard"]
    **Unique skills:** [list skill names and 1-sentence descriptions if found]
    **Upstream potential:** [Yes — N new skills worth reviewing / No — schedule changes only]
 
-   ### 2. owner/aeon — Score: N
+   ### 2. owner/aeon — Score: N [MANAGED INSTANCE | COMMUNITY FORK]
    ...
 
    ---
@@ -82,6 +87,13 @@ Today is ${today}. Track Aeon's fork fleet: discover active forks, analyze diver
    **Suggested action:** [Open a PR from fork's branch, or reach out to fork owner]
 
    ---
+
+   ## Fleet vs Community
+   | Category | Count |
+   |----------|-------|
+   | Managed instances | N |
+   | Community forks | N |
+   | Inactive (30+ days) | N |
 
    ## Coverage Gaps
    Forks not analyzed (inactive for 30+ days): [list]

--- a/skills/spawn-instance/SKILL.md
+++ b/skills/spawn-instance/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: Spawn Instance
+description: Clone this Aeon agent into a new GitHub repo — fork, configure skills, register in fleet
+var: ""
+tags: [dev]
+---
+> **${var}** — Name and purpose of the new instance, e.g. `crypto-tracker: monitor DeFi protocols and token movements`. If empty, the skill will ask via notification what kind of instance to create and stop.
+
+Today is ${today}. Create a new Aeon instance by forking this repo, configuring it for a specific purpose, and registering it in the fleet.
+
+## Security Model
+
+This skill creates the repo and configuration but does **NOT** propagate secrets.
+The new instance is inert until the owner manually sets secrets (ANTHROPIC_API_KEY, etc.).
+This is intentional — each instance should have its own API keys for billing isolation and blast-radius containment.
+
+## Steps
+
+1. **Parse the var** to extract instance name and purpose:
+   - Format: `name: purpose` (e.g. `crypto-tracker: monitor DeFi protocols`)
+   - If var is empty, log to `memory/logs/${today}.md` and send a notification asking the owner to re-run with a var, then **stop**.
+   - Derive the repo name: `aeon-{name}` (e.g. `aeon-crypto-tracker`)
+   - Sanitize: lowercase, hyphens only, max 40 chars
+
+2. **Check the fleet registry** — read `memory/instances.json` (create if missing).
+   If an instance with the same name already exists and is not archived, log a warning and **stop**.
+
+   The registry format:
+   ```json
+   {
+     "instances": [
+       {
+         "name": "crypto-tracker",
+         "repo": "OWNER/aeon-crypto-tracker",
+         "purpose": "monitor DeFi protocols and token movements",
+         "created": "2026-04-08",
+         "status": "pending_secrets",
+         "skills_enabled": ["token-movers", "defi-monitor", "heartbeat"],
+         "parent": "aaronjmars/aeon"
+       }
+     ]
+   }
+   ```
+
+3. **Determine the owner** for the new repo:
+   ```bash
+   OWNER=$(gh api user --jq '.login')
+   ```
+
+4. **Fork the repo** into the owner's account with the custom name:
+   ```bash
+   gh repo fork aaronjmars/aeon --fork-name "aeon-{name}" --clone=false
+   ```
+   If the fork already exists (gh returns an error), check if it's already registered. If not, proceed to configure it.
+
+   Note: `gh repo fork` may not support `--fork-name` in all versions. If it fails, fall back to:
+   ```bash
+   gh api repos/aaronjmars/aeon/forks -X POST -f name="aeon-{name}"
+   ```
+
+5. **Wait for fork availability** — GitHub forks are async. Poll until ready:
+   ```bash
+   for i in 1 2 3 4 5; do
+     gh api "repos/${OWNER}/aeon-{name}" --jq '.full_name' 2>/dev/null && break
+     sleep 5
+   done
+   ```
+
+6. **Select skills for the instance** based on its purpose. Analyze the purpose string and choose from the available skills. Use these heuristics:
+   - **crypto/defi/token** purpose: enable `token-movers`, `token-alert`, `defi-monitor`, `wallet-digest`, `trending-coins`, `heartbeat`
+   - **research/papers/academic** purpose: enable `paper-digest`, `paper-pick`, `research-brief`, `deep-research`, `heartbeat`
+   - **social/twitter/x** purpose: enable `fetch-tweets`, `tweet-digest`, `write-tweet`, `reply-maker`, `heartbeat`
+   - **news/digest** purpose: enable `morning-brief`, `rss-digest`, `hn-digest`, `reddit-digest`, `heartbeat`
+   - **dev/code/github** purpose: enable `github-monitor`, `github-issues`, `pr-review`, `code-health`, `changelog`, `heartbeat`
+   - **general** or unclear: enable `morning-brief`, `heartbeat`, `reflect`
+   - Always include `heartbeat` for health monitoring.
+
+7. **Clone the fork, configure it, and push**:
+   ```bash
+   # Clone into a temp directory
+   TMPDIR=$(mktemp -d)
+   gh repo clone "${OWNER}/aeon-{name}" "$TMPDIR/repo"
+   cd "$TMPDIR/repo"
+   git config user.name "aeonframework"
+   git config user.email "aeonframework@proton.me"
+   ```
+
+   a. **Write a customized `aeon.yml`**: Read the parent's `aeon.yml` as a base. Enable only the selected skills. Keep all others disabled. Preserve the structure and comments.
+
+   b. **Write `SETUP.md`** to the repo root:
+   ```markdown
+   # Aeon Instance Setup
+
+   This is a managed Aeon instance spawned from [parent-repo].
+
+   ## Purpose
+   {purpose description}
+
+   ## Activate This Instance
+
+   Go to **Settings > Secrets and variables > Actions** and add these secrets:
+
+   ### Required
+   | Secret | Description |
+   |--------|------------|
+   | `ANTHROPIC_API_KEY` | Claude API key — get one at console.anthropic.com |
+
+   ### Recommended
+   | Secret | Description |
+   |--------|------------|
+   | `TELEGRAM_BOT_TOKEN` | Telegram bot token for notifications |
+   | `TELEGRAM_CHAT_ID` | Telegram chat ID for notifications |
+
+   ### Optional (depends on enabled skills)
+   | Secret | Description |
+   |--------|------------|
+   | `COINGECKO_API_KEY` | For crypto skills |
+   | `XAI_API_KEY` | For X/Twitter skills |
+   | `DISCORD_WEBHOOK_URL` | Discord notifications |
+   | `SLACK_WEBHOOK_URL` | Slack notifications |
+
+   ## Enabled Skills
+   {list of enabled skills with descriptions}
+
+   ## Fleet Parent
+   This instance is managed by `{parent-repo}`.
+   The parent can dispatch skills and monitor health via the `fleet-control` skill.
+
+   ## Security Note
+   This instance has NO access to the parent's secrets.
+   Each instance maintains its own API keys and credentials.
+   ```
+
+   c. **Update the CLAUDE.md** to reference the parent:
+   Add a line under the "About This Repo" section: `- Managed instance of {parent-repo}. Purpose: {purpose}.`
+
+   d. **Clear the parent's memory** — reset `memory/MEMORY.md` to a fresh state for the child, remove `memory/logs/*` contents, clear `memory/cron-state.json` to `{}`. Keep `memory/topics/` empty. The child starts with a clean slate.
+
+   e. **Commit and push**:
+   ```bash
+   git add -A
+   git commit -m "chore: configure instance — {purpose}"
+   git push origin main
+   ```
+
+   f. **Clean up**:
+   ```bash
+   rm -rf "$TMPDIR"
+   ```
+
+8. **Enable GitHub Actions** on the fork (forks have Actions disabled by default):
+   ```bash
+   gh api "repos/${OWNER}/aeon-{name}/actions/permissions" -X PUT -f enabled=true -f allowed_actions=all
+   ```
+
+9. **Register the instance** — update `memory/instances.json` in the parent repo:
+   Add the new instance entry with `status: "pending_secrets"`.
+
+10. **Log to memory** — append to `memory/logs/${today}.md`:
+    ```
+    ## spawn-instance
+    - Created new instance: ${OWNER}/aeon-{name}
+    - Purpose: {purpose}
+    - Skills enabled: {list}
+    - Status: pending_secrets (owner must add API keys)
+    ```
+
+11. **Send notification** via `./notify`:
+    ```
+    *New Aeon Instance Created*
+
+    Repo: {OWNER}/aeon-{name}
+    Purpose: {purpose}
+    Skills: {comma-separated list of enabled skills}
+
+    Status: PENDING SECRETS — instance is inert until you add API keys.
+
+    Quick setup:
+    1. Go to https://github.com/{OWNER}/aeon-{name}/settings/secrets/actions
+    2. Add ANTHROPIC_API_KEY (required)
+    3. Add TELEGRAM_BOT_TOKEN + TELEGRAM_CHAT_ID (recommended)
+
+    See SETUP.md in the repo for full instructions.
+    ```
+
+Write complete, working code. No TODOs or placeholders.


### PR DESCRIPTION
## Summary

- **`spawn-instance`** skill: forks the repo, configures skills for a specific purpose (crypto, research, social, etc.), writes SETUP.md with secret setup instructions, registers in `memory/instances.json`. Does NOT propagate secrets — each instance is inert until the owner manually adds API keys. Security by design.
- **`fleet-control`** skill: monitors all managed instances via GitHub API. Three modes: health check (default, twice daily), dispatch (run skills on children), and status (full fleet report). Reads children's `cron-state.json`, classifies health as healthy/pending/degraded/stale/unreachable.
- **`fork-fleet`** (updated): now loads `memory/instances.json` to distinguish managed instances from organic community forks in reports.
- Both new skills registered in `aeon.yml` and `generate-skills-json` categories.

## Security model

No secret propagation. Each clone gets its own API keys set manually by the owner. This gives:
- Per-instance billing isolation
- Blast-radius containment (compromised child can't access parent's keys)
- No uncontrolled proliferation (children can't spawn grandchildren without explicit setup)

## Test plan

- [ ] Run `spawn-instance` with `var: "test-bot: testing instance creation"` via workflow_dispatch
- [ ] Verify fork is created with customized `aeon.yml` and `SETUP.md`
- [ ] Verify `memory/instances.json` is created with the new instance entry
- [ ] Set secrets on the child repo and verify heartbeat runs
- [ ] Run `fleet-control` to verify health check picks up the new instance
- [ ] Run `fleet-control` with `var: "dispatch test-bot heartbeat"` to dispatch a skill
- [ ] Run `fleet-control` with `var: "status"` to generate fleet report
- [ ] Run `fork-fleet` and verify managed instances are tagged differently from community forks

Closes HYP-32

🤖 Generated with [Claude Code](https://claude.com/claude-code)