### PR TITLE
feat: skill quality metrics + post-run analysis + API degradation detection

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -298,6 +298,8 @@ jobs:
             --model "$MODEL" --allowedTools "$ALLOWED" \
             --output-format json 2>&1); then
             echo "::error::Claude CLI failed. Output: $CLAUDE_OUTPUT"
+            # Save error signature for quality tracking (cron-state step reads this)
+            echo "$CLAUDE_OUTPUT" | tail -c 500 | tr '\n' ' ' | cut -c1-200 > /tmp/skill-error.txt
             exit 1
           fi
 
@@ -366,6 +368,108 @@ jobs:
           fi
           echo "::notice::Skill output captured to .outputs/${SKILL}.md ($(wc -c < ".outputs/${SKILL}.md") bytes)"
 
+      - name: Analyze skill output
+        id: analyze
+        if: steps.work.outputs.mode != '' && steps.run.outcome == 'success'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          BANKR_LLM_KEY: ${{ secrets.BANKR_LLM_KEY }}
+        run: |
+          SKILL="${{ steps.skill.outputs.name }}"
+
+          # Skip analysis for meta skills (they don't produce scorable output)
+          case "$SKILL" in heartbeat|skill-health|reflect|memory-flush|self-review|cost-report) echo "Skipping analysis for meta skill"; exit 0;; esac
+
+          # Route through gateway if configured
+          if [ "${{ steps.run.outputs.GATEWAY }}" = "bankr" ] && [ -n "${BANKR_LLM_KEY:-}" ]; then
+            export ANTHROPIC_BASE_URL="https://llm.bankr.bot"
+            export ANTHROPIC_AUTH_TOKEN="$BANKR_LLM_KEY"
+            unset ANTHROPIC_API_KEY
+            unset CLAUDE_CODE_OAUTH_TOKEN
+          fi
+
+          # Read and truncate skill output for analysis
+          OUTPUT=""
+          if [ -f /tmp/skill-result.txt ] && [ -s /tmp/skill-result.txt ]; then
+            OUTPUT=$(head -c 3000 /tmp/skill-result.txt)
+          fi
+          [ -z "$OUTPUT" ] && { echo "No output to analyze"; exit 0; }
+
+          ANALYSIS_PROMPT="Score this autonomous agent skill output on a 1-5 scale. Respond with ONLY valid JSON.
+
+          Scoring:
+          1 = Failed/empty/error output
+          2 = Ran but low quality, generic, or boilerplate
+          3 = Acceptable — completed the task adequately
+          4 = Good — substantive, well-structured, useful
+          5 = Excellent — insightful, well-sourced, actionable
+
+          Flag any issues from: api_error, empty_output, low_quality, stale_data, generic_content, rate_limited
+
+          Skill: $SKILL
+          Output (truncated):
+          $OUTPUT
+
+          JSON format: {\"score\": N, \"assessment\": \"one line\", \"flags\": []}"
+
+          if ! RAW=$(echo "$ANALYSIS_PROMPT" | claude -p - \
+            --model claude-haiku-4-5-20251001 --output-format json 2>&1); then
+            echo "::warning::Skill analysis failed (non-fatal)"
+            exit 0
+          fi
+
+          ANALYSIS_TEXT=$(echo "$RAW" | jq -r '.result // empty')
+          [ -z "$ANALYSIS_TEXT" ] && { echo "::warning::Empty analysis result"; exit 0; }
+
+          # Parse score from response (try direct JSON, then extract embedded JSON)
+          if echo "$ANALYSIS_TEXT" | jq empty 2>/dev/null; then
+            PARSED="$ANALYSIS_TEXT"
+          else
+            PARSED=$(echo "$ANALYSIS_TEXT" | grep -o '{[^{}]*}' | head -1 || true)
+            if [ -z "$PARSED" ] || ! echo "$PARSED" | jq empty 2>/dev/null; then
+              echo "::warning::Could not parse analysis JSON"
+              exit 0
+            fi
+          fi
+
+          SCORE=$(echo "$PARSED" | jq -r '.score // 0')
+          ASSESSMENT=$(echo "$PARSED" | jq -r '.assessment // "analysis incomplete"')
+          FLAGS=$(echo "$PARSED" | jq -c '.flags // []')
+
+          # Validate score range
+          if [ "$SCORE" -lt 1 ] || [ "$SCORE" -gt 5 ] 2>/dev/null; then
+            SCORE=0
+          fi
+
+          echo "QUALITY_SCORE=$SCORE" >> "$GITHUB_OUTPUT"
+
+          # Write skill health file with rolling history
+          mkdir -p memory/skill-health
+          HEALTH_FILE="memory/skill-health/${SKILL}.json"
+          NOW_ISO=$(date -u +%FT%TZ)
+          TODAY=$(date -u +%Y-%m-%d)
+
+          if [ -f "$HEALTH_FILE" ] && jq empty "$HEALTH_FILE" 2>/dev/null; then
+            HISTORY=$(jq -c '.history // []' "$HEALTH_FILE")
+          else
+            HISTORY='[]'
+          fi
+
+          # Append to history (keep last 30 entries)
+          HISTORY=$(echo "$HISTORY" | jq -c --arg d "$TODAY" --argjson s "$SCORE" \
+            '. + [{"date": $d, "score": $s}] | .[-30:]')
+
+          AVG=$(echo "$HISTORY" | jq '([.[].score] | add / length * 100 | round) / 100')
+
+          jq -n --arg sk "$SKILL" --arg ts "$NOW_ISO" --argjson sc "$SCORE" \
+            --arg as "$ASSESSMENT" --argjson fl "$FLAGS" \
+            --argjson hi "$HISTORY" --argjson avg "$AVG" \
+            '{skill: $sk, last_analyzed: $ts, quality_score: $sc, assessment: $as, flags: $fl, avg_score: $avg, history: $hi}' \
+            > "$HEALTH_FILE"
+
+          echo "::notice::Skill quality — $SKILL: score=$SCORE, avg=$AVG — $ASSESSMENT"
+
       - name: Convert feed outputs
         if: steps.work.outputs.mode != '' && vars.JSONRENDER_ENABLED != 'false'
         env:
@@ -429,7 +533,7 @@ jobs:
                 CONFLICTED=$(git diff --name-only --diff-filter=U) || true
                 [ -z "$CONFLICTED" ] && break
                 for f in $CONFLICTED; do
-                  if [[ "$f" == memory/logs/* ]] || [[ "$f" == memory/topics/* ]] || [[ "$f" == memory/MEMORY.md ]] || [[ "$f" == dashboard/outputs/* ]] || [[ "$f" == .outputs/* ]]; then
+                  if [[ "$f" == memory/logs/* ]] || [[ "$f" == memory/topics/* ]] || [[ "$f" == memory/MEMORY.md ]] || [[ "$f" == memory/skill-health/* ]] || [[ "$f" == dashboard/outputs/* ]] || [[ "$f" == .outputs/* ]]; then
                     sed -i '/^<<<<<<< /d; /^=======/d; /^>>>>>>> /d' "$f"
                     git add "$f"
                   else
@@ -462,6 +566,7 @@ jobs:
           RUN_OUTCOME="${{ steps.run.outcome }}"
           NOW_ISO=$(date -u +%FT%TZ)
           STATE_FILE="memory/cron-state.json"
+          QUALITY_SCORE="${{ steps.analyze.outputs.QUALITY_SCORE }}"
 
           # Determine status from step outcome
           if [ "$RUN_OUTCOME" = "success" ]; then
@@ -469,6 +574,60 @@ jobs:
           else
             CRON_STATUS="failed"
           fi
+
+          # Read error signature if the skill failed
+          ERROR_SIG=""
+          if [ "$CRON_STATUS" = "failed" ] && [ -f /tmp/skill-error.txt ]; then
+            ERROR_SIG=$(cat /tmp/skill-error.txt)
+          fi
+
+          # Function: apply quality metrics update to STATE
+          apply_state_update() {
+            # Core status update
+            STATE=$(echo "$STATE" | jq --arg s "$SKILL" --arg st "$CRON_STATUS" --arg ts "$NOW_ISO" \
+              '.[$s].last_status = $st | .[$s]["last_" + $st] = $ts')
+
+            # Read current counters from state
+            PREV_RUNS=$(echo "$STATE" | jq --arg s "$SKILL" '.[$s].total_runs // 0')
+            PREV_SUCC=$(echo "$STATE" | jq --arg s "$SKILL" '.[$s].total_successes // 0')
+            PREV_FAIL=$(echo "$STATE" | jq --arg s "$SKILL" '.[$s].total_failures // 0')
+
+            NEW_RUNS=$((PREV_RUNS + 1))
+            if [ "$CRON_STATUS" = "success" ]; then
+              NEW_SUCC=$((PREV_SUCC + 1))
+              NEW_FAIL=$PREV_FAIL
+              NEW_CONSEC=0
+            else
+              NEW_SUCC=$PREV_SUCC
+              NEW_FAIL=$((PREV_FAIL + 1))
+              PREV_CONSEC=$(echo "$STATE" | jq --arg s "$SKILL" '.[$s].consecutive_failures // 0')
+              NEW_CONSEC=$((PREV_CONSEC + 1))
+            fi
+
+            RATE=$(jq -n "if $NEW_RUNS > 0 then ($NEW_SUCC / $NEW_RUNS * 100 | round) / 100 else 0 end")
+
+            STATE=$(echo "$STATE" | jq --arg s "$SKILL" \
+              --argjson runs "$NEW_RUNS" --argjson succ "$NEW_SUCC" --argjson fail "$NEW_FAIL" \
+              --argjson consec "$NEW_CONSEC" --argjson rate "$RATE" '
+              .[$s].total_runs = $runs |
+              .[$s].total_successes = $succ |
+              .[$s].total_failures = $fail |
+              .[$s].consecutive_failures = $consec |
+              .[$s].success_rate = $rate
+            ')
+
+            # Record error signature on failure
+            if [ "$CRON_STATUS" = "failed" ] && [ -n "$ERROR_SIG" ]; then
+              STATE=$(echo "$STATE" | jq --arg s "$SKILL" --arg err "$ERROR_SIG" \
+                '.[$s].last_error = $err')
+            fi
+
+            # Record quality score on success (from analysis step)
+            if [ -n "$QUALITY_SCORE" ] && [ "$QUALITY_SCORE" != "0" ]; then
+              STATE=$(echo "$STATE" | jq --arg s "$SKILL" --argjson q "$QUALITY_SCORE" \
+                '.[$s].last_quality_score = $q')
+            fi
+          }
 
           # Ensure we're on main with latest
           git checkout main 2>/dev/null || true
@@ -481,9 +640,7 @@ jobs:
             STATE='{}'
           fi
 
-          # Update this skill's entry
-          STATE=$(echo "$STATE" | jq --arg s "$SKILL" --arg st "$CRON_STATUS" --arg ts "$NOW_ISO" \
-            '.[$s].last_status = $st | .[$s]["last_" + $st] = $ts')
+          apply_state_update
 
           mkdir -p memory
           echo "$STATE" | jq '.' > "$STATE_FILE"
@@ -511,8 +668,7 @@ jobs:
             else
               STATE='{}'
             fi
-            STATE=$(echo "$STATE" | jq --arg s "$SKILL" --arg st "$CRON_STATUS" --arg ts "$NOW_ISO" \
-              '.[$s].last_status = $st | .[$s]["last_" + $st] = $ts')
+            apply_state_update
             echo "$STATE" | jq '.' > "$STATE_FILE"
             git add "$STATE_FILE"
             git diff --staged --quiet && { echo "State already up to date"; exit 0; }

--- a/skills/heartbeat/SKILL.md
+++ b/skills/heartbeat/SKILL.md
@@ -14,14 +14,21 @@ Read memory/MEMORY.md and the last 2 days of memory/logs/ for context.
 
 ### P0 — Failed & stuck skills (check first)
 
-Read `memory/cron-state.json`. This file tracks every scheduled skill's state:
+Read `memory/cron-state.json`. This file tracks every scheduled skill's state and quality metrics:
 ```json
 {
   "skill-name": {
     "last_dispatch": "2026-04-06T12:00:00Z",
     "last_status": "dispatched|success|failed",
     "last_success": "2026-04-06T12:05:00Z",
-    "last_failed": "2026-04-05T12:03:00Z"
+    "last_failed": "2026-04-05T12:03:00Z",
+    "total_runs": 10,
+    "total_successes": 8,
+    "total_failures": 2,
+    "consecutive_failures": 0,
+    "success_rate": 0.80,
+    "last_quality_score": 4,
+    "last_error": "error signature text"
   }
 }
 ```
@@ -29,6 +36,8 @@ Read `memory/cron-state.json`. This file tracks every scheduled skill's state:
 Flag these conditions:
 - **Failed skills**: any entry with `last_status: "failed"`. Report the skill name and when it failed.
 - **Stuck skills**: any entry with `last_status: "dispatched"` where `last_dispatch` is **>45 minutes ago**. The skill was dispatched but never reported back — likely hung or crashed before the state update step ran.
+- **API degradation**: any skill with `consecutive_failures >= 3`. This likely indicates an external API is down or rate-limiting. Report the skill, failure count, and `last_error`. If multiple skills share similar error signatures, flag the shared dependency.
+- **Chronic failures**: any skill with `success_rate < 0.5` (and `total_runs >= 5`). The skill is failing more than it succeeds.
 - **Self-check**: if heartbeat's own entry shows `last_success` is **>36 hours ago** (or missing), note that heartbeat itself may be unreliable.
 
 ### P1 — Stalled PRs & urgent issues

--- a/skills/reflect/SKILL.md
+++ b/skills/reflect/SKILL.md
@@ -20,6 +20,7 @@ Steps:
    - What features were built? Record key decisions and outcomes.
    - Are there any stale entries in MEMORY.md that are no longer relevant? Remove them.
    - Are there recurring errors or issues worth noting for future runs?
+   - Check `memory/skill-health/*.json` for quality trends — note any skills with declining scores or persistent flags. Summarize overall skill health in the appropriate topic file.
 5. Reorganize memory:
    - Keep MEMORY.md as a short index (~50 lines): goals, active topics, and pointers to topic files.
    - Move detailed notes into `memory/topics/` files (e.g. `crypto.md`, `research.md`, `projects.md`).

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -14,12 +14,15 @@ Read ALL memory/logs/ entries from the last 7 days.
 
 Steps:
 1. Audit quality of outputs:
+   - Read `memory/skill-health/*.json` for quality scores and trends. Flag any skills with avg_score < 3 or declining trends (score dropping over last 10 runs).
    - Read recent articles in articles/ — are they substantive or formulaic?
    - Check recent notifications in logs — were they useful or noisy?
    - Review any PR comments posted — were they actionable?
 2. Audit reliability:
-   - How many skills ran vs expected?
-   - Any repeated errors or patterns of failure?
+   - Read `memory/cron-state.json` for hard metrics: success_rate, total_runs, consecutive_failures per skill.
+   - How many skills ran vs expected? Use total_runs and success_rate.
+   - Any repeated errors or patterns of failure? Check last_error fields for recurring signatures.
+   - Any skills with consecutive_failures >= 3? Likely API degradation — recommend investigation or disabling.
    - Are monitors catching real issues or always returning OK?
 3. Audit memory hygiene:
    - Is MEMORY.md current and under 50 lines?

--- a/skills/skill-health/SKILL.md
+++ b/skills/skill-health/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Skill Health
-description: Check which scheduled skills haven't run recently
+description: Audit skill quality metrics, detect API degradation, and report health trends
 var: ""
 tags: [meta]
 ---
@@ -8,30 +8,95 @@ tags: [meta]
 
 If `${var}` is set, only check that specific skill.
 
+## Data sources
 
-Read aeon.yml for the full list of scheduled skills.
-Read the last 7 days of memory/logs/ for evidence of skill runs.
+1. **`memory/cron-state.json`** — Per-skill quality metrics:
+   ```json
+   {
+     "skill-name": {
+       "last_status": "success|failed|dispatched",
+       "last_success": "ISO timestamp",
+       "last_failed": "ISO timestamp",
+       "total_runs": 10,
+       "total_successes": 8,
+       "total_failures": 2,
+       "consecutive_failures": 0,
+       "success_rate": 0.80,
+       "last_quality_score": 4,
+       "last_error": "error signature text"
+     }
+   }
+   ```
 
-Steps:
-1. For each skill in aeon.yml that has a schedule:
-   - Search recent logs for evidence it ran (look for the skill name or its outputs)
-   - Calculate expected runs based on its cron schedule
-   - Compare expected vs actual
-2. Flag any skills that:
-   - Haven't run in their expected window (e.g., daily skill missing > 1 day)
-   - Logged errors on their last run
-   - Logged an ack (OK) every time — might need more interesting inputs
-3. Check for workflow-level issues:
-   - Look at recent GitHub Actions runs: `gh run list --limit 20 --json status,conclusion,name,createdAt`
-   - Flag any failed runs
-4. Format a health report:
+2. **`memory/skill-health/*.json`** — Per-skill quality analysis (written by post-run Haiku analysis):
+   ```json
+   {
+     "skill": "digest",
+     "last_analyzed": "ISO timestamp",
+     "quality_score": 4,
+     "assessment": "one-line quality summary",
+     "flags": ["api_error", "stale_data", ...],
+     "avg_score": 3.8,
+     "history": [{"date": "2026-04-08", "score": 4}, ...]
+   }
+   ```
+
+3. **`aeon.yml`** — Enabled skills and their schedules.
+
+## Steps
+
+1. Read `aeon.yml` for all enabled skills with schedules.
+2. Read `memory/cron-state.json` for quality metrics.
+3. Read all files in `memory/skill-health/` for quality trends.
+
+4. For each enabled skill, classify its health:
+
+   **CRITICAL** (consecutive_failures >= 3):
+   - Likely API degradation or persistent config issue
+   - Report the skill, failure count, and `last_error` signature
+   - If multiple skills share the same error signature, flag as systemic (e.g. "3 crypto skills failing with rate_limit — CoinGecko API may be down")
+
+   **DEGRADED** (success_rate < 0.6 OR avg quality score < 2.5):
+   - Skill runs but produces poor output
+   - Report success rate, average quality score, and recent flags
+
+   **WARNING** (success_rate < 0.8 OR consecutive_failures >= 1):
+   - Occasional issues worth monitoring
+   - Report recent failure and error if available
+
+   **HEALTHY** (success_rate >= 0.8 AND no consecutive failures AND avg score >= 3):
+   - Working well
+
+   **NO DATA** (no entry in cron-state.json or total_runs == 0):
+   - Never been dispatched by the scheduler
+
+5. Detect API degradation patterns:
+   - Group skills by their external API dependencies (crypto skills use CoinGecko/Alchemy, research skills use web APIs, etc.)
+   - If 2+ skills in the same group are CRITICAL or DEGRADED, flag the shared dependency
+   - Check `last_error` fields for common patterns: "rate limit", "403", "timeout", "connection refused"
+
+6. Check for quality trends:
+   - Any skill whose avg_score dropped by > 1 point over the last 10 runs
+   - Any skill with recurring flags (same flag in 3+ consecutive analyses)
+
+7. Format the health report:
    ```
    *Skill Health — ${today}*
 
-   OK: skill1, skill2, skill3
-   MISSED: skill4 (last ran DATE)
-   ERRORS: skill5 (error description)
+   🔴 CRITICAL (N):
+   skill-a: 5 consecutive failures — "rate limit exceeded" (CoinGecko)
+   skill-b: 3 consecutive failures — "timeout"
+
+   ⚠️ API DEGRADATION: CoinGecko skills (token-alert, trending-coins) — shared failure pattern
+
+   🟡 DEGRADED (N):
+   skill-c: 45% success rate, avg quality 2.1
+
+   🟢 HEALTHY (N): skill-d, skill-e, skill-f, ...
+   ⚪ NO DATA (N): skill-g, skill-h
    ```
-5. Send via `./notify` if any skills are missed or erroring.
-6. Log to memory/logs/${today}.md.
+
+8. Send via `./notify` if any skills are CRITICAL or DEGRADED.
+9. Log to memory/logs/${today}.md.
+
 If all skills healthy, log "SKILL_HEALTH_OK" and end.


### PR DESCRIPTION
## Summary

Integrates three ideas from [OpenSpace](https://github.com/HKUDS/OpenSpace) (HYP-22) — adapted for aeon's architecture (no new dependencies, no Python, no external platform):

- **Skill quality metrics** — `cron-state.json` now tracks `total_runs`, `total_successes`, `total_failures`, `consecutive_failures`, `success_rate`, `last_quality_score`, and `last_error` per skill. Backward-compatible with existing state data.
- **Post-execution analysis** — New workflow step runs Haiku (~$0.001/run) after each non-meta skill to score output quality 1-5. Writes rolling 30-entry history to `memory/skill-health/{skill}.json`. Gracefully skips on failure.
- **API degradation detection** — Consecutive failure tracking + error signature capture. `skill-health` groups failures by shared API dependencies to detect systemic issues (e.g. "3 crypto skills failing with rate_limit").

Updated skills: `heartbeat`, `skill-health`, `self-review`, `reflect`.

## Test plan

- [ ] Run a skill manually (`gh workflow run aeon.yml -f skill=heartbeat`) and verify `cron-state.json` gets the new fields
- [ ] Run a content skill (e.g. `digest`) and verify `memory/skill-health/digest.json` is created with a quality score
- [ ] Simulate a failure and verify `consecutive_failures` increments and `last_error` is populated
- [ ] Run `skill-health` and verify it reads the new data format

Closes HYP-22

🤖 Generated with [Claude Code](https://claude.com/claude-code)