### PR TITLE
feat: skill version tracking — provenance lock and upstream change detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 .claude/
 .DS_Store
+skills.lock

--- a/add-skill
+++ b/add-skill
@@ -232,6 +232,33 @@ for skill in "${SKILL_NAMES[@]}"; do
   cp -r "$src" "$dest"
   INSTALLED=$((INSTALLED + 1))
 
+  # Record provenance in skills.lock
+  LOCK_FILE="$(cd "$(dirname "$0")" && pwd)/skills.lock"
+  SKILL_REMOTE_PATH="skills/$skill/SKILL.md"
+  COMMIT_SHA=$(gh api "repos/$REPO/commits" -f path="$SKILL_REMOTE_PATH" --jq '.[0].sha' 2>/dev/null || echo "unknown")
+  IMPORTED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+
+  # Initialize lock file if missing or empty
+  if [[ ! -f "$LOCK_FILE" ]] || [[ ! -s "$LOCK_FILE" ]]; then
+    echo "[]" > "$LOCK_FILE"
+  fi
+
+  # Build new entry and upsert into lock file (replace existing entry for this skill)
+  NEW_ENTRY=$(jq -n \
+    --arg name "$skill" \
+    --arg repo "$REPO" \
+    --arg path "$SKILL_REMOTE_PATH" \
+    --arg branch "$BRANCH" \
+    --arg sha "$COMMIT_SHA" \
+    --arg at "$IMPORTED_AT" \
+    '{skill_name: $name, source_repo: $repo, source_path: $path, branch: $branch, commit_sha: $sha, imported_at: $at}')
+
+  jq --argjson entry "$NEW_ENTRY" \
+    '[.[] | select(.skill_name != $entry.skill_name)] + [$entry]' \
+    "$LOCK_FILE" > "${LOCK_FILE}.tmp" && mv "${LOCK_FILE}.tmp" "$LOCK_FILE"
+
+  echo "    -> provenance recorded in skills.lock (sha: ${COMMIT_SHA:0:7})"
+
   # Add to aeon.yml if not already present
   if ! grep -q "^  $skill:" "$AEON_YML" 2>/dev/null; then
     # Insert before the heartbeat entry (fallback section)

--- a/aeon.yml
+++ b/aeon.yml
@@ -93,6 +93,7 @@ skills:
   # --- Weekly (Monday only) ---
   fork-fleet: { enabled: false, schedule: "0 10 * * 1" } # fork fleet scan — inventory active forks, detect diverged work
   skill-evals: { enabled: false, schedule: "0 6 * * 0", model: "claude-sonnet-4-6" } # Sunday 6 AM UTC — output quality assertions across all tracked skills
+  skill-update-check: { enabled: false, schedule: "0 19 * * 0", model: "claude-sonnet-4-6" } # Sunday 7 PM UTC — check imported skills for upstream changes and security regressions
   spawn-instance: { enabled: false, schedule: "workflow_dispatch", var: "" } # on-demand — var: "name: purpose"
   fleet-control: { enabled: false, schedule: "0 9,15 * * *" } # fleet health checks twice daily, dispatch via var
   weekly-review: { enabled: false, schedule: "0 19 * * 1" }

--- a/skills/skill-update-check/SKILL.md
+++ b/skills/skill-update-check/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: skill-update-check
+description: Check imported skills for upstream changes and security regressions since the version in skills.lock
+var: ""
+tags: [dev, security]
+cron: "0 19 * * 0"
+---
+> **${var}** — Skill name to check. If empty, checks all skills tracked in `skills.lock`.
+
+Today is ${today}. Your task is to audit imported skills for upstream changes since they were installed, detect security regressions in changed content, and report what has drifted.
+
+## Steps
+
+1. **Read `skills.lock`** at the repo root. If the file does not exist or is empty, log "SKILL_UPDATE_CHECK_SKIP: skills.lock not found — no imported skills tracked" to `memory/logs/${today}.md` and stop. Do NOT send a notification.
+
+   Each entry in `skills.lock` has the shape:
+   ```json
+   {
+     "skill_name": "bankr",
+     "source_repo": "BankrBot/skills",
+     "source_path": "skills/bankr/SKILL.md",
+     "branch": "main",
+     "commit_sha": "abc1234...",
+     "imported_at": "2026-04-01T12:00:00Z"
+   }
+   ```
+
+2. **Filter entries** — if `${var}` is set, only process the entry whose `skill_name` matches `${var}`.
+
+3. **For each tracked skill**, fetch the latest commit SHA for that file path:
+   ```bash
+   gh api repos/{source_repo}/commits \
+     -f path={source_path} \
+     --jq '.[0] | {sha: .sha, message: .commit.message, date: .commit.author.date, author: .commit.author.name}'
+   ```
+   If the API call fails (repo deleted, private, rate limited), mark the skill as `UNREACHABLE` and continue.
+
+4. **Compare SHAs** — if the latest SHA matches the locked SHA, the skill is up-to-date. If they differ, the skill has changed upstream.
+
+5. **For each changed skill**, fetch the diff between the locked SHA and the current HEAD:
+   ```bash
+   gh api repos/{source_repo}/compare/{locked_sha}...{current_sha} \
+     --jq '{ahead_by: .ahead_by, files: [.files[] | {filename, status, patch}]}'
+   ```
+   Extract the diff for the SKILL.md file specifically.
+
+6. **Security check each changed skill** — pass the diff to the skill security scanner by reading the updated SKILL.md content:
+   ```bash
+   gh api repos/{source_repo}/contents/{source_path} \
+     -f ref={current_sha} --jq '.content' | base64 -d > /tmp/updated-skill.md
+   ./skills/skill-security-scan/scan.sh /tmp/updated-skill.md
+   ```
+   If the scanner is not present, skip the security check and note it in the report.
+
+7. **Build the results table** with one row per tracked skill:
+
+   | Skill | Source | Status | Last Changed | SHA (locked → current) | Security |
+   |-------|--------|--------|--------------|------------------------|----------|
+   | bankr | BankrBot/skills | CHANGED | 2026-04-10 | abc1234 → def5678 | PASS |
+   | hydrex | BankrBot/skills | UP-TO-DATE | — | abc1234 | — |
+   | custom | unknown/repo | UNREACHABLE | — | abc1234 | — |
+
+   Status values:
+   - `UP-TO-DATE` — SHA matches, no action needed
+   - `CHANGED` — upstream has new commits for this file
+   - `UNREACHABLE` — could not contact source repo
+
+8. **Write the report** to `articles/skill-update-check-${today}.md`:
+   ```markdown
+   # Skill Update Check — ${today}
+
+   Checked N imported skills against their upstream sources.
+
+   ## Summary
+   - Up-to-date: N
+   - Changed: N
+   - Unreachable: N
+
+   ## Results
+
+   [results table from step 7]
+
+   ## Changed Skills — Diffs
+
+   ### skill-name
+   **Source:** owner/repo at path/to/SKILL.md
+   **Locked SHA:** abc1234 (imported YYYY-MM-DD)
+   **Current SHA:** def5678 (committed YYYY-MM-DD by Author — "commit message")
+   **Security verdict:** PASS / WARN (details) / FAIL (details)
+
+   **Diff summary:**
+   [describe what changed in plain language based on the patch — what instructions were added, removed, or modified]
+
+   **Recommendation:** Safe to update / Review before updating / Do NOT update (security risk)
+   ```
+
+9. **Update `skills.lock`** for any skills that are safe to track at the new SHA. If a skill has a CHANGED status and a PASS security verdict, update its entry:
+   ```bash
+   jq --arg name "skill_name" --arg sha "new_sha" --arg at "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+     '[.[] | if .skill_name == $name then .commit_sha = $sha | .last_checked = $at else . end]' \
+     skills.lock > skills.lock.tmp && mv skills.lock.tmp skills.lock
+   ```
+   Do NOT update the lock for skills with WARN or FAIL security findings — those require manual review.
+
+   Add a `last_checked` field to ALL entries (even UP-TO-DATE ones) so the next run knows when each was last verified.
+
+10. **Send notification** only if at least one skill has CHANGED status. Format:
+    ```
+    *Skill Update Check — ${today}*
+
+    Checked N imported skills. X changed upstream, Y up-to-date, Z unreachable.
+
+    Changed skills:
+    - skill-name (owner/repo): [1-sentence summary of what changed] — Security: PASS/WARN/FAIL
+    - skill-name2 ...
+
+    [If any FAIL]: ⚠ Security regression detected in [skill-name] — do NOT run until reviewed.
+    [If any WARN]: Review recommended for [skill-name] before next execution.
+
+    Full report: articles/skill-update-check-${today}.md
+    ```
+    If all skills are up-to-date or unreachable, do NOT send a notification — log "SKILL_UPDATE_CHECK_OK: N skills current" to `memory/logs/${today}.md` only.
+
+11. **Log to `memory/logs/${today}.md`**:
+    ```
+    ## skill-update-check
+    - Checked N skills from skills.lock
+    - Up-to-date: N, Changed: N, Unreachable: N
+    - [Changed: skill-name — old_sha → new_sha — security: PASS]
+    - Report: articles/skill-update-check-${today}.md
+    ```
+
+Write the complete report. No TODOs or placeholders.


### PR DESCRIPTION
## What

Two additions that close the supply-chain visibility gap for imported skills:

1. **`add-skill` provenance recording** — after every successful skill installation, the script now records `{skill_name, source_repo, source_path, branch, commit_sha, imported_at}` into a `skills.lock` file (JSON array). On subsequent imports of the same skill the entry is updated in place. `skills.lock` is instance-specific and added to `.gitignore` so it won't be committed to the template repo.

2. **`skills/skill-update-check` skill** — a new weekly skill (Sunday 7 PM UTC) that reads `skills.lock`, fetches the latest commit SHA for each tracked file from its source repo, and surfaces any that have changed. For changed skills it fetches the full diff, passes the updated content through `skill-security-scan`, and notifies with a per-skill verdict (PASS / WARN / FAIL). If all skills are current, it logs quietly and sends no notification.

## Why

`./add-skill` copies SKILL.md files from external repos with no record of what version was installed. Once imported, there is no way to know if the upstream has changed — a modified skill could introduce prompt injection, secret exfiltration, or shell injection that would be silently picked up on the next pull. With 17 forks now cross-importing skills, the blast radius of an undetected upstream change is significant. This is the skill equivalent of `package-lock.json` — the data is already available via the GitHub API, it just needed to be captured and checked.

## Changes

- `add-skill`: adds provenance recording block (27 lines) after successful skill copy — calls `gh api repos/{repo}/commits` to get per-file SHA, upserts into `skills.lock` via `jq`
- `skills/skill-update-check/SKILL.md`: new skill — reads lock, fetches current SHAs, diffs changed files, runs security scan, reports with recommendations
- `aeon.yml`: adds `skill-update-check` entry (disabled by default, Sunday 7 PM UTC, Sonnet model)
- `.gitignore`: adds `skills.lock` (instance-specific, not template config)

---
*Built autonomously by Aeon*