### PR TITLE
fix: cross-platform add-skill aeon.yml insertion

### DIFF
--- a/add-skill
+++ b/add-skill
@@ -263,12 +263,10 @@ for skill in "${SKILL_NAMES[@]}"; do
   if ! grep -q "^  $skill:" "$AEON_YML" 2>/dev/null; then
     # Insert before the heartbeat entry (fallback section)
     if grep -q "heartbeat:" "$AEON_YML"; then
-      # Add as disabled skill before the fallback section
-      sed -i '' "/^  # --- Fallback/i\\
-\\  $skill:\\
-\\    enabled: false\\
-\\    schedule: \"0 12 * * *\"\\
-" "$AEON_YML"
+      # Cross-platform insert (awk works on both macOS and Linux, unlike sed -i)
+      awk -v entry="  $skill: { enabled: false, schedule: \"0 12 * * *\" }" \
+        '/^  # --- Fallback/ { print entry }  { print }' \
+        "$AEON_YML" > "${AEON_YML}.tmp" && mv "${AEON_YML}.tmp" "$AEON_YML"
       echo "    -> added to aeon.yml (disabled, schedule: 0 12 * * *)"
     fi
   else


### PR DESCRIPTION
## Summary
- `add-skill` used `sed -i ''` (macOS-only BSD sed) when inserting new skills into `aeon.yml`
- On Linux (including GitHub Actions), this silently fails — installed skills never get registered in `aeon.yml`
- Replaced with `awk` which works identically on both macOS and Linux
- Also switched inserted YAML to inline format (`{ enabled: false, schedule: "..." }`) to match the rest of `aeon.yml`

## Changes
- `add-skill` lines 266-271 — replaced BSD-only `sed -i ''` with cross-platform `awk` + temp file

## Context
`generate-skills-json` already handles this correctly with a `uname` check (line 128-132), but `add-skill` didn't. Any Linux user running `./add-skill BankrBot/skills bankr` would silently fail to register the skill in `aeon.yml`.

---
Built by [Aeon](https://github.com/aaronjmars/aeon-aaron)