### PR TITLE
improve(startup-idea): autoresearch evolution

### DIFF
--- a/skills/startup-idea/SKILL.md
+++ b/skills/startup-idea/SKILL.md
@@ -1,63 +1,128 @@
 ---
 name: Startup Idea
-description: 2 startup ideas tailored to the user's skills, interests, and context
+description: 2 evidence-backed startup memos with ICP, wedge, monetization, and numeric kill criteria
 var: ""
 tags: [creative]
 ---
+<!-- autoresearch: variation B — sharper output via rigid memo schema + tarpit filter + cited pain evidence -->
+
 > **${var}** — Constraint or theme (e.g. "solo founder", "crypto infra", "B2B SaaS", "under $10k to launch"). If empty, generates freely.
 
-Read memory/MEMORY.md for current goals and recent thinking.
-Read the last 7 days of memory/logs/ for recent research, articles, and signals.
-If soul files exist (`soul/SOUL.md`), read them for identity, expertise, and worldview.
+Read `memory/MEMORY.md` for current goals and recent thinking.
+Read the last 14 days of `memory/logs/` for recent research, articles, and signals — and to dedup against recently proposed ideas.
+If soul files exist (`soul/SOUL.md`, `soul/STYLE.md`), read them for identity, expertise, and voice.
 
 ## Steps
 
-1. Build the founder profile from available context:
-   - What domains does the user have expertise in? (from memory, soul, and recent logs)
-   - What projects are they currently working on?
-   - What topics have they been researching or tracking?
-   - If none of this is available, generate broadly applicable ideas based on `${var}` or current tech trends
+### 1. Build the founder profile
+From memory, soul, and recent logs, extract:
+- **Domains of earned expertise** — what has the user actually shipped or deeply researched? ("earned secret" test)
+- **Active projects** — what's currently being worked on
+- **Recent signal** — topics, papers, market moves tracked this week
+- **Recently proposed ideas** — scan the last 14 days of logs; do not re-pitch these
 
-2. Gather fresh signals:
-   - Use WebSearch to find 3-5 emerging trends, unmet needs, or market gaps across ANY industry or domain — not just the user's usual lanes
-   - Cross-reference with recent logs — what topics, papers, or market movements have been notable this week?
-   - If `${var}` is set, constrain the search to that theme
-   - IMPORTANT: Vary the domains across runs. Check the last 7 days of logs — if recent ideas were crypto focused, go somewhere else this time
+If none of this exists, generate broadly applicable ideas anchored to `${var}` and 2026 tech trends.
 
-3. Generate **2 startup ideas**. Each should:
-   - Play to the user's actual strengths and knowledge (not generic "AI for X" slop)
-   - Have a plausible path to revenue or traction
-   - Be differentiated from obvious competitors
-   - One should be more ambitious (bigger swing), one more executable (could launch in weeks)
+### 2. Gather fresh pain evidence
 
-4. For each idea, provide:
-   - **Name** — a working title
-   - **One-liner** — what it does in one sentence
-   - **Why now** — what shift makes this possible today (1 sentence)
-   - **First move** — the smallest thing to build/test to validate (1 sentence)
+Use WebSearch + WebFetch to collect **real customer pain signals**, not model priors. Aim for ≥3 high-signal sources across at least 2 of these channels:
 
-5. Send via `./notify` (under 4000 chars):
-   ```
-   *Startup Ideas — ${today}*
+- **G2 / Capterra 1–3★ reviews** — named frustrated buyers with budget. Search: `"[category] site:g2.com" OR "[category] 1 star review"`
+- **Reddit pain threads** — `r/SaaS`, `r/startups`, `r/smallbusiness`, `r/Entrepreneur`. Search: `"I wish there was" OR "why is there no" OR "anyone else frustrated with"`
+- **Indie Hackers + HN "Ask HN: who is hiring"** — bottom-up demand signals
+- **YC Requests for Startups** — `ycombinator.com/rfs` (current cycle)
+- **Upwork / job postings** — people paying humans to do it → productizable
+- **ProductHunt comment sections** (not launches) — gaps in recent launches
 
-   *1. [Name]* — [one-liner]
-   Why now: [one sentence]
-   First move: [one sentence]
+Save 2+ permalinks per idea with a one-line quote of the pain. If `${var}` is set, scope the search to that theme. **Vary domains across runs** — if recent logs pitched crypto, go elsewhere this time.
 
-   *2. [Name]* — [one-liner]
-   Why now: [one sentence]
-   First move: [one sentence]
-   ```
+Sandbox fallback: if curl/WebFetch both fail for a source, note `[source unreachable]` inline and proceed with remaining sources. Never fabricate quotes.
 
-6. Log to memory/logs/${today}.md:
-   ```
-   ## Startup Idea
-   - **Idea 1:** [name] — [one-liner]
-   - **Idea 2:** [name] — [one-liner]
-   - **Constraint:** [var or "none"]
-   - **Notification sent:** yes
-   ```
+### 3. Apply the tarpit filter (reject before generation)
+
+Pre-reject these categories unless the user has an overwhelming earned-secret advantage:
+- Generic "ChatGPT/AI for [X]" wrappers with no data or workflow moat
+- AI meeting notetakers, AI email assistants, AI chatbots for SMBs
+- Social apps for niche demographics
+- Crypto "community/social" apps without distribution
+- Anything where the answer to "why hasn't this been built" is "it has, 50 times"
+
+### 4. Generate 2 startup memos
+
+Produce **exactly 2 ideas**:
+- **Idea 1 — Executable**: launchable in 2–6 weeks solo, clear first customer, <$5k to MVP
+- **Idea 2 — Ambitious**: bigger swing (new category, harder tech, or platform play) but with a defensible wedge
+
+Each idea **must** fill every field below. If a field can't be filled with a concrete answer, drop the idea and try another.
+
+```
+### Idea [1|2] — [Name]
+
+**Thesis** (1 sentence): why this wins
+**ICP** (role + trigger event): e.g. "Ops manager at 50–200-person logistics co who just lost a client to tracking failures"
+**Wedge** (first 12 months): the single sharp product
+**Pain evidence** (2+ permalinks):
+  - [quote] — [url]
+  - [quote] — [url]
+**Monetization**: price point, target gross margin, rough unit economics
+**Distribution** (specific channel + CAC estimate): not "content marketing" — name the channel
+**Moat** (what compounds): data, workflow lock-in, regulatory, network, proprietary integration
+**Why now (2026)**: one of — regulatory shift, capability unlock, cost-curve shift, distribution change
+**MVP test** (2 weeks): what to build, what metric proves/disproves demand
+**Kill criteria** (numeric): e.g. "<3 paid pilots in 60 days → kill"
+**Expansion** (what if it works): the adjacent market
+```
+
+Quality bar before emitting:
+- Does each idea pass Paul Graham's organic test (something the user would want, can build, few others see)?
+- Is the ICP a named role with a trigger event, not "SMBs" or "developers"?
+- Is distribution a specific channel, not a generic category?
+- Is the kill criteria numeric and time-bound?
+
+If an idea fails the bar, iterate. Do not emit slop.
+
+### 5. Send via `./notify` (under 4000 chars)
+
+```
+*Startup Ideas — ${today}*${var ? ` (${var})` : ``}
+
+*1. [Name]* (executable) — [thesis]
+ICP: [role + trigger]
+Wedge: [first product]
+Why now: [one sentence]
+MVP test: [what to build, metric]
+Kill: [numeric criteria]
+
+*2. [Name]* (ambitious) — [thesis]
+ICP: [role + trigger]
+Wedge: [first product]
+Why now: [one sentence]
+MVP test: [what to build, metric]
+Kill: [numeric criteria]
+```
+
+Keep the notification tight — full memos go to the log.
+
+### 6. Log to `memory/logs/${today}.md`
+
+Append the full 2-memo output (all fields from step 4), plus:
+
+```
+## Startup Idea
+- **Constraint:** [var or "none"]
+- **Idea 1:** [name] — [one-liner]
+- **Idea 2:** [name] — [one-liner]
+- **Sources cited:** [count of permalinks]
+- **Notification sent:** yes
+```
 
 ## Sandbox note
 
-The sandbox may block outbound curl. Use **WebFetch** as a fallback for any URL fetch. For auth-required APIs, use the pre-fetch/post-process pattern (see CLAUDE.md).
+The sandbox may block outbound curl. Use **WebFetch** as a fallback for any URL fetch. If both fail for a pain source, note `[source unreachable]` inline and proceed — never fabricate quotes or permalinks. For auth-required APIs, use the pre-fetch/post-process pattern (see CLAUDE.md).
+
+## Constraints
+
+- Never emit an idea without 2+ cited pain permalinks (or explicit `[source unreachable]` for the attempted source).
+- Never emit a tarpit-category idea (step 3) without an explicit earned-secret justification.
+- Never repeat an idea proposed in the last 14 days of logs.
+- Notification stays under 4000 chars; full memos live in the daily log.


### PR DESCRIPTION
## Winner: Variation B — Sharper output (49.5/50)

**Thesis:** the biggest lever for startup-idea quality is *output discipline* — force a rigid memo schema with cited pain evidence, named ICP with trigger event, specific distribution channel with CAC, numeric kill criteria, and pre-reject tarpit categories. Model priors generate plausible-sounding slop; sourced evidence + schema rigor fixes that.

## Scoring table (weighted, /50)

| Criterion | Weight | A: Better inputs | B: Sharper output | C: More robust | D: Adversarial critic |
|-----------|-------:|-----------------:|------------------:|---------------:|----------------------:|
| Clarity | 1.5× | 4 | 4 | 4 | 3 |
| Data quality | 1.5× | 5 | 5 | 3 | 3 |
| Output value | 2× | 3 | **5** | 3 | 4 |
| Robustness | 1.5× | 3 | 4 | 5 | 3 |
| Conventions | 1× | 5 | 5 | 5 | 4 |
| Improvement | 3× | 4 | **5** | 3 | 4 |
| **Total** |  | **41** | **49.5** | **38** | **37.5** |

## Variations considered

- **A — Better inputs (41):** prefetch G2 1-3★ reviews, r/SaaS pain threads, YC RFS, Upwork postings; require 3+ cited permalinks. Strong data layer but leaves output format weak.
- **B — Sharper output (49.5):** rigid memo schema (Thesis, ICP+trigger, Wedge, Pain evidence, Monetization+CAC, Distribution channel, Moat, Why now, MVP test, numeric kill criteria, Expansion). Folds in source diversity from A and tarpit filter from C. **Selected.**
- **C — More robust (38):** tarpit filter, earned-secret test, 14-day dedup, web-research fallbacks. Safer but doesn't raise output ceiling.
- **D — Adversarial critic (37.5):** generate 5 candidates, run adversarial critic applying PG organic test + Dalton tarpit list + moat test. Interesting but process-heavy for marginal gain over B.

## Key changes in the winner

1. Added **pain evidence requirement**: 2+ permalinked customer pain sources per idea (G2, Reddit, Upwork, IH, YC RFS, ProductHunt comments). No fabrication — `[source unreachable]` if fetch fails.
2. Replaced loose "Why now / First move" with a **full memo schema**: ICP (role + trigger event), Wedge, Pain evidence, Monetization (price + margin), Distribution (specific channel + CAC), Moat, Why now (regulatory/capability/cost/distribution), MVP test, numeric Kill criteria, Expansion.
3. Added a **tarpit pre-filter** (step 3) rejecting generic AI wrappers, meeting notetakers, niche social apps, crypto community plays — unless user has an earned-secret advantage.
4. **Dedup window extended to 14 days** (was 7) to avoid repeat pitches.
5. **Notification stays tight** (under 4000 chars); full memos go to the daily log.
6. Added explicit **quality bar** (PG organic test, named ICP, specific distribution, numeric kill) before emitting.

## Diff summary

- `skills/startup-idea/SKILL.md`: +115 / -50 lines. Frontmatter description updated to reflect memo depth. Core workflow restructured from 4-field quick pitch to 11-field memo with cited evidence and quality gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via autoresearch

---
Ported from aaronjmars/aeon-tmp#15.
