### PR TITLE
feat: add star-milestone skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Click on `http://localhost:5555` to open the dashboard in your browser. From the
 | Category | Skills |
 |----------|--------|
 | **Research & Content** (17) | `article`, `digest`, `rss-digest`, `hacker-news-digest`, `paper-digest`, `paper-pick`, `last30`, `deep-research`, `technical-explainer`, `list-digest`, `research-brief`, `fetch-tweets`, `reddit-digest`, `telegram-digest`, `security-digest`, `channel-recap`, `vibecoding-digest` |
-| **Dev & Code** (28) | `pr-review`, `github-monitor`, `github-issues`, `github-releases`, `issue-triage`, `auto-merge`, `changelog`, `code-health`, `skill-security-scan`, `github-trending`, `push-recap`, `repo-pulse`, `repo-article`, `repo-actions`, `repo-scanner`, `project-lens`, `external-feature`, `create-skill`, `autoresearch`, `search-skill`, `auto-workflow`, `deploy-prototype`, `vuln-scanner`, `workflow-security-audit`, `vercel-projects`, `spawn-instance`, `fleet-control`, `fork-fleet` |
+| **Dev & Code** (29) | `pr-review`, `github-monitor`, `github-issues`, `github-releases`, `issue-triage`, `auto-merge`, `changelog`, `code-health`, `skill-security-scan`, `github-trending`, `push-recap`, `repo-pulse`, `star-milestone`, `repo-article`, `repo-actions`, `repo-scanner`, `project-lens`, `external-feature`, `create-skill`, `autoresearch`, `search-skill`, `auto-workflow`, `deploy-prototype`, `vuln-scanner`, `workflow-security-audit`, `vercel-projects`, `spawn-instance`, `fleet-control`, `fork-fleet` |
 | **Crypto & Markets** (16) | `token-alert`, `token-movers`, `token-report`, `token-pick`, `monitor-runners`, `on-chain-monitor`, `defi-monitor`, `defi-overview`, `market-context-refresh`, `narrative-tracker`, `monitor-polymarket`, `monitor-kalshi`, `polymarket-comments`, `unlock-monitor`, `treasury-info`, `distribute-tokens` |
 | **Social & Writing** (7) | `write-tweet`, `reply-maker`, `remix-tweets`, `refresh-x`, `tweet-roundup`, `agent-buzz`, `farcaster-digest` |
 | **Productivity** (12) | `morning-brief`, `daily-routine`, `evening-recap`, `weekly-review`, `weekly-shiplog`, `goal-tracker`, `idea-capture`, `action-converter`, `tool-builder`, `startup-idea`, `deal-flow`, `reg-monitor` |
@@ -266,7 +266,7 @@ Claude only installs and runs when a skill actually matches.
 ```
 CLAUDE.md                ← agent identity (auto-loaded by Claude Code)
 aeon.yml                 ← skill schedules, chains, reactive triggers, and enabled flags
-skills.json              ← machine-readable skill catalog (91 skills)
+skills.json              ← machine-readable skill catalog (92 skills)
 ./aeon                   ← launch the local dashboard (Next.js on port 5555)
 ./notify                 ← multi-channel notifications (Telegram, Discord, Slack, Email, json-render)
 ./notify-jsonrender      ← convert skill output to dashboard feed cards via Haiku
@@ -281,7 +281,7 @@ skills/                  ← each skill is a SKILL.md prompt file
   article/
   digest/
   heartbeat/
-  ...                    ← 91 skills total
+  ...                    ← 92 skills total
 workflows/               ← GitHub Agentic Workflow templates (.md)
 mcp-server/              ← MCP server — exposes skills as Claude tools
 a2a-server/              ← A2A protocol gateway — exposes skills to any agent framework

--- a/aeon.yml
+++ b/aeon.yml
@@ -63,6 +63,7 @@ skills:
   repo-article: { enabled: false, schedule: "0 15 * * *" }
   repo-actions: { enabled: false, schedule: "0 15 * * *" }
   repo-pulse: { enabled: false, schedule: "0 15 * * *" }
+  star-milestone: { enabled: false, schedule: "15 15 * * *" } # daily — announce when watched repos cross star-count milestones
   project-lens: { enabled: false, schedule: "30 15 * * 1,3,5" } # articles through rotating analytical lenses
   repo-scanner: { enabled: false, schedule: "0 15 * * 0", model: "claude-sonnet-4-6", var: "" } # catalog all GitHub repos — set var to username
 

--- a/generate-skills-json
+++ b/generate-skills-json
@@ -35,7 +35,7 @@ get_category() {
     autoresearch|auto-workflow|push-recap|repo-pulse|repo-article|repo-actions) echo "dev" ;;
     repo-scanner|project-lens|external-feature|deploy-prototype|vuln-scanner) echo "dev" ;;
     workflow-security-audit|skill-security-scan|vercel-projects) echo "dev" ;;
-    spawn-instance|fleet-control|fork-fleet) echo "dev" ;;
+    spawn-instance|fleet-control|fork-fleet|star-milestone) echo "dev" ;;
     # Crypto & Markets
     token-alert|token-movers|token-report|token-pick|monitor-runners) echo "crypto" ;;
     on-chain-monitor|defi-monitor|defi-overview|market-context-refresh|narrative-tracker) echo "crypto" ;;

--- a/skills.json
+++ b/skills.json
@@ -1,8 +1,8 @@
 {
     "version": "1.0",
-    "generated": "2026-04-15T16:31:31Z",
+    "generated": "2026-04-18T00:00:00Z",
     "repo": "aaronjmars/aeon",
-    "total": 91,
+    "total": 92,
     "categories": {
         "research": "Research & Content",
         "dev": "Dev & Code",
@@ -874,6 +874,18 @@
             "sha": "ba0143d",
             "updated": "2026-04-15",
             "install": "./add-skill aaronjmars/aeon spawn-instance"
+        },
+        {
+            "slug": "star-milestone",
+            "name": "star-milestone",
+            "description": "Announces when a watched repo crosses a star-count milestone (100, 150, 200, 250, 500, 1000, ...) with a highlight reel of recent work",
+            "category": "dev",
+            "schedule": "15 15 * * *",
+            "var": "",
+            "files": 0,
+            "sha": "",
+            "updated": "2026-04-18",
+            "install": "./add-skill aaronjmars/aeon star-milestone"
         },
         {
             "slug": "startup-idea",

--- a/skills/star-milestone/SKILL.md
+++ b/skills/star-milestone/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: star-milestone
+description: Announces when a watched repo crosses a star-count milestone (100, 150, 200, 250, 500, 1000, ...) with a highlight reel of recent work
+var: ""
+tags: [dev]
+---
+> **${var}** — Repo (`owner/repo`) to check. If empty, checks all watched repos.
+
+Today is ${today}. Detect milestone star-count crossings on watched repos and celebrate them with a bonus notification. Milestones are a shareable social moment — an autonomous "we crossed 200 stars" post at exactly the right audience (operators already watching the repo) is a free word-of-mouth amplifier.
+
+## Thresholds
+
+The skill watches these star-count milestones (in this order):
+
+```
+25, 50, 100, 150, 175, 200, 250, 300, 400, 500, 750, 1000, 1500, 2000, 3000, 5000, 7500, 10000, 15000, 25000, 50000, 100000
+```
+
+## Steps
+
+1. **Load the repo list.** If `${var}` is set, use it as a single repo. Otherwise read `memory/watched-repos.md`. Skip any repo whose name ends with `-aeon` or contains `aeon-agent` (agent repos, not project repos).
+
+2. **Load milestone state.** Read `memory/topics/milestones.md` if present. If absent, treat state as empty. The file has a section per repo listing every milestone recorded so far, one per line:
+
+   ```markdown
+   # Star Milestones
+
+   ## aaronjmars/aeon
+   - 150 stars — 2026-04-01 (bootstrap)
+   - 175 stars — 2026-04-15
+   - 200 stars — 2026-04-19
+   ```
+
+3. **For each repo, fetch the current star count:**
+   ```bash
+   STARS=$(gh api repos/owner/repo --jq '.stargazers_count')
+   ```
+
+4. **Find the highest threshold `M` where `M <= STARS`.** If no threshold is <= current count (e.g. fresh repo with 3 stars), log `STAR_MILESTONE_QUIET: below first threshold` and skip this repo.
+
+5. **Decide whether to announce:**
+   - If `memory/topics/milestones.md` already lists milestone `M` for this repo → no action.
+   - If the repo has **no prior entries** in `milestones.md` → this is the first run. **Bootstrap silently**: record `M` with the `(bootstrap)` suffix. Do NOT send a notification. This prevents retroactive spam on an established repo.
+   - Otherwise → a new milestone was crossed. Proceed to step 6.
+
+6. **Build the highlight reel.** Read the last 14 days of `memory/logs/YYYY-MM-DD.md` (if fewer files exist, use what's available). Extract 3–5 concrete highlights from log sections such as `## Push Recap`, `## Feature Built`, `## Repo Article`, `## Repo Actions`, `## Hyperstitions Ideas`, and `## Changelog`. Prefer items that ship tangible value (merged PRs, new skills, articles) over ongoing monitoring runs. De-duplicate and keep the entries concise (one line each).
+
+   If there are no log entries in the window, use `gh api repos/owner/repo/commits?since=<14d-ago>` to pull recent commit subjects and pick 3 interesting ones.
+
+7. **Send the notification** via `./notify`. Required structure — do not compress this; the message goes to a Telegram group and should stand on its own:
+
+   ```
+   *Milestone — ${M} stars*
+   ${owner/repo}
+
+   [owner/repo] just crossed ${M} stars on GitHub (now at ${STARS}).
+   [1–2 sentences framing why this matters — e.g. "This is the third milestone in 30 days, mirroring the post-launch growth curve since X."]
+
+   Highlights since the last milestone:
+   - [highlight 1]
+   - [highlight 2]
+   - [highlight 3]
+   - [highlight 4 — optional]
+
+   Repo: https://github.com/owner/repo
+   ```
+
+8. **Update `memory/topics/milestones.md`.** Append the new entry under the repo's section. Create the file with a `# Star Milestones` header if it doesn't exist. Keep entries in ascending threshold order per repo.
+
+9. **Log** to `memory/logs/${today}.md`:
+   ```
+   ## Star Milestone
+   - **owner/repo**: stargazers_count=N, milestone crossed: M
+   - **Highlights used:** [count]
+   - **Notification sent:** yes/no (reason if no)
+   ```
+
+## Edge cases
+
+- **Multiple milestones crossed in one run** (e.g. skill was disabled for a long time and the repo jumped from 180 to 260). Announce only the **highest** crossed milestone. Record intermediate ones silently with the `(skipped)` suffix — they're historical anchors but don't deserve individual announcements.
+- **Unstars dropping count below a recorded milestone.** Do not "un-record" milestones. Once crossed, they stay in the file permanently.
+- **Repo deleted / 404 from `gh api`.** Log the error for that repo and continue with the rest of the list. Do not fail the whole run.
+
+## Sandbox note
+
+`gh api` handles auth via the workflow's `GITHUB_TOKEN` automatically, so no env-var curl workaround is needed. The skill writes notifications via `./notify`, which fans out to every configured channel.


### PR DESCRIPTION
## What
New `star-milestone` skill that announces when a watched repo crosses a star-count milestone (25, 50, 100, 150, 175, 200, 250, 300, 400, 500, 750, 1000, 1500, 2000, 3000, 5000, 7500, 10000, 15000, 25000, 50000, 100000). Each announcement includes a short highlight reel of what shipped since the previous milestone, turning a passive metric into a shareable social moment at exactly the audience already watching the repo.

## Why
Source: `articles/repo-actions-2026-04-16.md` idea #3 (Star Milestone Announcer). Aeon has been tracking stars daily via `repo-pulse` but never doing anything with threshold crossings. The repo is sitting at ~189 stars today, meaning the 200-star milestone is imminent — this skill will catch it and produce a natural share moment for the operator. Low ongoing cost, high signal-per-run, fits the pattern of other reactive-like skills already in the tree.

## Changes
- **`skills/star-milestone/SKILL.md`** — new skill definition. Reads watched repos, loads milestone state from `memory/topics/milestones.md`, fetches `stargazers_count` via `gh api`, finds the highest threshold crossed, and emits a detailed notification with 3–5 highlights pulled from the last 14 days of `memory/logs/`. First-run bootstrap logic prevents retroactive spam on established repos (records the already-passed milestone silently).
- **`aeon.yml`** — schedules the skill daily at 15:15 UTC (15 minutes after `repo-pulse` so star counts are fresh).
- **`generate-skills-json`** — adds `star-milestone` to the `dev` category mapping.
- **`README.md`** — adds to the Dev & Code skills row, bumps category count 28→29 and total 91→92.
- **`skills.json`** — adds the manifest entry and bumps `total` to 92 so marketplace discovery picks it up immediately.

## Notes
- Skill is `enabled: false` by default — operators opt in.
- No new secrets required. Uses the existing `GITHUB_TOKEN` path via `gh api`.
- Handles edge cases: multiple milestones crossed in one run (announce highest, record lower ones silently), unstars dropping count (milestones stay recorded), missing repos (log + continue).

---
*Built autonomously by Aeon*