### PR TITLE
feat: skill-evals — output quality assertion framework

### DIFF
--- a/aeon.yml
+++ b/aeon.yml
@@ -91,6 +91,7 @@ skills:
 
   # --- Weekly (Monday only) ---
   fork-fleet: { enabled: false, schedule: "0 10 * * 1" } # fork fleet scan — inventory active forks, detect diverged work
+  skill-evals: { enabled: false, schedule: "0 6 * * 0", model: "claude-sonnet-4-6" } # Sunday 6 AM UTC — output quality assertions across all tracked skills
   spawn-instance: { enabled: false, schedule: "workflow_dispatch", var: "" } # on-demand — var: "name: purpose"
   fleet-control: { enabled: false, schedule: "0 9,15 * * *" } # fleet health checks twice daily, dispatch via var
   weekly-review: { enabled: false, schedule: "0 19 * * 1" }

--- a/skills/skill-evals/SKILL.md
+++ b/skills/skill-evals/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: Skill Evals
+description: Evaluate skill output quality against assertion manifests — detects regressions before users notice
+var: ""
+tags: [meta]
+---
+
+> **${var}** — Skill name to evaluate. If empty, evaluates all skills in evals.json.
+
+Today is ${today}. Your task is to evaluate skill output quality by validating recent outputs against assertions defined in `skills/skill-evals/evals.json`.
+
+## Steps
+
+1. **Read the assertion manifest** — read `skills/skill-evals/evals.json`.
+
+2. **Read `aeon.yml`** to get the full registered skill list.
+
+3. **Read `memory/cron-state.json`** — contains `total_runs`, `success_rate`, `last_quality_score` per skill.
+
+4. **Determine which skills to evaluate**:
+   - If `${var}` is set, evaluate only that skill.
+   - Otherwise evaluate all skills listed in evals.json.
+
+5. **For each skill being evaluated**, run the following checks:
+
+   a. **Find the most recent output file** using the glob pattern from evals.json (`output_pattern`).
+      - Use Glob to find all matching files.
+      - Sort by filename descending to get the most recent.
+      - If no matching file exists → mark as **NO COVERAGE**.
+
+   b. **Word count check**: count words in the file. Fail if below `min_words`.
+
+   c. **Required pattern check**: for each pattern in `required_patterns`, search the file content.
+      - Patterns are pipe-separated alternatives (e.g. `"stars|forks"` — either must appear).
+      - Fail if any required pattern is not found.
+
+   d. **Forbidden pattern check**: for each pattern in `forbidden_patterns`, search the file.
+      - Fail if any forbidden pattern IS found.
+
+   e. **Numeric checks** (if `numeric_checks` is defined): for each entry:
+      - Extract the first number matching the regex `pattern` from the file.
+      - Fail if the extracted value is outside [`min`, `max`].
+      - If no match found and the field is expected (skip if not found is not specified), flag as WARN.
+
+   f. **Quality score cross-check**: read `memory/skill-health/{skill}.json` if it exists.
+      - If `avg_score` < 2.5 → flag as **QUALITY_DEGRADED** even if assertions pass.
+      - If `avg_score` >= 2.5 → note the score in the report.
+
+6. **Classify each skill**:
+   - **PASS** — all assertions pass, quality score >= 2.5 (or no health data yet)
+   - **FAIL** — one or more assertions failed (word count, required pattern, forbidden pattern, or numeric check)
+   - **QUALITY_DEGRADED** — assertions pass but avg quality score < 2.5
+   - **NO COVERAGE** — no output file found matching the pattern
+
+7. **Detect coverage gaps** — skills that have cron-state entries with `total_runs > 0` but are NOT in evals.json.
+   These are skills running in production without any eval spec.
+
+8. **Write the report** to `articles/skill-evals-${today}.md`:
+
+   ```markdown
+   # Skill Evals — ${today}
+
+   ## Results
+
+   | Skill | Status | Details |
+   |-------|--------|---------|
+   | heartbeat | PASS | 52 words, all patterns matched |
+   | repo-pulse | FAIL | Missing pattern: "stars" |
+   | token-report | NO COVERAGE | No output file found |
+
+   ## Summary
+   - Evaluated: N skills (from evals.json)
+   - Passing: N
+   - Failing: N
+   - Quality degraded: N
+   - No coverage: N
+
+   ## Coverage Gaps (running in production but not in evals.json)
+   - skill-name: N runs (success_rate: X%)
+
+   ## Recommendations
+   [List specific fixes for failing skills and skills to add to evals.json]
+   ```
+
+9. **Send notification** via `./notify` if any skills are FAILING or QUALITY_DEGRADED. Include the full results table in the message.
+   If all skills pass or have no coverage issues, send a brief summary: "Skill Evals PASS — N/N skills healthy."
+
+10. **Log to `memory/logs/${today}.md`**:
+    ```
+    ## Skill Evals — ${today}
+    - Evaluated N skills from evals.json
+    - PASS: X, FAIL: Y, NO_COVERAGE: Z
+    - Coverage gaps: [list skill names]
+    ```
+
+Write complete output with no placeholders.

--- a/skills/skill-evals/evals.json
+++ b/skills/skill-evals/evals.json
@@ -1,0 +1,102 @@
+{
+  "version": "1",
+  "description": "Per-skill output quality assertions for Aeon Skill Evals. Each entry defines the output file pattern and assertions to run against the most recent output.",
+  "skills": {
+    "heartbeat": {
+      "output_pattern": "memory/logs/*.md",
+      "min_words": 20,
+      "required_patterns": ["heartbeat|Heartbeat|HEARTBEAT"],
+      "forbidden_patterns": ["\\$\\{var\\}", "\\[TODO\\]", "PLACEHOLDER"]
+    },
+    "repo-pulse": {
+      "output_pattern": "articles/repo-pulse-*.md",
+      "min_words": 80,
+      "required_patterns": ["star", "fork"],
+      "forbidden_patterns": ["\\$\\{var\\}", "\\[TODO\\]"],
+      "numeric_checks": [
+        { "label": "star count", "pattern": "(\\d+) star", "min": 1, "max": 1000000 }
+      ]
+    },
+    "changelog": {
+      "output_pattern": "articles/changelog-*.md",
+      "min_words": 150,
+      "required_patterns": ["commit|feat|fix|change"],
+      "forbidden_patterns": ["\\$\\{var\\}", "\\[TODO\\]", "PLACEHOLDER"]
+    },
+    "push-recap": {
+      "output_pattern": "articles/push-recap-*.md",
+      "min_words": 80,
+      "required_patterns": ["commit|push|branch|merge"],
+      "forbidden_patterns": ["\\$\\{var\\}", "\\[TODO\\]"]
+    },
+    "fork-fleet": {
+      "output_pattern": "articles/fork-fleet-*.md",
+      "min_words": 150,
+      "required_patterns": ["fork|Fork"],
+      "forbidden_patterns": ["\\$\\{var\\}", "\\[TODO\\]"]
+    },
+    "cost-report": {
+      "output_pattern": "articles/cost-report-*.md",
+      "min_words": 100,
+      "required_patterns": ["cost|\\$|token"],
+      "forbidden_patterns": ["\\$\\{var\\}", "\\[TODO\\]"],
+      "numeric_checks": [
+        { "label": "dollar amount", "pattern": "\\$([\\d.]+)", "min": 0, "max": 100000 }
+      ]
+    },
+    "repo-article": {
+      "output_pattern": "articles/repo-article-*.md",
+      "min_words": 300,
+      "required_patterns": ["Aeon|aeon"],
+      "forbidden_patterns": ["\\$\\{var\\}", "\\[TODO\\]", "PLACEHOLDER"]
+    },
+    "repo-actions": {
+      "output_pattern": "articles/repo-actions-*.md",
+      "min_words": 300,
+      "required_patterns": ["skill|Skill|feature|Feature"],
+      "forbidden_patterns": ["\\$\\{var\\}", "\\[TODO\\]", "PLACEHOLDER"]
+    },
+    "deep-research": {
+      "output_pattern": "articles/deep-research-*.md",
+      "min_words": 800,
+      "required_patterns": ["source|Source|http|reference"],
+      "forbidden_patterns": ["\\$\\{var\\}", "\\[TODO\\]", "PLACEHOLDER"]
+    },
+    "hn-digest": {
+      "output_pattern": "articles/hn-digest-*.md",
+      "min_words": 150,
+      "required_patterns": ["Hacker News|hacker.news|ycombinator|HN"],
+      "forbidden_patterns": ["\\$\\{var\\}", "\\[TODO\\]"]
+    },
+    "rss-digest": {
+      "output_pattern": "articles/rss-digest-*.md",
+      "min_words": 100,
+      "required_patterns": ["feed|article|post|item"],
+      "forbidden_patterns": ["\\$\\{var\\}", "\\[TODO\\]"]
+    },
+    "polymarket": {
+      "output_pattern": "articles/polymarket-*.md",
+      "min_words": 100,
+      "required_patterns": ["market|Market|probability|volume"],
+      "forbidden_patterns": ["\\$\\{var\\}", "\\[TODO\\]"],
+      "numeric_checks": [
+        { "label": "probability", "pattern": "([\\d.]+)%", "min": 0, "max": 100 }
+      ]
+    },
+    "token-alert": {
+      "output_pattern": "articles/token-alert-*.md",
+      "min_words": 50,
+      "required_patterns": ["AEON|aeon|token|Token|price|Price"],
+      "forbidden_patterns": ["\\$\\{var\\}", "\\[TODO\\]"],
+      "numeric_checks": [
+        { "label": "price", "pattern": "\\$([\\d.]+)", "min": 0, "max": 1000000 }
+      ]
+    },
+    "skill-health": {
+      "output_pattern": "articles/skill-health-*.md",
+      "min_words": 80,
+      "required_patterns": ["HEALTHY|DEGRADED|CRITICAL|healthy|skill"],
+      "forbidden_patterns": ["\\$\\{var\\}", "\\[TODO\\]"]
+    }
+  }
+}


### PR DESCRIPTION
## What
Adds **Skill Evals** — a new meta-skill that validates recent skill outputs against per-skill assertion manifests, catching output quality regressions before users notice them.

## Why
The existing smoke-test CI (PR #10) validates SKILL.md *structure* (frontmatter, cron syntax, no placeholders). It says nothing about whether a skill actually produces good output. A skill can pass every structural check and still return a blank article, a hallucinated price, or a truncated digest. With 60+ skills and 15 forks now depending on them, a silent regression in `repo-pulse` or `cost-report` can go undetected for days. Skill Evals closes this gap — output validation is stage two of CI maturity.

## Changes
- `skills/skill-evals/SKILL.md`: Evaluates recent output files for each tracked skill. For each skill in the manifest, it finds the most recent matching output file, then runs: word count check, required pattern check (e.g. "stars" must appear in repo-pulse output), forbidden pattern check (no `${var}` or `[TODO]` in final output), numeric range validation for data skills (e.g. price values in plausible range), and cross-checks with `memory/skill-health/*.json` avg quality scores. Classifies each skill as PASS / FAIL / QUALITY_DEGRADED / NO COVERAGE. Also detects coverage gaps — skills running in production with no eval spec.
- `skills/skill-evals/evals.json`: Assertion manifest for 14 core skills covering all major categories: meta (heartbeat, skill-health), repo intelligence (repo-pulse, changelog, push-recap, fork-fleet), research (deep-research, hn-digest, rss-digest), content (repo-article, repo-actions), social (polymarket), DeFi (token-alert), and cost (cost-report). Each entry defines `output_pattern`, `min_words`, `required_patterns`, `forbidden_patterns`, and optional `numeric_checks`.
- `aeon.yml`: Registers `skill-evals` at Sunday 6 AM UTC using Sonnet for cost efficiency.

---
*Built autonomously by Aeon*