### PR TITLE
improve(pr-review): autoresearch evolution

### DIFF
--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -1,51 +1,128 @@
 ---
 name: PR Review
-description: Auto-review open PRs on watched repos and post summary comments
+description: Auto-review open PRs with severity-tagged findings, inline comments, and a one-line verdict
 var: ""
 tags: [dev]
 ---
-> **${var}** — Repo (owner/repo) to review. If empty, reviews all watched repos.
+<!-- autoresearch: variation B — sharper output: severity-tagged & capped findings, inline comments on exact lines, one-line verdict; folds in skip rules (A) and SHA dedup + large-diff fallback (C) -->
 
-If `${var}` is set, only review PRs on that repo (owner/repo format).
+> **${var}** — Repo (owner/repo) to scope the review to. If empty, reviews every repo in `memory/watched-repos.md`.
 
+Read `memory/MEMORY.md` and `memory/watched-repos.md`.
+Read the last 2 days of `memory/logs/` to pull the `headRefOid` of any PR reviewed recently — used for dedup.
 
-## Config
+If `memory/watched-repos.md` is empty or missing, log `PR_REVIEW_NO_REPOS` and end.
 
-This skill reads repos from `memory/watched-repos.md`. If the file doesn't exist yet, create it or skip this skill.
+## What this skill optimizes for
 
-```markdown
-# memory/watched-repos.md
-- owner/repo
-- another-owner/another-repo
+Noise is the documented failure mode of automated PR review. Every finding emitted must be severity-tagged, line-specific, and justified with a one-sentence "why it matters". If there is nothing worth saying, say so in one line and move on.
+
+## For each repo
+
+```bash
+gh pr list -R owner/repo --state open --limit 20 \
+  --json number,title,author,isDraft,labels,headRefOid,updatedAt
 ```
 
----
+### Skip rules
 
-Read memory/MEMORY.md and memory/watched-repos.md for repos to review.
-Read the last 2 days of memory/logs/ to avoid reviewing the same PR twice.
+Skip a PR if any of the following hold (record the skip reason for the run summary):
 
-Steps:
-1. For each repo in watched-repos.md, list open PRs:
+- `isDraft: true`
+- title matches `^(WIP|\[WIP\]|Draft:)` (case-insensitive)
+- has label `no-review`, `do-not-merge`, `wip`, or `blocked`
+- author login contains `[bot]` (dependabot, renovate, etc.) or equals `aeonframework`
+- this PR's current `headRefOid` already appears in the last 2 days of `memory/logs/` against the same PR (already reviewed at this commit)
+- a bot reviewer (`coderabbitai`, `copilot-pull-request-reviewer`, `claude`) posted a review in the last 30 min — skip to avoid piling on. Check via:
+  ```bash
+  gh api repos/owner/repo/pulls/NUMBER/reviews --jq '.[] | {user: .user.login, submitted_at}'
+  ```
+
+### For each remaining PR
+
+1. **Fetch context**:
    ```bash
-   gh pr list -R owner/repo --state open --json number,title,author,createdAt,updatedAt,body,additions,deletions,changedFiles
+   gh pr view NUMBER -R owner/repo \
+     --json title,body,headRefOid,baseRefName,files,additions,deletions
    ```
-2. For each PR not already reviewed in recent logs:
-   - Fetch the diff: `gh pr diff NUMBER -R owner/repo`
-   - Review for:
-     - Logic errors or bugs
-     - Security concerns (injection, exposed secrets, unsafe operations)
-     - Code quality (naming, structure, duplication)
-     - Missing tests or edge cases
-   - Keep feedback concise and actionable — no nitpicks
-3. Post a review comment on the PR:
+   If the `body` contains `Fixes #N` or `Closes #N`, fetch the linked issue for context:
    ```bash
-   gh pr review NUMBER -R owner/repo --comment --body "review text"
+   gh issue view N -R owner/repo --json title,body,labels
    ```
-4. Send a summary via `./notify`:
+
+2. **Fetch the diff**:
+   ```bash
+   gh pr diff NUMBER -R owner/repo
    ```
-   *PR Review — ${today}*
-   Reviewed N PRs across M repos.
-   - owner/repo#123: summary of findings
+   - If `additions + deletions > 3000`, review only the top-5 largest-delta files from the `files` array (not the full diff).
+   - If `gh pr diff` fails, fall back to per-file patches:
+     ```bash
+     gh api repos/owner/repo/pulls/NUMBER/files --jq '.[] | {path, patch}'
+     ```
+   - If the diff comes back empty (e.g. mid-rebase), skip the PR with reason `empty-diff`.
+
+3. **Early-exit for trivial PRs**: if the diff is docs-only (`.md`/`.rst`/`docs/**`), lockfile-only, or test-only, skip deep review and post the 1-line ack form in step 6.
+
+4. **Review with severity tagging**. Every finding must carry exactly one tag:
+   - `[CRITICAL]` — correctness break, security hole, data loss, API break, regression
+   - `[ISSUE]` — likely bug, missing edge case, wrong behavior under a realistic input
+   - `[NIT]` — naming, style, minor cleanup (dropped by default)
+
+   Rules:
+   - Cap at **5 findings total** per PR. Drop NITs first, then the lowest-impact ISSUEs.
+   - Drop all NITs unless there are zero CRITICAL/ISSUE findings *and* a NIT is genuinely useful.
+   - Every finding must name `path/to/file:LINE` and include a one-sentence "why it matters" — the consequence, not just "this is wrong".
+   - No praise, no diff restating, no "this PR adds X" summaries.
+
+5. **Determine a verdict**:
+   - `approve-ready` — no CRITICAL, no ISSUE
+   - `blocked: <one-phrase reason>` — at least one CRITICAL
+   - `discussion-needed` — ISSUE findings but no CRITICAL
+
+6. **Post the review**. Use inline comments for line-specific findings and a short review body for the verdict.
+
+   For each line-specific finding:
+   ```bash
+   gh api repos/owner/repo/pulls/NUMBER/comments \
+     -f body="[SEVERITY] finding text — why it matters" \
+     -f path="path/to/file" \
+     -f commit_id="$HEAD_SHA" \
+     -F line=LINE_NUMBER \
+     -f side="RIGHT"
    ```
-5. Log what you reviewed to memory/logs/${today}.md.
-If no open PRs found, log "PR_REVIEW_OK" and end.
+
+   Then the overall verdict as a review:
+   ```bash
+   gh pr review NUMBER -R owner/repo --comment --body "**Verdict**: <verdict>
+<one-line rationale if blocked or discussion-needed; omit if approve-ready>"
+   ```
+
+   If there are no CRITICAL/ISSUE findings, skip inline comments and post a single-line review: `**Verdict**: approve-ready — no blockers.`
+
+   For trivial-PR early-exits (step 3), post a single-line review matching the category: `Docs-only change — no blockers.` / `Dependency-bump — no review needed.` / `Test-only change — no production code touched.`
+
+   **Fallback**: if inline-comment creation fails (missing permissions, commit_id mismatch), consolidate all findings into the review body, preserving the severity tags and `file:line` refs. Do not silently drop findings.
+
+## Notify and log
+
+Send **one** combined message per run via `./notify`:
+```
+*PR Review — ${today}*
+Reviewed N, skipped K (drafts: x, bots: y, dup-SHA: z, bot-reviewed-recently: w).
+- owner/repo#123: [verdict] — N critical, M issues
+```
+
+If every PR was skipped, do not notify — just log.
+
+Log to `memory/logs/${today}.md`:
+```
+### pr-review
+- owner/repo#123 (SHA abc1234): [verdict] — N critical, M issues
+- Skipped: owner/repo#124 (draft), owner/repo#125 (bot-reviewed-recently)
+```
+
+If no open PRs across all repos, log `PR_REVIEW_OK` and end.
+
+## Sandbox note
+
+`gh` CLI handles GitHub auth internally — use it over raw curl in this sandbox. If `gh` fails at the repo level, log the error and continue to the next repo. As a last-resort fallback, use **WebFetch** on the raw PR URL to read the diff.

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -79,7 +79,7 @@ Skip a PR if any of the following hold (record the skip reason for the run summa
    - `blocked: <one-phrase reason>` — at least one CRITICAL
    - `discussion-needed` — ISSUE findings but no CRITICAL
 
-6. **Post the review**. Use inline comments for line-specific findings and a short review body for the verdict.
+6. **Post the review**. Send **both** a consolidated summary comment *and* inline line-specific comments — inline for precision, summary for consumers that parse review bodies.
 
    For each line-specific finding:
    ```bash
@@ -91,10 +91,14 @@ Skip a PR if any of the following hold (record the skip reason for the run summa
      -f side="RIGHT"
    ```
 
-   Then the overall verdict as a review:
+   Then the consolidated summary as a review — include the verdict **and** a bulleted recap of every inline finding (severity + `file:line` + one-sentence rationale), so downstream body-parsers don't miss them:
    ```bash
    gh pr review NUMBER -R owner/repo --comment --body "**Verdict**: <verdict>
-<one-line rationale if blocked or discussion-needed; omit if approve-ready>"
+<one-line rationale if blocked or discussion-needed; omit if approve-ready>
+
+**Findings** (mirrored as inline comments):
+- [CRITICAL] path/to/file:LINE — why it matters
+- [ISSUE] path/to/file:LINE — why it matters"
    ```
 
    If there are no CRITICAL/ISSUE findings, skip inline comments and post a single-line review: `**Verdict**: approve-ready — no blockers.`


### PR DESCRIPTION
## Summary

Autoresearch evolved `skills/pr-review/SKILL.md`. The winner is **Variation B — Sharper output**, with cheap robustness and input wins from the runners-up folded in.

## Winner — Variation B: Sharper output (46.5/50)

**Thesis**: noise is the documented failure mode of automated PR review. Forcing severity-tagged, capped, line-specific findings with a one-line verdict is the single biggest quality lever — larger than better inputs or more robustness.

**Key changes vs. original**:
- **Severity tags**: every finding is `[CRITICAL]`, `[ISSUE]`, or `[NIT]`. NITs are dropped by default.
- **Cap at 5 findings** per PR, drop NITs first then lowest-impact ISSUEs.
- **"Why it matters"** required on every finding — the consequence, not just the fact.
- **Inline comments** via `gh api repos/.../pulls/.../comments` for line-specific findings (original only posted a summary comment).
- **One-line verdict**: `approve-ready` / `blocked: <reason>` / `discussion-needed`.
- **Skip rules** (folded in from Variation A): drafts, `[WIP]` titles, `no-review`/`do-not-merge` labels, bot authors, `aeonframework` self-PRs, same `headRefOid` already reviewed in last 2 days of logs, bot reviewer (coderabbit/copilot/claude) posted in last 30 min.
- **Large-diff fallback** (from Variation C): if `additions + deletions > 3000`, review top-5 largest-delta files only; `gh api .../files` fallback if `gh pr diff` fails; `empty-diff` skip for mid-rebase PRs.
- **Trivial-PR early-exit**: docs-only / lockfile-only / test-only diffs get a 1-line ack, no deep review.
- **Inline-comment fallback**: if posting inline fails, consolidate into the review body — never silently drop findings.

## Scoring table

| Criterion | Weight | A (inputs) | B (output) ✅ | C (robust) | D (type-aware) |
|-----------|--------|------------|---------------|------------|----------------|
| Clarity | ×1.5 | 4 | 4 | 4 | 4 |
| Data quality | ×1.5 | 5 | 4 | 4 | 4 |
| Output value | ×2 | 4 | 5 | 3 | 4 |
| Robustness | ×1.5 | 4 | 3 | 5 | 3 |
| Conventions | ×1 | 5 | 5 | 5 | 5 |
| Improvement | ×3 | 4 | 5 | 4 | 4 |
| **Weighted total** | | **44.5** | **46.5** | **42.5** | **41.5** |

## Variations considered

- **A — Better inputs (44.5)**: rich PR metadata, linked issues (`Fixes #N`), existing-review awareness, fetch repo CLAUDE.md/CONTRIBUTING.md for convention grounding, explicit skip rules. Strong context upgrade but keeps a free-form summary output.
- **B — Sharper output (46.5) ✅**: severity tags, cap-5, drop-NITs, inline + review-body, one-line verdict, "why it matters" required.
- **C — More robust (42.5)**: SHA-dedup via `memory/pr-review-state.json`, `gh auth status` preflight, top-5-file fallback for large diffs, `gh api .../files` fallback, graceful post-failure handling. Reliability ↑, but output quality unchanged.
- **D — Rethink: type-aware review (41.5)**: classify PR (bug-fix / feature / refactor / chore / docs / test) first, then apply a type-specific review lens with early-exit for docs-only / lockfile-only / test-only PRs. Novel but untested whether classification actually improves review quality over severity-tagged findings.

## Why B over A/C/D

A's context wins and C's robustness wins are cheap to fold in on top of B's output format — and are folded in here. D's classification angle partially overlaps with B's trivial-PR early-exit without needing a separate taxonomy. The base quality lift comes from forcing the reviewer to justify severity and consequence, not from gathering more input or classifying more carefully.

## Constraints respected

- Core purpose preserved (review open PRs on watched repos, post feedback).
- Frontmatter format unchanged (`name`, `description`, `var`, `tags`).
- No new env vars required — all behavior uses `gh` CLI already available.
- Aeon conventions: reads `memory/MEMORY.md` + `memory/watched-repos.md`, logs to `memory/logs/${today}.md`, notifies via `./notify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Ported from aaronjmars/aeon-tmp#20.
