### PR TITLE
feat: add Farcaster syndication to syndicate-article

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -204,6 +204,7 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           DEVTO_API_KEY: ${{ secrets.DEVTO_API_KEY }}
           NEYNAR_API_KEY: ${{ secrets.NEYNAR_API_KEY }}
+          NEYNAR_SIGNER_UUID: ${{ secrets.NEYNAR_SIGNER_UUID }}
           JSONRENDER_ENABLED: ${{ vars.JSONRENDER_ENABLED || 'true' }}
           SKILL_VAR: ${{ inputs.var }}
         run: |
@@ -601,6 +602,9 @@ jobs:
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           REPLICATE_API_TOKEN: ${{ secrets.REPLICATE_API_TOKEN }}
+          DEVTO_API_KEY: ${{ secrets.DEVTO_API_KEY }}
+          NEYNAR_API_KEY: ${{ secrets.NEYNAR_API_KEY }}
+          NEYNAR_SIGNER_UUID: ${{ secrets.NEYNAR_SIGNER_UUID }}
         run: |
           # Run all scripts/postprocess-*.sh after Claude finishes.
           # Each script handles its own .pending-{service}/ directory

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@
 .pending-replicate/
 .pending-supernotes/
 .pending-deploy/
+.pending-devto/
+.pending-farcaster/
 .tg_cache/
 
 # Skill provenance lock (per-repo, not committed)

--- a/dashboard/app/api/secrets/route.ts
+++ b/dashboard/app/api/secrets/route.ts
@@ -16,6 +16,8 @@ const BUILTIN_SECRETS = [
   { name: 'SENDGRID_API_KEY', group: 'Email', description: 'SendGrid API key — create at sendgrid.com/settings/api_keys' },
   { name: 'NOTIFY_EMAIL_TO', group: 'Email', description: 'Recipient email address for skill notifications' },
   { name: 'DEVTO_API_KEY', group: 'Distribution', description: 'Dev.to API key — generate at dev.to/settings/extensions' },
+  { name: 'NEYNAR_API_KEY', group: 'Distribution', description: 'Neynar API key — used by farcaster-digest (read) and syndicate-article (cast)' },
+  { name: 'NEYNAR_SIGNER_UUID', group: 'Distribution', description: 'Neynar managed signer UUID — required to publish Farcaster casts' },
   { name: 'XAI_API_KEY', group: 'Skill Keys', description: 'xAI/Grok API key (for tweet skills)' },
   { name: 'COINGECKO_API_KEY', group: 'Skill Keys', description: 'CoinGecko API key (for crypto skills)' },
   { name: 'ALCHEMY_API_KEY', group: 'Skill Keys', description: 'Alchemy API key (for on-chain skills)' },

--- a/scripts/postprocess-farcaster.sh
+++ b/scripts/postprocess-farcaster.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# postprocess-farcaster.sh — Post pending Farcaster casts after Claude finishes
+# Called automatically by the workflow via: bash scripts/postprocess-farcaster.sh
+#
+# Reads payloads from .pending-farcaster/*.json, injects NEYNAR_SIGNER_UUID,
+# and POSTs to the Neynar cast endpoint. Successful payloads are deleted.
+set -euo pipefail
+
+PENDING_DIR=".pending-farcaster"
+
+if [ ! -d "$PENDING_DIR" ] || [ -z "$(ls -A "$PENDING_DIR" 2>/dev/null)" ]; then
+  exit 0
+fi
+
+if [ -z "${NEYNAR_API_KEY:-}" ]; then
+  echo "postprocess-farcaster: NEYNAR_API_KEY not set, skipping"
+  exit 0
+fi
+
+if [ -z "${NEYNAR_SIGNER_UUID:-}" ]; then
+  echo "postprocess-farcaster: NEYNAR_SIGNER_UUID not set, skipping"
+  exit 0
+fi
+
+for payload in "$PENDING_DIR"/*.json; do
+  [ -f "$payload" ] || continue
+
+  echo "postprocess-farcaster: casting $(basename "$payload")"
+
+  # Inject signer_uuid at post time so the on-disk payload never contains it
+  body=$(jq --arg uuid "$NEYNAR_SIGNER_UUID" '. + {signer_uuid: $uuid}' "$payload")
+
+  response=$(curl -s -w "\n%{http_code}" \
+    -X POST "https://api.neynar.com/v2/farcaster/cast" \
+    -H "Content-Type: application/json" \
+    -H "x-api-key: ${NEYNAR_API_KEY}" \
+    -d "$body")
+
+  http_code=$(echo "$response" | tail -1)
+  resp_body=$(echo "$response" | sed '$d')
+
+  if [ "$http_code" = "200" ]; then
+    hash=$(echo "$resp_body" | jq -r '.cast.hash // empty')
+    author=$(echo "$resp_body" | jq -r '.cast.author.username // empty')
+    if [ -n "$hash" ] && [ -n "$author" ]; then
+      echo "postprocess-farcaster: published → https://warpcast.com/${author}/${hash:0:10}"
+    else
+      echo "postprocess-farcaster: published (hash=$hash)"
+    fi
+    rm -f "$payload"
+  elif [ "$http_code" = "400" ] || [ "$http_code" = "422" ]; then
+    echo "postprocess-farcaster: validation error or duplicate, removing payload"
+    echo "$resp_body"
+    rm -f "$payload"
+  elif [ "$http_code" = "401" ] || [ "$http_code" = "403" ]; then
+    echo "postprocess-farcaster: auth error (HTTP $http_code) — check NEYNAR_API_KEY / NEYNAR_SIGNER_UUID"
+    echo "$resp_body"
+    exit 0
+  else
+    echo "postprocess-farcaster: failed with HTTP $http_code"
+    echo "$resp_body"
+  fi
+done
+
+# Clean up empty directory
+rmdir "$PENDING_DIR" 2>/dev/null || true

--- a/skills/syndicate-article/SKILL.md
+++ b/skills/syndicate-article/SKILL.md
@@ -1,27 +1,32 @@
 ---
 name: syndicate-article
-description: Cross-post articles to Dev.to for wider developer reach
+description: Cross-post articles to Dev.to and Farcaster for wider developer and crypto-native reach
 var: ""
 tags: [content, growth]
 ---
 > **${var}** — Filename of a specific article to syndicate (e.g. `repo-article-2026-04-16.md`). If empty, syndicates the most recently written article.
 
-Cross-post Aeon articles to [Dev.to](https://dev.to) for organic developer discovery. Articles are published with a canonical URL pointing back to the GitHub Pages gallery, preserving SEO attribution.
+Cross-post Aeon articles to [Dev.to](https://dev.to) (developer audience) and [Farcaster](https://warpcast.com) (crypto-native audience) for organic discovery. Articles are published with a canonical URL pointing back to the GitHub Pages gallery, preserving SEO attribution.
+
+Each channel is opt-in — set the relevant secrets and it activates. If neither is configured, the skill logs a skip and exits silently.
 
 ## Prerequisites
 
-- `DEVTO_API_KEY` — Dev.to API key. Generate at https://dev.to/settings/extensions (scroll to "DEV Community API Keys"). If not set, the skill logs a skip and exits silently — no error, no notification.
+- `DEVTO_API_KEY` — Dev.to API key. Generate at https://dev.to/settings/extensions (scroll to "DEV Community API Keys").
+- `NEYNAR_API_KEY` + `NEYNAR_SIGNER_UUID` — Neynar credentials for Farcaster posting. Get an API key at [neynar.com](https://neynar.com) and create a managed signer to obtain the signer UUID.
+
+If none of `DEVTO_API_KEY` or `NEYNAR_SIGNER_UUID` are set, the skill logs a skip and exits silently — no error, no notification.
 
 ## Steps
 
-1. **Check for API key** — verify `DEVTO_API_KEY` is available:
+1. **Check for at least one API key** — verify at least one syndication channel is configured:
    ```bash
-   if [ -z "$DEVTO_API_KEY" ]; then
-     echo "SYNDICATE_SKIP: DEVTO_API_KEY not configured"
+   if [ -z "$DEVTO_API_KEY" ] && [ -z "$NEYNAR_SIGNER_UUID" ]; then
+     echo "SYNDICATE_SKIP: no syndication channels configured"
      exit 0
    fi
    ```
-   If missing, log "SYNDICATE_SKIP: DEVTO_API_KEY not configured" to `memory/logs/${today}.md` and stop. Do NOT send any notification.
+   If all missing, log "SYNDICATE_SKIP: no syndication channels configured" to `memory/logs/${today}.md` and stop. Do NOT send any notification.
 
 2. **Select the article to syndicate:**
    - If `${var}` is set, use `articles/${var}` directly.
@@ -31,9 +36,10 @@ Cross-post Aeon articles to [Dev.to](https://dev.to) for organic developer disco
      ```
    - If no articles exist, log "SYNDICATE_SKIP: no articles found" and stop.
 
-3. **Check for duplicates** — before posting, check if this article was already syndicated:
-   - Search the last 7 days of `memory/logs/` for `SYNDICATED:` entries containing this filename.
-   - If found, log "SYNDICATE_SKIP: already syndicated {filename}" and stop.
+3. **Check for duplicates** — before posting, check if this article was already syndicated on each channel:
+   - Search the last 7 days of `memory/logs/` for `SYNDICATED:` (Dev.to) and `FARCAST:` (Farcaster) entries containing this filename.
+   - Track per-channel: if Dev.to already posted, skip Dev.to step but still attempt Farcaster (and vice versa).
+   - If both already posted, log "SYNDICATE_SKIP: already syndicated {filename} to all channels" and stop.
 
 4. **Parse the article:**
    - **Title**: Extract from the first `# Heading` line. If the article has Jekyll frontmatter with a `title:` field, use that instead.
@@ -41,61 +47,101 @@ Cross-post Aeon articles to [Dev.to](https://dev.to) for organic developer disco
    - **Date**: Extract `YYYY-MM-DD` from the filename using regex `([0-9]{4}-[0-9]{2}-[0-9]{2})`.
    - **Slug**: Everything before the date in the filename, with trailing hyphens removed.
 
-5. **Determine tags** from the filename slug (max 4 tags for Dev.to):
-   - `repo-article`, `article` → `ai, github, automation, agents`
-   - `token-report`, `token-alert`, `defi-overview`, `defi-monitor` → `crypto, defi, blockchain, trading`
-   - `changelog`, `push-recap`, `weekly-shiplog` → `opensource, devops, changelog, github`
-   - `digest`, `rss-digest`, `hacker-news` → `news, tech, ai, digest`
-   - `deep-research`, `research-brief`, `paper-pick` → `research, ai, machinelearning, papers`
-   - `technical-explainer` → `tutorial, ai, explainer, programming`
-   - Everything else → `ai, automation, agents, programming`
-
-6. **Build the canonical URL** pointing to the GitHub Pages post:
+5. **Build the canonical URL** pointing to the GitHub Pages post:
    ```
    https://aaronjmars.github.io/aeon/articles/YYYY/MM/DD/<slug>/
    ```
    Where `<slug>` is derived the same way `update-gallery` builds Jekyll post filenames: title lowercased, spaces replaced with hyphens, special characters removed, truncated to 50 chars.
 
-7. **Post to Dev.to** using WebFetch (not curl, due to sandbox auth limitations):
-   - Use WebFetch to POST to `https://dev.to/api/articles` with headers:
-     - `Content-Type: application/json`
-     - `api-key: <DEVTO_API_KEY>`
-   - Request body:
-     ```json
-     {
-       "article": {
-         "title": "<extracted title>",
-         "body_markdown": "<article body>",
-         "published": true,
-         "tags": ["tag1", "tag2", "tag3", "tag4"],
-         "canonical_url": "<github pages URL>",
-         "series": "Aeon"
-       }
-     }
-     ```
-   - Parse the response for the `url` field (the Dev.to article URL) and `id`.
-   - **If WebFetch cannot send POST requests with custom headers**, fall back to the post-process pattern (see Sandbox note).
+6. **If `DEVTO_API_KEY` is set and Dev.to not yet syndicated, post to Dev.to.**
 
-8. **Handle errors:**
-   - If the API returns 422 (title already taken / duplicate), log "SYNDICATE_SKIP: article already exists on Dev.to" and stop gracefully.
-   - If the API returns 401, log "SYNDICATE_ERROR: DEVTO_API_KEY is invalid" and stop.
-   - If any other error, log the status code and response body.
+   a. Determine tags from the filename slug (max 4 tags for Dev.to):
+      - `repo-article`, `article` → `ai, github, automation, agents`
+      - `token-report`, `token-alert`, `defi-overview`, `defi-monitor` → `crypto, defi, blockchain, trading`
+      - `changelog`, `push-recap`, `weekly-shiplog` → `opensource, devops, changelog, github`
+      - `digest`, `rss-digest`, `hacker-news` → `news, tech, ai, digest`
+      - `deep-research`, `research-brief`, `paper-pick` → `research, ai, machinelearning, papers`
+      - `technical-explainer` → `tutorial, ai, explainer, programming`
+      - Everything else → `ai, automation, agents, programming`
 
-9. **Log the result** to `memory/logs/${today}.md`:
+   b. Post to Dev.to using WebFetch (not curl, due to sandbox auth limitations):
+      - URL: `https://dev.to/api/articles`
+      - Method: POST
+      - Headers: `Content-Type: application/json`, `api-key: <DEVTO_API_KEY>`
+      - Body:
+        ```json
+        {
+          "article": {
+            "title": "<extracted title>",
+            "body_markdown": "<article body>",
+            "published": true,
+            "tags": ["tag1", "tag2", "tag3", "tag4"],
+            "canonical_url": "<github pages URL>",
+            "series": "Aeon"
+          }
+        }
+        ```
+      - If WebFetch cannot pass custom headers, fall back to the post-process pattern: write the payload to `.pending-devto/post.json` and let `scripts/postprocess-devto.sh` execute the API call after Claude finishes.
+
+   c. Handle errors:
+      - 422: log "SYNDICATE_SKIP: article already exists on Dev.to" and continue to Farcaster step.
+      - 401: log "SYNDICATE_ERROR: DEVTO_API_KEY is invalid" and continue to Farcaster step.
+      - Other: log status code and body, continue.
+
+   d. On success, record in `memory/logs/${today}.md`:
+      ```
+      SYNDICATED: {filename} → {devto_url}
+      ```
+
+7. **If `NEYNAR_SIGNER_UUID` is set and Farcaster not yet syndicated, queue a Farcaster cast.**
+
+   a. Build the cast text (keep under 300 bytes to leave room for URL unfurl):
+      ```
+      New post: <title truncated to 200 chars>
+
+      <canonical_url>
+      ```
+
+   b. Write the payload to `.pending-farcaster/<slug>-<date>.json` — do NOT include `NEYNAR_SIGNER_UUID`; the postprocess script injects it from env at post time:
+      ```json
+      {
+        "text": "<cast text>",
+        "embeds": [{"url": "<canonical_url>"}]
+      }
+      ```
+      Use `mkdir -p .pending-farcaster/` first. The filename pattern `<slug>-<date>.json` prevents collisions across runs.
+
+   c. The cast is posted after Claude finishes by `scripts/postprocess-farcaster.sh` — it reads each JSON payload, POSTs to `https://api.neynar.com/v2/farcaster/cast` with `x-api-key: $NEYNAR_API_KEY`, and removes the payload on success. No further action needed from this skill.
+
+   d. Record in `memory/logs/${today}.md` (the cast URL is only known post-run, so log the queued intent):
+      ```
+      FARCAST: {filename} → queued (canonical: {canonical_url})
+      ```
+
+8. **Send notification** via `./notify` summarising what shipped.
+
+   If Dev.to published:
    ```
-   SYNDICATED: {filename} → {devto_url}
+   Article syndicated
+
+   "{article title}" is now live on Dev.to (1M+ developers) and queued for Farcaster (crypto-native reach).
+
+   Dev.to: {devto_url}
+   Original: {canonical_url}
    ```
 
-10. **Send notification** via `./notify`:
-    ```
-    Article syndicated to Dev.to
+   If only Farcaster queued (Dev.to skipped or failed):
+   ```
+   Article syndicated to Farcaster
 
-    "{article title}" is now live on Dev.to, reaching 1M+ developers beyond our GitHub Pages audience.
+   "{article title}" is queued for Farcaster — a cast will publish when the post-process hook runs.
 
-    Dev.to: {devto_url}
-    Original: {canonical_url}
-    ```
+   Original: {canonical_url}
+   ```
+
+   If nothing published, do NOT send a notification.
 
 ## Sandbox note
 
-The Dev.to API requires `DEVTO_API_KEY` in request headers. Since the sandbox blocks env var expansion in curl headers, use **WebFetch** for the API call — WebFetch can make authenticated HTTP requests. If WebFetch cannot pass custom headers, fall back to the post-process pattern: write the request payload to `.pending-devto/post.json` and let `scripts/postprocess-devto.sh` execute the actual API call after Claude finishes.
+- **Dev.to**: `DEVTO_API_KEY` goes in request headers. Since the sandbox blocks env var expansion in curl headers, use **WebFetch** for the API call. If WebFetch cannot pass custom headers, fall back to writing `.pending-devto/post.json` and letting `scripts/postprocess-devto.sh` execute the call after Claude finishes.
+- **Farcaster**: Always uses the post-process pattern. The skill writes `.pending-farcaster/<slug>-<date>.json` during its run; `scripts/postprocess-farcaster.sh` reads the payload outside the sandbox, injects `NEYNAR_SIGNER_UUID` from env, and POSTs to Neynar. This means the signer UUID never touches any on-disk file.


### PR DESCRIPTION
## What
Extends the existing `syndicate-article` skill to also cross-post Aeon articles to **Farcaster** via the Neynar API. Every article that goes to Dev.to can now also land as a Farcaster cast in parallel — mirroring the existing Dev.to post-process pattern.

## Why
Dev.to reaches the developer audience; Farcaster reaches the crypto-native audience that overlaps most directly with AEON token holders and DeFi users. With the token in breakout territory (+109% 7d) and 189 stars, extending syndication into the channel where this audience already lives is a zero-overhead growth lever. This is idea #2 from `articles/repo-actions-2026-04-16.md`.

## Changes
- **`scripts/postprocess-farcaster.sh`** (new): reads `.pending-farcaster/*.json`, injects `NEYNAR_SIGNER_UUID` from env at post time, and POSTs to `https://api.neynar.com/v2/farcaster/cast` with the `x-api-key: $NEYNAR_API_KEY` header. Cleans up payloads on success; removes the empty directory when done. Handles 400/422 (duplicate/validation), 401/403 (auth), and other non-fatal errors.
- **`skills/syndicate-article/SKILL.md`**: reworked to treat Dev.to and Farcaster as independent channels — setting either secret activates that channel. Each channel has its own duplicate check (`SYNDICATED:` for Dev.to, `FARCAST:` for Farcaster) so they don't double-post across runs. The skill writes the Farcaster payload (without signer UUID) to `.pending-farcaster/<slug>-<date>.json` during its run.
- **`.github/workflows/aeon.yml`**: passes `NEYNAR_SIGNER_UUID` to the Claude step and passes `DEVTO_API_KEY`, `NEYNAR_API_KEY`, `NEYNAR_SIGNER_UUID` to the post-process step. The Dev.to key was previously missing from the post-process env block, which meant `postprocess-devto.sh` was always skipping — this PR fixes that as a drive-by.
- **`dashboard/app/api/secrets/route.ts`**: adds `NEYNAR_API_KEY` and `NEYNAR_SIGNER_UUID` to the `Distribution` group so operators can configure them from the dashboard Secrets panel.
- **`.gitignore`**: adds `.pending-devto/` and `.pending-farcaster/` so failed/retained payloads never accidentally land in a commit.

## Sandbox note
Farcaster posting always uses the post-process pattern (never inline from the skill), which means:
1. The signer UUID never touches any on-disk file — it's injected from env at POST time.
2. No curl-with-header sandbox issues during the skill run — the skill only writes a JSON payload.
3. If Neynar is unreachable, the payload sits in `.pending-farcaster/` for the next workflow run to retry.

## Test plan
- [ ] Verify `scripts/postprocess-farcaster.sh` is idempotent when `.pending-farcaster/` is empty (exits 0)
- [ ] Verify it skips cleanly when `NEYNAR_API_KEY` or `NEYNAR_SIGNER_UUID` are unset
- [ ] With both secrets set, trigger `syndicate-article` on a recent article and confirm a cast appears on the configured Farcaster account
- [ ] Confirm duplicate detection works across channels (running twice only posts once per channel)

---
*Built autonomously by Aeon*