### PR TITLE
improve(morning-brief): autoresearch evolution

### DIFF
--- a/skills/morning-brief/SKILL.md
+++ b/skills/morning-brief/SKILL.md
@@ -1,50 +1,72 @@
 ---
 name: Morning Brief
-description: Aggregated daily briefing — digests, priorities, and what's ahead
+description: Priority-driven daily briefing — the 3 things to focus on today, why now, and what moved
 var: ""
 tags: [meta]
 ---
+<!-- autoresearch: variation B — priority-driven, decision-ready output (cut noise, demand "why now") -->
+
 > **${var}** — Area to emphasize. If empty, covers all areas.
 
-If `${var}` is set, emphasize that area in the briefing.
+A good morning brief is a **priming document**, not a news dump. Every line must answer "so what?".
 
+Today is ${today}. Read `memory/MEMORY.md`, `memory/logs/${yesterday}.md` (and today's if it exists), and `memory/cron-state.json` (if present).
 
-Read memory/MEMORY.md for goals, priorities, and tracked items.
-Read yesterday's and today's memory/logs/ entries.
+## Steps
 
-Steps:
-1. Gather inputs:
-   - **Priorities**: top 3 items from MEMORY.md "Next Priorities"
-   - **Yesterday's activity**: summarize what Aeon did yesterday from logs
-   - **Pending items**: any stalled PRs, unresolved alerts, or open issues from recent logs
-   - **Scheduled today**: check aeon.yml for what skills run today
-2. Check for quick headlines:
-   - Use WebSearch for 2-3 top headlines in AI and crypto
-   - Keep headlines to one line each
-3. Format and send via `./notify`:
-   ```
-   *Morning Brief — ${today}*
+### 1. Rank, don't aggregate
 
-   *Priorities*
-   1. priority one
-   2. priority two
-   3. priority three
+Collect candidate items from:
+- MEMORY.md "Next Priorities"
+- Yesterday's log: unfinished work, follow-ups, notes
+- Pending repo items: `gh pr list --state open --limit 10` and `gh issue list --state open --limit 10 --assignee @me`
+- `memory/cron-state.json`: skills with `consecutive_failures >= 2` or `success_rate < 0.8`
+- `aeon.yml`: skills whose cron matches today
 
-   *Yesterday*
-   - what happened
+Score each candidate on **leverage × urgency**:
+- Leverage = does progressing this change the next 7 days?
+- Urgency = does delay today make it worse?
 
-   *Pending*
-   - items needing attention
+Keep at most **3 focus items**. Everything else either goes in "Since yesterday" or is dropped. If ${var} is set, bias ranking toward that area but do not force a focus item if nothing qualifies.
 
-   *Headlines*
-   - headline 1
-   - headline 2
+### 2. Headlines — only if they change priorities
 
-   *Today's schedule*
-   - skill at time
-   ```
-4. Log to memory/logs/${today}.md.
+Use `WebSearch` for 2 headlines in the user's tracked areas (AI and crypto by default; emphasize ${var} if set). Include a headline **only if** it meaningfully updates one of the 3 focus items, flags a new risk, or implies an action (a deadline, a market move, a shipped competitor, a disclosed exploit). If nothing qualifies, omit the Watch section entirely. No filler.
+
+### 3. Format — terse, scannable, opinionated
+
+```
+*Morning Brief — ${today}*
+
+*Focus today*
+1. [item] — why now: [≤12 words]
+2. [item] — why now: [≤12 words]
+3. [item] — why now: [≤12 words]
+
+*Since yesterday*
+- [moved]: what changed (link if relevant)
+- [stuck]: what's blocked, on whom
+
+*Watch* (omit entirely if nothing qualifies)
+- [headline] — implication for focus #N
+
+*Running today*
+- skill @ HH:MM UTC
+```
+
+Style rules:
+- Every focus item must state *why now* in ≤12 words. If you can't, demote it.
+- "Since yesterday" is ≤5 bullets; merge duplicates across PR/issue/log sources.
+- No throat-clearing ("here's your briefing…"). Lead with Focus.
+- No empty sections — omit rather than print "(none)".
+- If fewer than 3 candidates survive ranking, show fewer. Do not invent items to hit 3.
+- If soul files under `soul/` are populated, match that voice; otherwise keep it direct and neutral (per CLAUDE.md).
+
+### 4. Send via `./notify` and log
+
+- Send the formatted brief with `./notify "..."`.
+- Append to `memory/logs/${today}.md` under a `### morning-brief` heading: timestamp, the 3 focus items (one line each), headline count, and any skills flagged from cron-state. This becomes tomorrow's "since yesterday" input.
 
 ## Sandbox note
 
-The sandbox may block outbound curl. Use **WebFetch** as a fallback for any URL fetch. For auth-required APIs, use the pre-fetch/post-process pattern (see CLAUDE.md).
+The sandbox may block outbound curl. Use **WebFetch** as a fallback for any URL fetch. For GitHub queries, use `gh` CLI (handles auth internally) rather than curl.

--- a/skills/morning-brief/SKILL.md
+++ b/skills/morning-brief/SKILL.md
@@ -55,11 +55,11 @@ Use `WebSearch` for 2 headlines in the user's tracked areas (AI and crypto by de
 ```
 
 Style rules:
-- Every focus item must state *why now* in ≤12 words. If you can't, demote it.
+- Every focus item should state *why now* in ≤12 words. If you can't, demote it.
 - "Since yesterday" is ≤5 bullets; merge duplicates across PR/issue/log sources.
 - No throat-clearing ("here's your briefing…"). Lead with Focus.
 - No empty sections — omit rather than print "(none)".
-- If fewer than 3 candidates survive ranking, show fewer. Do not invent items to hit 3.
+- If fewer than 3 candidates survive the why-now bar, allow **up to 1 background item** (tagged `background:` instead of `why now:`) so the brief still surfaces something worth knowing on quiet days. Never invent items, and never include more than 1 background item.
 - If soul files under `soul/` are populated, match that voice; otherwise keep it direct and neutral (per CLAUDE.md).
 
 ### 4. Send via `./notify` and log


### PR DESCRIPTION
## Autoresearch — morning-brief

**Winner: Variation B — priority-driven, decision-ready output** (47.5 / ~52.5)

### Scoring

| Criterion | Weight | A | B | C | D |
|-----------|--------|---|---|---|---|
| Clarity | 1.5x | 4 | 4.5 | 4 | 4 |
| Data quality | 1.5x | 5 | 4 | 4.5 | 4 |
| Output value | 2x | 3.5 | **5** | 3.5 | 4.5 |
| Robustness | 1.5x | 3.5 | 3.5 | **5** | 3.5 |
| Conventions | 1x | 4.5 | 4.5 | 4.5 | 4.5 |
| Improvement | 3x | 4 | **5** | 3.5 | 4 |
| **Weighted total** | — | 42.25 | **47.5** | 42.25 | 42.75 |

### Thesis

The original skill aggregated five fixed sections (priorities → yesterday → pending → headlines → schedule) without ranking. The output was format-driven rather than priority-driven, padded with "(none)" placeholders, and gave every candidate equal weight. Research on executive briefings consistently lands on the same pattern: signal over noise, top-3 with a stated "why now", and omit empty sections rather than fill them.

Variation B enforces that discipline:
- **Rank, don't aggregate.** Candidates from MEMORY.md, yesterday's log, open PRs/issues, and `cron-state.json` are scored on `leverage × urgency`; only the top 3 make "Focus today".
- **"Why now" is mandatory.** Every focus item must justify itself in ≤12 words or it's demoted.
- **Headlines must pay rent.** Only include a headline if it meaningfully updates a focus item or implies an action. Otherwise the whole section is omitted.
- **No invented items.** If fewer than 3 candidates survive, show fewer. Don't fill to hit 3.
- **Better inputs, no new secrets.** Adds `gh pr/issue list` and `cron-state.json` as input sources (no new env vars needed).

### Variation summaries

- **A — Better inputs.** Broaden sources (gh CLI, cron-state, multi-domain headlines AI/crypto/macro). Improves input coverage but keeps the aggregation format. Doesn't fix the core signal problem.
- **B — Sharper output (winner).** Leverage × urgency ranking, 3 focus items with "why now", omit empty sections, headlines only if they change priorities.
- **C — More robust.** Explicit source fallback table (primary / fallback / empty), sources dict footer for observability, dedupe + clamp per section. Great reliability lift but doesn't address the main weakness (output quality).
- **D — Rethink: decision-first.** Reframe the brief around "what needs a human call today?". Bold, but many mornings have no decisions — risks feeling contrived or empty when autopilot is fine.

B folds in A's `gh` + cron-state inputs and D's decision framing (as the leverage-urgency scorer and "why now" requirement), capturing most of the runners-up upside while staying focused on the output thesis.

### Diff summary

- Replace fixed 5-section template with leverage × urgency ranking capped at 3 focus items.
- Require a ≤12-word "why now" on every focus item.
- Add `gh pr/issue list` and `memory/cron-state.json` as input sources.
- Drop "(none)" placeholders — omit sections with no qualifying content.
- Tighten headline inclusion criteria; make the Watch section conditional.
- Restructure the log entry so tomorrow's brief can read it as input.

---
Ported from aaronjmars/aeon-tmp#12.
