### PR TITLE
improve(fetch-tweets): autoresearch evolution

### DIFF
--- a/skills/fetch-tweets/SKILL.md
+++ b/skills/fetch-tweets/SKILL.md
@@ -101,6 +101,10 @@ Today is ${today}. Search X for tweets matching **${var}** and produce a *curate
    - The signal one-liner goes in italics (`_..._`) directly under the title.
    - Cluster headers use `*bold*`.
 
+## Output shape note
+
+This skill has no chain consumers as of this commit (no `consume: [fetch-tweets]` references). If a downstream chain step starts consuming this output, emit a flat list of URLs before the clustered output so consumers aren't broken by cluster headers.
+
 ## Sandbox note
 
 Sandbox may block outbound curl. Path A (cache) avoids the issue entirely. If Path B is needed and curl fails, fall back to Path C (WebSearch) — it's a built-in Claude tool and bypasses the sandbox.

--- a/skills/fetch-tweets/SKILL.md
+++ b/skills/fetch-tweets/SKILL.md
@@ -1,31 +1,34 @@
 ---
 name: Fetch Tweets
-description: Search X/Twitter for tweets about a token, keyword, username, or topic
+description: Search X/Twitter for tweets about a token, keyword, username, or topic — clustered by sub-narrative
 var: ""
 tags: [social]
 ---
+<!-- autoresearch: variation B — sharper output via clustering + signal line + insight extraction -->
 > **${var}** — Search query for X/Twitter. **Required** — set your query in aeon.yml.
 
-Today is ${today}. Search X for tweets matching **${var}**.
+Today is ${today}. Search X for tweets matching **${var}** and produce a *curated* digest grouped by sub-narrative — not a flat chronological list.
 
 ## Steps
 
 1. **Load previously-reported tweet URLs** from two sources, then union them into `SEEN_TWEETS`:
-   - **Persistent seen-file** (`memory/fetch-tweets-seen.txt`) — if it exists, read all URLs. This file contains every tweet URL ever reported, preventing stale tweets from cycling back into notifications once log entries age out of the 3-day window.
-   - **Last 3 days of `memory/logs/`** — grep each log file for lines matching `https://x.com/` (catches URLs not yet in the seen-file).
-   
+   - **Persistent seen-file** (`memory/fetch-tweets-seen.txt`) — if it exists, read all URLs.
+   - **Last 3 days of `memory/logs/`** — grep each log file for lines matching `https://x.com/`.
+
    You'll use `SEEN_TWEETS` in step 5 to filter duplicates.
 
-2. **Build the search prompt for Grok.** Pass `${var}` to Grok **verbatim** as the search query. Do NOT narrow it to a single angle (e.g. don't force "crypto token only", don't inject a contract address, don't filter by chain). Let Grok interpret OR/AND operators in the var as-is. The goal is broad coverage — token mentions, repo mentions, handle mentions, general chatter, all of it.
+2. **Build the search prompt for Grok.** Pass `${var}` to Grok **verbatim** as the search query — let Grok interpret OR/AND operators in the var as-is. Do NOT narrow it to a single angle; broad coverage is the goal.
 
-3. **Search tweets.** Use whichever path is available:
+   Ask Grok to return **at least 15–20 candidate tweets** (you'll cull to ~7–10 in curation). Always require explicit engagement counts (likes, retweets, replies) so ranking is data-driven, not vibes.
+
+3. **Search tweets.** Use whichever path is available, and **record which path produced the result** (you'll log it in step 6 as `SOURCE_PATH=cache|api|websearch`):
 
    **Path A — pre-fetched cache** (preferred, when the workflow ran `scripts/prefetch-xai.sh`):
    ```bash
    cat .xai-cache/fetch-tweets.json 2>/dev/null | jq -r '.output[] | select(.type == "message") | .content[] | select(.type == "output_text") | .text'
    ```
 
-   **Path B — X.AI API** (fallback, use when `XAI_API_KEY` is set and cache is empty):
+   **Path B — X.AI API** (fallback, when `XAI_API_KEY` is set and cache is empty):
    ```bash
    FROM_DATE=$(date -u -d "yesterday" +%Y-%m-%d 2>/dev/null || date -u -v-1d +%Y-%m-%d)
    TO_DATE=$(date -u +%Y-%m-%d)
@@ -34,47 +37,74 @@ Today is ${today}. Search X for tweets matching **${var}**.
      -H "Authorization: Bearer $XAI_API_KEY" \
      -d '{
        "model": "grok-4-1-fast",
-       "input": [{"role": "user", "content": "Search X for ALL tweets about: ${var}. Date range: '"$FROM_DATE"' to '"$TO_DATE"'. Return at least 10 tweets (more if available) — prioritize the most interesting, insightful, or highly-engaged posts but also include smaller accounts. For each tweet include: @handle, the full text, date posted, engagement (likes/retweets if available), and the direct link (https://x.com/handle/status/ID). Return as a numbered list."}],
+       "input": [{"role": "user", "content": "Search X for tweets about: ${var}. Date range: '"$FROM_DATE"' to '"$TO_DATE"'. Return at least 15-20 candidate tweets — mix of high-engagement posts and smaller accounts that add a distinct angle. For each tweet include: @handle, the full text, date posted, exact engagement counts (likes, retweets, replies — never N/A; if unknown, say 0), and the direct link (https://x.com/handle/status/ID). Return as a numbered list."}],
        "tools": [{"type": "x_search"}]
      }'
    ```
-   Parse the response JSON to extract the text from the output array:
-   ```bash
-   echo "$RESPONSE" | jq -r '.output[] | select(.type == "message") | .content[] | select(.type == "output_text") | .text'
+   Parse with: `jq -r '.output[] | select(.type == "message") | .content[] | select(.type == "output_text") | .text'`
+
+   **Path C — WebSearch fallback** (use when both cache and `XAI_API_KEY` are unavailable):
+   Use the built-in WebSearch tool with a query like `site:x.com "${query_terms}" after:${FROM_DATE}`. Note at the top of the log entry: "XAI_API_KEY not available; results compiled via WebSearch — quality lower than usual". WebSearch tends to favour high-engagement older tweets — **prioritise results dated within the last 48 hours**.
+
+4. **Empty-data handling** (distinguish empty from error):
+   - **Legitimate empty** (API returned 0 tweets, no results): log `FETCH_TWEETS_EMPTY (source=${SOURCE_PATH})` to `memory/logs/${today}.md` and **stop — no notification**.
+   - **API/cache error** (HTTP error, malformed JSON, all paths failed): log `FETCH_TWEETS_ERROR (last_path=${SOURCE_PATH}, reason=...)` so skill-health can pick it up, and **stop — no notification**.
+
+5. **Deduplicate against `SEEN_TWEETS` from step 1.** Compare each candidate URL against the set. Remove any tweet already reported. If ALL candidates are dupes: log `FETCH_TWEETS_NO_NEW: all results already reported` and **stop — no notification**.
+
+6. **Curate — this is the new core step.** Don't dump all surviving tweets into the notification. Instead:
+
+   a. **Cluster** the surviving candidates into 2–4 sub-narratives based on what they're actually claiming or discussing. Examples for a token query: "price action", "team announcement", "criticism/FUD", "ecosystem integration". Examples for a person query: "their new post", "responses to it", "unrelated activity". Pick cluster names that describe *the angle*, not the topic itself.
+
+   b. **Within each cluster, rank by signal**, not just engagement. Signal = (likes + 2×retweets + replies) but **demote** tweets that are pure replies, generic shilling, or near-duplicate paraphrases of another already-included tweet. Drop tweets with <5 total engagement unless they come from an account that adds a unique angle.
+
+   c. **Cap each cluster at 2–3 tweets** and total at **7–10 tweets**. Quality over quantity — if only 5 tweets pass the bar, send 5. Do not pad.
+
+   d. **Extract the claim or signal** for each tweet — the summary should say *what's new or interesting*, not paraphrase the literal text. Bad: "User says token is going up." Good: "Calls out the team's silence on the postponed unlock — first major holder to do so publicly."
+
+   e. **Compute a one-line signal** for the top of the notification: a single observation about the *shape* of the conversation. Examples: "Sentiment split — 4 bullish on the launch, 3 critical of the unlock terms." or "Mostly quiet — 6 of 7 tweets are from the same 3 accounts repeating yesterday's narrative." This is the most valuable single sentence for a reader scanning fast.
+
+7. **Save the results** to `memory/logs/${today}.md`. Include for each kept tweet: URL, handle, engagement counts, the cluster it belongs to, and the source path used. Format:
+   ```
+   ### fetch-tweets (${var})
+   - source_path: cache
+   - signal: [the one-liner from step 6e]
+   - cluster: [name]
+     - https://x.com/handle/status/ID — likes:N rts:N replies:N — [insight summary]
    ```
 
-   **Path C — WebSearch fallback** (use when both cache and XAI_API_KEY are unavailable):
-   Use the built-in WebSearch tool to search for recent tweets. Construct a query like:
-   `site:x.com "${query_terms}" after:${FROM_DATE}`
-   Note at the top of the log entry: "XAI_API_KEY not available; results compiled via WebSearch". WebSearch rankings favour high-engagement older tweets — **prioritise results that mention a date within the last 48 hours** when possible.
+7b. **Update the persistent seen-file** — append each new tweet URL (one per line) to `memory/fetch-tweets-seen.txt`. Create the file if it doesn't exist.
 
-4. **If no relevant tweets found** (no results, API error, or empty): log "FETCH_TWEETS_EMPTY" to `memory/logs/${today}.md` and **stop here — do NOT send any notification**.
-
-5. **Deduplicate against `SEEN_TWEETS` from step 1.** Compare each candidate tweet URL against the collected set of already-reported URLs. Remove any tweet that was already reported in the last 3 days. If ALL tweets found are already in the recent logs: log "FETCH_TWEETS_NO_NEW: all results already reported" to `memory/logs/${today}.md` and **stop here — do NOT send any notification**.
-
-6. **Save the results** (new tweets only) to `memory/logs/${today}.md`. Include the tweet URLs, handles, and engagement so future runs can deduplicate and so downstream skills (like `tweet-allocator`) can consume them.
-
-6b. **Update the persistent seen-file** — append each new tweet URL (one per line) to `memory/fetch-tweets-seen.txt`. Create the file if it doesn't exist. This ensures these URLs are excluded from all future runs, regardless of log rotation.
-
-7. **Send a notification via `./notify`** with up to 10 NEW tweets (those that survived dedup). Each tweet MUST include a clickable link. Use Telegram Markdown link format: `[link text](url)`.
-
-   Format the notification like this:
+8. **Send a notification via `./notify`** with the curated, clustered output. Format:
    ```
    *Top Tweets — ${var} (${today})*
+   _${signal_one_liner}_
 
-   1. x.com/handle — [brief summary of tweet content]
-   Likes: X | RTs: Y
+   *${cluster_1_name}*
+   1. x.com/handle — [insight summary]
+   Likes: X | RTs: Y | Replies: Z
    [View tweet](https://x.com/handle/status/ID)
 
-   2. x.com/handle — [brief summary]
-   Likes: X | RTs: Y
+   2. x.com/handle — [insight summary]
+   Likes: X | RTs: Y | Replies: Z
    [View tweet](https://x.com/handle/status/ID)
 
-   ... (up to 10 tweets)
+   *${cluster_2_name}*
+   3. x.com/handle — [insight summary]
+   ...
    ```
 
-   IMPORTANT: Do NOT use @handle format — it tags/pings users on Telegram. Use x.com/handle instead (shows the profile URL without tagging anyone). The `[View tweet](URL)` link is required so users can tap to open each tweet.
+   IMPORTANT formatting rules:
+   - Use `x.com/handle` (NOT `@handle`) so Telegram doesn't ping/tag users.
+   - Each tweet MUST have a `[View tweet](URL)` link — required so users can tap to open it.
+   - Use Telegram Markdown link format: `[link text](url)`.
+   - The signal one-liner goes in italics (`_..._`) directly under the title.
+   - Cluster headers use `*bold*`.
+
+## Sandbox note
+
+Sandbox may block outbound curl. Path A (cache) avoids the issue entirely. If Path B is needed and curl fails, fall back to Path C (WebSearch) — it's a built-in Claude tool and bypasses the sandbox.
 
 ## Environment Variables Required
 
-- `XAI_API_KEY` — X.AI API key (optional; skill falls back to WebSearch when not set, but quality is lower)
+- `XAI_API_KEY` — X.AI API key (optional; skill falls back to WebSearch when not set, but quality is lower).


### PR DESCRIPTION
## Winner: Variation B — Sharper output

**Thesis:** The biggest lever for fetch-tweets quality is *curation*, not fetching. The original returned a flat chronological list of up to 10 tweets ranked vaguely by "interesting/insightful". The new version clusters surviving candidates into 2–4 sub-narratives, ranks within each cluster by a signal score (likes + 2×retweets + replies, demoting pure replies and near-duplicates), demands *insight* summaries instead of paraphrases, and leads with a one-line observation about the *shape* of the conversation.

Folded in two cheap wins from runners-up:
- From **A**: require explicit engagement counts (likes/RTs/replies — never N/A) so ranking is data-driven.
- From **C**: record `SOURCE_PATH` (cache/api/websearch) and distinguish `FETCH_TWEETS_EMPTY` (legit empty) from `FETCH_TWEETS_ERROR` (degraded) — gives skill-health a hook.

## Scoring

| Variation | Thesis | Clarity | Data | Output | Robust | Conv | Improve | **Weighted** |
|-----------|--------|---------|------|--------|--------|------|---------|----------|
| A — Better inputs | Multi-angle queries + explicit engagement metrics | 4 | 5 | 4 | 3 | 5 | 4 | **43** |
| **B — Sharper output** | **Cluster by sub-narrative + signal line + insight extraction** | **4** | **4** | **5** | **4** | **5** | **5** | **48** |
| C — More robust | Source-path observability + URL regex + seen-file cap | 5 | 3 | 3 | 5 | 5 | 3 | 39.5 |
| D — Two-pass refinement | Broad retrieval pass → Grok re-rank/cluster pass | 3 | 4 | 5 | 3 | 4 | 4 | 41 |

Weights: Improvement ×3, Output value ×2, Clarity / Data quality / Robustness ×1.5, Conventions ×1.

## Variation summaries

- **A — Better inputs:** Run multiple angle queries (split OR-separated vars, add auxiliary "${var} repo / contract" queries), require explicit engagement counts, add nitter mirror as Path D fallback. Strong on data quality but doesn't address the core "flat list" problem.
- **B — Sharper output (chosen):** See above.
- **C — More robust:** Source-path logging, URL regex validation, seen-file rotation cap, distinguish empty vs error, dedupe on near-duplicate text. Solid reliability gains but no improvement to what the user actually reads.
- **D — Two-pass refinement:** First call gets 30–50 candidates broadly; second call asks Grok to re-rank/cluster/filter. Powerful idea but doubles API surface area and adds two-phase complexity that's a clarity risk.

## Diff summary

- New step 6 (Curate): cluster → rank by signal → cap per cluster → extract insight → compute one-line signal.
- Step 3 prompts now require 15–20 candidates with exact engagement counts (was 10 with vague "prioritise interesting").
- Step 4 splits empty-vs-error logging.
- Step 6/7 logs `source_path` and `signal` for downstream observability.
- Step 8 notification format gains a signal one-liner (italic) and cluster headers (bold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Ported from aaronjmars/aeon-tmp#3.
