### PR TITLE
fix(notify): chunk long Telegram messages instead of truncating

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -290,24 +290,58 @@ jobs:
 
           # Telegram: 4096 char limit, strict Markdown parsing
           if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ]; then
-            TG_MSG="$MSG"
-            if [ ${#TG_MSG} -gt 4000 ]; then
-              TG_MSG="${TG_MSG:0:3990}
-
-          ...(truncated)"
-            fi
-            TG_RESULT=$(curl -s -w "\n%{http_code}" -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
-              -H "Content-Type: application/json" \
-              -d "$(jq -n --arg chat "$TELEGRAM_CHAT_ID" --arg text "$TG_MSG" '{chat_id: $chat, text: $text, parse_mode: "Markdown"}')" 2>/dev/null) || true
-            TG_HTTP=$(echo "$TG_RESULT" | tail -1)
-            TG_OK=$(echo "$TG_RESULT" | sed '$d' | jq -r '.ok // false' 2>/dev/null || echo "false")
-            if [ "$TG_HTTP" = "200" ] && [ "$TG_OK" = "true" ]; then
-              DELIVERED=true
-            else
-              curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            # Split $MSG into chunks ≤3900 chars (Telegram cap 4096, leaves room for
+            # "[i/N]" suffix). Prefer paragraph (\n\n) then line (\n) boundaries,
+            # hard-split only if a single paragraph/line exceeds the limit.
+            # Chunks emitted one per line as base64 to preserve embedded newlines.
+            TG_CHUNKS_B64=$(printf '%s' "$MSG" | python3 -c '
+          import sys, base64
+          LIMIT = 3900
+          text = sys.stdin.read()
+          def pack(parts, sep):
+              out, cur = [], ""
+              for p in parts:
+                  glue = sep if cur else ""
+                  if len(cur) + len(glue) + len(p) <= LIMIT:
+                      cur += glue + p
+                  else:
+                      if cur:
+                          out.append(cur); cur = ""
+                      if len(p) > LIMIT and sep == "\n\n":
+                          out.extend(pack(p.split("\n"), "\n"))
+                      elif len(p) > LIMIT:
+                          while len(p) > LIMIT:
+                              out.append(p[:LIMIT]); p = p[LIMIT:]
+                          cur = p
+                      else:
+                          cur = p
+              if cur:
+                  out.append(cur)
+              return out
+          chunks = [text] if len(text) <= LIMIT else pack(text.split("\n\n"), "\n\n")
+          N = len(chunks)
+          for i, c in enumerate(chunks):
+              suffix = f"\n\n[{i+1}/{N}]" if N > 1 else ""
+              sys.stdout.write(base64.b64encode((c + suffix).encode()).decode() + "\n")
+          ')
+            while IFS= read -r TG_CHUNK_B64; do
+              [ -z "$TG_CHUNK_B64" ] && continue
+              TG_MSG=$(printf '%s' "$TG_CHUNK_B64" | base64 -d)
+              TG_RESULT=$(curl -s -w "\n%{http_code}" -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
                 -H "Content-Type: application/json" \
-                -d "$(jq -n --arg chat "$TELEGRAM_CHAT_ID" --arg text "$TG_MSG" '{chat_id: $chat, text: $text}')" > /dev/null 2>&1 && DELIVERED=true || true
-            fi
+                -d "$(jq -n --arg chat "$TELEGRAM_CHAT_ID" --arg text "$TG_MSG" '{chat_id: $chat, text: $text, parse_mode: "Markdown"}')" 2>/dev/null) || true
+              TG_HTTP=$(echo "$TG_RESULT" | tail -1)
+              TG_OK=$(echo "$TG_RESULT" | sed '$d' | jq -r '.ok // false' 2>/dev/null || echo "false")
+              if [ "$TG_HTTP" = "200" ] && [ "$TG_OK" = "true" ]; then
+                DELIVERED=true
+              else
+                curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+                  -H "Content-Type: application/json" \
+                  -d "$(jq -n --arg chat "$TELEGRAM_CHAT_ID" --arg text "$TG_MSG" '{chat_id: $chat, text: $text}')" > /dev/null 2>&1 && DELIVERED=true || true
+              fi
+              # Preserve chunk ordering in the Telegram channel
+              sleep 0.3
+            done <<< "$TG_CHUNKS_B64"
           fi
 
           if [ -n "${DISCORD_WEBHOOK_URL:-}" ]; then

--- a/skills/article/SKILL.md
+++ b/skills/article/SKILL.md
@@ -25,7 +25,9 @@ Steps:
 5. Save the article to: articles/${today}.md
 6. Update memory/MEMORY.md to record that this article was written and its topic.
 7. Log what you did to memory/logs/${today}.md.
-8. Send a notification via `./notify`: "New article written: [title]\n\nhttps://github.com/${repo}/blob/main/articles/${today}.md"
+8. Send a notification via `./notify`: "New article written: [title]\n\nhttps://github.com/${GITHUB_REPOSITORY}/blob/main/articles/${today}.md"
+
+   Use the `$GITHUB_REPOSITORY` env var (GitHub Actions sets it to `owner/repo` of the running instance).
 
 ## Sandbox note
 

--- a/skills/fork-contributor-leaderboard/SKILL.md
+++ b/skills/fork-contributor-leaderboard/SKILL.md
@@ -123,7 +123,9 @@ The `tweet-allocator` skill rewards social mentions with $AEON. Code contributor
    Rising: @login (↑N), @login (new entry)
    Most-merged: @login with N upstream PRs
 
-   Full leaderboard: articles/fork-contributor-leaderboard-${today}.md
+   Full leaderboard: https://github.com/${GITHUB_REPOSITORY}/blob/main/articles/fork-contributor-leaderboard-${today}.md
+
+   Use the `$GITHUB_REPOSITORY` env var (GitHub Actions sets it to `owner/repo`) to build the URL. Do NOT use the watched repo — the article lives in this running instance's repo.
    ```
 
    **Only send a notification if at least 2 contributors qualify** (otherwise the signal is not meaningful). If fewer than 2 qualify, log `FORK_CONTRIBUTOR_LEADERBOARD_INSUFFICIENT_DATA` and stop.

--- a/skills/skill-leaderboard/SKILL.md
+++ b/skills/skill-leaderboard/SKILL.md
@@ -84,7 +84,9 @@ Today is ${today}. Generate a leaderboard of the most popular Aeon skills across
    Consensus: [list of skills enabled by >50% of forks, or "none yet"]
    Adoption gaps: [skills with zero fork enables]
 
-   Full leaderboard: articles/skill-leaderboard-${today}.md
+   Full leaderboard: https://github.com/${GITHUB_REPOSITORY}/blob/main/articles/skill-leaderboard-${today}.md
+
+   Use the `$GITHUB_REPOSITORY` env var (GitHub Actions sets it to `owner/repo`) to build the URL. Do NOT use the watched repo — the article lives in this running instance's repo.
    ```
    **Only send a notification if at least 2 active forks were found with readable aeon.yml files.** Otherwise log "SKILL_LEADERBOARD_INSUFFICIENT_DATA" and stop.
 


### PR DESCRIPTION
## Why

Feature and weekly-shiplog notifications routinely cross Telegram's 4096-char cap. The existing notify script truncated at byte 3990 and appended `...(truncated)` — meaning PR links, How-it-works sections, and calls-to-action at the bottom of long messages were being silently lost.

Reported today on `aaronjmars/miroshark-aeon`: "Feature Built — Scenario Auto-Suggest" notification sliced mid-paragraph, so the PR URL never reached the Telegram channel.

## Fix

Split `$MSG` into chunks ≤3900 chars (leaves room for `[i/N]` suffix under the 4096 cap), preferring paragraph (`\n\n`) then line (`\n`) boundaries. Hard-split only if a single paragraph/line exceeds the limit. Each chunk is base64-encoded on its own line so embedded newlines survive the while-read loop, then sent one at a time through the existing Markdown-parse-mode + raw-text fallback paths. A 0.3s delay between sends keeps ordering sane in the Telegram channel.

No behavior change for short messages: when `len($MSG) ≤ 3900`, python produces a single chunk with no `[i/N]` suffix and the loop sends it exactly once — the happy path is byte-identical to before.

## Verification

- Unit test (the python splitter in isolation): short/long/empty/paragraph-too-big cases all produce chunks ≤4096 after suffix.
- E2E bash simulation (base64 round-trip + while-read loop): 4659-char synthetic message → 2 chunks of 3835 + 836 chars, both ending cleanly at paragraph boundaries with `[1/2]` / `[2/2]` tags.
- Real GitHub Actions smoke test on `aaronjmars/miroshark-aeon` (run 24667852587): heartbeat skill completed successfully and delivered its short notification after the fix was deployed — confirms the short-message path isn't regressed.

## Rollout

Already hotfixed on active instances:
- `aaronjmars/aeon-aaron` — commit eb43aa4 (Markdown parse mode variant)
- `aaronjmars/aeon-agent` — commit 6e9b34b (HTML parse mode variant)
- `aaronjmars/miroshark-aeon` — commit c79401a (HTML parse mode variant)

This PR brings the canonical template in line (Markdown parse mode, matching upstream's current default).

## Test plan

- [ ] Merge
- [ ] Next `feature` / `weekly-shiplog` / `repo-article` run on any live instance produces a multi-chunk notification where needed, no trailing `...(truncated)`, and `[i/N]` suffixes match
- [ ] Short-message skills (heartbeat, token-report) still deliver as single messages with no suffix