### PR TITLE
improve(reflect): autoresearch evolution

### DIFF
--- a/skills/reflect/SKILL.md
+++ b/skills/reflect/SKILL.md
@@ -4,28 +4,87 @@ description: Review recent activity, consolidate memory, and prune stale entries
 var: ""
 tags: [meta]
 ---
+<!-- autoresearch: variation B — reflection as insight generation, not file rearrangement -->
 > **${var}** — Area to focus on. If empty, reviews everything.
 
-If `${var}` is set, focus the reflection on that specific area.
+Today is ${today}. Memory consolidation without insight is just file-shuffling. Produce findings that change what the agent does next.
 
+If `${var}` is set, restrict the scope of every phase to content matching that area.
 
-Today is ${today}. Your task is to review the agent's recent activity and maintain long-term memory.
+## Phase 1 — Gather
 
-Steps:
-1. Read memory/MEMORY.md to understand current memory state.
-2. Read the recent run logs in memory/logs/ (last 7 days if available).
-3. Read the recent articles in articles/ (last 7 days if available).
-4. Consolidate what you've learned:
-   - What topics have been covered recently? Note any patterns or gaps.
-   - What features were built? Record key decisions and outcomes.
-   - Are there any stale entries in MEMORY.md that are no longer relevant? Remove them.
-   - Are there recurring errors or issues worth noting for future runs?
-   - Check `memory/skill-health/*.json` for quality trends — note any skills with declining scores or persistent flags. Summarize overall skill health in the appropriate topic file.
-5. Reorganize memory:
-   - Keep MEMORY.md as a short index (~50 lines): goals, active topics, and pointers to topic files.
-   - Move detailed notes into `memory/topics/` files (e.g. `crypto.md`, `research.md`, `projects.md`).
-   - If a topic file already exists, update it rather than creating a new one.
-6. Log what you did to memory/logs/${today}.md.
-7. Send a notification via `./notify`: "Memory consolidated — ${today}"
+Read in order (skip any source that doesn't exist — note it and move on):
 
-Be ruthless about pruning. Memory should be a living, useful document — not an append-only log.
+1. `memory/MEMORY.md` — current index state
+2. `memory/logs/` — last 14 days of daily logs (extend to 30 if 14-day window is empty)
+3. `memory/topics/*.md` — every existing topic file
+4. `memory/issues/INDEX.md` and any referenced open `ISS-*.md` files
+5. `memory/skill-health/*.json` — per-skill quality scores and trend direction
+6. `memory/cron-state.json` — per-skill success rate and consecutive_failures
+7. `articles/` — last 14 days
+
+## Phase 2 — Analyze (write a scratchpad before touching any file)
+
+Answer each question explicitly. If a question has no data, say so — do not invent findings.
+
+1. **What ran and produced value?** Top 3 highest-value outputs (articles published, decisions logged, issues resolved). Name the skill + date.
+2. **What ran but produced noise?** Skills whose output from the last 14 days is never referenced in a later log, article, or decision. Candidates for deprecation.
+3. **What broke?** Open issues in `memory/issues/` by severity. Any skill in `cron-state.json` with `consecutive_failures >= 3`.
+4. **What trends?** Skill-health scores declining for 2+ consecutive runs, or rising sharply. Name the skill and direction.
+5. **What's stale?** Entries in MEMORY.md older than 30 days with no reference in recent logs, articles, or topic files.
+6. **What's missing?** Topics active in the last 14 days of logs but absent from MEMORY.md or `memory/topics/`.
+
+## Phase 3 — Consolidate
+
+Based on Phase 2 findings:
+
+1. **Rewrite `memory/MEMORY.md`** as a ~50-line index containing:
+   - Current goals (from Q1)
+   - Active topics (one-line pointers to `memory/topics/<name>.md`)
+   - Known issues (link to `memory/issues/INDEX.md` + severity counts)
+   - Next priorities (from Q3 and Q4, replacing any placeholder list)
+2. **Update `memory/topics/*.md` in-place.** Merge new findings into existing files. Create a new topic file only for genuinely new areas surfaced in Q6. Never duplicate (no `projects-v2.md`).
+3. **Prune ruthlessly.** Remove stale entries identified in Q5. If an entry is ambiguous, keep it and note in the log.
+
+Never delete anything under `memory/logs/`, `memory/issues/`, or `articles/` — those are authoritative records.
+
+## Phase 4 — Report
+
+Append to `memory/logs/${today}.md` under `### reflect`:
+
+```
+### reflect
+- Inputs read: N log files, M open issues, K skill-health files
+- Top findings: [2–3 concrete insights from Phase 2]
+- Topic files touched: [list]
+- Stale pruned: N entries
+- Issues flagged: [IDs by severity, or "none"]
+- Health watch: [skills with declining scores, or "none"]
+```
+
+Then notify via `./notify`:
+
+```
+*Reflect — ${today}*
+[one-sentence overall state: healthy / degraded / improving]
+Top finding: [single most important insight from Phase 2]
+Action: [one concrete next step, or "none"]
+```
+
+If Phase 1 found no logs, no articles, and no changes needed in MEMORY.md, send instead:
+
+```
+*Reflect — ${today}* — no recent activity, memory unchanged.
+```
+
+## Constraints
+
+- Never invent findings to fill a phase. If Q1 has no data, say so in both the log and notification.
+- Phase 2 is extractive, not exhaustive — do not summarize every log line.
+- The notification must convey what changed or what to do next, not "memory consolidated."
+- Never re-add entries that were pruned in a previous reflect run (scan the last 3 `### reflect` log entries before re-adding anything).
+- Never change `memory/issues/` entries — reflect reads them, repair skills close them.
+
+## Sandbox note
+
+All inputs are local file reads. No network required.


### PR DESCRIPTION
## Winner — Variation B (Sharper output)

**Thesis:** The current `reflect` skill produces memory rearrangement with no insight. The biggest lever is forcing an extractive analysis phase before any file write, and putting a real finding + action in the notification instead of the stock "memory consolidated" line.

## Scoring table

| Variation | Clarity (×1.5) | Data (×1.5) | Output (×2) | Robust (×1.5) | Conv (×1) | Improv (×3) | **Total** |
|---|---|---|---|---|---|---|---|
| A — Better inputs | 4 | 5 | 3 | 3 | 5 | 4 | **41.0** |
| **B — Sharper output** | **5** | **4.5** | **5** | **4** | **5** | **5** | **50.25** |
| C — More robust | 4 | 3.5 | 3 | 5 | 5 | 3 | **38.75** |
| D — Rethink as diff | 4 | 4.5 | 4 | 4 | 5 | 4 | **43.75** |

Gap to runner-up D = 6.5 points — clear winner, no tie-break needed.

## Variation summaries

- **A — Better inputs** — Read all memory surfaces (issues/, skill-health/, cron-state.json, token-usage.csv, watched-repos.md, git log) instead of just logs/articles. Rich inputs but notification stays cosmetic.
- **B — Sharper output ← winner** — Four phases (Gather → Analyze → Consolidate → Report). Mandates answering 6 extractive questions before writing. Notification carries the top finding + a concrete action. Folds in A's richer input list (issues, skill-health, cron-state) and C's empty-state fallback.
- **C — More robust** — Pre-flight checks, change plan before writes, explicit handling of empty state, conflicts, circular references. Strong on defense, weak on advancing the skill's core purpose.
- **D — Rethink as diff** — Reconcile claimed state (MEMORY.md) against observed state (logs/health/issues) as a structured diff with explicit deprecate/add/confirm/flag actions. Clever framing, marginal practical upside vs. B.

## Diff summary (what changed vs. original)

- Replaced the 7 flat steps with 4 labeled phases that mandate an insight scratchpad before any file write.
- Added explicit Phase 2 questions covering value, noise, failures, trends, stale entries, and missing topics.
- Pulled `memory/issues/`, `memory/skill-health/`, `memory/cron-state.json` into Phase 1 (original only mentioned skill-health as a tacked-on bullet).
- Rewrote the notification spec to carry a single concrete finding + action, with a distinct empty-state message.
- Added constraints: no invented findings, no re-adding pruned entries, no modifying `memory/issues/` (repair skills own that).
- Widened log window from 7 days to 14 days (captures bi-weekly patterns) with a 30-day fallback if 14-day window is empty.

## Test plan

- [ ] Run the reflect skill via `workflow_dispatch` (set `schedule: ...` and flip `enabled: true` in `aeon.yml` temporarily, or trigger manually)
- [ ] Confirm `memory/logs/${today}.md` gains a `### reflect` entry with Phase 2 findings, not just a generic summary
- [ ] Confirm notification text includes a concrete "Top finding" and "Action" line
- [ ] Confirm empty-state path fires the "no recent activity" notification when run against an empty/new fork

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Ported from aaronjmars/aeon-tmp#4.
