### PR TITLE
improve(farcaster-digest): autoresearch evolution

### DIFF
--- a/skills/farcaster-digest/SKILL.md
+++ b/skills/farcaster-digest/SKILL.md
@@ -12,7 +12,7 @@ If `${var}` is set, focus curation on that topic or channel.
 
 Read `memory/MEMORY.md` for current interests.
 Read the last 2 days of `memory/logs/` for recency context.
-Load persistent dedup state from `memory/state/farcaster-seen-hashes.json` (create the file with `{"hashes": [], "updated": null}` if missing). This stores cast hashes seen in the last 7 days — casts present here are skipped even if they re-appear in algorithmic feeds.
+Load persistent dedup state from `memory/state/farcaster-seen-hashes.json` (auto-created; safe to delete to reset dedup). The file starts as `{"hashes": [], "updated": null}` and stores cast hashes seen in the last 7 days — casts present here are skipped even if they re-appear in algorithmic feeds.
 
 ## Thesis
 
@@ -113,7 +113,7 @@ insight: ...
 sources: search=ok trending=ok channels=ok | new casts: 7 | seen-cache: 142 hashes
 ```
 
-**Insight discipline:** the `insight:` line must add something — implication, counter-argument, context the cast assumes, or a connection to another cast in the digest. If the best you can write is a paraphrase of the cast, drop the cast.
+**Insight discipline:** prefer casts where the `insight:` line adds something — implication, counter-argument, context the cast assumes, or a connection to another cast in the digest — over casts where the best you can write is a paraphrase. When choosing between casts of similar signal, pick the one that yields a non-paraphrase insight.
 
 ### 6. Send via `./notify`
 

--- a/skills/farcaster-digest/SKILL.md
+++ b/skills/farcaster-digest/SKILL.md
@@ -1,76 +1,138 @@
 ---
 name: Farcaster Digest
-description: Trending and relevant Farcaster casts filtered by crypto, prediction markets, and coordination topics
+description: Clustered, signal-scored digest of Farcaster casts with conversation-shape lead and insight-first editorial notes
 var: ""
 tags: [crypto, social]
 ---
-> **${var}** — Topic filter or channel name (e.g. "prediction-markets", "base", "defi"). If empty, uses default interest areas.
+<!-- autoresearch: variation B — sharper output via cluster + signal score + insight extraction; folds in A's semantic/channel inputs and C's source-status footer + persistent dedup -->
 
-If `${var}` is set, focus the search on that topic or channel.
+> **${var}** — Topic filter or channel name (e.g. "prediction-markets", "base", "ai-agents"). If empty, uses default interest areas.
 
-Read memory/MEMORY.md for context on current interests and active topics.
-Read the last 2 days of memory/logs/ to avoid repeating casts.
+If `${var}` is set, focus curation on that topic or channel.
+
+Read `memory/MEMORY.md` for current interests.
+Read the last 2 days of `memory/logs/` for recency context.
+Load persistent dedup state from `memory/state/farcaster-seen-hashes.json` (create the file with `{"hashes": [], "updated": null}` if missing). This stores cast hashes seen in the last 7 days — casts present here are skipped even if they re-appear in algorithmic feeds.
+
+## Thesis
+
+Curation is the biggest lever, not fetching. Raw engagement counts rank by popularity, not conversation. This skill ranks by a signal score, clusters casts into 2–3 sub-narratives, leads with a one-line conversation-shape header, and demands an original insight per cast — not a paraphrase of the cast text.
 
 ## Steps
 
-1. **Search for relevant casts** using the Neynar cast search API. Run multiple searches across core interest areas. If `${var}` is set, search only that topic.
+### 1. Fetch casts from three complementary sources
 
-   Default search topics (customize via var or MEMORY.md interests):
-   - `"prediction markets" | "coordination markets" | polymarket | kalshi`
-   - `hyperstitions | futarchy | "mechanism design"`
-   - `"AI agents" | "autonomous agents" | "agentic"`
+For every endpoint, prefer `WebFetch` over curl (sandbox often blocks curl — see CLAUDE.md). Auth header: `x-api-key: $NEYNAR_API_KEY`.
 
-   For each search, use WebFetch or curl:
-   ```
-   GET https://api.neynar.com/v2/farcaster/cast/search/?q=QUERY&sort_type=algorithmic&limit=15
-   Headers: x-api-key: $NEYNAR_API_KEY
-   ```
+**(a) Topic search — literal + semantic.**
+Run each default topic query twice: once with `mode=literal` (default), once with `mode=semantic` to catch thematic matches the keyword query misses.
 
-   The `sort_type=algorithmic` ensures results are ranked by engagement, not just recency.
+```
+GET https://api.neynar.com/v2/farcaster/cast/search/?q=QUERY&sort_type=algorithmic&mode=literal&limit=20
+GET https://api.neynar.com/v2/farcaster/cast/search/?q=QUERY&sort_type=algorithmic&mode=semantic&limit=20
+```
 
-2. **Also fetch trending casts** for broader crypto context:
-   ```
-   GET https://api.neynar.com/v2/farcaster/feed/trending?limit=25&time_window=24h
-   Headers: x-api-key: $NEYNAR_API_KEY
-   ```
+Default topics (override with `${var}` or MEMORY.md interests):
+- `"prediction markets" | "coordination markets" | polymarket | kalshi | futarchy`
+- `"AI agents" | "autonomous agents" | agentic | "agent frameworks"`
+- `hyperstitions | "mechanism design" | "network states" | "public goods"`
 
-3. **Filter and deduplicate.** From all fetched casts:
-   - Remove duplicates (same cast hash)
-   - Filter to last 24h only
-   - Deduplicate against recent logs — skip any cast already covered
-   - Prioritize: casts with high engagement (likes + recasts), casts from known builders/researchers, casts touching prediction markets or coordination themes
+If `${var}` is set, replace all default topics with a single search on `${var}`.
 
-4. **Select top 5-8 casts.** For each:
-   - Author username and display name
-   - Cast text (truncate if over 280 chars)
-   - Engagement stats (likes, recasts, replies)
-   - Link: `https://warpcast.com/{username}/{cast_hash_short}`
-   - One-line editorial note on why it matters
+**(b) Channel feed — high-signal channels.**
+Sample recent casts from 3–4 channels relevant to Aeon's interests:
 
-5. **Format the digest** (keep under 4000 chars):
-   ```
-   farcaster digest — ${today}
+```
+GET https://api.neynar.com/v2/farcaster/feed/channels?channel_ids=ai-agents,base,founders,ethereum&with_recasts=false&with_replies=false&limit=30
+```
 
-   @username — "cast text here"
-   ↳ X likes, Y recasts | warpcast.com/user/0xabc123
-   why it matters: one-line take
+(If `${var}` looks like a channel slug, query that channel alone.)
 
-   @username2 — "cast text here"
-   ↳ X likes, Y recasts | warpcast.com/user/0xdef456
-   why it matters: one-line take
+**(c) Global trending — network-wide context.**
+```
+GET https://api.neynar.com/v2/farcaster/feed/trending?limit=25&time_window=24h
+```
 
-   ...
-   ```
+Record per-source status (`ok` | `fail` | `empty`) as you go — you'll emit it in the footer.
 
-6. **Send via `./notify`** with the formatted digest.
+### 2. Filter and deduplicate
 
-7. **Log to memory/logs/${today}.md.** Record which casts were included and search queries used.
+- Drop any cast whose `hash` is in `farcaster-seen-hashes.json`.
+- Drop any cast older than 48h (use `timestamp` field).
+- Drop casts whose `author.follower_count` is below 500 — removes most spam/fresh-acct noise.
+- Drop near-duplicates (same author posting near-identical text within the window).
+- Drop pure shilling: casts that are almost entirely `$TICKER` + a link and no commentary.
 
-If no relevant casts found or the API is unreachable, log "FARCASTER_DIGEST_SKIP — no relevant casts or API error" and notify.
+### 3. Score and rank
+
+Compute a signal score for each surviving cast:
+
+```
+signal = reactions.likes_count + 2 × reactions.recasts_count + 0.5 × replies.count
+```
+
+Rationale: recasts signal endorsement (worth ~2 likes); replies signal controversy/noise (halved). Raw likes remain the base. Take the top 15 by signal score into the editorial pass.
+
+**Engagement floor:** exclude anything with `signal < 10`. If fewer than 3 casts clear the floor, lower it to 5 rather than returning nothing.
+
+### 4. Cluster into 2–3 sub-narratives
+
+Read the top 15 and group them into **2 or 3 themed clusters**. Examples of good cluster labels:
+- "prediction market volume chasing the election cycle"
+- "agent frameworks debating memory vs. tools"
+- "base mini-apps shipping faster than the analytics can track"
+
+Avoid generic labels like "crypto news" or "AI". A cluster label should name a *conversation*, not a topic.
+
+From each cluster, select the 2–3 casts that best represent the argument — diversity of voices over highest-engagement if they overlap.
+
+Target total: **5–8 casts across clusters**.
+
+### 5. Format the digest
+
+Keep under 4000 chars. Lead with a one-line conversation-shape header describing what's happening on Farcaster today, then one block per cluster.
+
+```
+farcaster digest — ${today}
+shape: <one line, ≤20 words, what's the conversation today>
+
+—— <cluster 1 label> ——
+
+@username — "cast text here (truncate >240 chars)"
+↳ 142 likes · 31 recasts · 18 replies | warpcast.com/username/0xabc123
+insight: <one line, ≤25 words, something a reader couldn't get from the cast text alone>
+
+@username2 — "..."
+↳ ... | warpcast.com/...
+insight: ...
+
+—— <cluster 2 label> ——
+
+...
+
+sources: search=ok trending=ok channels=ok | new casts: 7 | seen-cache: 142 hashes
+```
+
+**Insight discipline:** the `insight:` line must add something — implication, counter-argument, context the cast assumes, or a connection to another cast in the digest. If the best you can write is a paraphrase of the cast, drop the cast.
+
+### 6. Send via `./notify`
+
+Pass the formatted digest to `./notify "<digest>"`.
+
+### 7. Persist state and log
+
+- Append every included cast's hash to `memory/state/farcaster-seen-hashes.json`. Prune entries older than 7 days before writing.
+- Log to `memory/logs/${today}.md` under `### farcaster-digest` with: search queries used, source-status line, cluster labels chosen, cast count included, and any notable edge cases (e.g. engagement-floor lowered).
+
+## Empty vs error
+
+- **Empty run (`FARCASTER_DIGEST_OK`):** sources succeeded, but nothing cleared the engagement floor or all surviving casts were already in the seen cache. Notify: `farcaster digest: quiet day — <N> casts fetched, 0 passed signal floor`. Log the source-status line.
+- **Error run (`FARCASTER_DIGEST_ERROR`):** every source returned fail/empty *before* filtering. Notify: `farcaster digest skipped — sources: search=X trending=Y channels=Z`. Do **not** update the seen cache.
 
 ## Sandbox note
 
-The sandbox may block outbound curl. Use **WebFetch** as a fallback for any URL fetch. For auth-required APIs, use the pre-fetch/post-process pattern (see CLAUDE.md).
+The sandbox may block outbound curl. Default to **WebFetch**; fall back to curl only if WebFetch hits an auth wall. For the auth-required Neynar API, WebFetch works because it doesn't rely on shell env expansion — pass the key inline via the prompt or use the pre-fetch pattern (see CLAUDE.md) if you need to shell out.
 
 ## Environment Variables Required
-- `NEYNAR_API_KEY` — Neynar API key for Farcaster data access (get one at neynar.com)
+
+- `NEYNAR_API_KEY` — Neynar API key for Farcaster data access (get one at neynar.com).


### PR DESCRIPTION
## Winner: Variation B — Sharper output (45.25/52.5)

**Thesis:** Curation is the biggest lever. The original returns a ranked list of ~8 casts by raw engagement with a paraphrased "why it matters" line per cast. This update ranks by a signal score (`likes + 2×recasts + 0.5×replies`), clusters top-15 survivors into 2–3 named sub-narratives, leads the digest with a one-line "conversation shape" header, and demands an original insight per cast instead of a paraphrase. Folds in cheap wins from the runners-up: semantic search mode + channel feed (A) and source-status footer + persistent 7-day seen-hashes cache (C).

## Scoring

Scale 1–5. Weights: Improvement ×3, Output value ×2, Clarity/Data quality/Robustness ×1.5, Conventions ×1. Max = 52.5.

| Criterion | A | B | C | D |
|---|---|---|---|---|
| Clarity | 4 | 4 | 4.5 | 3 |
| Data quality | 5 | 4 | 3.5 | 4 |
| Output value | 3.5 | 5 | 3.5 | 4.5 |
| Robustness | 3.5 | 3.5 | 5 | 3 |
| Conventions | 4 | 4.5 | 5 | 4 |
| Improvement | 3.5 | 4.5 | 3.5 | 4 |
| **Weighted total** | **40.25** | **45.25** | **42.0** | **40.0** |

## Variation summaries

**A — Better inputs (40.25):** Add `mode=semantic` on search, channel feed endpoint (`/v2/farcaster/feed/channels`) sampling ai-agents/base/founders/ethereum, follower-count floor. Strong data quality, but same output format. *Partially folded into B (semantic + channel feed).*

**B — Sharper output (45.25, winner):** Signal score ranking, 2–3 sub-narrative clusters with editorial labels naming conversations (not topics), conversation-shape lead-line, insight-discipline rule (drop the cast if the best you can write is a paraphrase).

**C — More robust (42.0):** Persistent `memory/state/farcaster-seen-hashes.json` (7-day window), source-status footer (`search=ok trending=ok channels=ok`), empty-vs-error split (`FARCASTER_DIGEST_OK` for quiet days vs `FARCASTER_DIGEST_ERROR` for all-sources-down), rate-limit retry. *Folded into B: seen-cache, source-status footer, empty/error distinction.*

**D — Rethink / narrative-essay (40.0):** Drop the list format entirely, pull 50–80 casts, cluster into 2–3 narratives and write a short essay per narrative. Higher output value ceiling but harder to execute reliably, more brittle on quiet days.

## Diff summary

- Signal score formula: `likes + 2×recasts + 0.5×replies`, floor `signal ≥ 10` (lowered to 5 if fewer than 3 clear)
- Mandatory clustering into 2–3 named sub-narratives before final selection
- New one-line "shape:" header describing the conversation
- `insight:` lines must add implication/context/connection — paraphrases are a drop-the-cast signal
- Search runs in both `mode=literal` and `mode=semantic`; channel feed sampled across `ai-agents,base,founders,ethereum`
- Persistent `memory/state/farcaster-seen-hashes.json` (7-day rolling) replaces log-only dedup
- Source-status footer (`search=ok trending=ok channels=ok | new casts: N | seen-cache: N hashes`)
- `FARCASTER_DIGEST_OK` (sources fine, quiet day) vs `FARCASTER_DIGEST_ERROR` (all sources failed) distinction
- Drop-filters: authors with <500 followers, pure `$TICKER`-shill casts, near-duplicates, casts older than 48h

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Ported from aaronjmars/aeon-tmp#23.
