### PR TITLE
fix(skills): emit clickable article URLs via $GITHUB_REPOSITORY

### DIFF
--- a/skills/article/SKILL.md
+++ b/skills/article/SKILL.md
@@ -25,7 +25,9 @@ Steps:
 5. Save the article to: articles/${today}.md
 6. Update memory/MEMORY.md to record that this article was written and its topic.
 7. Log what you did to memory/logs/${today}.md.
-8. Send a notification via `./notify`: "New article written: [title]\n\nhttps://github.com/${repo}/blob/main/articles/${today}.md"
+8. Send a notification via `./notify`: "New article written: [title]\n\nhttps://github.com/${GITHUB_REPOSITORY}/blob/main/articles/${today}.md"
+
+   Use the `$GITHUB_REPOSITORY` env var (GitHub Actions sets it to `owner/repo` of the running instance).
 
 ## Sandbox note
 

--- a/skills/fork-contributor-leaderboard/SKILL.md
+++ b/skills/fork-contributor-leaderboard/SKILL.md
@@ -123,7 +123,9 @@ The `tweet-allocator` skill rewards social mentions with $AEON. Code contributor
    Rising: @login (↑N), @login (new entry)
    Most-merged: @login with N upstream PRs
 
-   Full leaderboard: articles/fork-contributor-leaderboard-${today}.md
+   Full leaderboard: https://github.com/${GITHUB_REPOSITORY}/blob/main/articles/fork-contributor-leaderboard-${today}.md
+
+   Use the `$GITHUB_REPOSITORY` env var (GitHub Actions sets it to `owner/repo`) to build the URL. Do NOT use the watched repo — the article lives in this running instance's repo.
    ```
 
    **Only send a notification if at least 2 contributors qualify** (otherwise the signal is not meaningful). If fewer than 2 qualify, log `FORK_CONTRIBUTOR_LEADERBOARD_INSUFFICIENT_DATA` and stop.

--- a/skills/skill-leaderboard/SKILL.md
+++ b/skills/skill-leaderboard/SKILL.md
@@ -84,7 +84,9 @@ Today is ${today}. Generate a leaderboard of the most popular Aeon skills across
    Consensus: [list of skills enabled by >50% of forks, or "none yet"]
    Adoption gaps: [skills with zero fork enables]
 
-   Full leaderboard: articles/skill-leaderboard-${today}.md
+   Full leaderboard: https://github.com/${GITHUB_REPOSITORY}/blob/main/articles/skill-leaderboard-${today}.md
+
+   Use the `$GITHUB_REPOSITORY` env var (GitHub Actions sets it to `owner/repo`) to build the URL. Do NOT use the watched repo — the article lives in this running instance's repo.
    ```
    **Only send a notification if at least 2 active forks were found with readable aeon.yml files.** Otherwise log "SKILL_LEADERBOARD_INSUFFICIENT_DATA" and stop.
 


### PR DESCRIPTION
## Why

Three skills were producing non-clickable or outright wrong URLs in their `./notify` messages:

| Skill | Old URL fragment | Problem |
|---|---|---|
| `article` | `https://github.com/\${repo}/blob/main/...` | `\${repo}` is an undefined placeholder — Claude sometimes filled it with the watched repo (`aaronjmars/miroshark` instead of `aaronjmars/miroshark-aeon`), producing 404s |
| `skill-leaderboard` | `articles/skill-leaderboard-\${today}.md` | Bare repo-relative path — rendered as plain text on Telegram/Discord, not clickable |
| `fork-contributor-leaderboard` | `articles/fork-contributor-leaderboard-\${today}.md` | Same bare-path bug (introduced in #42, fixing before it ever ran in production) |

User reported both: *"Wrong URL at the end of New Article: First Outside Hand on the Throttle..."* and the skill-leaderboard notification showing just `articles/skill-leaderboard-2026-04-19.md` as plain text.

## Fix

Unify on `\$GITHUB_REPOSITORY` — the env var GitHub Actions always sets to `owner/repo` of the *running* instance. No ambiguity with the watched repo, no undefined placeholder, no plain-text paths. Also added an explicit note in each skill that this is the running repo, not the watched one — that's the trap for skills that also scan forks of a target repo.

## Rollout

Already hotfixed on live instances:
- `aaronjmars/aeon-agent` — skill-leaderboard (8563ccf) + article (86b2feb)
- `aaronjmars/miroshark-aeon` — skill-leaderboard (f5a06a9) + article (1cde4f3)

This PR brings the canonical template + the new fork-contributor-leaderboard skill in line.

## Test plan

- [ ] Merge
- [ ] Next `article`, `skill-leaderboard`, or `fork-contributor-leaderboard` run on any fork emits a clickable URL matching the running instance's repo