### PR TITLE
feat: MCP skill adaptor — invoke any Aeon skill from Claude

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,37 @@ Non-Claude models are available in the workflow dispatch dropdown and per-skill 
 
 ---
 
+## Use with Claude (MCP)
+
+Aeon's skills are available as tools in Claude Desktop and Claude Code via the MCP server bundled in `mcp-server/`.
+
+```bash
+./add-mcp
+```
+
+That's it. Every Aeon skill appears as an `aeon-<name>` tool in your Claude interface — no GitHub Actions required. Skills run locally via `claude -p -`, identical to how they run in Actions.
+
+**Example usage in Claude:**
+
+> Use the `aeon-hacker-news-digest` tool to get today's top HN stories
+
+> Run `aeon-deep-research` with `var="AI agent frameworks"` and write a summary
+
+> Use `aeon-token-movers` to get today's top crypto movers
+
+**Options:**
+
+| Flag | Effect |
+|------|--------|
+| `./add-mcp` | Build and register with Claude Code |
+| `./add-mcp --desktop` | Also print Claude Desktop config snippet |
+| `./add-mcp --build-only` | Build without registering (CI use) |
+| `./add-mcp --uninstall` | Remove the MCP server |
+
+Skills that need API keys (CoinGecko, Alchemy, etc.) read from the same environment variables they use in Actions — set them in your shell or a `.env` file in the repo root. Notification channels (Telegram, Discord, Slack) are optional; if not set, output is returned directly to Claude.
+
+---
+
 ## GitHub Pages Gallery
 
 Aeon publishes articles to a browsable gallery via GitHub Pages. After merging, enable it in **Settings → Pages** → source `Deploy from a branch`, branch `main`, folder `/docs`.

--- a/add-mcp
+++ b/add-mcp
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# add-mcp — Install the Aeon MCP server so Claude Code and Claude Desktop
+# can invoke any Aeon skill directly from the Claude interface.
+#
+# Usage:
+#   ./add-mcp                  Build the MCP server and register it with Claude Code
+#   ./add-mcp --desktop        Also print Claude Desktop config snippet
+#   ./add-mcp --build-only     Build without registering (useful for CI)
+#   ./add-mcp --uninstall      Remove the Aeon MCP server from Claude Code
+#   ./add-mcp --help           Show this help
+#
+# After running, every Aeon skill appears as an 'aeon-<name>' tool in Claude.
+# Skills run locally via `claude -p -` exactly as they do on GitHub Actions.
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+MCP_DIR="$DIR/mcp-server"
+
+usage() {
+  sed -n '3,12p' "$0" | sed 's/^# //'
+  exit 0
+}
+
+err() { echo "Error: $*" >&2; exit 1; }
+info() { printf '\033[0;34m%s\033[0m\n' "$*"; }
+ok() { printf '\033[0;32m✓ %s\033[0m\n' "$*"; }
+warn() { printf '\033[0;33m⚠ %s\033[0m\n' "$*"; }
+
+BUILD_ONLY=false
+SHOW_DESKTOP=false
+UNINSTALL=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --build-only) BUILD_ONLY=true ;;
+    --desktop) SHOW_DESKTOP=true ;;
+    --uninstall) UNINSTALL=true ;;
+    --help|-h) usage ;;
+    *) err "Unknown option: $arg" ;;
+  esac
+done
+
+# ── Uninstall ────────────────────────────────────────────────────────────────
+
+if [[ "$UNINSTALL" == "true" ]]; then
+  if ! command -v claude &>/dev/null; then
+    err "'claude' CLI not found. Nothing to uninstall."
+  fi
+  info "Removing Aeon MCP server from Claude Code..."
+  if claude mcp remove aeon 2>/dev/null; then
+    ok "Removed 'aeon' from Claude Code MCP servers"
+  else
+    warn "No 'aeon' MCP server was registered (already removed?)"
+  fi
+  exit 0
+fi
+
+# ── Pre-flight checks ────────────────────────────────────────────────────────
+
+info "Checking prerequisites..."
+
+if ! command -v node &>/dev/null; then
+  err "Node.js not found. Install it from https://nodejs.org (v18 or later required)"
+fi
+
+NODE_VERSION=$(node --version | sed 's/v//' | cut -d. -f1)
+if [[ "$NODE_VERSION" -lt 18 ]]; then
+  err "Node.js v18 or later required (found v$NODE_VERSION). Upgrade at https://nodejs.org"
+fi
+ok "Node.js $(node --version)"
+
+if ! command -v npm &>/dev/null; then
+  err "npm not found. It should come with Node.js."
+fi
+ok "npm $(npm --version)"
+
+if [[ ! -d "$MCP_DIR" ]]; then
+  err "mcp-server/ directory not found at $MCP_DIR"
+fi
+
+if [[ ! -f "$DIR/skills.json" ]]; then
+  err "skills.json not found at $DIR/skills.json. Run this script from the repo root."
+fi
+
+# ── Build ────────────────────────────────────────────────────────────────────
+
+info "Installing MCP server dependencies..."
+(cd "$MCP_DIR" && npm install --silent)
+ok "Dependencies installed"
+
+info "Building TypeScript..."
+(cd "$MCP_DIR" && npm run build)
+ok "Build complete → mcp-server/dist/index.js"
+
+SERVER_PATH="$MCP_DIR/dist/index.js"
+if [[ ! -f "$SERVER_PATH" ]]; then
+  err "Build failed: $SERVER_PATH not found"
+fi
+
+if [[ "$BUILD_ONLY" == "true" ]]; then
+  ok "Build complete (--build-only: skipping registration)"
+  exit 0
+fi
+
+# ── Register with Claude Code ─────────────────────────────────────────────────
+
+if ! command -v claude &>/dev/null; then
+  warn "'claude' CLI not found — skipping Claude Code registration."
+  warn "Install it with: npm install -g @anthropic-ai/claude-code"
+  warn "Then run: claude mcp add aeon node \"$SERVER_PATH\""
+else
+  info "Registering with Claude Code..."
+  # Remove existing entry to avoid duplicates, then re-add
+  claude mcp remove aeon 2>/dev/null || true
+  claude mcp add aeon node "$SERVER_PATH"
+  ok "Aeon MCP server registered with Claude Code"
+fi
+
+# ── Count skills ─────────────────────────────────────────────────────────────
+
+SKILL_COUNT=$(node -e "const s=JSON.parse(require('fs').readFileSync('$DIR/skills.json','utf8')); console.log(s.skills.length);" 2>/dev/null || echo "?")
+
+echo ""
+echo "┌──────────────────────────────────────────────────────────┐"
+echo "│  ⚡ Aeon MCP Server installed                            │"
+echo "│                                                          │"
+printf "│  %d skills now available as aeon-* tools in Claude       │\n" "$SKILL_COUNT"
+echo "│                                                          │"
+echo "│  Example usage in Claude:                                │"
+echo "│    Use the aeon-hn-digest tool to get today's HN top     │"
+echo "│    Use aeon-token-movers with var=\"bitcoin\"              │"
+echo "│    Run aeon-deep-research with var=\"AI agent frameworks\" │"
+echo "└──────────────────────────────────────────────────────────┘"
+echo ""
+
+# ── Claude Desktop config snippet ────────────────────────────────────────────
+
+if [[ "$SHOW_DESKTOP" == "true" ]]; then
+  echo "Claude Desktop configuration:"
+  echo "Add the following to your Claude Desktop config file:"
+  echo ""
+  if [[ "$(uname)" == "Darwin" ]]; then
+    echo "  ~/Library/Application Support/Claude/claude_desktop_config.json"
+  else
+    echo "  %APPDATA%\\Claude\\claude_desktop_config.json"
+  fi
+  echo ""
+  cat <<EOF
+{
+  "mcpServers": {
+    "aeon": {
+      "command": "node",
+      "args": ["$SERVER_PATH"]
+    }
+  }
+}
+EOF
+  echo ""
+  echo "Then restart Claude Desktop — Aeon skills will appear as tools."
+fi
+
+echo "To verify, run: claude mcp list"
+echo "To remove:      ./add-mcp --uninstall"

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "aeon-mcp",
+  "version": "1.0.0",
+  "description": "MCP server that exposes all Aeon skills as Claude tools",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": {
+    "aeon-mcp": "dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+/**
+ * Aeon MCP Server
+ *
+ * Exposes all Aeon skills as MCP tools so any Claude Desktop or Claude Code
+ * user can invoke them directly from their Claude interface.
+ *
+ * Tool naming: aeon-{slug} (e.g. aeon-article, aeon-hacker-news-digest)
+ * Each tool accepts a single optional `var` argument (the skill's variable input).
+ *
+ * Skill execution: spawns `claude -p -` with the skill prompt, exactly as
+ * GitHub Actions does, so local runs are identical to scheduled runs.
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { readFileSync, existsSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import { spawnSync } from "child_process";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// mcp-server/dist/index.js → mcp-server/ → repo root
+const REPO_ROOT = join(__dirname, "..", "..");
+
+interface Skill {
+  slug: string;
+  name: string;
+  description: string;
+  category: string;
+  schedule: string;
+  var: string;
+}
+
+interface SkillsManifest {
+  version: string;
+  repo: string;
+  skills: Skill[];
+}
+
+function loadSkills(): Skill[] {
+  const manifestPath = join(REPO_ROOT, "skills.json");
+  if (!existsSync(manifestPath)) {
+    process.stderr.write(
+      `[aeon-mcp] skills.json not found at ${manifestPath}\n`
+    );
+    return [];
+  }
+  const manifest: SkillsManifest = JSON.parse(
+    readFileSync(manifestPath, "utf-8")
+  );
+  return manifest.skills ?? [];
+}
+
+function skillToToolName(slug: string): string {
+  return `aeon-${slug}`;
+}
+
+function toolNameToSlug(toolName: string): string {
+  return toolName.replace(/^aeon-/, "");
+}
+
+function buildTools(skills: Skill[]) {
+  return skills.map((skill) => ({
+    name: skillToToolName(skill.slug),
+    description: buildDescription(skill),
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        var: {
+          type: "string",
+          description: buildVarDescription(skill),
+        },
+      },
+      required: [],
+    },
+  }));
+}
+
+function buildDescription(skill: Skill): string {
+  const categoryLabel = categoryName(skill.category);
+  const scheduleLabel =
+    skill.schedule === "on-demand"
+      ? "on-demand"
+      : `cron: ${skill.schedule}`;
+  return `[Aeon · ${categoryLabel}] ${skill.description} (${scheduleLabel})`;
+}
+
+function buildVarDescription(skill: Skill): string {
+  if (skill.var) return skill.var;
+  const defaults: Record<string, string> = {
+    research: "Topic or keyword to focus the skill on (e.g. 'AI agents'). Leave empty for auto-selection.",
+    dev: "Repo in owner/repo format to narrow scope. Leave empty to scan all watched repos.",
+    crypto: "Token symbol or contract address to focus on. Leave empty for all tracked tokens.",
+    social: "Topic, handle, or keyword. Leave empty to use configured defaults.",
+    productivity: "Focus area or goal. Leave empty for general operation.",
+  };
+  return (
+    defaults[skill.category] ??
+    `Optional variable input for the ${skill.name} skill.`
+  );
+}
+
+function categoryName(category: string): string {
+  const labels: Record<string, string> = {
+    research: "Research",
+    dev: "Dev",
+    crypto: "Crypto",
+    social: "Social",
+    productivity: "Productivity",
+  };
+  return labels[category] ?? category;
+}
+
+async function runSkill(slug: string, varValue: string): Promise<string> {
+  const skillFile = join(REPO_ROOT, "skills", slug, "SKILL.md");
+  if (!existsSync(skillFile)) {
+    return [
+      `Error: skill '${slug}' not found.`,
+      `Expected SKILL.md at: ${skillFile}`,
+      `Make sure you're running the MCP server from inside an Aeon repo clone.`,
+    ].join("\n");
+  }
+
+  const today = new Date().toISOString().split("T")[0];
+  let prompt = `Today is ${today}. Read and execute the skill defined in skills/${slug}/SKILL.md`;
+
+  if (varValue.trim()) {
+    prompt += `\n\nUse this variable (override the default in the skill file):\nvar=${varValue.trim()}`;
+  }
+
+  process.stderr.write(`[aeon-mcp] Running skill: ${slug}${varValue ? ` (var=${varValue})` : ""}\n`);
+
+  const result = spawnSync("claude", ["-p", "-", "--output-format", "json"], {
+    input: prompt,
+    cwd: REPO_ROOT,
+    timeout: 600_000, // 10 minutes — same as GitHub Actions timeout
+    maxBuffer: 10 * 1024 * 1024, // 10 MB
+    encoding: "utf-8",
+  });
+
+  if (result.error) {
+    const msg = (result.error as NodeJS.ErrnoException).code === "ENOENT"
+      ? `'claude' command not found. Install it with: npm install -g @anthropic-ai/claude-code`
+      : `Failed to spawn claude: ${result.error.message}`;
+    return `Error: ${msg}`;
+  }
+
+  if (result.status !== 0) {
+    const output = (result.stderr || result.stdout || "").trim();
+    return `Skill '${slug}' failed (exit ${result.status}):\n${output}`;
+  }
+
+  const stdout = (result.stdout || "").trim();
+  if (!stdout) {
+    return `Skill '${slug}' produced no output.`;
+  }
+
+  // The claude CLI with --output-format json wraps result in { result: "..." }
+  try {
+    const parsed = JSON.parse(stdout) as { result?: string };
+    return parsed.result ?? stdout;
+  } catch {
+    return stdout;
+  }
+}
+
+// ---- Server setup ----
+
+const server = new Server(
+  { name: "aeon-mcp", version: "1.0.0" },
+  { capabilities: { tools: {} } }
+);
+
+const skills = loadSkills();
+const tools = buildTools(skills);
+
+process.stderr.write(
+  `[aeon-mcp] Loaded ${skills.length} skills from ${REPO_ROOT}\n`
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools }));
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const toolName = request.params.name;
+  const slug = toolNameToSlug(toolName);
+  const skill = skills.find((s) => s.slug === slug);
+
+  if (!skill) {
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Unknown Aeon tool: ${toolName}\nAvailable tools: ${tools.map((t) => t.name).join(", ")}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+
+  const varValue = (request.params.arguments?.var as string) ?? "";
+  const output = await runSkill(slug, varValue);
+
+  return {
+    content: [{ type: "text" as const, text: output }],
+  };
+});
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  process.stderr.write("[aeon-mcp] Server running on stdio\n");
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(`[aeon-mcp] Fatal error: ${err}\n`);
+  process.exit(1);
+});

--- a/mcp-server/tsconfig.json
+++ b/mcp-server/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## What

Adds an MCP (Model Context Protocol) server that exposes all Aeon skills as Claude tools — one tool per skill, named `aeon-<slug>` (e.g. `aeon-article`, `aeon-hacker-news-digest`, `aeon-deep-research`).

Install with a single command:

```bash
./add-mcp
```

Every skill in `skills.json` immediately appears in Claude Code and Claude Desktop as a callable tool. No GitHub Actions, no secrets config, no manual setup beyond a one-time install.

## Why

Aeon has 54+ production-quality skills that currently require GitHub Actions to run. The only other way to invoke them is `claude -p "Read skills/..."` manually. An MCP adaptor changes the install from "fork + configure Actions + push config" to `./add-mcp` — a completely different distribution surface. Triggered by the MCP Skill Adaptor idea in the 2026-04-07 repo-actions output.

## Changes

- `mcp-server/src/index.ts`: TypeScript MCP server using `@modelcontextprotocol/sdk`. Reads `skills.json` at startup; generates one tool per skill. Tool invocation spawns `claude -p -` with the same prompt format Actions uses, so local runs are identical to scheduled CI runs. Var input is passed through. Output returned as tool text result.
- `mcp-server/package.json`: ESM package with `@modelcontextprotocol/sdk` dependency.
- `mcp-server/tsconfig.json`: TypeScript ESM build config targeting ES2022/NodeNext.
- `add-mcp`: One-command install script. Runs `npm install` + `tsc` in `mcp-server/`, then calls `claude mcp add aeon node dist/index.js`. Supports `--desktop` (prints Claude Desktop config), `--uninstall`, and `--build-only` flags.
- `README.md`: New "Use with Claude (MCP)" section with usage examples and flag reference.

## How it works

The MCP server is a stdio-transport Node.js process. Claude spawns it on startup and queries it for available tools via `ListTools`. When a user invokes an `aeon-*` tool, the server receives a `CallTool` request, reads the matching `skills/{slug}/SKILL.md`, builds the same prompt that GitHub Actions builds (`Today is {date}. Read and execute the skill defined in...`), and spawns `claude -p -` as a subprocess. The result is returned as the tool's text content.

Skills requiring secrets (API keys, tokens) read from environment variables — same as Actions. Notification channels are optional; without them, output is returned directly to Claude as tool result text.

## What's next

Could add a skills discovery mode (`aeon-search-skill` returns available skills to install), and a `./add-mcp` npm publish step so the server is installable without cloning the repo.

---
*Built autonomously by Aeon*