### PR TITLE
fix(fetch-tweets): prefetch timeout + workflow var expansion

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -163,12 +163,15 @@ jobs:
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           REPLICATE_API_TOKEN: ${{ secrets.REPLICATE_API_TOKEN }}
+          SKILL_VAR: ${{ inputs.var }}
         run: |
           # Run all scripts/prefetch-*.sh before Claude starts (outside sandbox).
           # Each script receives the skill name and var as arguments.
           # Scripts should check their own env vars and exit 0 if not configured.
+          # SKILL_VAR comes through env (not template interpolation) so embedded
+          # $TOKEN / $VAR references in the user input aren't eaten by bash.
           SKILL="${{ steps.skill.outputs.name }}"
-          VAR="${{ inputs.var }}"
+          VAR="$SKILL_VAR"
           for script in scripts/prefetch-*.sh; do
             [ -f "$script" ] || continue
             chmod +x "$script"

--- a/scripts/prefetch-xai.sh
+++ b/scripts/prefetch-xai.sh
@@ -49,13 +49,20 @@ xai_search() {
     '{model: $model, input: [{role: "user", content: $prompt}], tools: $tools}')
   local attempt=1
   while : ; do
-    response=$(curl -s --max-time 60 -w "\n__HTTP_CODE__%{http_code}" -X POST "https://api.x.ai/v1/responses" \
+    local curl_exit=0
+    response=$(curl -s --max-time 180 -w "\n__HTTP_CODE__%{http_code}" -X POST "https://api.x.ai/v1/responses" \
       -H "Content-Type: application/json" \
       -H "Authorization: Bearer $XAI_API_KEY" \
-      -d "$body" 2>&1) || {
-      echo "::warning::xai-prefetch: FAILED $outfile (curl error: $?)"
+      -d "$body" 2>&1) || curl_exit=$?
+    if [ "$curl_exit" -ne 0 ]; then
+      if [ "$curl_exit" = "28" ] && [ "$attempt" -lt 2 ]; then
+        echo "xai-prefetch: curl timeout on $outfile (attempt $attempt), retrying once"
+        attempt=$((attempt + 1))
+        continue
+      fi
+      echo "::warning::xai-prefetch: FAILED $outfile (curl error: $curl_exit)"
       return 1
-    }
+    fi
     http_code=$(echo "$response" | grep '__HTTP_CODE__' | sed 's/__HTTP_CODE__//')
     response=$(echo "$response" | grep -v '__HTTP_CODE__')
     if [ "$http_code" = "429" ] && [ "$attempt" -lt 2 ]; then


### PR DESCRIPTION
## Why this exists

`fetch-tweets` has been silently returning empty results on every live instance (aeon-agent, miroshark-aeon) for days. Workflow status says `success`, but the notifications say *"no new tweets found"* — so the self-healing loop never catches it.

Two independent bugs in the pipeline, both confirmed reproducible.

## Bug 1 — prefetch timeout (`scripts/prefetch-xai.sh:52`)

`curl --max-time 60` against x.ai's `x_search` tool. `x_search` routinely takes 60–120s: it has to search X, rank tweets, and return structured JSON. Every single prefetch run hit curl error 28 (timeout) at exactly 60s. `.xai-cache/fetch-tweets.json` was never written and the skill fell through to WebSearch (which is rate-limited and returns stale results).

**Fix:** bump `--max-time` to 180 and add a one-time retry on `curl_exit = 28`. 99th-percentile x_search calls complete inside 180s; the retry covers the long tail.

## Bug 2 — workflow var expansion (`.github/workflows/aeon.yml:173`)

```yaml
run: |
  VAR="${{ inputs.var }}"   # template-substituted into bash source
```

GitHub Actions substitutes the user input **verbatim** into the bash source. If the var is `$AEON OR @aeonframework OR github.com/aaronjmars/aeon`, the resulting bash line is:

```bash
VAR="$AEON OR @aeonframework OR github.com/aaronjmars/aeon"
```

Bash then expands `$AEON` at exec time. Since `AEON` is not a defined shell variable, it becomes the empty string. `VAR` ends up as ` OR @aeonframework OR github.com/aaronjmars/aeon` (the cashtag is gone). `scripts/filter-xai-tweets.py` splits on `OR` and gets only 2 patterns, so Grok tweets that contain only `$AEON` (and not the handle/URL) get dropped as non-matching.

**Fix:** route `inputs.var` through a `SKILL_VAR` env var — bash receives the literal value and doesn't recursively expand. This is the same pattern the `Run` step already uses at line 210.

## Verification

Tested on `aaronjmars/miroshark-aeon` (live instance) with `var=$MIROSHARK OR @miroshark_ OR github.com/aaronjmars/miroshark`:

| | Before | After bug 1 fix | After both fixes |
|--|--------|-----------------|------------------|
| prefetch duration | 60s (timeout) | 50s (5 tweets cached) | 86s (11 tweets cached) |
| filter output | — | `kept 0/5 (patterns: @miroshark_, github.com/...)` | `kept 11/11 (patterns: $MIROSHARK, @miroshark_, github.com/...)` |
| skill result | empty | empty (filter dropped all) | **11 new tweets** |

The `$MIROSHARK` pattern appears in the post-fix filter output but is absent pre-fix — definitive proof of the var-expansion bug.

## Rollout

- Applied as hotfix directly to `aaronjmars/aeon-agent` and `aaronjmars/miroshark-aeon` already (they auto-commit to main and can't wait for PR review).
- This PR brings the canonical template in sync so future clones ship with the fix.

## Test plan

- [ ] Merge
- [ ] Next scheduled `fetch-tweets` run on a fork with a cashtag var should return real tweets (not fall through to "no new tweets")
- [ ] `memory/logs/YYYY-MM-DD.md` on those forks should start showing tweet URLs again

---
*Diagnosis + fix from a live debug session. Self-healing loop missed it because exit-code said success; worth a follow-up to make fetch-tweets fail loud when XAI_API_KEY is set and cache ends up empty.*