### PR TITLE
feat: email notification channel via SendGrid

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -174,6 +174,10 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
+          NOTIFY_EMAIL_TO: ${{ secrets.NOTIFY_EMAIL_TO }}
+          NOTIFY_EMAIL_FROM: ${{ vars.NOTIFY_EMAIL_FROM || 'aeon@notifications.aeon.bot' }}
+          NOTIFY_EMAIL_SUBJECT_PREFIX: ${{ vars.NOTIFY_EMAIL_SUBJECT_PREFIX || '[Aeon]' }}
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
           COINGECKO_API_KEY: ${{ secrets.COINGECKO_API_KEY }}
           ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
@@ -255,6 +259,24 @@ jobs:
             curl -sf -X POST "$SLACK_WEBHOOK_URL" \
               -H "Content-Type: application/json" \
               -d "$(jq -n --arg text "$MSG" '{text: $text}')" > /dev/null || true
+          fi
+          # Email via SendGrid
+          if [ -n "${SENDGRID_API_KEY:-}" ] && [ -n "${NOTIFY_EMAIL_TO:-}" ]; then
+            FROM="${NOTIFY_EMAIL_FROM:-aeon@notifications.aeon.bot}"
+            PREFIX="${NOTIFY_EMAIL_SUBJECT_PREFIX:-[Aeon]}"
+            SUBJECT="$PREFIX ${SKILL_NAME:-notification}"
+            HTML_BODY=$(printf '%s' "$MSG" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g')
+            HTML_BODY="<html><body><pre style=\"font-family:monospace;white-space:pre-wrap;\">${HTML_BODY}</pre></body></html>"
+            curl -sf -X POST "https://api.sendgrid.com/v3/mail/send" \
+              -H "Authorization: Bearer ${SENDGRID_API_KEY}" \
+              -H "Content-Type: application/json" \
+              -d "$(jq -n \
+                --arg from "$FROM" \
+                --arg to "$NOTIFY_EMAIL_TO" \
+                --arg subject "$SUBJECT" \
+                --arg html "$HTML_BODY" \
+                --arg text "$MSG" \
+                '{personalizations:[{to:[{email:$to}]}],from:{email:$from},subject:$subject,content:[{type:"text/plain",value:$text},{type:"text/html",value:$html}]}')" > /dev/null 2>&1 || true
           fi
           # json-render channel — save raw message for post-run conversion
           if [ "${JSONRENDER_ENABLED:-false}" = "true" ] && [ -n "${SKILL_NAME:-}" ]; then

--- a/README.md
+++ b/README.md
@@ -368,10 +368,12 @@ Set the secret → channel activates. No code changes needed.
 | Telegram | `TELEGRAM_BOT_TOKEN` + `TELEGRAM_CHAT_ID` | Same |
 | Discord | `DISCORD_WEBHOOK_URL` | `DISCORD_BOT_TOKEN` + `DISCORD_CHANNEL_ID` |
 | Slack | `SLACK_WEBHOOK_URL` | `SLACK_BOT_TOKEN` + `SLACK_CHANNEL_ID` |
+| Email | `SENDGRID_API_KEY` + `NOTIFY_EMAIL_TO` | — |
 
 **Telegram:** Create a bot with @BotFather → get token + chat ID.  
 **Discord:** Outbound: Channel → Integrations → Webhooks → Create. Inbound: discord.com/developers → bot → add `channels:history` scope → copy token + channel ID.  
-**Slack:** api.slack.com → Create App → Incoming Webhooks → install → copy URL. Inbound: add `channels:history`, `reactions:write` scopes → copy bot token + channel ID.
+**Slack:** api.slack.com → Create App → Incoming Webhooks → install → copy URL. Inbound: add `channels:history`, `reactions:write` scopes → copy bot token + channel ID.  
+**Email:** sendgrid.com/settings/api_keys → Create API Key (Mail Send permission) → add as `SENDGRID_API_KEY`. Set `NOTIFY_EMAIL_TO` to your recipient address. Optional: set repository variable `NOTIFY_EMAIL_FROM` (default: `aeon@notifications.aeon.bot`) and `NOTIFY_EMAIL_SUBJECT_PREFIX` (default: `[Aeon]`).
 
 ### Telegram instant mode (optional)
 

--- a/dashboard/app/api/secrets/route.ts
+++ b/dashboard/app/api/secrets/route.ts
@@ -13,6 +13,8 @@ const BUILTIN_SECRETS = [
   { name: 'SLACK_BOT_TOKEN', group: 'Slack', description: 'Slack bot OAuth token' },
   { name: 'SLACK_CHANNEL_ID', group: 'Slack', description: 'Channel ID for messages' },
   { name: 'SLACK_WEBHOOK_URL', group: 'Slack', description: 'Webhook URL for notifications' },
+  { name: 'SENDGRID_API_KEY', group: 'Email', description: 'SendGrid API key — create at sendgrid.com/settings/api_keys' },
+  { name: 'NOTIFY_EMAIL_TO', group: 'Email', description: 'Recipient email address for skill notifications' },
   { name: 'XAI_API_KEY', group: 'Skill Keys', description: 'xAI/Grok API key (for tweet skills)' },
   { name: 'COINGECKO_API_KEY', group: 'Skill Keys', description: 'CoinGecko API key (for crypto skills)' },
   { name: 'ALCHEMY_API_KEY', group: 'Skill Keys', description: 'Alchemy API key (for on-chain skills)' },

--- a/dashboard/components/SecretsPanel.tsx
+++ b/dashboard/components/SecretsPanel.tsx
@@ -29,7 +29,7 @@ export function SecretsPanel({ secrets, busy, onSave, onDelete }: SecretsPanelPr
   return (
     <div className="max-w-2xl mx-auto space-y-[var(--space-lg)]">
       <h2 className="font-display text-2xl">Access Credentials</h2>
-      {['Core', 'Telegram', 'Discord', 'Slack', 'Skill Keys'].map(group => {
+      {['Core', 'Telegram', 'Discord', 'Slack', 'Email', 'Skill Keys'].map(group => {
         const gs = secrets.filter(s => s.group === group); if (!gs.length) return null
         return (
           <div key={group}>


### PR DESCRIPTION
## What
Adds email as a fourth notification channel to Aeon's fan-out `./notify` system. Set two secrets (`SENDGRID_API_KEY` + `NOTIFY_EMAIL_TO`) and every skill notification is also delivered to your inbox.

## Why
Aeon currently notifies via Telegram, Discord, and Slack — all real-time messaging apps. A meaningful segment of users (corporate environments, users who prefer email, anyone without a Telegram/Discord account) had no way to receive skill output. This was idea #5 from the 2026-04-10 repo-actions run and the most self-contained of the remaining unbuilt ideas.

## Changes
- `.github/workflows/aeon.yml`: Added `SENDGRID_API_KEY`, `NOTIFY_EMAIL_TO`, `NOTIFY_EMAIL_FROM`, and `NOTIFY_EMAIL_SUBJECT_PREFIX` to the Run step env. Added email sending block to the dynamically generated `notify` script — fires after the Slack block, before json-render. Uses SendGrid `/v3/mail/send` via `curl`/`jq`. Sends both `text/plain` and `text/html` (markdown wrapped in `<pre>`) content parts. Subject: `[Aeon] <skill-name>` (configurable via repo variables).
- `dashboard/app/api/secrets/route.ts`: Added `SENDGRID_API_KEY` and `NOTIFY_EMAIL_TO` to `BUILTIN_SECRETS` under a new `Email` group so they appear in the dashboard credentials panel.
- `dashboard/components/SecretsPanel.tsx`: Added `'Email'` to the rendered groups list so the Email section appears in the Access Credentials view.
- `README.md`: Added Email row to the Notifications table and setup instructions (SendGrid API key creation, optional `NOTIFY_EMAIL_FROM`/`NOTIFY_EMAIL_SUBJECT_PREFIX` repo variables).

---
*Built autonomously by Aeon*