### PR TITLE
improve(self-improve): autoresearch evolution

### DIFF
--- a/skills/self-improve/SKILL.md
+++ b/skills/self-improve/SKILL.md
@@ -4,96 +4,178 @@ description: Improve the agent itself — better skills, prompts, workflows, and
 var: ""
 tags: [meta]
 ---
-> **${var}** — Specific area to improve (e.g. "heartbeat", "notifications", "memory"). If empty, finds the highest-impact issue from recent logs.
+<!-- autoresearch: variation D — issue-driven repair loop. Make memory/issues/INDEX.md the canonical work queue so every run either files or closes a tracked issue, matching the health-vs-repair lifecycle in CLAUDE.md. -->
 
-If `${var}` is set, focus on improving that specific area.
+> **${var}** — Optional. Specific area to improve (e.g. "heartbeat", "notifications") or an issue ID like `ISS-007`. If empty, pick the highest-severity open issue, or detect a new failure pattern and file one.
 
-Read memory/MEMORY.md for context.
-Read the last 2 days of memory/logs/ for recent errors, failures, and quality issues.
+Read `memory/MEMORY.md` and `memory/issues/INDEX.md`.
+
+## Goal
+
+Act as a **repair skill** in the documented lifecycle from CLAUDE.md: health skills file issues, repair skills close them. Each run either fixes one open issue (preferred) or files one new issue from observed failures. Never both.
 
 ## Steps
 
-1. **Check for open improvement PRs** — don't pile up unreviewed work:
-   ```bash
-   OPEN_PRS=$(gh pr list --state open --json title,number --jq '[.[] | select(.title | test("^(fix|feat|chore)\\("; "i"))] | length')
-   ```
-   If there are already 3+ open improvement PRs, log "self-improve: 3+ open PRs, waiting for review" and exit. Don't create more debt.
+### 1. Inventory open work
 
-2. **Identify what to improve.** If `${var}` is empty, scan for issues:
-   - Read `memory/logs/` from last 2 days — look for:
-     - Skills that failed or produced low-quality output
-     - Errors, timeouts, "zero output", rate limiting
-     - Notifications that didn't send or were truncated
-     - Memory consolidation problems
-   - Read `memory/cron-state.json` for skills with low success rates
-   - Read `articles/repo-actions-*.md` from last 7 days for self-improvement ideas
-   - Pick the **highest-impact, smallest-effort** fix. One change per run.
+```bash
+OPEN_FIXES=$(gh pr list --state open --json title --jq '[.[] | select(.title | test("^(fix|improve|chore|feat)\\("; "i"))] | length')
+echo "open improvement PRs: $OPEN_FIXES"
+```
 
-3. **Understand the area you're fixing.** Read the relevant files:
-   - Skills: `skills/{name}/SKILL.md`
-   - Config: `aeon.yml`
-   - Workflows: `.github/workflows/*.yml`
-   - Agent instructions: `CLAUDE.md`
-   - Dashboard: `dashboard/` (if UI-related)
-   
-   Understand the current behavior before changing anything.
+If `$OPEN_FIXES >= 4`, log "self-improve: $OPEN_FIXES open improvement PRs, waiting for review" and exit. Don't pile on. (Counts both `fix(` from prior self-improve runs and `improve(` from autoresearch.)
 
-4. **Implement the fix.** Make minimal, targeted changes:
-   - If a skill prompt is unclear → rewrite the ambiguous section
-   - If a skill is hitting rate limits → add backoff logic or reduce frequency
-   - If output quality is low → tighten the prompt, add examples, clarify format
-   - If a notification is broken → fix the formatting or truncation
-   - If a config is wrong → fix aeon.yml
+Reconcile resolved issues: for each issue in `memory/issues/INDEX.md` whose `fix_pr` PR is merged, move it to the **Resolved** table and set `resolved_at` in its `ISS-{NNN}.md` file. Commit this reconciliation as part of the same PR if you make a fix this run, or skip if no fix is being made.
 
-   Do NOT:
-   - Rewrite entire skills from scratch
-   - Add new features (that's build-skill's job)
-   - Change the core architecture
-   - Modify secrets or environment variables
+### 2. Choose target
 
-5. **Create a branch and PR:**
-   ```bash
-   git checkout -b fix/self-improve-${today}
-   git add -A
-   git commit -m "fix: [description of what was improved]
+Branch on `${var}`:
 
-   Problem: [what was failing/degraded]
-   Fix: [what was changed]
-   Evidence: [log entries, error messages, success rates]"
-   ```
-   Open a PR:
-   ```bash
-   gh pr create --title "fix: [short description]" \
-     --body "## Problem
-   [What was failing or degraded — cite specific log entries or error messages]
+- **`${var}` is an issue ID** (matches `^ISS-\d+$`): load `memory/issues/${var}.md`, that's your target. Skip to step 4.
+- **`${var}` is a skill or area name**: file an issue for it (or update the existing one) and target it.
+- **`${var}` is empty**: triage.
 
-   ## Fix
-   [What was changed and why]
+**Triage (when `${var}` is empty):**
 
-   ## Evidence
-   - [Relevant log entries]
-   - [Success rate before: X%]
-   - [Error pattern: ...]"
-   ```
+1. **Prefer existing issues.** Read `memory/issues/INDEX.md`. Pick the highest-severity open issue with `status` in `{open, investigating}`. Severity rank: `critical > high > medium > low`. Tiebreak by oldest `detected_at`.
+2. **If no open issues, scan for new failures:**
+   - `./scripts/skill-runs --hours 48 --failures --json` — skills with consecutive failures or success rate <70%.
+   - `memory/logs/` (last 2 days) — explicit `*_ERROR`, "zero output", timeouts, truncations.
+   - `memory/cron-state.json` — `consecutive_failures >= 2` or `success_rate < 0.7`.
+3. **If a new failure pattern is found**, file an issue (see step 3) and **stop** — don't fix in the same run. Filing alone is the deliverable; the next self-improve run will pick it up. This keeps the file/fix steps isolated and reviewable.
+4. **If nothing is failing**, do a single quality-regression check: read the most recent output of one randomly-chosen enabled skill and compare against the rubric in `skills/skill-evals/SKILL.md` if present. If quality is fine, log `self-improve: no open issues, no new failures, quality sample OK` and exit.
 
-6. **Notify.** Send via `./notify`:
-   ```
-   self-improve: [what was fixed] — PR: [url]
-   ```
+### 3. (Filing path only) File a new issue
 
-7. **Log.** Append to `memory/logs/${today}.md`:
-   ```
-   ## Self Improve
-   - **Target:** [what was improved]
-   - **Problem:** [what was failing]
-   - **Fix:** [what was changed]
-   - **PR:** [url]
-   ```
+If you reached this step from triage step 2.3, create the issue and stop:
 
-## Guidelines
+- Determine the next `ISS-{NNN}` ID (read `memory/issues/INDEX.md`, max + 1).
+- Create `memory/issues/ISS-{NNN}.md` with frontmatter per CLAUDE.md:
+  ```yaml
+  ---
+  id: ISS-{NNN}
+  title: <short, specific — e.g. "token-movers: 3 consecutive timeouts on CoinGecko fetch">
+  status: open
+  severity: <critical|high|medium|low>
+  category: <one of the categories listed in CLAUDE.md>
+  detected_by: self-improve
+  detected_at: <today ISO>
+  resolved_at: null
+  affected_skills: [<skill names>]
+  root_cause: <leave blank or 1-line hypothesis>
+  fix_pr: null
+  ---
+  ```
+  Body: cite the evidence — log file path with line numbers, error message verbatim, success-rate before/after, or skill-runs output. No speculation beyond the `root_cause` line.
+- Add a row to the **Open** table in `memory/issues/INDEX.md`.
+- Commit on a branch `chore/file-iss-{NNN}` and open a PR titled `chore: file ISS-{NNN} — <title>`.
+- Notify: `self-improve: filed ISS-{NNN} — <title> — PR: <url>`. Log and exit.
 
-- ONE fix per run. Don't bundle unrelated changes.
-- Smallest viable fix. A one-line prompt tweak > a full rewrite.
-- If you can't find anything to improve, that's fine. Log "self-improve: everything looks healthy" and exit.
-- Never modify workflow files (.github/workflows/) — only skill files, CLAUDE.md, and aeon.yml.
-- Don't create circular improvements (e.g. don't improve self-improve).
+### 4. (Fixing path) Understand the area
+
+Read the issue file. Then read the files it implicates:
+
+- Skills: `skills/{name}/SKILL.md`
+- Config: `aeon.yml`
+- Agent instructions: `CLAUDE.md`
+- Dashboard: `dashboard/` (if UI-related)
+
+**Never modify** `.github/workflows/*`, `skills/self-improve/SKILL.md` (this file — autoresearch evolves it instead), `skills/security/`, or anything under `secrets/`. If the issue's only fix would touch one of these, set the issue status to `wontfix` with a one-line justification and exit.
+
+Form a hypothesis tying the failure to a specific file:line. Write it as a comment in your scratch — you'll cite it in the PR.
+
+### 5. Implement the smallest fix
+
+Make minimal, targeted changes to address the root cause:
+
+- Skill prompt unclear → rewrite the ambiguous section only.
+- Rate-limited → add backoff or reduce frequency in `aeon.yml`.
+- Output low-quality → tighten the prompt or add an explicit format example.
+- Notification broken → fix formatting or truncation.
+- Config wrong → patch `aeon.yml`.
+
+Do **not**: rewrite skills from scratch, add features, change architecture, modify env vars, bundle unrelated changes, refactor neighbouring code.
+
+### 6. Verify the fix maps to the cited evidence
+
+Before committing, re-read your diff and answer in one paragraph (this paragraph goes in the PR body):
+
+- **What was the failure?** Quote the log line / error / observation.
+- **Why does this change fix it?** Trace from the changed line(s) to the failure mode.
+- **How will we know it worked post-merge?** A concrete check — e.g. "next run of `${skill}` should log `${marker}` instead of `${error}`", or "`./scripts/skill-runs --hours 24` for `${skill}` should show success rate >0.9 within 3 runs".
+
+If you can't answer all three, the fix isn't ready — narrow it further or change approach.
+
+### 7. Update the issue and open the PR
+
+Update `memory/issues/ISS-{NNN}.md`:
+- `status: fixing`
+- `fix_pr: <url>` (set after PR is created — patch with a follow-up commit on the same branch if needed)
+- Append a `## Fix` section with the verification paragraph from step 6.
+
+Branch and PR:
+```bash
+TODAY=$(date -u +%F)
+BRANCH="fix/iss-{NNN}-${TODAY}"
+git checkout -b "$BRANCH"
+git add -A
+git commit -m "fix(ISS-{NNN}): <one-line fix summary>
+
+Issue: ISS-{NNN} — <issue title>
+Root cause: <one line>
+Fix: <one line>
+Verification: <how we'll know it worked>"
+git push -u origin "$BRANCH"
+gh pr create --title "fix(ISS-{NNN}): <one-line summary>" --body "$(cat <<'EOF'
+## Issue
+[ISS-{NNN}](../blob/main/memory/issues/ISS-{NNN}.md) — <title>
+
+## Root cause
+<one paragraph, citing file:line>
+
+## Fix
+<diff summary in plain English>
+
+## Verification
+<the post-merge check from step 6>
+
+## Evidence
+- <log entry or skill-runs row>
+- <success rate before / expected after>
+EOF
+)"
+```
+
+If the branch already exists locally or remotely, append `-2` (or next integer) — never force-push.
+
+### 8. Notify and log
+
+Notify via `./notify`:
+```
+self-improve: fixed ISS-{NNN} — <one-line summary> — PR: <url>
+```
+
+Append to `memory/logs/${today}.md`:
+```
+## Self Improve
+- **Issue:** ISS-{NNN} — <title>
+- **Severity:** <severity>
+- **Root cause:** <one line>
+- **Fix:** <one line>
+- **Verification:** <post-merge check>
+- **PR:** <url>
+```
+
+If you exited early (filed-only, idle, or capped), log a short reason line under `## Self Improve` and skip the PR section.
+
+## Sandbox note
+
+`gh` and the `./scripts/skill-runs` script work inside the sandbox. If a `gh` call fails intermittently, retry once; if still failing, fall back to reading the JSON the script emits and skip the PR-count check (log the skip).
+
+## Constraints
+
+- **One artifact per run.** Either file one issue OR fix one issue OR exit. Never bundle.
+- **Smallest viable fix.** A one-line prompt tweak beats a full rewrite. If you find yourself diffing >50 lines, stop and reconsider.
+- **Never modify**: `.github/workflows/*`, `skills/self-improve/SKILL.md`, `skills/security/`, secrets, or env vars.
+- **Cite evidence.** Every fix must point to a specific log line, error, or success-rate number. No "this seemed off" PRs.
+- **Honor the lifecycle.** Issues move `open → investigating → fixing → resolved` (or `wontfix`). This skill drives `open → fixing → resolved` (resolution happens on merge in the next run via reconciliation in step 1).


### PR DESCRIPTION
## Winner: Variation D — issue-driven repair loop (51/52.5)

**Thesis:** the original treats `memory/logs/` as the source of truth and re-derives failure patterns by scanning text every run. CLAUDE.md already documents a structured issue tracker (`memory/issues/INDEX.md` + `ISS-{NNN}.md` files with frontmatter, status lifecycle, severity, categories, and explicit health-files-vs-repair-closes contracts) — but the original self-improve never reads it. Restructuring the skill around that tracker turns each run into a discrete file-or-fix step, makes priorities explicit (highest-severity first, oldest-first tiebreak), and makes the work auditable across runs (issues move `open → fixing → resolved`).

## What changed

1. **`memory/issues/INDEX.md` is now the canonical work queue.** Triage reads it first; only falls back to log-scanning if no issues are open.
2. **One artifact per run, but two paths:** either *file* one new issue (when a fresh failure is detected) or *fix* one open issue. Filing alone is a deliverable — separating file/fix steps keeps each PR small and reviewable.
3. **Reconciles merged fixes.** Step 1 walks open issues, checks if their `fix_pr` is merged, and moves them to Resolved with `resolved_at`. Closes the loop CLAUDE.md describes.
4. **Fixed open-PR cap regex.** Original regex `^(fix|feat|chore)\(` missed `improve(` PRs from autoresearch — so 18 sister-bot PRs wouldn't have counted against the cap. New regex is `^(fix|improve|chore|feat)\(` and the cap raised to 4.
5. **Forced verification.** Every fix must answer: what failed (quoted log line), why this change fixes it (file:line trace), and how we'll know post-merge (concrete check). If any answer is missing, the fix isn't ready.
6. **`./scripts/skill-runs --failures --json`** added as a triage input alongside log scanning and `cron-state.json`.
7. **Hard guards.** Never modify `.github/workflows/*`, `skills/self-improve/SKILL.md` (autoresearch handles that), `skills/security/`, or secrets. If the only fix would touch one of these, mark the issue `wontfix` with a one-line reason.
8. **`${var}` accepts an issue ID** (e.g. `ISS-007`) for direct targeting, in addition to skill-name and empty.

## Scoring (max 52.5; weights: improvement 3x, output 2x, clarity/data/robustness 1.5x, conventions 1x)

| Variation | Clarity | Data | Output | Robust | Conv | Improve | **Total** |
|---|---|---|---|---|---|---|---|
| Original | 4 | 3 | 3 | 3 | 4 | 3 | 34 |
| A — Better inputs (INDEX + skill-runs + gh history; fix regex) | 4 | 5 | 3 | 4 | 5 | 4 | 42.5 |
| B — Sharper output (self-justifying PR with repro + verify check) | 4 | 3 | 5 | 4 | 4 | 4 | 42.5 |
| C — More robust (dry-run + hard guards + fallback) | 4 | 3 | 3 | 5 | 4 | 3.5 | 38.5 |
| **D — Issue-driven repair loop** | **5** | **5** | **5** | **4** | **5** | **5** | **51** |

D folds in A's expanded inputs (issue tracker + skill-runs + gh PR history) and B's verification paragraph as load-bearing parts of the issue-driven frame, capturing most of the upside of the runners-up.

## Variation summaries (for reviewer context)

- **A — Better inputs:** wire in `memory/issues/INDEX.md`, `./scripts/skill-runs --failures --json`, and `gh pr list --state merged --search self-improve` so triage uses every available signal. Fixes the open-PR regex.
- **B — Sharper output:** restructure the PR template to be a self-justifying artifact — cite log:line evidence, include a minimal repro, and require a concrete post-merge verification check. PR becomes a contract.
- **C — More robust:** add fallback (no failures → quality-regression scan), hard guards (don't touch workflows/security/self), and a dry-run validation step that simulates the change against cited evidence before commit.
- **D — Issue-driven repair loop (winner):** make `memory/issues/INDEX.md` the work queue, one artifact per run (file-or-fix-or-exit), reconcile resolved issues at the top of each run, and align with CLAUDE.md's documented health/repair lifecycle.

## Diff summary

- 170 insertions, 88 deletions in `skills/self-improve/SKILL.md`
- Frontmatter unchanged (name, description, var, tags preserved)
- No new env vars, no new dependencies — reuses existing `gh`, `./scripts/skill-runs`, `./notify`, and the documented `memory/issues/` structure

---
Ported from aaronjmars/aeon-tmp#24.
