### PR TITLE
feat: A2A Protocol Gateway — open Aeon to any AI agent framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,70 @@ Skills that need API keys (CoinGecko, Alchemy, etc.) read from the same environm
 
 ---
 
+## Use with any AI agent (A2A)
+
+Aeon implements [Google's Agent-to-Agent (A2A) protocol](https://google.github.io/A2A/), making all skills accessible to any A2A-compliant agent framework — LangChain, AutoGen, CrewAI, OpenAI Agents SDK, Vertex AI — without needing Claude or MCP.
+
+```bash
+./add-a2a
+```
+
+The gateway starts an HTTP server (default port `41241`) that advertises all Aeon skills via the A2A agent card endpoint and accepts task invocations via JSON-RPC.
+
+**Discovery endpoint** — fetch this to see all available skills:
+
+```
+GET http://localhost:41241/.well-known/agent.json
+```
+
+**Invoke a skill** (Python example with any A2A-compatible HTTP client):
+
+```python
+import requests, uuid
+
+# Send task
+task = requests.post("http://localhost:41241/", json={
+    "jsonrpc": "2.0", "id": 1, "method": "tasks/send",
+    "params": {
+        "id": str(uuid.uuid4()),
+        "skillId": "aeon-deep-research",
+        "var": "AI agent frameworks 2025",
+        "message": {"role": "user", "parts": [{"type": "text", "text": "Run aeon-deep-research"}]}
+    }
+}).json()
+
+task_id = task["result"]["id"]  # poll with tasks/get or use SSE streaming
+```
+
+**SSE streaming** for long-running skills (`deep-research`, `last30`):
+
+```bash
+curl -N -X POST http://localhost:41241/tasks/sendSubscribe \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tasks/send","params":{"skillId":"aeon-hn-digest"}}'
+```
+
+**Options:**
+
+| Flag | Effect |
+|------|--------|
+| `./add-a2a` | Build and start on port 41241 |
+| `./add-a2a --port 8080` | Use a custom port |
+| `./add-a2a --build-only` | Build without starting (CI use) |
+| `./add-a2a --print-config` | Print LangChain/Python client examples |
+
+**A2A endpoints:**
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/.well-known/agent.json` | GET | Agent card — lists all skills |
+| `/` | POST | JSON-RPC: `tasks/send`, `tasks/get`, `tasks/cancel` |
+| `/tasks/sendSubscribe` | POST | SSE streaming for async skill output |
+
+Run `./add-a2a --print-config` for ready-to-paste LangChain tool wrappers and Python polling examples.
+
+---
+
 ## GitHub Pages Gallery
 
 Aeon publishes articles to a browsable gallery via GitHub Pages. After merging, enable it in **Settings → Pages** → source `Deploy from a branch`, branch `main`, folder `/docs`.

--- a/a2a-server/.gitignore
+++ b/a2a-server/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/a2a-server/package.json
+++ b/a2a-server/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "aeon-a2a-server",
+  "version": "1.0.0",
+  "description": "A2A Protocol Gateway — expose all Aeon skills to any AI agent framework",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "tsc && node dist/index.js"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.4.5"
+  }
+}

--- a/a2a-server/src/index.ts
+++ b/a2a-server/src/index.ts
@@ -1,0 +1,536 @@
+#!/usr/bin/env node
+/**
+ * Aeon A2A Gateway Server
+ *
+ * Implements Google's Agent-to-Agent (A2A) protocol, exposing all Aeon skills
+ * as callable tasks. Any A2A-compliant agent framework — LangChain, AutoGen,
+ * CrewAI, OpenAI Agents SDK, Vertex AI — can invoke Aeon skills via standard
+ * HTTP + JSON-RPC, no MCP client or Claude interface required.
+ *
+ * Endpoints:
+ *   GET  /.well-known/agent.json   — Agent card advertising all skills
+ *   POST /                          — JSON-RPC: tasks/send, tasks/get, tasks/cancel
+ *   POST /tasks/sendSubscribe       — SSE streaming for long-running skills
+ *
+ * Usage:
+ *   node dist/index.js              # default port 41241
+ *   A2A_PORT=8080 node dist/index.js
+ *   A2A_URL=https://your-host.com node dist/index.js
+ */
+
+import { createServer, IncomingMessage, ServerResponse } from "http";
+import { readFileSync, existsSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import { spawn } from "child_process";
+import { randomUUID } from "crypto";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// a2a-server/dist/index.js → a2a-server/ → repo root
+const REPO_ROOT = join(__dirname, "..", "..");
+const DEFAULT_PORT = parseInt(process.env.A2A_PORT ?? "41241", 10);
+const SERVER_URL = process.env.A2A_URL ?? `http://localhost:${DEFAULT_PORT}`;
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface Skill {
+  slug: string;
+  name: string;
+  description: string;
+  category: string;
+  schedule: string;
+  var: string;
+}
+
+interface SkillsManifest {
+  version: string;
+  repo: string;
+  skills: Skill[];
+}
+
+type TaskState = "submitted" | "working" | "completed" | "failed" | "canceled";
+
+interface MessagePart {
+  type: string;
+  text: string;
+}
+
+interface A2AMessage {
+  role: string;
+  parts: MessagePart[];
+}
+
+interface TaskStatus {
+  state: TaskState;
+  timestamp: string;
+  message?: A2AMessage;
+}
+
+interface TaskArtifact {
+  name?: string;
+  mimeType?: string;
+  parts: MessagePart[];
+}
+
+interface Task {
+  id: string;
+  sessionId?: string;
+  status: TaskStatus;
+  artifacts: TaskArtifact[];
+  history: A2AMessage[];
+  metadata?: Record<string, unknown>;
+  skillSlug?: string;
+  _subscribers: ServerResponse[];
+}
+
+interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id: string | number;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+// ── State ─────────────────────────────────────────────────────────────────────
+
+const tasks = new Map<string, Task>();
+const skills = loadSkills();
+
+// ── Skill loading ─────────────────────────────────────────────────────────────
+
+function loadSkills(): Skill[] {
+  const manifestPath = join(REPO_ROOT, "skills.json");
+  if (!existsSync(manifestPath)) {
+    process.stderr.write(`[aeon-a2a] skills.json not found at ${manifestPath}\n`);
+    return [];
+  }
+  const manifest: SkillsManifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+  return manifest.skills ?? [];
+}
+
+function getSkillBySlug(slug: string): Skill | undefined {
+  return skills.find((s) => s.slug === slug);
+}
+
+/**
+ * Parse a skill slug and optional var from an A2A message.
+ * Accepts: "aeon-<slug>", "skill: <slug>", or a bare slug (if exact match).
+ * Var extraction: "var=<value>", "var: <value>", or var="<value>".
+ */
+function parseSkillFromMessage(message: A2AMessage): { slug: string; varValue: string } | null {
+  const text = message.parts.find((p) => p.type === "text")?.text ?? "";
+
+  const slugMatch =
+    text.match(/\baeon-([a-z0-9-]+)\b/i) ??
+    text.match(/\bskill:\s*([a-z0-9-]+)\b/i) ??
+    text.match(/^([a-z0-9-]+)$/);
+
+  if (!slugMatch) return null;
+  const slug = slugMatch[1].toLowerCase();
+  if (!getSkillBySlug(slug)) return null;
+
+  const varMatch = text.match(/\bvar\s*[=:]\s*["']?([^"'\n]+?)["']?(?:\s|$)/i);
+  return { slug, varValue: varMatch ? varMatch[1].trim() : "" };
+}
+
+// ── Skill execution ───────────────────────────────────────────────────────────
+
+function runSkillAsync(task: Task, slug: string, varValue: string): void {
+  const skillFile = join(REPO_ROOT, "skills", slug, "SKILL.md");
+  if (!existsSync(skillFile)) {
+    completeTask(task, "failed", `Error: skill '${slug}' not found at ${skillFile}`);
+    return;
+  }
+
+  const today = new Date().toISOString().split("T")[0];
+  let prompt = `Today is ${today}. Read and execute the skill defined in skills/${slug}/SKILL.md`;
+  if (varValue) {
+    prompt += `\n\nUse this variable (override the default in the skill file):\nvar=${varValue}`;
+  }
+
+  process.stderr.write(
+    `[aeon-a2a] Starting skill: ${slug}${varValue ? ` (var=${varValue})` : ""}\n`
+  );
+
+  setTaskState(task, "working");
+
+  const chunks: string[] = [];
+  const child = spawn("claude", ["-p", "-", "--output-format", "json"], {
+    cwd: REPO_ROOT,
+    env: { ...process.env },
+  });
+
+  child.stdin.write(prompt);
+  child.stdin.end();
+
+  child.stdout.on("data", (chunk: Buffer) => chunks.push(chunk.toString()));
+
+  child.on("close", (code) => {
+    const raw = chunks.join("").trim();
+    if (code !== 0) {
+      completeTask(task, "failed", `Skill '${slug}' failed (exit ${code}):\n${raw}`);
+      return;
+    }
+    let result = raw;
+    try {
+      const parsed = JSON.parse(raw) as { result?: string };
+      result = parsed.result ?? raw;
+    } catch {
+      // use raw output
+    }
+    completeTask(task, "completed", result);
+  });
+
+  child.on("error", (err) => {
+    const code = (err as NodeJS.ErrnoException).code;
+    const msg =
+      code === "ENOENT"
+        ? "'claude' CLI not found. Install: npm install -g @anthropic-ai/claude-code"
+        : `Failed to spawn claude: ${err.message}`;
+    completeTask(task, "failed", msg);
+  });
+}
+
+function setTaskState(task: Task, state: TaskState): void {
+  task.status = { state, timestamp: new Date().toISOString() };
+  broadcastSSE(task, "status", { id: task.id, status: task.status });
+}
+
+function completeTask(task: Task, state: TaskState, text: string): void {
+  const msg: A2AMessage = { role: "agent", parts: [{ type: "text", text }] };
+  task.status = { state, timestamp: new Date().toISOString() };
+  task.history.push(msg);
+
+  if (state === "completed") {
+    task.artifacts = [{ mimeType: "text/plain", parts: [{ type: "text", text }] }];
+    broadcastSSE(task, "artifact", {
+      id: task.id,
+      artifact: task.artifacts[0],
+    });
+  }
+
+  broadcastSSE(task, "status", { id: task.id, status: task.status });
+
+  // Close all SSE connections
+  for (const res of task._subscribers) {
+    if (!res.writableEnded) {
+      writeSSE(res, "close", {});
+      res.end();
+    }
+  }
+  task._subscribers = [];
+}
+
+// ── SSE helpers ───────────────────────────────────────────────────────────────
+
+function writeSSE(res: ServerResponse, event: string, data: unknown): void {
+  res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+}
+
+function broadcastSSE(task: Task, event: string, data: unknown): void {
+  for (const res of task._subscribers) {
+    if (!res.writableEnded) writeSSE(res, event, data);
+  }
+}
+
+// ── Agent Card ────────────────────────────────────────────────────────────────
+
+function buildAgentCard(): Record<string, unknown> {
+  return {
+    name: "Aeon",
+    description:
+      "Background intelligence agent with 68+ skills across research, dev tooling, " +
+      "crypto monitoring, and productivity. Runs on GitHub Actions — always available, " +
+      "no infra required.",
+    url: SERVER_URL,
+    version: "1.0.0",
+    documentationUrl: "https://github.com/aaronjmars/aeon",
+    capabilities: {
+      streaming: true,
+      pushNotifications: false,
+      stateTransitionHistory: true,
+    },
+    authentication: {
+      schemes: [],
+    },
+    defaultInputModes: ["text"],
+    defaultOutputModes: ["text"],
+    skills: skills.map((s) => ({
+      id: `aeon-${s.slug}`,
+      name: s.name,
+      description: s.description,
+      tags: [s.category, "aeon", "background-agent"],
+      inputModes: ["text"],
+      outputModes: ["text"],
+      examples: [
+        {
+          role: "user",
+          parts: [
+            {
+              type: "text",
+              text: `Run aeon-${s.slug}${s.var ? ` with var="${s.var}"` : ""}`,
+            },
+          ],
+        },
+      ],
+    })),
+  };
+}
+
+// ── JSON-RPC handlers ─────────────────────────────────────────────────────────
+
+type RpcResult<T> = T | { error: { code: number; message: string } };
+
+function handleTasksSend(params: Record<string, unknown>): RpcResult<Task> {
+  const id = (params.id as string | undefined) ?? randomUUID();
+  const message = params.message as A2AMessage | undefined;
+  const skillId = params.skillId as string | undefined;
+  const varOverride = params.var as string | undefined;
+
+  let slug: string | undefined;
+  let varValue = varOverride ?? "";
+
+  if (skillId) {
+    slug = skillId.replace(/^aeon-/, "");
+  } else if (message) {
+    const parsed = parseSkillFromMessage(message);
+    if (parsed) {
+      slug = parsed.slug;
+      if (!varOverride) varValue = parsed.varValue;
+    }
+  }
+
+  if (!slug || !getSkillBySlug(slug)) {
+    const examples = skills
+      .slice(0, 5)
+      .map((s) => `aeon-${s.slug}`)
+      .join(", ");
+    return {
+      error: {
+        code: -32602,
+        message:
+          `No valid skill found. Pass skillId (e.g. "aeon-deep-research") or ` +
+          `mention an aeon-<slug> in your message. Examples: ${examples}, ...`,
+      },
+    };
+  }
+
+  const task: Task = {
+    id,
+    status: { state: "submitted", timestamp: new Date().toISOString() },
+    artifacts: [],
+    history: message ? [message] : [],
+    metadata: params.metadata as Record<string, unknown> | undefined,
+    skillSlug: slug,
+    _subscribers: [],
+  };
+  tasks.set(id, task);
+
+  // Kick off async — return submitted state immediately
+  setImmediate(() => runSkillAsync(task, slug!, varValue));
+
+  return task;
+}
+
+function handleTasksGet(params: Record<string, unknown>): RpcResult<Record<string, unknown>> {
+  const id = params.id as string;
+  const task = tasks.get(id);
+  if (!task) {
+    return { error: { code: -32602, message: `Task not found: ${id}` } };
+  }
+  const historyLength = (params.historyLength as number | undefined) ?? task.history.length;
+  // Omit internal _subscribers from response
+  const { _subscribers: _, ...safe } = task;
+  return { ...safe, history: task.history.slice(-historyLength) };
+}
+
+function handleTasksCancel(params: Record<string, unknown>): RpcResult<Record<string, unknown>> {
+  const id = params.id as string;
+  const task = tasks.get(id);
+  if (!task) {
+    return { error: { code: -32602, message: `Task not found: ${id}` } };
+  }
+  if (task.status.state === "submitted" || task.status.state === "working") {
+    completeTask(task, "canceled", "Task canceled by caller.");
+  }
+  const { _subscribers: _, ...safe } = task;
+  return safe;
+}
+
+// ── HTTP request handling ─────────────────────────────────────────────────────
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
+    req.on("error", reject);
+  });
+}
+
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+};
+
+function json(res: ServerResponse, status: number, data: unknown): void {
+  res.writeHead(status, { "Content-Type": "application/json", ...CORS_HEADERS });
+  res.end(JSON.stringify(data));
+}
+
+function rpcError(id: string | number, code: number, message: string): Record<string, unknown> {
+  return { jsonrpc: "2.0", id, error: { code, message } };
+}
+
+async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const url = new URL(req.url ?? "/", "http://localhost");
+  const method = req.method ?? "GET";
+
+  // CORS preflight
+  if (method === "OPTIONS") {
+    res.writeHead(204, CORS_HEADERS);
+    res.end();
+    return;
+  }
+
+  // Agent card — the discovery endpoint A2A clients fetch first
+  if (method === "GET" && url.pathname === "/.well-known/agent.json") {
+    json(res, 200, buildAgentCard());
+    return;
+  }
+
+  // SSE streaming: POST /tasks/sendSubscribe
+  if (method === "POST" && url.pathname === "/tasks/sendSubscribe") {
+    let body: string;
+    try {
+      body = await readBody(req);
+    } catch {
+      json(res, 400, { error: "Cannot read request body" });
+      return;
+    }
+
+    let rpc: JsonRpcRequest;
+    try {
+      rpc = JSON.parse(body);
+    } catch {
+      json(res, 400, { error: "Invalid JSON" });
+      return;
+    }
+
+    const result = handleTasksSend((rpc.params ?? {}) as Record<string, unknown>);
+    if ("error" in result) {
+      json(res, 400, { jsonrpc: "2.0", id: rpc.id, error: result.error });
+      return;
+    }
+
+    const task = result as Task;
+    res.writeHead(200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+      ...CORS_HEADERS,
+    });
+
+    writeSSE(res, "status", { id: task.id, status: task.status });
+    task._subscribers.push(res);
+
+    req.on("close", () => {
+      task._subscribers = task._subscribers.filter((s) => s !== res);
+    });
+    return;
+  }
+
+  // JSON-RPC endpoint: POST /  or  POST /rpc
+  if (method === "POST" && (url.pathname === "/" || url.pathname === "/rpc")) {
+    let body: string;
+    try {
+      body = await readBody(req);
+    } catch {
+      json(res, 400, rpcError(0, -32700, "Parse error"));
+      return;
+    }
+
+    let rpc: JsonRpcRequest;
+    try {
+      rpc = JSON.parse(body);
+    } catch {
+      json(res, 400, rpcError(0, -32700, "Parse error"));
+      return;
+    }
+
+    if (rpc.jsonrpc !== "2.0" || !rpc.method) {
+      json(res, 400, rpcError(rpc?.id ?? 0, -32600, "Invalid Request"));
+      return;
+    }
+
+    const params = (rpc.params ?? {}) as Record<string, unknown>;
+
+    switch (rpc.method) {
+      case "tasks/send": {
+        const r = handleTasksSend(params);
+        if ("error" in r) {
+          json(res, 200, { jsonrpc: "2.0", id: rpc.id, error: r.error });
+          return;
+        }
+        const { _subscribers: _, ...safe } = r as Task;
+        json(res, 200, { jsonrpc: "2.0", id: rpc.id, result: safe });
+        return;
+      }
+      case "tasks/get": {
+        const r = handleTasksGet(params);
+        if ("error" in r) {
+          json(res, 200, { jsonrpc: "2.0", id: rpc.id, error: r.error });
+          return;
+        }
+        json(res, 200, { jsonrpc: "2.0", id: rpc.id, result: r });
+        return;
+      }
+      case "tasks/cancel": {
+        const r = handleTasksCancel(params);
+        if ("error" in r) {
+          json(res, 200, { jsonrpc: "2.0", id: rpc.id, error: r.error });
+          return;
+        }
+        json(res, 200, { jsonrpc: "2.0", id: rpc.id, result: r });
+        return;
+      }
+      default:
+        json(res, 200, rpcError(rpc.id, -32601, `Method not found: ${rpc.method}`));
+        return;
+    }
+  }
+
+  json(res, 404, { error: "Not found" });
+}
+
+// ── Entry point ───────────────────────────────────────────────────────────────
+
+const httpServer = createServer((req, res) => {
+  handleRequest(req, res).catch((err: unknown) => {
+    process.stderr.write(`[aeon-a2a] Unhandled error: ${err}\n`);
+    if (!res.headersSent) {
+      json(res, 500, { error: "Internal server error" });
+    }
+  });
+});
+
+httpServer.listen(DEFAULT_PORT, () => {
+  process.stderr.write(`[aeon-a2a] Server running on port ${DEFAULT_PORT}\n`);
+  process.stderr.write(`[aeon-a2a] Agent card : ${SERVER_URL}/.well-known/agent.json\n`);
+  process.stderr.write(`[aeon-a2a] JSON-RPC   : POST ${SERVER_URL}/\n`);
+  process.stderr.write(`[aeon-a2a] SSE stream : POST ${SERVER_URL}/tasks/sendSubscribe\n`);
+  process.stderr.write(`[aeon-a2a] Loaded ${skills.length} skills\n`);
+});
+
+httpServer.on("error", (err: NodeJS.ErrnoException) => {
+  if (err.code === "EADDRINUSE") {
+    process.stderr.write(
+      `[aeon-a2a] Port ${DEFAULT_PORT} already in use. Set A2A_PORT=<port> to change.\n`
+    );
+  } else {
+    process.stderr.write(`[aeon-a2a] Server error: ${err.message}\n`);
+  }
+  process.exit(1);
+});

--- a/a2a-server/src/index.ts
+++ b/a2a-server/src/index.ts
@@ -22,7 +22,7 @@ import { createServer, IncomingMessage, ServerResponse } from "http";
 import { readFileSync, existsSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
-import { spawn } from "child_process";
+import { spawn, ChildProcess } from "child_process";
 import { randomUUID } from "crypto";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -83,6 +83,8 @@ interface Task {
   metadata?: Record<string, unknown>;
   skillSlug?: string;
   _subscribers: ServerResponse[];
+  _childProcess?: ChildProcess;
+  _completedAt?: number;
 }
 
 interface JsonRpcRequest {
@@ -96,6 +98,28 @@ interface JsonRpcRequest {
 
 const tasks = new Map<string, Task>();
 const skills = loadSkills();
+
+const TASK_TTL_MS = 30 * 60 * 1000; // 30 minutes
+const MAX_TASKS = 1000;
+
+function evictStaleTasks(): void {
+  const now = Date.now();
+  for (const [id, task] of tasks) {
+    if (task._completedAt && now - task._completedAt > TASK_TTL_MS) {
+      tasks.delete(id);
+    }
+  }
+  // Hard cap: if still over limit, drop oldest completed tasks
+  if (tasks.size > MAX_TASKS) {
+    const completed = [...tasks.entries()]
+      .filter(([, t]) => t._completedAt)
+      .sort((a, b) => (a[1]._completedAt ?? 0) - (b[1]._completedAt ?? 0));
+    for (const [id] of completed) {
+      tasks.delete(id);
+      if (tasks.size <= MAX_TASKS) break;
+    }
+  }
+}
 
 // ── Skill loading ─────────────────────────────────────────────────────────────
 
@@ -160,6 +184,7 @@ function runSkillAsync(task: Task, slug: string, varValue: string): void {
     cwd: REPO_ROOT,
     env: { ...process.env },
   });
+  task._childProcess = child;
 
   child.stdin.write(prompt);
   child.stdin.end();
@@ -201,6 +226,8 @@ function completeTask(task: Task, state: TaskState, text: string): void {
   const msg: A2AMessage = { role: "agent", parts: [{ type: "text", text }] };
   task.status = { state, timestamp: new Date().toISOString() };
   task.history.push(msg);
+  task._completedAt = Date.now();
+  task._childProcess = undefined;
 
   if (state === "completed") {
     task.artifacts = [{ mimeType: "text/plain", parts: [{ type: "text", text }] }];
@@ -240,7 +267,7 @@ function buildAgentCard(): Record<string, unknown> {
   return {
     name: "Aeon",
     description:
-      "Background intelligence agent with 68+ skills across research, dev tooling, " +
+      `Background intelligence agent with ${skills.length} skills across research, dev tooling, ` +
       "crypto monitoring, and productivity. Runs on GitHub Actions — always available, " +
       "no infra required.",
     url: SERVER_URL,
@@ -326,6 +353,7 @@ function handleTasksSend(params: Record<string, unknown>): RpcResult<Task> {
     _subscribers: [],
   };
   tasks.set(id, task);
+  evictStaleTasks();
 
   // Kick off async — return submitted state immediately
   setImmediate(() => runSkillAsync(task, slug!, varValue));
@@ -352,6 +380,9 @@ function handleTasksCancel(params: Record<string, unknown>): RpcResult<Record<st
     return { error: { code: -32602, message: `Task not found: ${id}` } };
   }
   if (task.status.state === "submitted" || task.status.state === "working") {
+    if (task._childProcess) {
+      task._childProcess.kill("SIGTERM");
+    }
     completeTask(task, "canceled", "Task canceled by caller.");
   }
   const { _subscribers: _, ...safe } = task;
@@ -360,10 +391,21 @@ function handleTasksCancel(params: Record<string, unknown>): RpcResult<Record<st
 
 // ── HTTP request handling ─────────────────────────────────────────────────────
 
+const MAX_BODY_BYTES = 1024 * 1024; // 1 MB
+
 function readBody(req: IncomingMessage): Promise<string> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
-    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    let size = 0;
+    req.on("data", (chunk: Buffer) => {
+      size += chunk.length;
+      if (size > MAX_BODY_BYTES) {
+        req.destroy();
+        reject(new Error("Request body too large"));
+        return;
+      }
+      chunks.push(chunk);
+    });
     req.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
     req.on("error", reject);
   });

--- a/a2a-server/tsconfig.json
+++ b/a2a-server/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true
+  },
+  "include": ["src/**/*"]
+}

--- a/add-a2a
+++ b/add-a2a
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# add-a2a — Build and start the Aeon A2A Gateway so any AI agent framework
+# (LangChain, AutoGen, CrewAI, OpenAI Agents SDK, Vertex AI) can invoke Aeon
+# skills directly via Google's Agent-to-Agent protocol.
+#
+# Usage:
+#   ./add-a2a                   Build and start the gateway (port 41241)
+#   ./add-a2a --port 8080       Use a custom port
+#   ./add-a2a --build-only      Build without starting
+#   ./add-a2a --print-config    Print agent card URL and sample client code
+#   ./add-a2a --help            Show this help
+#
+# The gateway runs in the foreground. For production, run it under a process
+# manager (pm2, systemd, Docker) or expose it with ngrok for external access.
+#
+# Agent card URL: http://localhost:41241/.well-known/agent.json
+# JSON-RPC:       POST http://localhost:41241/
+# SSE streaming:  POST http://localhost:41241/tasks/sendSubscribe
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+A2A_DIR="$DIR/a2a-server"
+PORT=41241
+
+usage() {
+  sed -n '3,14p' "$0" | sed 's/^# //'
+  exit 0
+}
+
+err()  { printf '\033[0;31mError: %s\033[0m\n' "$*" >&2; exit 1; }
+info() { printf '\033[0;34m%s\033[0m\n' "$*"; }
+ok()   { printf '\033[0;32m✓ %s\033[0m\n' "$*"; }
+warn() { printf '\033[0;33m⚠ %s\033[0m\n' "$*"; }
+
+BUILD_ONLY=false
+PRINT_CONFIG=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --port)        PORT="${2:?--port requires a value}"; shift 2 ;;
+    --build-only)  BUILD_ONLY=true; shift ;;
+    --print-config) PRINT_CONFIG=true; shift ;;
+    --help|-h)     usage ;;
+    *) err "Unknown option: $1" ;;
+  esac
+done
+
+# ── Pre-flight ────────────────────────────────────────────────────────────────
+
+info "Checking prerequisites..."
+
+if ! command -v node &>/dev/null; then
+  err "Node.js not found. Install it from https://nodejs.org (v18 or later required)"
+fi
+NODE_VERSION=$(node --version | sed 's/v//' | cut -d. -f1)
+if [[ "$NODE_VERSION" -lt 18 ]]; then
+  err "Node.js v18 or later required (found v$NODE_VERSION)"
+fi
+ok "Node.js $(node --version)"
+
+if ! command -v npm &>/dev/null; then
+  err "npm not found. It should come with Node.js."
+fi
+ok "npm $(npm --version)"
+
+if [[ ! -d "$A2A_DIR" ]]; then
+  err "a2a-server/ directory not found at $A2A_DIR"
+fi
+if [[ ! -f "$DIR/skills.json" ]]; then
+  err "skills.json not found at $DIR/skills.json. Run this from the repo root."
+fi
+
+# ── Build ─────────────────────────────────────────────────────────────────────
+
+info "Installing dependencies..."
+(cd "$A2A_DIR" && npm install --silent)
+ok "Dependencies installed"
+
+info "Building TypeScript..."
+(cd "$A2A_DIR" && npm run build)
+ok "Build complete → a2a-server/dist/index.js"
+
+SERVER_PATH="$A2A_DIR/dist/index.js"
+if [[ ! -f "$SERVER_PATH" ]]; then
+  err "Build failed: $SERVER_PATH not found"
+fi
+
+if [[ "$BUILD_ONLY" == "true" ]]; then
+  ok "Build complete (--build-only: skipping server start)"
+  exit 0
+fi
+
+# ── Skill count ───────────────────────────────────────────────────────────────
+
+SKILL_COUNT=$(node -e \
+  "const s=JSON.parse(require('fs').readFileSync('$DIR/skills.json','utf8')); \
+   console.log(s.skills.length);" 2>/dev/null || echo "?")
+
+URL="http://localhost:${PORT}"
+
+echo ""
+echo "┌──────────────────────────────────────────────────────────┐"
+echo "│  ⚡ Aeon A2A Gateway                                     │"
+echo "│                                                          │"
+printf "│  %d skills available to any A2A-compliant agent          │\n" "$SKILL_COUNT"
+echo "│                                                          │"
+echo "│  Agent card:  /.well-known/agent.json                   │"
+echo "│  JSON-RPC:    POST /                                     │"
+echo "│  SSE stream:  POST /tasks/sendSubscribe                  │"
+echo "│                                                          │"
+printf "│  Running at: %s                              │\n" "$URL"
+echo "│                                                          │"
+echo "│  Ctrl+C to stop                                          │"
+echo "└──────────────────────────────────────────────────────────┘"
+echo ""
+
+# ── Print sample config ───────────────────────────────────────────────────────
+
+if [[ "$PRINT_CONFIG" == "true" ]]; then
+  echo "── LangChain / OpenAI Agents (A2A client) ──────────────────"
+  cat <<EOF
+# Install: pip install a2a-sdk  (or use any A2A-compatible client)
+import a2a
+
+client = a2a.Client("${URL}")
+card   = client.get_agent_card()       # discovers all ${SKILL_COUNT} skills
+
+# Invoke a skill (async — poll with tasks/get or use SSE):
+task = client.send_task(
+    skill_id="aeon-deep-research",
+    message="Run aeon-deep-research",
+    var="AI agent frameworks 2025",
+)
+result = client.wait_for_task(task["id"])
+print(result["artifacts"][0]["parts"][0]["text"])
+
+EOF
+
+  echo "── LangChain Tool wrapper ───────────────────────────────────"
+  cat <<EOF
+from langchain.tools import Tool
+import requests, time, uuid
+
+def call_aeon(skill_id: str, var: str = "") -> str:
+    task_id = str(uuid.uuid4())
+    resp = requests.post("${URL}/", json={
+        "jsonrpc": "2.0", "id": 1, "method": "tasks/send",
+        "params": {"id": task_id, "skillId": skill_id, "var": var,
+                   "message": {"role": "user", "parts": [{"type": "text",
+                   "text": f"Run {skill_id} var={var}"}]}}
+    }).json()
+    # Poll until complete
+    for _ in range(120):
+        time.sleep(5)
+        status = requests.post("${URL}/", json={
+            "jsonrpc": "2.0", "id": 2, "method": "tasks/get",
+            "params": {"id": task_id}
+        }).json()
+        state = status["result"]["status"]["state"]
+        if state == "completed":
+            return status["result"]["artifacts"][0]["parts"][0]["text"]
+        if state in ("failed", "canceled"):
+            raise RuntimeError(f"Skill failed: {status}")
+    raise TimeoutError("Skill timed out after 10 minutes")
+
+aeon_research = Tool(
+    name="aeon_deep_research",
+    func=lambda q: call_aeon("aeon-deep-research", q),
+    description="Exhaustive multi-source research on any topic (30-50 sources)"
+)
+EOF
+  echo ""
+fi
+
+# ── Start server ──────────────────────────────────────────────────────────────
+
+export A2A_PORT="$PORT"
+export A2A_URL="$URL"
+
+exec node "$SERVER_PATH"

--- a/add-a2a
+++ b/add-a2a
@@ -118,22 +118,34 @@ echo ""
 # ── Print sample config ───────────────────────────────────────────────────────
 
 if [[ "$PRINT_CONFIG" == "true" ]]; then
-  echo "── LangChain / OpenAI Agents (A2A client) ──────────────────"
+  echo "── Plain HTTP (works with any language/framework) ──────────"
   cat <<EOF
-# Install: pip install a2a-sdk  (or use any A2A-compatible client)
-import a2a
+# No SDK required — A2A is just HTTP + JSON-RPC.
+# Use requests, httpx, fetch, curl, or any HTTP client.
+import requests, uuid
 
-client = a2a.Client("${URL}")
-card   = client.get_agent_card()       # discovers all ${SKILL_COUNT} skills
+task_id = str(uuid.uuid4())
+resp = requests.post("${URL}/", json={
+    "jsonrpc": "2.0", "id": 1, "method": "tasks/send",
+    "params": {
+        "id": task_id,
+        "skillId": "aeon-deep-research",
+        "var": "AI agent frameworks 2025",
+        "message": {"role": "user", "parts": [{"type": "text", "text": "Run aeon-deep-research"}]}
+    }
+}).json()
 
-# Invoke a skill (async — poll with tasks/get or use SSE):
-task = client.send_task(
-    skill_id="aeon-deep-research",
-    message="Run aeon-deep-research",
-    var="AI agent frameworks 2025",
-)
-result = client.wait_for_task(task["id"])
-print(result["artifacts"][0]["parts"][0]["text"])
+# Poll for completion:
+import time
+for _ in range(120):
+    time.sleep(5)
+    status = requests.post("${URL}/", json={
+        "jsonrpc": "2.0", "id": 2, "method": "tasks/get",
+        "params": {"id": task_id}
+    }).json()
+    if status["result"]["status"]["state"] == "completed":
+        print(status["result"]["artifacts"][0]["parts"][0]["text"])
+        break
 
 EOF
 


### PR DESCRIPTION
## What

Adds an [A2A (Agent-to-Agent)](https://google.github.io/A2A/) protocol gateway that exposes all Aeon skills to any compliant AI agent framework — LangChain, AutoGen, CrewAI, OpenAI Agents SDK, Vertex AI — without requiring Claude Desktop or the MCP client.

```bash
./add-a2a   # build and start on port 41241
```

## Why

MCP covers Claude users. A2A covers everyone else. Google's A2A protocol is now supported by LangChain, AutoGen, CrewAI, OpenAI Agents SDK, and Vertex AI — it's the framework-agnostic standard for agent interoperability. With 68 skills and 17 active forks, Aeon is substantial enough to serve as a "background intelligence" module that other agents delegate to. A GPT-4o research pipeline can call `aeon-deep-research`, a Gemini trading bot can call `aeon-token-report`, a LangChain content scheduler can call `aeon-article` — all via standard HTTP + JSON-RPC. This PR closes the biggest ecosystem gap identified across three consecutive `repo-actions` runs (Apr 10, Apr 12, Apr 14).

## Changes

- **`a2a-server/src/index.ts`**: Zero-dependency TypeScript HTTP server (Node.js built-ins only). Implements the three A2A endpoints:
  - `GET /.well-known/agent.json` — agent card listing all 68 skills with descriptions, tags, and input/output modes
  - `POST /` — JSON-RPC hub handling `tasks/send`, `tasks/get`, and `tasks/cancel`
  - `POST /tasks/sendSubscribe` — SSE streaming endpoint for real-time output from long-running skills (`deep-research`, `last30`)
  
  Full A2A task state machine: `submitted → working → completed / failed / canceled`. Skill execution is identical to GitHub Actions — spawns `claude -p -` with the SKILL.md prompt. SSE subscribers receive `status` and `artifact` events as they arrive.

- **`a2a-server/package.json`** + **`tsconfig.json`**: TypeScript ESM build. Zero runtime dependencies — only `@types/node` as a devDep.

- **`a2a-server/.gitignore`**: excludes `node_modules/` and `dist/`.

- **`add-a2a`**: One-command install script mirroring `add-mcp`. Runs `npm install + tsc`, starts the server. Flags: `--port`, `--build-only`, `--print-config` (prints ready-to-paste LangChain tool wrapper + Python polling example).

- **`README.md`**: New "Use with any AI agent (A2A)" section with endpoint reference table, Python `requests` usage example, and SSE `curl` snippet.

---
*Built autonomously by Aeon*