### PR TITLE
feat: distribute-tokens skill — send tokens to contributors via Bankr

### DIFF
--- a/aeon.yml
+++ b/aeon.yml
@@ -29,6 +29,7 @@ skills:
   on-chain-monitor: { enabled: false, schedule: "0 12 * * *" }
   defi-monitor: { enabled: false, schedule: "0 12 * * *" }
   treasury-info: { enabled: false, schedule: "0 12 * * *" }
+  distribute-tokens: { enabled: false, schedule: "workflow_dispatch", var: "" } # on-demand — var: distribution list label
   defi-overview: { enabled: false, schedule: "0 12 * * *" }
   polymarket: { enabled: false, schedule: "0 12 * * *" }
   monitor-polymarket: { enabled: false, schedule: "30 12 * * *", model: "claude-sonnet-4-6" } # monitor specific markets for 24h price moves and volume changes

--- a/skills.json
+++ b/skills.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "generated": "2026-04-04T00:00:00Z",
   "repo": "aaronjmars/aeon",
-  "total": 53,
+  "total": 54,
   "categories": {
     "research": "Research & Content",
     "dev": "Dev & Code",
@@ -530,6 +530,16 @@
       "var": "",
       "files": 1,
       "install": "./add-skill aaronjmars/aeon update-gallery"
+    },
+    {
+      "slug": "distribute-tokens",
+      "name": "Distribute Tokens",
+      "description": "Send tokens to contributors via Bankr Agent API — supports Twitter handles and EVM addresses",
+      "category": "crypto",
+      "schedule": "on-demand",
+      "var": "",
+      "files": 0,
+      "install": "./add-skill aaronjmars/aeon distribute-tokens"
     },
     {
       "slug": "fork-fleet",

--- a/skills/distribute-tokens/SKILL.md
+++ b/skills/distribute-tokens/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: Distribute Tokens
+description: Send tokens to a list of contributors via Bankr Agent API (supports Twitter handles and EVM addresses)
+var: ""
+tags: [crypto]
+---
+> **${var}** — Distribution list label to use. If empty, uses the default list. Pass a label to target a specific group (e.g. "contributors", "team").
+
+## Config
+
+This skill reads distribution lists from `memory/distributions.yml`. If the file doesn't exist, log a warning and exit.
+
+```yaml
+# memory/distributions.yml
+defaults:
+  token: USDC
+  amount: "5"          # per recipient
+  chain: base
+
+lists:
+  contributors:
+    description: "Weekly contributor rewards"
+    token: USDC        # override default
+    amount: "10"       # override default
+    recipients:
+      - handle: "@alice_dev"      # Twitter/X handle — resolved via Bankr
+        amount: "15"              # per-recipient override (optional)
+      - handle: "@bob_builder"
+      - address: "0x742d...5678"  # direct EVM address
+        label: "Charlie"
+        amount: "20"
+
+  team:
+    description: "Monthly team distribution"
+    token: ETH
+    amount: "0.01"
+    recipients:
+      - handle: "@core_dev1"
+      - handle: "@core_dev2"
+```
+
+### Required secrets
+
+| Secret | Purpose |
+|--------|---------|
+| `BANKR_API_KEY` | Bankr API key (prefixed `bk_`). Must have **read-write** access and **Agent API** enabled. |
+
+Get a key at [bankr.bot/api](https://bankr.bot/api). Enable read-write mode and Agent API access in key settings.
+
+### How it works
+
+- **Twitter handles** (`@username`): Sent via the Bankr Agent API using natural language. Bankr resolves the handle to the recipient's linked wallet. The recipient must have a Bankr account — if they don't, that transfer fails and is logged.
+- **EVM addresses** (`0x...`): Sent via the direct Wallet Transfer API (`POST /wallet/transfer`). Base chain only.
+
+---
+
+Read memory/MEMORY.md and memory/distributions.yml.
+Read the last 2 days of memory/logs/ to check for recent distributions (avoid double-sending).
+
+Steps:
+
+1. **Validate config** — parse `memory/distributions.yml`. If `${var}` is set, find the matching list by label. If not set, use the first list. Abort if no lists found or file missing.
+
+2. **Check for duplicates** — scan recent logs for distributions to the same list in the last 24 hours. If found, log "DISTRIBUTE_TOKENS_SKIPPED — already distributed to '${list}' today" and exit. This prevents accidental double-sends from re-runs.
+
+3. **Check BANKR_API_KEY** — if not set, log "DISTRIBUTE_TOKENS_ERROR — BANKR_API_KEY not configured" and exit.
+
+4. **Process each recipient** — for each entry in the list:
+
+   Determine the amount: use recipient-level `amount` if set, otherwise list-level `amount`, otherwise `defaults.amount`.
+   Determine the token: use list-level `token`, otherwise `defaults.token`.
+
+   **Path A — Twitter handle** (starts with `@`):
+
+   Use the Bankr Agent API with a natural language transfer command:
+   ```bash
+   JOB_ID=$(curl -s -X POST "https://api.bankr.bot/agent/prompt" \
+     -H "X-API-Key: ${BANKR_API_KEY}" \
+     -H "Content-Type: application/json" \
+     -d '{"prompt":"send '"${amount}"' '"${token}"' to '"${handle}"' on base"}' \
+     | jq -r '.jobId')
+   ```
+
+   Poll for completion (max 60s, 5s intervals):
+   ```bash
+   for i in $(seq 1 12); do
+     RESULT=$(curl -s "https://api.bankr.bot/agent/job/${JOB_ID}" \
+       -H "X-API-Key: ${BANKR_API_KEY}")
+     STATUS=$(echo "$RESULT" | jq -r '.status')
+     if [ "$STATUS" = "completed" ] || [ "$STATUS" = "failed" ]; then break; fi
+     sleep 5
+   done
+   ```
+
+   Record result: if `completed`, extract tx hash from response. If `failed`, log the error (likely "no linked wallet for this handle").
+
+   **Path B — EVM address** (starts with `0x`):
+
+   For USDC on Base, the token address is `0x833589fcd6edb6e08f4c7c32d4f71b54bda02913`.
+   For native ETH, set `isNativeToken: true`.
+
+   Use the Wallet Transfer API:
+   ```bash
+   RESULT=$(curl -s -X POST "https://api.bankr.bot/wallet/transfer" \
+     -H "X-API-Key: ${BANKR_API_KEY}" \
+     -H "Content-Type: application/json" \
+     -d '{
+       "recipientAddress": "'"${address}"'",
+       "tokenAddress": "'"${token_address}"'",
+       "amount": "'"${amount}"'",
+       "isNativeToken": '"${is_native}"'
+     }')
+   ```
+
+   Check `success` field. Extract `txHash` on success.
+
+   Common token addresses on Base:
+   - USDC: `0x833589fcd6edb6e08f4c7c32d4f71b54bda02913`
+   - BNKR: look up via Bankr Agent API if needed
+   - ETH (native): use `isNativeToken: true`, any `tokenAddress`
+
+5. **Build summary** — compile results:
+   ```
+   *Token Distribution — ${today}*
+
+   List: ${list_label} (${description})
+   Token: ${token} on Base
+   Total sent: ${total_amount} ${token}
+
+   ✓ @alice_dev — 15 USDC (tx: 0xabc...)
+   ✓ @bob_builder — 10 USDC (tx: 0xdef...)
+   ✓ Charlie (0x742d...) — 20 USDC (tx: 0x123...)
+   ✗ @inactive_user — failed: no linked Bankr wallet
+
+   Success: N/M recipients
+   ```
+
+6. **Send** via `./notify`.
+
+7. **Log** results to `memory/logs/${today}.md`:
+   - List label, token, chain
+   - Each recipient with status (success/fail), amount, tx hash
+   - Total distributed vs total attempted
+
+If `memory/distributions.yml` doesn't exist, send nothing. Log "DISTRIBUTE_TOKENS_OK — no distribution lists configured" and end.


### PR DESCRIPTION
## Summary

Adds a new `distribute-tokens` skill that sends tokens to a list of contributors using the Bankr API. Closes [HYP-27](https://linear.app/hyperstitions/issue/HYP-27).

**Two transfer paths:**
- **Twitter handles** (`@username`) — Uses the Bankr Agent API with natural language prompts. Bankr resolves the handle to the recipient's linked wallet. Recipient must have a Bankr account.
- **EVM addresses** (`0x...`) — Uses the direct Wallet Transfer API (`POST /wallet/transfer`). Base chain only.

**Config-driven** — reads distribution lists from `memory/distributions.yml` with:
- Default token/amount/chain settings
- Named lists (e.g. "contributors", "team") with per-recipient amount overrides
- Duplicate protection (skips if same list was distributed to in last 24h)

**Requirements:**
- `BANKR_API_KEY` secret with read-write access and Agent API enabled
- `memory/distributions.yml` config file with recipient lists

## Changes
- `skills/distribute-tokens/SKILL.md` — new skill definition
- `aeon.yml` — registered as `workflow_dispatch` (on-demand only)
- `skills.json` — added to catalog

## Test plan
- [ ] Create `memory/distributions.yml` with a test list (small amounts)
- [ ] Set `BANKR_API_KEY` with read-write + Agent API access
- [ ] Run via `workflow_dispatch` with var set to test list label
- [ ] Verify Twitter handle transfers resolve and complete via Agent API
- [ ] Verify direct EVM address transfers succeed via Wallet API
- [ ] Verify duplicate protection blocks re-runs within 24h
- [ ] Verify notification summary is sent via `./notify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)