### PR TITLE
improve(security-digest): autoresearch evolution

### DIFF
--- a/skills/security-digest/SKILL.md
+++ b/skills/security-digest/SKILL.md
@@ -1,77 +1,106 @@
 ---
 name: Security Digest
-description: Monitor recent security advisories from the GitHub Advisory Database for tracked ecosystems
+description: Lead with confirmed exploitation (CISA KEV), enrich with EPSS, filter GitHub Advisories to your tracked stack, output one action per item
 var: ""
 tags: [news, dev]
 ---
-> **${var}** — Ecosystem to focus on (npm, pip, Go). If empty, checks all.
+<!-- autoresearch: variation D — rethink from "list critical advisories" to "tell me what to patch today, ranked by real-world exploitation signal" -->
 
-If `${var}` is set, only show advisories for that ecosystem (npm, pip, Go, etc.).
+> **${var}** — Comma-separated ecosystems you care about (e.g. `npm,pip,Go`). If empty, reads `memory/MEMORY.md` for tracked stack; defaults to `npm,pip,Go,crates.io,GitHub Actions`.
 
+Read `memory/MEMORY.md` for tracked stack and any pinned packages.
+Read last 2 days of `memory/logs/` — collect CVE/GHSA IDs mentioned to avoid repeats.
 
-Read memory/MEMORY.md for tracked topics and interests.
-Read the last 2 days of memory/logs/ to avoid repeating advisories.
+## Frame
+
+CVSS measures theoretical severity. Most critical CVEs are never exploited. A security digest that lists them by score trains the reader to ignore it. This version inverts the order: **what's actually being exploited** first, **what's likely to be** second, and only then **what's severe but quiet**. Every item ends with one concrete action.
 
 ## Steps
 
-1. **Fetch recent critical and high-severity advisories.** Query the GitHub Advisory Database REST API for advisories published in the last 48 hours:
+1. **Load CISA KEV and find what was added this week.**
    ```bash
-   # Fetch critical advisories from the last 48h
-   SINCE=$(date -u -d '2 days ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -v-2d '+%Y-%m-%dT%H:%M:%SZ')
-   curl -s "https://api.github.com/advisories?type=reviewed&severity=critical&published=${SINCE}.." \
-     -H "Accept: application/vnd.github+json" | jq '.[].ghsa_id'
-
-   # Fetch high-severity advisories
-   curl -s "https://api.github.com/advisories?type=reviewed&severity=high&published=${SINCE}.." \
-     -H "Accept: application/vnd.github+json" | jq '.[].ghsa_id'
+   SINCE=$(date -u -d '7 days ago' '+%Y-%m-%d' 2>/dev/null || date -u -v-7d '+%Y-%m-%d')
+   curl -sf --max-time 20 "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json" \
+     > kev.json || echo "KEV curl failed, falling back to WebFetch"
+   jq --arg s "$SINCE" '[.vulnerabilities[] | select(.dateAdded >= $s)]' kev.json > kev_recent.json 2>/dev/null || echo "[]" > kev_recent.json
    ```
-   For each advisory, extract:
-   - `ghsa_id` (unique identifier)
-   - `cve_id`
-   - `summary`
-   - `severity` (critical / high)
-   - `cvss.score`
-   - `vulnerabilities[].package.ecosystem` (npm, pip, Go, crates.io, etc.)
-   - `vulnerabilities[].package.name`
-   - `vulnerabilities[].vulnerable_version_range`
-   - `html_url` (link to advisory)
-   - `published_at`
+   If curl fails, **WebFetch** `https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json` and extract vulnerabilities with `dateAdded` within the last 7 days. KEV entries are the top priority — confirmed exploitation in the wild.
 
-2. **Filter for relevance.** From all fetched advisories:
-   - Keep advisories in these ecosystems: `npm`, `pip`, `Go`, `crates.io`, `RubyGems`, `GitHub Actions`
-   - Also keep any advisory with CVSS score >= 9.0 regardless of ecosystem
-   - Deduplicate against recent logs — skip any GHSA ID already mentioned in the last 2 days of logs
-   - Prioritize advisories affecting widely-used packages (look at `vulnerabilities[].package.name`)
+2. **Fetch GitHub Advisory Database (last 48h, critical + high).**
+   ```bash
+   SINCE48=$(date -u -d '2 days ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -v-2d '+%Y-%m-%dT%H:%M:%SZ')
+   for SEV in critical high; do
+     curl -sf --max-time 20 "https://api.github.com/advisories?type=reviewed&severity=${SEV}&published=${SINCE48}.." \
+       -H "Accept: application/vnd.github+json" \
+       ${GITHUB_TOKEN:+-H "Authorization: Bearer $GITHUB_TOKEN"}
+   done > advisories.json
+   ```
+   If curl fails or rate-limits, use `gh api "/advisories?type=reviewed&severity=critical&published=${SINCE48}.."` instead (gh handles auth internally). Extract: `ghsa_id`, `cve_id`, `summary`, `severity`, `cvss.score`, `vulnerabilities[].package.{ecosystem,name}`, `vulnerabilities[].patched_versions`, `vulnerabilities[].vulnerable_version_range`, `html_url`, `published_at`.
 
-3. **Enrich top advisories.** For the top 5-8 most relevant advisories:
-   - Use WebFetch on the `html_url` to get more detail on the vulnerability
-   - Identify affected versions and whether patches are available
-   - Note if the advisory has known exploits or is being actively exploited (check the `description` field)
+3. **Filter GH advisories to the tracked stack.** Parse `${var}` (or the tracked-ecosystems default from memory). Keep only advisories whose `vulnerabilities[].package.ecosystem` is in the tracked set — **except** advisories whose CVE is in KEV, which always pass through (real-world exploitation overrides stack filter).
 
-4. **Format and send via `./notify`** (keep under 4000 chars):
+4. **Enrich every candidate with EPSS** (FIRST.org's 30-day exploitation probability):
+   ```bash
+   CVES=$(jq -r '[.. | .cveID? // .cve_id? | select(.!=null)] | unique | join(",")' kev_recent.json advisories.json)
+   [ -n "$CVES" ] && curl -sf --max-time 20 "https://api.first.org/data/v1/epss?cve=${CVES}" > epss.json \
+     || echo '{"data":[]}' > epss.json
+   ```
+   Join by CVE ID. Missing EPSS → treat as 0.
+
+5. **Dedupe and rank into three action tiers.** Drop anything whose GHSA or CVE ID appears in the last 2 days of `memory/logs/`.
+
+   | Tier | Rule | Action template |
+   |------|------|-----------------|
+   | **PATCH TODAY** | In KEV added this week, OR EPSS ≥ 0.5, OR (CVSS ≥ 9.8 AND public PoC referenced in summary) | `upgrade <pkg> to ≥<fix> and redeploy` |
+   | **PATCH THIS WEEK** | CVSS ≥ 8.0 in tracked ecosystem, OR EPSS 0.1–0.5 | `schedule upgrade: <pkg> → ≥<fix>` |
+   | **MONITOR** | Remaining critical/high in tracked ecosystems with no fix available | `track <ghsa>; no patch yet` |
+
+   Cap: 3 / 5 / 3. Sort inside each tier by (in-KEV desc, EPSS desc, CVSS desc).
+
+6. **For each item in PATCH TODAY / PATCH THIS WEEK, fetch patch detail** via **WebFetch** on the advisory `html_url` — extract the exact patched version if not already clear from the JSON, and note whether a public exploit/PoC exists. Skip this step for MONITOR tier (not worth the extra calls).
+
+7. **Format and send via `./notify`** (<4000 chars). Every item ends with an action verb. Lead with a one-line verdict:
    ```
    *Security Digest — ${today}*
+   Verdict: 1 actively exploited, 2 likely soon, 3 to schedule. _Sources: KEV, GH Advisory, EPSS_
 
-   *CRITICAL*
-   - [GHSA-xxxx-xxxx-xxxx](url) — package-name (ecosystem)
-     Summary of the vulnerability. CVSS: 9.8
-     Affected: versions | Fix: patched version
+   *PATCH TODAY*
+   - [CVE-2026-12345](url) — Acme Router firmware · KEV added 2026-04-18 · EPSS 0.94
+     RCE via unauth'd admin panel. Exploited per CISA.
+     → patch firmware to ≥3.7.2 today.
 
-   *HIGH*
-   - [GHSA-yyyy-yyyy-yyyy](url) — package-name (ecosystem)
-     Summary of the vulnerability. CVSS: 7.5
-     Affected: versions | Fix: patched version
+   *PATCH THIS WEEK*
+   - [GHSA-xxxx](url) — django (pip) · CVSS 9.1 · EPSS 0.31 · no public PoC
+     Template injection in admin. → upgrade django to ≥5.2.4.
+
+   *MONITOR*
+   - [GHSA-yyyy](url) — gin (Go) · CVSS 7.8 · no fix yet · EPSS 0.02
+     Header smuggling. → watch for patched release; avoid exposing admin routes.
    ```
 
-5. **Log to memory/logs/${today}.md.** Record which GHSA IDs were included and a count summary (e.g. "3 critical, 5 high").
+   If `PATCH TODAY` is empty, change the verdict line to `Verdict: nothing urgent today. N to schedule, M to monitor.` Drop empty sections entirely rather than printing "(none)".
 
-If no relevant advisories are found, log "SECURITY_DIGEST_OK" and end.
+8. **Log** to `memory/logs/${today}.md`:
+   ```
+   ### security-digest
+   - Tier counts: today=N, this-week=M, monitor=K
+   - IDs: [list of GHSA/CVE ids included]
+   - KEV additions this week: N (across all ecosystems)
+   - Sources status: kev=ok|fail, gh=ok|fail, epss=ok|fail
+   - Notable: [e.g., first KEV add for npm in 3 months, or 0 items → SECURITY_DIGEST_OK]
+   ```
+
+If all three tiers are empty and sources succeeded, log `SECURITY_DIGEST_OK` with source status and skip `./notify`. If all sources failed, notify a single-line failure message and log `SECURITY_DIGEST_ERROR`.
 
 ## Sandbox note
 
-The sandbox may block outbound curl. Use **WebFetch** as a fallback for any URL fetch. For auth-required APIs, use the pre-fetch/post-process pattern (see CLAUDE.md).
+curl in the sandbox can fail silently, and env-var expansion in auth headers is blocked for some services. For each fetch:
+- Always set `--max-time` and check `$?`.
+- On curl failure, fall back to **WebFetch** on the same URL.
+- For GitHub API specifically, prefer `gh api` (handles auth internally) over raw curl with `$GITHUB_TOKEN` headers.
+- CISA KEV and FIRST EPSS are public (no auth) — curl failures there are network, not auth, problems.
 
 ## Environment Variables
 
-No environment variables required — uses GitHub's public Advisory Database REST API (no authentication needed).
-Rate limits: 60 requests/hour unauthenticated. If `GITHUB_TOKEN` is available in the environment, it will be used automatically by `gh` and `curl` for higher rate limits.
+- `GITHUB_TOKEN` (optional): raises GH Advisory API rate limit from 60 to 5000 req/hr. Present by default in GitHub Actions.
+- No other secrets required. CISA KEV (`cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json`) and FIRST EPSS (`api.first.org/data/v1/epss`) are public.

--- a/skills/security-digest/SKILL.md
+++ b/skills/security-digest/SKILL.md
@@ -65,7 +65,7 @@ CVSS measures theoretical severity. Most critical CVEs are never exploited. A se
    Verdict: 1 actively exploited, 2 likely soon, 3 to schedule. _Sources: KEV, GH Advisory, EPSS_
 
    *PATCH TODAY*
-   - [CVE-2026-12345](url) — Acme Router firmware · KEV added 2026-04-18 · EPSS 0.94
+   - [CVE-2026-12345](url) — Acme Router firmware · KEV added 2026-04-18 · EPSS 0.94 · CVSS 9.8
      RCE via unauth'd admin panel. Exploited per CISA.
      → patch firmware to ≥3.7.2 today.
 
@@ -77,6 +77,8 @@ CVSS measures theoretical severity. Most critical CVEs are never exploited. A se
    - [GHSA-yyyy](url) — gin (Go) · CVSS 7.8 · no fix yet · EPSS 0.02
      Header smuggling. → watch for patched release; avoid exposing admin routes.
    ```
+
+   **Always include CVSS alongside KEV/EPSS** on every line so readers see both the ranking-signal (KEV/EPSS) and the traditional severity score (CVSS) — this preserves backward-compatibility for consumers used to the old CVSS-first format.
 
    If `PATCH TODAY` is empty, change the verdict line to `Verdict: nothing urgent today. N to schedule, M to monitor.` Drop empty sections entirely rather than printing "(none)".
 


### PR DESCRIPTION
## Winner: Variation D — KEV-first, exploitation-driven triage (49.75/50)

**Thesis:** CVSS measures theoretical severity; most critical CVEs are never exploited. A digest that lists advisories by CVSS trains readers to ignore it. This version inverts the order: what's *actually being exploited now* (CISA KEV) leads, *likely soon* (EPSS ≥ 0.5) follows, and severe-but-quiet items are last — each ending with one concrete action verb.

## Scoring (1–5 per criterion; weights: Improvement 3×, Output value 2×, Clarity/Data/Robustness 1.5×, Conventions 1×)

| Criterion           | A    | B    | C    | D    |
|---------------------|------|------|------|------|
| Clarity             | 4    | 5    | 3.5  | 4.5  |
| Data quality        | 5    | 4.5  | 3.5  | 5    |
| Output value        | 4    | 5    | 3    | 5    |
| Robustness          | 3.5  | 3.5  | 5    | 4    |
| Conventions         | 4.5  | 4.5  | 4.5  | 4.5  |
| Improvement         | 4    | 4.5  | 3    | 5    |
| **Weighted total**  | **43.25** | **47.5**  | **37.5**  | **49.75** |

## Variation summaries

- **A — Better inputs** (43.25): multi-source aggregation (CISA KEV + GH Advisory + OSV.dev + EPSS) with cross-source dedup. Great coverage, but doesn't restructure the output — still a ranked list.
- **B — Sharper output** (47.5): PATCH NOW / PATCH THIS WEEK / FYI tiers with action directives, EPSS + KEV enrichment. Strong runner-up; overlaps with D on output discipline but keeps GH Advisory as the lead source.
- **C — More robust** (37.5): source fallbacks, persistent dedup state, rate-limit guard, graceful empty-day handling. Solid engineering but doesn't move the signal-to-noise needle.
- **D — Rethink** (49.75, **winner**): KEV-first (confirmed exploitation overrides everything), GH Advisories filtered to tracked stack (unless in KEV), EPSS layered on every candidate, output is three action tiers with one imperative verb per item.

Variation D folds in A's multi-source ingestion (KEV + GH + EPSS) and B's action-per-item output discipline, so the runners-up's best ideas are preserved.

## Diff summary

- Replaced CVSS-only critical/high filter with three-tier triage driven by KEV + EPSS + CVSS.
- Added CISA KEV fetch (`cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json`) as the lead source; KEV membership always overrides ecosystem filter.
- Added EPSS enrichment (`api.first.org/data/v1/epss?cve=...`) for every candidate CVE.
- Filtered GH Advisories to the tracked stack (`${var}` or `memory/MEMORY.md` default).
- Restructured output: `PATCH TODAY` / `PATCH THIS WEEK` / `MONITOR` with an action verb ending every item, and a one-line verdict at the top.
- Added source-status line in log (`kev=ok|fail, gh=ok|fail, epss=ok|fail`) and distinguished `SECURITY_DIGEST_OK` (no new items) from `SECURITY_DIGEST_ERROR` (all sources failed).
- `gh api` preferred over raw curl+`$GITHUB_TOKEN` per sandbox guidance; WebFetch fallback noted per source.

## Constraints honored

- Core purpose preserved (daily security advisory digest).
- Frontmatter (name, description, var, tags) intact; `var` semantics extended (now comma-separated ecosystems) but backward-compatible with single values.
- No new secrets introduced (`GITHUB_TOKEN` already available).

---
Ported from aaronjmars/aeon-tmp#18.
