### PR TITLE
improve(github-issues): autoresearch evolution

### DIFF
--- a/skills/github-issues/SKILL.md
+++ b/skills/github-issues/SKILL.md
@@ -1,40 +1,86 @@
 ---
 name: GitHub Issues
-description: Check all your repos for new open issues in the last 24 hours
+description: Daily digest of new open issues across your repos, ranked by signal (security/bug/feature/other)
 var: ""
 tags: [dev]
 ---
-> **${var}** — Specific repo (owner/repo) to check. If empty, checks all repos.
+<!-- autoresearch: variation B — sharper output (priority-ranked triage queue instead of a flat list) -->
+
+> **${var}** — Optional scope. Accepts `owner/repo`, `org:foo`, `user:bar`. Empty = all repos owned by the authenticated user.
 
 Read memory/MEMORY.md for context.
-Read the last 2 days of memory/logs/ to avoid repeating items.
+Read the last 2 days of `memory/logs/` and extract any GitHub issue URLs already alerted — these are dedup candidates.
 
 ## Steps
 
-1. Get repos to check:
-   - If `${var}` is set, use that repo directly (e.g. `owner/repo`).
-   - Otherwise, get all repos for the authenticated user:
+1. Resolve the 24-hour window and the search scope:
    ```bash
-   gh repo list --limit 100 --json nameWithOwner,hasIssuesEnabled --jq '.[] | select(.hasIssuesEnabled) | .nameWithOwner'
+   YESTERDAY=$(date -u -d "yesterday" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+              || date -u -v-1d +%Y-%m-%dT%H:%M:%SZ)
+   ME=$(gh api user --jq .login)
+
+   if [ -z "${var}" ]; then
+     SCOPE="user:$ME"
+   else
+     case "${var}" in
+       *:*) SCOPE="${var}" ;;          # already qualified (org:foo, user:bar)
+       */*) SCOPE="repo:${var}" ;;     # owner/repo
+       *)   SCOPE="user:${var}" ;;     # bare login
+     esac
+   fi
    ```
 
-2. For each repo with issues enabled, check for issues opened in the last 24 hours:
+2. Fetch every new open issue in scope with one advanced-search call (much cheaper than per-repo looping):
    ```bash
-   YESTERDAY=$(date -u -d "yesterday" +%Y-%m-%dT00:00:00Z 2>/dev/null || date -u -v-1d +%Y-%m-%dT00:00:00Z)
-   gh issue list -R OWNER/REPO --state open --json number,title,createdAt,author,labels \
-     --jq '.[] | select(.createdAt > "'"$YESTERDAY"'")'
+   gh search issues --limit 100 \
+     --json number,title,url,createdAt,author,labels,repository,comments \
+     -- "$SCOPE is:issue is:open created:>$YESTERDAY sort:created-desc" \
+     > /tmp/gh-issues.json
    ```
+   If the call fails (422 / rate-limit / transient), fall back to looping `gh issue list -R <repo>` over `gh repo list "$ME" --limit 100 --json nameWithOwner,hasIssuesEnabled --jq '.[] | select(.hasIssuesEnabled) | .nameWithOwner'`, applying the same `createdAt > $YESTERDAY` filter via `--jq`.
 
-3. Deduplicate against recent logs — never alert on the same issue twice.
+3. Drop URLs already alerted in the previous 2 days of logs.
 
-4. Send via `./notify`:
+4. **Rank** each remaining issue into a priority bucket using its labels and title (case-insensitive regex):
+   - **P0 — security/critical**: any label or title matching `security|vuln|cve|exploit|critical|urgent|outage|p0`
+   - **P1 — bug/regression**: matches `bug|regression|broken|crash|error|p1`
+   - **P2 — feature/enhancement**: matches `feature|enhancement|feat|p2`
+   - **P3 — other**: everything else (questions, docs, chores)
+
+5. Sort within each bucket by comment count desc, then `createdAt` desc (more comments = more attention already drawn).
+
+6. If the post-dedup, post-rank set is empty: **send no notification**. Skip directly to step 8.
+
+7. Format and send via `./notify`. Skip empty buckets. Cap message at ~3500 chars; if over, truncate P3 first, then P2:
    ```
    *GitHub Issues — ${today}*
+   <K> new issue(s) across <N> repo(s)
 
-   repo-name: #N Issue title (@author)
-   repo-name: #M Another issue (@author)
+   🔴 P0 — security/critical
+   • <repo> · #N Title (@author) [labels] — <url>
+
+   🟠 P1 — bugs
+   • <repo> · #N Title (@author) [labels] — <url>
+
+   🟡 P2 — features
+   • <repo> · #N Title (@author) — <url>
+
+   ⚪ P3 — other
+   • <repo> · #N Title (@author) — <url>
    ```
-   If no new issues across any repo, **skip the notification entirely** — do not send anything.
+   If P3 has more than 5 entries, collapse the tail to `+X more low-priority`.
 
-5. Log to memory/logs/${today}.md.
-   If no new issues, log "GITHUB_ISSUES_OK" and end.
+8. Log to `memory/logs/${today}.md` under `### github-issues`:
+   - Scope used
+   - Counts: `P0=<n> P1=<n> P2=<n> P3=<n>`
+   - URLs (one per line, so the next run can dedup against this log)
+
+   If counts are all zero, log a single line `GITHUB_ISSUES_OK` and end.
+
+## Sandbox note
+`gh` CLI handles auth internally — no curl env-var expansion issues. The `gh search issues` → per-repo `gh issue list` fallback in step 2 covers transient sandbox or API failures.
+
+## Constraints
+- **Never alert the same issue twice** — dedup against the prior 2 days of logs is mandatory.
+- **Silence on a clean day is a feature** — do not send a "0 issues" message.
+- Read-only: do not label, comment on, or close issues. This skill reports; it does not act.


### PR DESCRIPTION
## Autoresearch summary

Replace the flat per-repo new-issue list with a **priority-ranked triage queue** (P0/P1/P2/P3) driven by labels + title regex, using a single `gh search issues` advanced-search call instead of N per-repo loops. Adds silence-on-clean-day, char-cap with P3-first truncation, dedup against the prior 2 days of logs, and a per-repo fallback for transient API failures.

## Variations considered

| # | Thesis | Score |
|---|--------|------:|
| **B (winner)** | **Sharper output — priority-ranked triage queue with one search call** | **45.5** |
| D | Rethink — per-issue auto-triage with severity + suggested labels + recommended action | 42.5 |
| C | Robustness — persistent dedup ledger, retry loop, archived/disabled repo filtering | 40.0 |
| A | Better inputs — single `gh search issues` call with richer per-issue fields (comments, body) | 35.5 |

### Scoring detail (1–5 per criterion)

| Criterion (weight) | A | B | C | D |
|---|---|---|---|---|
| Clarity (×1.5) | 4 | 4 | 4 | 4 |
| Data quality (×1.5) | 4 | 4 | 3 | 4 |
| Output value (×2) | 3 | **5** | 3 | 5 |
| Robustness (×1.5) | 3 | 3 | **5** | 3 |
| Conventions (×1) | 4 | 4 | 4 | 4 |
| Improvement (×3) | 3 | **5** | 4 | 4 |
| **Weighted** | 35.5 | **45.5** | 40.0 | 42.5 |

## Why B won

- **Biggest single lever for usability**: the original output was a flat list — fine if there are 2 issues, useless when there are 20. P0/P1/P2/P3 grouping makes the digest scannable in 3 seconds and surfaces security/critical at the top where it belongs.
- **Folds in A's input upgrade for free**: the priority-rank format requires labels, so we move to `gh search issues` (one API call, richer fields) anyway. A's main contribution is absorbed without picking it.
- **Sort-by-comments inside each bucket** is a cheap signal multiplier — issues with active discussion bubble up.
- **D's per-issue triage suggestions** (severity + suggested labels + recommended action) scored close, but adds a spam-classification step with non-trivial false-positive risk and pushes the skill from "monitor" to "act on", which is a larger product change. Saved for a future iteration.
- **C's robustness wins** (persistent dedup ledger, retry loop) are real but address a problem that hasn't bitten yet — the original log-scrape dedup has been fine. Adopting C now would be premature.

## Diff summary

- Switched from `gh repo list` + per-repo `gh issue list` loop to a single `gh search issues` call with `$SCOPE is:issue is:open created:>$YESTERDAY` advanced-search query.
- Scope resolution now accepts `owner/repo`, `org:foo`, `user:bar`, or empty (defaults to `user:$(gh api user --jq .login)`).
- Added P0/P1/P2/P3 bucketing with regex rules covering security, bug/regression, feature/enhancement, and "other".
- Output format: grouped by bucket with traffic-light emoji, sorted by comment count then created-desc within each bucket.
- Silence-on-clean-day: 0 issues → no notification, log `GITHUB_ISSUES_OK`.
- Char-cap (~3500) with P3-then-P2 truncation order.
- Per-repo `gh issue list` fallback if the search call returns 422 / hits rate limits.
- Explicit read-only constraint (no labeling, commenting, or closing).

## Test plan

- [ ] Run `var=aaronjmars/aeon-tmp` against this repo and verify output structure
- [ ] Run with empty `var` and verify scope resolves to `user:<gh-user>`
- [ ] Confirm dedup: re-run the same day and verify no duplicate alerts
- [ ] Verify clean-day path: run on a repo with no new issues → no notification sent, log contains `GITHUB_ISSUES_OK`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Ported from aaronjmars/aeon-tmp#5.
