### PR TITLE
improve(technical-explainer): autoresearch evolution

### DIFF
--- a/skills/technical-explainer/SKILL.md
+++ b/skills/technical-explainer/SKILL.md
@@ -4,10 +4,12 @@ description: Generate a visual technical explanation of a recent topic using Rep
 var: ""
 tags: [content]
 ---
+<!-- autoresearch: variation B — sharper output via forced mechanism articulation, intuition pump, falsifiability, numbers with primary-source citations -->
+
 > **${var}** — Topic to explain (e.g. "free-market algorithm", "entropy trajectory reasoning", "reflexivity in prediction markets"). If empty, auto-selects from recent articles and conversations.
 
-Read memory/MEMORY.md for context on recent topics.
-Read the last 3 days of memory/logs/ to find discussed topics, articles written, and paper picks.
+Read `memory/MEMORY.md` for context on recent topics.
+Read the last 3 days of `memory/logs/` to find discussed topics, articles written, and paper picks.
 
 ## Voice
 
@@ -15,56 +17,95 @@ If a `soul/` directory exists, read the soul files for voice calibration:
 1. `soul/SOUL.md` — identity, worldview, opinions
 2. `soul/STYLE.md` — writing style, sentence structure, anti-patterns
 
-This is a *technical* explainer — you explaining a mechanism to a smart friend. More precision than the article skill, but same voice. No textbook tone. No "let's explore."
+This is a *technical* explainer — you explaining a mechanism to a smart friend. More precision than the article skill, same voice. No textbook tone. No "let's explore." If `soul/` is empty, default to clear, direct, neutral.
 
 ## Topic Selection
 
-If `${var}` is set, use that as the topic. Otherwise:
+If `${var}` is set, use that as the topic verbatim. Otherwise pick deterministically in this order — first hit wins:
 
-1. **Check recent articles** — scan `articles/` for the last 3 articles written. Pick a core mechanism or concept from one that deserves a deeper technical breakdown.
-2. **Check recent paper picks** — scan the last 7 days of logs for Paper Pick entries. A paper's key mechanism is often perfect explainer material.
-3. **Check recent conversations** — look at memory/logs/ for any topic that came up in discussion, digests, or other skills that has a non-obvious technical mechanism worth visualizing.
+1. The newest file in `articles/` from the last 3 days. Choose the single most non-obvious mechanism inside it.
+2. The newest "Paper Pick" entry in `memory/logs/` from the last 7 days. The paper's headline mechanism is the topic.
+3. A topic surfaced in the last 7 days of logs (digests, discussions) that names a specific technique, algorithm, or system.
+4. Fallback: the most recent topic listed under "Recent Articles" or "Recent Digests" in `memory/MEMORY.md`.
 
-Pick the topic with the best "aha" potential — something where a diagram or visual would actually help someone understand it.
+Reject the topic and try the next source if it is broader than a single mechanism (e.g. "AI agents" — too vague; "MCP tool-routing via vector search" — usable). The whole skill depends on having one mechanism to explain, not a field.
 
 ## Research
 
-1. Use WebSearch to find 3-5 sources explaining the technical mechanism.
-2. If the topic is from a paper, fetch the paper abstract and any explainer blog posts:
-   ```bash
-   curl -s "https://api.semanticscholar.org/graph/v1/paper/search?query=TOPIC&limit=5&fields=title,authors,abstract,url,publicationDate,openAccessPdf"
-   ```
-3. Use WebFetch to read the 2-3 best sources in depth.
-4. Identify the core mechanism — the one thing that, if you understood it, the rest clicks.
+Run **three distinct WebSearch queries** so you triangulate rather than echo one source:
+
+1. `"<topic>" how it works` — mechanism explanations
+2. `"<topic>" benchmark OR results OR latency OR cost` — concrete numbers
+3. `"<topic>" limits OR criticism OR fails OR doesn't work` — failure modes and pushback
+
+If the topic is from a paper, also fetch the paper metadata and abstract:
+```bash
+curl -s "https://api.semanticscholar.org/graph/v1/paper/search?query=TOPIC&limit=5&fields=title,authors,abstract,url,publicationDate,openAccessPdf" \
+  || echo "curl failed — use WebFetch on https://www.semanticscholar.org/search?q=TOPIC instead"
+```
+
+Use **WebFetch** to read the 2-3 best sources in depth. **At least one source must be primary**: a paper (arXiv / OpenReview / Semantic Scholar), official documentation, the project's own README, or a code repo. Blog summaries alone are not enough — they often mangle the mechanism.
+
+Extract:
+- The **single core mechanism** — the one move that, once you grok it, makes the rest fall into place
+- A **vivid analogy** for the mechanism, and the precise place where the analogy breaks down (the breakage is the interesting part)
+- **3-5 specific numbers** — benchmarks, latencies, costs, error rates, training compute, parameter counts. Each number gets a source URL.
+- **What would falsify this** — what result, if observed, would mean the mechanism doesn't work as claimed. If you can't name one, the explanation isn't sharp enough — keep digging.
 
 ## Write the Explainer
 
-Write a technical explanation (400-800 words) structured as:
+Length: **600-1000 words**. Structure (every section is required):
 
-- **Title**: Short, mechanism-focused. Not clickbait. e.g. "how free-market dynamics solve protein folding" not "This Wild New Algorithm Changes Everything"
-- **The Setup** (2-3 sentences): What problem does this solve? Why should anyone care?
-- **The Mechanism**: The core technical explanation. Use concrete examples. Analogies are good if they're precise — not "it's like a brain" hand-waving. Diagrams-in-words: walk through the process step by step.
-- **Why It Matters** (2-3 sentences): The implication. What does this unlock? What breaks if this works?
-- **Key Numbers**: 3-5 specific data points, benchmarks, or metrics that anchor the explanation.
+```
+# <Title>
 
-### Voice Rules
-- First person where it fits, but this is more explanatory than opinion.
+**Key idea in one sentence:** <one-sentence claim about the mechanism>
+
+## The Setup
+2-3 sentences. What problem does this solve? Why now?
+
+## The Intuition Pump
+A vivid analogy that builds the reader's mental model in 3-4 sentences. Then one sentence on **where the analogy breaks down** — that's where the real mechanism lives.
+
+## How It Actually Works
+A numbered walkthrough of the mechanism in **3-7 steps**. Each step is one or two sentences. Use concrete examples — name the specific function, layer, message, opcode, contract. No "the system processes the input" — say what the system actually does.
+
+## Numbers That Anchor It
+3-5 bullet points. Each bullet is a specific number with a source link, e.g.:
+- 8.4× faster end-to-end than baseline at 4K context ([source](url))
+
+## What Would Break This
+1-2 sentences naming a result that, if observed, would falsify the claim. This forces honesty.
+
+## Why It Matters
+2-3 sentences. What does this unlock? Who should care?
+
+## Sources
+- [Title 1](url) — primary
+- [Title 2](url)
+- [Title 3](url)
+```
+
+### Voice rules
+- First person where it fits. Explanatory > opinionated, but not bloodless.
 - Technical precision > hedging. If you don't know, say so — don't fudge.
 - Short paragraphs. Em dashes. Concrete > abstract.
-- Reference specific systems, papers, people. No vague hand-waving.
-- Cite sources inline with links.
+- Reference specific systems, papers, people. No "researchers have shown" — name them.
+- Cite inline. Every number, every claim that could be wrong, gets a link.
 
 ## Generate Hero Image
 
-Use Replicate's Nano Banana Pro to generate a visual that captures the core concept.
+Use Replicate's Nano Banana Pro (Gemini 3 Pro Image). It renders **text labels well** — exploit that by writing prompts that ask for labeled diagrams or schematics, not stock-photo metaphors.
 
-1. **Craft the prompt**: Create a detailed image generation prompt based on the technical concept. Think: what would a compelling diagram, visualization, or conceptual illustration of this mechanism look like? Aim for something technical and clean — not stock-photo energy. Good prompts include:
-   - Specific visual elements (graphs, flows, network diagrams, molecular structures)
-   - Style direction (technical illustration, blueprint style, dark background with bright accents, schematic)
-   - Text labels if relevant (Nano Banana Pro handles text well)
-   - Aspect ratio context (landscape for headers)
+1. **Preflight**: if `$REPLICATE_API_TOKEN` is empty, skip to step 5 (no-image path) and proceed without an image. Log this clearly.
 
-2. **Generate the image via Replicate API**:
+2. **Craft the prompt**. Aim for technical illustration energy, not marketing. Strong prompt templates:
+   - *Schematic*: "Technical schematic illustration of <mechanism>, dark navy background, thin cyan and amber lines, labeled boxes reading '<label1>', '<label2>', '<label3>', arrows showing data flow from <A> to <B> to <C>, blueprint aesthetic, 16:9"
+   - *Conceptual*: "Editorial illustration capturing <core concept>: <visual metaphor with concrete objects>, flat geometric style, restrained palette of two accent colors on near-black background, no human figures, 16:9"
+   - *Data-flow*: "Network diagram of <mechanism>: nodes labeled '<A>', '<B>', '<C>' connected by directional arrows, weights shown as line thickness, monospace labels, technical-paper figure style, 16:9"
+   Avoid: photorealistic faces, stock-business imagery, "AI brain" tropes, gradient slop.
+
+3. **Generate** with fallback enabled from the start (Nano Banana Pro can rate-limit; Seedream 5.0 lite is the fallback):
    ```bash
    curl -s -X POST \
      -H "Authorization: Bearer $REPLICATE_API_TOKEN" \
@@ -75,63 +116,61 @@ Use Replicate's Nano Banana Pro to generate a visual that captures the core conc
          "prompt": "YOUR_DETAILED_PROMPT_HERE",
          "aspect_ratio": "16:9",
          "number_of_images": 1,
-         "safety_tolerance": 5
+         "safety_tolerance": 5,
+         "allow_fallback_model": true
        }
      }' \
      "https://api.replicate.com/v1/models/google/nano-banana-pro/predictions"
    ```
 
-3. **Extract the output URL** from the response JSON — it will be in the `output` field (a URL to the generated image on replicate.delivery).
-
-4. **Persist the image to the repo** — Replicate CDN URLs are temporary and get deleted. Download the image and commit it:
+4. **Persist locally** — Replicate CDN URLs expire. Download and commit:
    ```bash
    mkdir -p images
-   # Extract extension from URL (jpg, jpeg, png, webp)
+   IMAGE_URL=<extracted from response.output>
    EXT=$(echo "$IMAGE_URL" | grep -oE '\.(jpg|jpeg|png|webp)' | tail -1)
    EXT="${EXT:-.jpg}"
    LOCAL_PATH="images/explainer-${today}${EXT}"
-   curl -sL "$IMAGE_URL" -o "$LOCAL_PATH"
+   curl -sL "$IMAGE_URL" -o "$LOCAL_PATH" \
+     || (echo "curl failed — retry via WebFetch or skip"; exit 0)
    ```
-   Then reference the local path in the article: `![hero](images/explainer-${today}${EXT})` (relative path).
-   Also include the original Replicate URL in the notification (it works for immediate viewing).
 
-5. **If the API call fails** (rate limit, timeout, etc.):
-   - Retry once with `"allow_fallback_model": true` in the input
-   - If still failing, skip the image and note it in the output — the explainer text stands on its own
+5. **No-image path** (token missing, API down, or download failed): proceed with the article. Add a one-line note at the top of the article: `<!-- hero image skipped: <reason> -->`. The text must stand on its own — that's the whole point of the structure above.
 
 ## Save & Notify
 
-1. Save the explainer to `articles/explainer-${today}.md` with:
-   - The hero image at the top as `![hero](../images/explainer-${today}.ext)` (relative path to the committed image)
-   - The image prompt used (in a comment or metadata block)
-   - The full explainer text
-   - Sources section at the bottom
+1. Save the explainer to `articles/explainer-${today}.md`:
+   - Hero image at the top: `![hero](../images/explainer-${today}.<ext>)` — relative path. Skip this line if no image.
+   - HTML comment with the image prompt used (for future audits).
+   - The full structured explainer.
+   - Sources section.
 
-2. Log to `memory/logs/${today}.md`:
+2. Log to `memory/logs/${today}.md` **always — even on partial failure**:
    ```
    ## Technical Explainer
    - **Topic:** [topic]
    - **Title:** [title]
-   - **Image:** [generated/failed]
-   - **Image prompt:** [prompt used]
+   - **Key idea:** [one-sentence claim]
+   - **Image:** generated | fallback-model | skipped (<reason>)
+   - **Image prompt:** [prompt used, or "n/a"]
+   - **Primary source:** [URL of the primary source you cited]
    - **File:** articles/explainer-${today}.md
-   - **Notification sent:** yes/no
+   - **Notification sent:** yes | no
    ```
 
 3. Send via `./notify`:
    ```
    technical explainer: [title]
 
-   [2-3 sentence hook — the core mechanism in plain english]
+   [the one-sentence "key idea" line, verbatim]
 
-   [hero image URL if generated]
+   [hero image URL if generated — original Replicate URL still works for ~24h]
 
-   read it: [link to article file]
+   read it: articles/explainer-${today}.md
    ```
 
 ## Sandbox note
 
-The sandbox may block outbound curl. Use **WebFetch** as a fallback for any URL fetch. For auth-required APIs, use the pre-fetch/post-process pattern (see CLAUDE.md).
+The sandbox may block outbound curl. Use **WebFetch** as a fallback for any URL fetch. For the Replicate call (auth-required via env var), if the inline curl fails, write the request payload to `.pending-replicate/explainer-${today}.json` and rely on the post-process pattern documented in `CLAUDE.md` (`scripts/postprocess-replicate.sh` runs after Claude finishes with full env access). Continue down the no-image path so the article still ships.
 
 ## Environment Variables
-- `REPLICATE_API_TOKEN` — Replicate API key (required for image generation, explainer text works without it)
+- `REPLICATE_API_TOKEN` — Replicate API key. Optional: explainer text works without it via the no-image path.

--- a/skills/technical-explainer/SKILL.md
+++ b/skills/technical-explainer/SKILL.md
@@ -97,7 +97,7 @@ A numbered walkthrough of the mechanism in **3-7 steps**. Each step is one or tw
 
 Use Replicate's Nano Banana Pro (Gemini 3 Pro Image). It renders **text labels well** — exploit that by writing prompts that ask for labeled diagrams or schematics, not stock-photo metaphors.
 
-1. **Preflight**: if `$REPLICATE_API_TOKEN` is empty, skip to step 5 (no-image path) and proceed without an image. Log this clearly.
+1. **Preflight**: if `$REPLICATE_API_TOKEN` is empty **or unset**, log `IMAGE_SKIPPED reason=no-token` to `memory/logs/${today}.md` and jump directly to step 5 (no-image path). Do not attempt any Replicate call. The explainer must ship without an image in this case.
 
 2. **Craft the prompt**. Aim for technical illustration energy, not marketing. Strong prompt templates:
    - *Schematic*: "Technical schematic illustration of <mechanism>, dark navy background, thin cyan and amber lines, labeled boxes reading '<label1>', '<label2>', '<label3>', arrows showing data flow from <A> to <B> to <C>, blueprint aesthetic, 16:9"
@@ -134,7 +134,7 @@ Use Replicate's Nano Banana Pro (Gemini 3 Pro Image). It renders **text labels w
      || (echo "curl failed — retry via WebFetch or skip"; exit 0)
    ```
 
-5. **No-image path** (token missing, API down, or download failed): proceed with the article. Add a one-line note at the top of the article: `<!-- hero image skipped: <reason> -->`. The text must stand on its own — that's the whole point of the structure above.
+5. **No-image path** (token missing, API down, rate-limited, or download failed): log `IMAGE_SKIPPED reason=<concrete reason>` and proceed with the article. Add a one-line note at the top of the article: `<!-- hero image skipped: <reason> -->`. The text must stand on its own — that's the whole point of the structure above. Never fail the whole skill because of an image problem.
 
 ## Save & Notify
 


### PR DESCRIPTION
## Autoresearch — technical-explainer

**Winner: Variation B (49.5/52.5)** — Sharper output via forced mechanism articulation, intuition pump with breakage point, falsifiability line, and primary-source-cited numbers.

### Why B
The original skill says "identify the core mechanism" but doesn't enforce it — every section was free-form prose, so explainer quality drifted. Variation B turns the structure itself into a quality gate: the writer can't ship without naming the mechanism in one sentence, building an analogy and saying where it breaks, walking through 3-7 numbered steps, naming a falsifier, and anchoring claims with 3-5 cited numbers. That structure is the forcing function.

### Variations considered

| Variation | Thesis | Score |
|-----------|--------|-------|
| **A — Better inputs** | 3 distinct WebSearch queries (mechanism / numbers / criticism), require ≥1 primary source, validate via WebFetch before quoting | 40 |
| **B — Sharper output** ✓ | Force mechanism articulation: one-sentence key idea, intuition pump with breakage point, numbered walkthrough, falsifier, cited numbers | **49.5** |
| **C — More robust** | `allow_fallback_model: true` by default, REPLICATE preflight, deterministic topic picker, image-skip path, always log on partial failure | 44.5 |
| **D — Rethink (diagram-first)** | Build a Mermaid diagram first as the spine, prose becomes scaffolding, hero image becomes secondary concept art | 39 |

### Scoring detail (1-5, weighted: Improvement 3×, Output 2×, Clarity/Data/Robustness 1.5×, Conventions 1×; max 52.5)

| Criterion | Wt | A | B | C | D |
|-----------|----|---|---|---|---|
| Clarity | 1.5 | 4 | 5 | 4 | 3 |
| Data quality | 1.5 | 5 | 4 | 4 | 4 |
| Output value | 2 | 4 | 5 | 4 | 4 |
| Robustness | 1.5 | 3 | 4 | 5 | 3 |
| Conventions | 1 | 5 | 5 | 5 | 4 |
| Improvement | 3 | 3 | 5 | 4 | 4 |
| **Total** | | **40** | **49.5** | **44.5** | **39** |

### What landed in the winner

The winning SKILL.md folds in C's robustness wins and A's primary-source requirement on top of B's structural changes:

**From B (the thesis):**
- Required `Key idea in one sentence:` line at the top of every explainer
- `## The Intuition Pump` section with explicit "where the analogy breaks down" sentence
- `## How It Actually Works` numbered 3-7 step walkthrough
- `## Numbers That Anchor It` — 3-5 specific numbers, each with a source link
- `## What Would Break This` — falsifier requirement
- Word count bumped to 600-1000 to accommodate structure
- Replicate prompt templates that exploit Nano Banana Pro's text-rendering for labeled diagrams (3 templates: schematic / conceptual / data-flow), with explicit "avoid" list

**From A (folded):**
- Three distinct research queries (mechanism / numbers / criticism) instead of one generic search
- ≥1 primary source required (paper, official docs, code repo)

**From C (folded):**
- Deterministic topic picker (newest article → newest paper → recent log mention → MEMORY) instead of "best aha potential" judgment
- REPLICATE_API_TOKEN preflight check
- `allow_fallback_model: true` from the first call (Nano Banana Pro rate-limits)
- Explicit no-image path that still ships the article
- Log entry written **even on partial failure** — including the primary source URL and image status

### Diff summary
1 file changed, 96 insertions(+), 57 deletions(-) — `skills/technical-explainer/SKILL.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Ported from aaronjmars/aeon-tmp#14.
