### PR TITLE
fix(security): gate skills.lock auto-advance behind human confirmation

### DIFF
--- a/skills/skill-update-check/SKILL.md
+++ b/skills/skill-update-check/SKILL.md
@@ -91,18 +91,16 @@ Today is ${today}. Your task is to audit imported skills for upstream changes si
    **Diff summary:**
    [describe what changed in plain language based on the patch — what instructions were added, removed, or modified]
 
-   **Recommendation:** Safe to update / Review before updating / Do NOT update (security risk)
+   **Recommendation:** Safe to update — run `./add-skill <source_repo> <skill-name>` to accept / Review before updating / Do NOT update (security risk)
    ```
 
-9. **Update `skills.lock`** for any skills that are safe to track at the new SHA. If a skill has a CHANGED status and a PASS security verdict, update its entry:
+9. **Update `last_checked` only — do NOT advance the locked SHA.** For every entry (including UP-TO-DATE ones), set a `last_checked` timestamp so the next run knows when each was last verified:
    ```bash
-   jq --arg name "skill_name" --arg sha "new_sha" --arg at "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
-     '[.[] | if .skill_name == $name then .commit_sha = $sha | .last_checked = $at else . end]' \
+   jq --arg at "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+     '[.[] | .last_checked = $at]' \
      skills.lock > skills.lock.tmp && mv skills.lock.tmp skills.lock
    ```
-   Do NOT update the lock for skills with WARN or FAIL security findings — those require manual review.
-
-   Add a `last_checked` field to ALL entries (even UP-TO-DATE ones) so the next run knows when each was last verified.
+   **Never auto-advance `commit_sha` in `skills.lock`**, even when the security verdict is PASS. Advancing the lock is a supply-chain trust decision that requires explicit human approval. The notification in step 10 will tell the operator how to advance manually.
 
 10. **Send notification** only if at least one skill has CHANGED status. Format:
     ```
@@ -116,6 +114,8 @@ Today is ${today}. Your task is to audit imported skills for upstream changes si
 
     [If any FAIL]: ⚠ Security regression detected in [skill-name] — do NOT run until reviewed.
     [If any WARN]: Review recommended for [skill-name] before next execution.
+    [If any PASS]: To accept the update and advance the lock, re-run:
+      ./add-skill <source_repo> <skill-name>
 
     Full report: articles/skill-update-check-${today}.md
     ```


### PR DESCRIPTION
## Summary

- **Removes auto-advance of `commit_sha` in `skills.lock`** — Step 9 of `skill-update-check` previously updated the locked SHA automatically when the security scan returned PASS. This bypassed human approval for a supply-chain trust decision.
- **Step 9 now only updates `last_checked` timestamps** for all entries, without touching `commit_sha`.
- **Notification (step 10) now includes manual advance instructions** — tells the operator to run `./add-skill <source_repo> <skill-name>` to accept the upstream change.
- **Report recommendation (step 8) updated** to show the exact command needed to accept a safe update.

Closes #33

## Test plan

- [ ] Run `skill-update-check` against a `skills.lock` with a stale entry — verify the notification includes the `./add-skill` command and the lock SHA is NOT advanced
- [ ] Verify `last_checked` is updated for all entries after a run
- [ ] Confirm `./add-skill <repo> <skill>` still correctly advances the SHA when run manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)