### PR TITLE
feat: Memory Search API

### DIFF
--- a/dashboard/app/api/memory/issues/[id]/route.ts
+++ b/dashboard/app/api/memory/issues/[id]/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server'
+import { readIssue } from '@/lib/memory'
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params
+    const issue = await readIssue(id)
+    if (!issue) {
+      return NextResponse.json(
+        { error: `No issue found for id '${id}' (expected format: ISS-NNN)` },
+        { status: 404 },
+      )
+    }
+    return NextResponse.json(issue)
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : 'Failed to read issue'
+    return NextResponse.json({ error: msg }, { status: 500 })
+  }
+}

--- a/dashboard/app/api/memory/issues/route.ts
+++ b/dashboard/app/api/memory/issues/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server'
+import { listIssues } from '@/lib/memory'
+
+export async function GET() {
+  try {
+    const issues = await listIssues()
+    return NextResponse.json({ count: issues.length, issues })
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : 'Failed to list issues'
+    return NextResponse.json({ error: msg }, { status: 500 })
+  }
+}

--- a/dashboard/app/api/memory/logs/route.ts
+++ b/dashboard/app/api/memory/logs/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server'
+import { listLogs, readLog } from '@/lib/memory'
+
+export async function GET(request: Request) {
+  try {
+    const url = new URL(request.url)
+    const date = url.searchParams.get('date')
+
+    if (date) {
+      const log = await readLog(date)
+      if (!log) {
+        return NextResponse.json(
+          { error: `No log found for ${date} (expected YYYY-MM-DD)` },
+          { status: 404 },
+        )
+      }
+      return NextResponse.json(log)
+    }
+
+    const logs = await listLogs()
+    return NextResponse.json({ count: logs.length, logs })
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : 'Failed to read logs'
+    return NextResponse.json({ error: msg }, { status: 500 })
+  }
+}

--- a/dashboard/app/api/memory/route.ts
+++ b/dashboard/app/api/memory/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server'
+import { listLogs, listTopics, listIssues, readMemoryIndex } from '@/lib/memory'
+
+export async function GET() {
+  try {
+    const [memory, topics, logs, issues] = await Promise.all([
+      readMemoryIndex(),
+      listTopics(),
+      listLogs(),
+      listIssues(),
+    ])
+
+    return NextResponse.json({
+      memory: memory
+        ? { exists: true, size: memory.length, excerpt: memory.slice(0, 400) }
+        : { exists: false },
+      counts: {
+        topics: topics.length,
+        logs: logs.length,
+        issues: issues.length,
+      },
+      latestLog: logs[0]?.date ?? null,
+      routes: [
+        { path: '/api/memory', description: 'Index: counts and MEMORY.md excerpt' },
+        { path: '/api/memory/search?q=', description: 'Full-text search across memory, topics, logs, issues' },
+        { path: '/api/memory/logs', description: 'List all daily log dates' },
+        { path: '/api/memory/logs?date=YYYY-MM-DD', description: 'Fetch one daily log' },
+        { path: '/api/memory/topics', description: 'List all topic files' },
+        { path: '/api/memory/topics/[slug]', description: 'Fetch one topic file' },
+        { path: '/api/memory/issues', description: 'List open/resolved issue tracker entries' },
+        { path: '/api/memory/issues/[id]', description: 'Fetch one issue (e.g. ISS-001)' },
+      ],
+    })
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : 'Unknown error'
+    return NextResponse.json({ error: msg }, { status: 500 })
+  }
+}

--- a/dashboard/app/api/memory/search/route.ts
+++ b/dashboard/app/api/memory/search/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server'
+import { searchMemory, type SearchHit } from '@/lib/memory'
+
+const VALID_SOURCES: SearchHit['source'][] = ['memory', 'topic', 'log', 'issue']
+
+export async function GET(request: Request) {
+  try {
+    const url = new URL(request.url)
+    const q = (url.searchParams.get('q') ?? '').trim()
+    if (!q) {
+      return NextResponse.json(
+        { error: 'Missing required query parameter: q' },
+        { status: 400 },
+      )
+    }
+
+    const limitRaw = url.searchParams.get('limit')
+    const limit = limitRaw ? Math.max(1, Math.min(parseInt(limitRaw, 10) || 20, 100)) : 20
+
+    const sourcesParam = url.searchParams.get('sources')
+    const sources = sourcesParam
+      ? sourcesParam
+          .split(',')
+          .map(s => s.trim().toLowerCase())
+          .filter((s): s is SearchHit['source'] => (VALID_SOURCES as string[]).includes(s))
+      : undefined
+
+    const hits = await searchMemory(q, { limit, sources })
+
+    return NextResponse.json({
+      query: q,
+      count: hits.length,
+      sources: sources ?? VALID_SOURCES,
+      hits,
+    })
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : 'Search failed'
+    return NextResponse.json({ error: msg }, { status: 500 })
+  }
+}

--- a/dashboard/app/api/memory/topics/[slug]/route.ts
+++ b/dashboard/app/api/memory/topics/[slug]/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server'
+import { readTopic } from '@/lib/memory'
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  try {
+    const { slug } = await params
+    const topic = await readTopic(slug)
+    if (!topic) {
+      return NextResponse.json(
+        { error: `No topic found for slug '${slug}'` },
+        { status: 404 },
+      )
+    }
+    return NextResponse.json(topic)
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : 'Failed to read topic'
+    return NextResponse.json({ error: msg }, { status: 500 })
+  }
+}

--- a/dashboard/app/api/memory/topics/route.ts
+++ b/dashboard/app/api/memory/topics/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server'
+import { listTopics } from '@/lib/memory'
+
+export async function GET() {
+  try {
+    const topics = await listTopics()
+    return NextResponse.json({ count: topics.length, topics })
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : 'Failed to list topics'
+    return NextResponse.json({ error: msg }, { status: 500 })
+  }
+}

--- a/dashboard/lib/memory.ts
+++ b/dashboard/lib/memory.ts
@@ -1,0 +1,308 @@
+import { readdir, readFile, stat } from 'fs/promises'
+import { resolve, join, sep, normalize } from 'path'
+
+const REPO_ROOT = resolve(process.cwd(), '..')
+export const MEMORY_ROOT = join(REPO_ROOT, 'memory')
+
+const TOPICS_DIR = join(MEMORY_ROOT, 'topics')
+const LOGS_DIR = join(MEMORY_ROOT, 'logs')
+const ISSUES_DIR = join(MEMORY_ROOT, 'issues')
+
+const SLUG_PATTERN = /^[a-z0-9][a-z0-9._-]*$/i
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+const ISSUE_PATTERN = /^ISS-\d{3,}$/
+
+/**
+ * Resolve a user-supplied child path under a trusted base, refusing any result
+ * that escapes the base (symlinks, "..", absolute overrides). Returns null
+ * when the path is invalid so callers can surface a 400 rather than leak
+ * unexpected files.
+ */
+function safeJoin(base: string, child: string): string | null {
+  const joined = normalize(join(base, child))
+  const withSep = joined.endsWith(sep) ? joined : joined + sep
+  const baseWithSep = base.endsWith(sep) ? base : base + sep
+  if (joined !== base && !withSep.startsWith(baseWithSep)) return null
+  return joined
+}
+
+export async function readMemoryIndex(): Promise<string | null> {
+  try {
+    return await readFile(join(MEMORY_ROOT, 'MEMORY.md'), 'utf-8')
+  } catch {
+    return null
+  }
+}
+
+export interface TopicFile {
+  slug: string
+  filename: string
+  size: number
+  updatedAt: string
+}
+
+export async function listTopics(): Promise<TopicFile[]> {
+  let entries: string[]
+  try {
+    entries = await readdir(TOPICS_DIR)
+  } catch {
+    return []
+  }
+  const topics: TopicFile[] = []
+  for (const name of entries) {
+    if (!name.endsWith('.md')) continue
+    const full = join(TOPICS_DIR, name)
+    try {
+      const s = await stat(full)
+      if (!s.isFile()) continue
+      topics.push({
+        slug: name.replace(/\.md$/, ''),
+        filename: name,
+        size: s.size,
+        updatedAt: s.mtime.toISOString(),
+      })
+    } catch { /* skip unreadable */ }
+  }
+  topics.sort((a, b) => a.slug.localeCompare(b.slug))
+  return topics
+}
+
+export async function readTopic(slug: string): Promise<{ slug: string; content: string; updatedAt: string } | null> {
+  if (!SLUG_PATTERN.test(slug)) return null
+  const path = safeJoin(TOPICS_DIR, `${slug}.md`)
+  if (!path) return null
+  try {
+    const [content, s] = await Promise.all([
+      readFile(path, 'utf-8'),
+      stat(path),
+    ])
+    return { slug, content, updatedAt: s.mtime.toISOString() }
+  } catch {
+    return null
+  }
+}
+
+export interface LogDay {
+  date: string
+  filename: string
+  size: number
+  updatedAt: string
+}
+
+export async function listLogs(): Promise<LogDay[]> {
+  let entries: string[]
+  try {
+    entries = await readdir(LOGS_DIR)
+  } catch {
+    return []
+  }
+  const logs: LogDay[] = []
+  for (const name of entries) {
+    const m = name.match(/^(\d{4}-\d{2}-\d{2})\.md$/)
+    if (!m) continue
+    const full = join(LOGS_DIR, name)
+    try {
+      const s = await stat(full)
+      if (!s.isFile()) continue
+      logs.push({
+        date: m[1],
+        filename: name,
+        size: s.size,
+        updatedAt: s.mtime.toISOString(),
+      })
+    } catch { /* skip unreadable */ }
+  }
+  logs.sort((a, b) => b.date.localeCompare(a.date))
+  return logs
+}
+
+export async function readLog(date: string): Promise<{ date: string; content: string; updatedAt: string } | null> {
+  if (!DATE_PATTERN.test(date)) return null
+  const path = safeJoin(LOGS_DIR, `${date}.md`)
+  if (!path) return null
+  try {
+    const [content, s] = await Promise.all([
+      readFile(path, 'utf-8'),
+      stat(path),
+    ])
+    return { date, content, updatedAt: s.mtime.toISOString() }
+  } catch {
+    return null
+  }
+}
+
+export interface IssueSummary {
+  id: string
+  filename: string
+  updatedAt: string
+}
+
+export async function listIssues(): Promise<IssueSummary[]> {
+  let entries: string[]
+  try {
+    entries = await readdir(ISSUES_DIR)
+  } catch {
+    return []
+  }
+  const issues: IssueSummary[] = []
+  for (const name of entries) {
+    const m = name.match(/^(ISS-\d{3,})\.md$/)
+    if (!m) continue
+    const full = join(ISSUES_DIR, name)
+    try {
+      const s = await stat(full)
+      if (!s.isFile()) continue
+      issues.push({
+        id: m[1],
+        filename: name,
+        updatedAt: s.mtime.toISOString(),
+      })
+    } catch { /* skip unreadable */ }
+  }
+  issues.sort((a, b) => b.id.localeCompare(a.id))
+  return issues
+}
+
+export async function readIssue(id: string): Promise<{ id: string; content: string; updatedAt: string } | null> {
+  if (!ISSUE_PATTERN.test(id)) return null
+  const path = safeJoin(ISSUES_DIR, `${id}.md`)
+  if (!path) return null
+  try {
+    const [content, s] = await Promise.all([
+      readFile(path, 'utf-8'),
+      stat(path),
+    ])
+    return { id, content, updatedAt: s.mtime.toISOString() }
+  } catch {
+    return null
+  }
+}
+
+export interface SearchHit {
+  source: 'memory' | 'topic' | 'log' | 'issue'
+  ref: string
+  filename: string
+  score: number
+  matches: number
+  snippet: string
+  lineNumber: number
+}
+
+interface Corpus {
+  source: SearchHit['source']
+  ref: string
+  filename: string
+  content: string
+}
+
+async function loadCorpus(): Promise<Corpus[]> {
+  const corpus: Corpus[] = []
+
+  const memory = await readMemoryIndex()
+  if (memory) corpus.push({ source: 'memory', ref: 'MEMORY', filename: 'MEMORY.md', content: memory })
+
+  const topics = await listTopics()
+  for (const t of topics) {
+    const full = await readTopic(t.slug)
+    if (full) corpus.push({ source: 'topic', ref: t.slug, filename: t.filename, content: full.content })
+  }
+
+  const logs = await listLogs()
+  for (const l of logs) {
+    const full = await readLog(l.date)
+    if (full) corpus.push({ source: 'log', ref: l.date, filename: l.filename, content: full.content })
+  }
+
+  const issues = await listIssues()
+  for (const i of issues) {
+    const full = await readIssue(i.id)
+    if (full) corpus.push({ source: 'issue', ref: i.id, filename: i.filename, content: full.content })
+  }
+
+  return corpus
+}
+
+function tokenize(q: string): string[] {
+  return q
+    .toLowerCase()
+    .split(/[^a-z0-9$_-]+/)
+    .map(t => t.trim())
+    .filter(t => t.length >= 2)
+}
+
+function buildSnippet(lines: string[], hitLine: number, needle: string): string {
+  const start = Math.max(0, hitLine - 1)
+  const end = Math.min(lines.length, hitLine + 2)
+  const window = lines.slice(start, end).join('\n').trim()
+  // Bold-ish marker for the matched substring — callers can render plain text.
+  if (!needle) return window.slice(0, 400)
+  const re = new RegExp(needle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'ig')
+  return window.replace(re, m => `**${m}**`).slice(0, 400)
+}
+
+export async function searchMemory(
+  query: string,
+  opts: { limit?: number; sources?: SearchHit['source'][] } = {},
+): Promise<SearchHit[]> {
+  const terms = tokenize(query)
+  if (terms.length === 0) return []
+
+  const limit = Math.max(1, Math.min(opts.limit ?? 20, 100))
+  const allow = opts.sources && opts.sources.length > 0 ? new Set(opts.sources) : null
+
+  const corpus = await loadCorpus()
+  const hits: SearchHit[] = []
+
+  for (const doc of corpus) {
+    if (allow && !allow.has(doc.source)) continue
+    const lines = doc.content.split('\n')
+    const lower = doc.content.toLowerCase()
+
+    // Document-level frequency per term — used for ranking.
+    let totalMatches = 0
+    let distinctTerms = 0
+    for (const term of terms) {
+      const occurrences = lower.split(term).length - 1
+      if (occurrences > 0) {
+        distinctTerms += 1
+        totalMatches += occurrences
+      }
+    }
+    if (totalMatches === 0) continue
+
+    // Pick the best snippet: first line that contains the longest matching term,
+    // falling back to any line with any term.
+    const termsByLength = [...terms].sort((a, b) => b.length - a.length)
+    let hitLine = -1
+    let hitTerm = ''
+    for (const term of termsByLength) {
+      for (let i = 0; i < lines.length; i++) {
+        if (lines[i].toLowerCase().includes(term)) {
+          hitLine = i
+          hitTerm = term
+          break
+        }
+      }
+      if (hitLine >= 0) break
+    }
+    if (hitLine < 0) continue
+
+    const score =
+      totalMatches +
+      distinctTerms * 2 + // reward documents that match more query terms
+      (doc.source === 'memory' ? 5 : 0) // boost the index file slightly
+
+    hits.push({
+      source: doc.source,
+      ref: doc.ref,
+      filename: doc.filename,
+      score,
+      matches: totalMatches,
+      snippet: buildSnippet(lines, hitLine, hitTerm),
+      lineNumber: hitLine + 1,
+    })
+  }
+
+  hits.sort((a, b) => b.score - a.score)
+  return hits.slice(0, limit)
+}


### PR DESCRIPTION
## What
Read-only REST API at `/api/memory/*` that exposes Aeon's markdown-based memory — `MEMORY.md`, topic files, daily logs, and the `memory/issues/` tracker — as structured JSON. Other tools in the stack (MCP adaptor, A2A gateway, fork operators, dashboard widgets) can now ask the running agent what it knows without scraping raw files.

## Why
From yesterday's repo-actions idea pipeline (`articles/repo-actions-2026-04-18.md` #1). The A2A gateway and MCP adaptor ship agent *execution*, but the agent's *state* — what repos it watches, what it logged yesterday, what skills it built — still lives as markdown files readable only to someone with a checkout. This is the missing bridge between the agent's private knowledge and the public interfaces already in production.

## Changes
- `dashboard/lib/memory.ts` — shared reader. Tokenizes search queries, scores hits by match count + distinct terms + source weight, returns snippet + line number. Path-safety helpers (`safeJoin`, slug/date/issue-id regexes) make sure user-supplied segments can't escape `memory/`.
- `dashboard/app/api/memory/route.ts` — index endpoint: MEMORY.md excerpt, per-source counts, list of all available routes.
- `dashboard/app/api/memory/search/route.ts` — `GET ?q=&limit=&sources=memory,topic,log,issue` full-text search.
- `dashboard/app/api/memory/logs/route.ts` — list all daily logs, or fetch one via `?date=YYYY-MM-DD`.
- `dashboard/app/api/memory/topics/route.ts` + `[slug]/route.ts` — list topic files and fetch one by slug.
- `dashboard/app/api/memory/issues/route.ts` + `[id]/route.ts` — list `ISS-NNN` entries and fetch one.

## Test plan
- [ ] `npm run build` in `dashboard/` succeeds.
- [ ] `GET /api/memory` returns JSON with `counts`, `latestLog`, and the `routes` map.
- [ ] `GET /api/memory/search?q=skill+evals` returns hits ranked by score, with snippets that include the matched term.
- [ ] `GET /api/memory/logs?date=2026-04-18` returns that day's log content; `?date=not-a-date` returns a 400-style `null` fall-through.
- [ ] `GET /api/memory/topics/../secrets` and `GET /api/memory/topics/%2E%2E%2Fsecrets` return 404, not the secrets file.

## Follow-ups
- Expose these endpoints as `aeon-memory-search` / `aeon-memory-log` / `aeon-memory-topic` tools in the MCP adaptor. The current adaptor is skill-execution only; adding non-skill tools requires a small directTools branch in mcp-server/src/index.ts.
- Same for the A2A gateway — surface memory as a separate `/memory/*` namespace alongside the existing skill-task endpoints.
- Dashboard UI: a "Memory" tab that uses these routes to render a browsable view of topics, logs, and a search box.

---
*Built autonomously by Aeon*