### PR TITLE
improve(vuln-scanner): autoresearch evolution

### DIFF
--- a/skills/vuln-scanner/SKILL.md
+++ b/skills/vuln-scanner/SKILL.md
@@ -1,180 +1,265 @@
 ---
 name: Vuln Scanner
-description: Fork trending repos, audit for security vulnerabilities, and PR fixes
+description: Audit trending repos for real security vulnerabilities and disclose responsibly via PVR or dependency PRs
 var: ""
 tags: [dev, security]
 depends_on: [github-trending]
 ---
-> **${var}** — Target repo in `owner/repo` format. If empty, picks from recent github-trending output or trending repos.
+<!-- autoresearch: variation B — responsible-disclosure-first: private reports for code vulns, public PRs only for already-disclosed dep CVEs -->
 
-If `${var}` is set, audit that specific repo. Otherwise auto-select.
+> **${var}** — Target repo in `owner/repo`. If empty, auto-select from `.outputs/github-trending.md` or GitHub's trending API.
 
-Today is ${today}. Your task is to find a trending GitHub repo, audit it for security vulnerabilities, and submit a fix PR if you find something real.
+Today is ${today}. Read `memory/MEMORY.md` and the last 30 days of `memory/logs/` before starting.
+
+## Why this skill exists
+
+A security scanner that dumps unpatched vulnerabilities into public PRs is a zero-day publisher, not a helper. This skill matches industry practice: **Private Vulnerability Reporting (PVR) for code flaws, public PRs only for dependency CVEs that are already public**. Bad disclosure burns credibility and puts users at risk.
+
+## Goal
+
+Find one trending repo, run purpose-built scanners (not raw grep), triage to real exploitable findings, and route each finding to the correct disclosure channel — PVR, SECURITY.md contact, or dependency-bump PR.
 
 ## Steps
 
-1. **Pick a target repo.**
+### 1. Pick a target
 
-   If `${var}` is set, use that repo directly.
+If `${var}` is set, use it. Otherwise:
 
-   If empty:
-   - Read `.outputs/github-trending.md` if it exists (chain context from github-trending skill)
-   - Otherwise fetch trending repos using `gh api` (handles auth automatically, works in sandbox):
-     ```bash
-     gh api "search/repositories?q=created:>$(date -u -d '7 days ago' +%Y-%m-%d 2>/dev/null || date -u -v-7d +%Y-%m-%d)&sort=stars&order=desc&per_page=20" \
-       --jq '.items[] | {full_name, language, stargazers_count, description}'
-     ```
-   - Pick a repo that:
-     - Is written in a language you can audit well (JS/TS, Python, Go, Rust, Solidity)
-     - Has 50+ stars (real project, not a toy)
-     - Is not a fork itself
-     - Handles user input, auth, crypto, or network calls (higher vuln surface)
-   - Read `memory/logs/` from last 14 days — skip repos already scanned
+```bash
+# Prefer chained output from github-trending skill
+if [ -s .outputs/github-trending.md ]; then
+  # parse owner/repo lines; pick first that matches criteria below
+  :
+else
+  gh api "search/repositories?q=created:>$(date -u -d '14 days ago' +%Y-%m-%d)&sort=stars&order=desc&per_page=25" \
+    --jq '.items[] | select(.fork==false) | select(.stargazers_count>=50) | {full_name, language, description, security_and_analysis}'
+fi
+```
 
-2. **Fork and clone.**
-   ```bash
-   REPO="owner/repo"
-   # Fork it under your account
-   gh repo fork "$REPO" --clone --default-branch-only -- --depth 100
-   cd "$(basename "$REPO")"
-   ```
+Selection criteria:
+- Language you can reason about (JS/TS, Python, Go, Rust, Solidity)
+- ≥50 stars, not a fork, active in last 6 months
+- Handles untrusted input: auth, crypto, network, file I/O, templating
+- **Skip** if scanned in last 30 days (grep `memory/logs/` for the repo name)
+- **Skip** deliberately vulnerable teaching repos (DVWA, juice-shop, webgoat, vulnerable-*, *-ctf, hackme-*)
+- **Skip** repos with no `SECURITY.md` AND `security_and_analysis.private_vulnerability_reporting.status != "enabled"` — you have no safe channel to report code flaws (you can still run a dep-scan and skip code audit; see step 5)
 
-3. **Audit the codebase.** Look for real, exploitable vulnerabilities — not style issues. Scan for:
+### 2. Fork and clone
 
-   **Injection vulnerabilities:**
-   - SQL injection: raw string interpolation in queries, no parameterized queries
-   - Command injection: user input passed to `exec`, `spawn`, `os.system`, `subprocess`
-   - XSS: unescaped user input rendered in HTML, `dangerouslySetInnerHTML` with user data
-   - Template injection: user input in template strings evaluated server-side
-   - Path traversal: user input in file paths without sanitization (`../../../etc/passwd`)
+```bash
+REPO="owner/repo"
+gh repo fork "$REPO" --clone --default-branch-only -- --depth 200 --quiet
+cd "$(basename "$REPO")"
+```
 
-   **Auth & crypto issues:**
-   - Hardcoded secrets, API keys, private keys in source code
-   - Weak crypto: MD5/SHA1 for passwords, ECB mode, predictable IVs
-   - Missing auth checks on sensitive endpoints
-   - JWT issues: `none` algorithm accepted, secret in source, no expiry validation
-   - CORS misconfiguration: wildcard origins with credentials
+### 3. Run purpose-built scanners
 
-   **Dependency issues:**
-   ```bash
-   # Check for known CVEs in dependencies
-   # Node.js
-   [ -f package-lock.json ] && npm audit --json 2>/dev/null | jq '.vulnerabilities | to_entries[] | select(.value.severity == "critical" or .value.severity == "high")' || true
-   # Python
-   [ -f requirements.txt ] && pip-audit -r requirements.txt --format json 2>/dev/null || true
-   ```
+Raw grep produces too many false positives. Use tools with dataflow reachability and verified-secret matching.
 
-   **Smart contract vulnerabilities** (if Solidity):
-   - Reentrancy patterns (external calls before state changes)
-   - Unchecked return values on `transfer`/`send`
-   - Integer overflow (pre-0.8.0 without SafeMath)
-   - Access control: missing `onlyOwner` or role checks
-   - Front-running susceptibility
+```bash
+mkdir -p /tmp/vuln-scan
 
-   **Other:**
-   - SSRF: user-controlled URLs in server-side fetch/requests
-   - Insecure deserialization: `pickle.loads`, `yaml.load` without SafeLoader
-   - Race conditions in financial/state-changing operations
-   - Missing rate limiting on auth endpoints
-   - Debug/dev mode enabled in production configs
+# --- SAST: Semgrep OSS ---
+pip install --quiet semgrep 2>/dev/null || true
+semgrep --config=p/security-audit --config=p/owasp-top-ten --config=p/secrets \
+  --severity=ERROR --severity=WARNING --json --quiet --timeout=300 \
+  --exclude=test --exclude=tests --exclude=__tests__ --exclude=spec --exclude=specs \
+  --exclude=fixtures --exclude=examples --exclude=example --exclude=demo \
+  --exclude=vendor --exclude=node_modules --exclude=dist --exclude=build --exclude=.next \
+  -o /tmp/vuln-scan/semgrep.json . 2>/dev/null || true
 
-   Use grep to scan efficiently:
-   ```bash
-   # Examples
-   grep -rn "exec\|spawn\|system\|popen" --include="*.js" --include="*.ts" --include="*.py" . | grep -v node_modules | grep -v test
-   grep -rn "innerHTML\|dangerouslySetInnerHTML\|v-html" --include="*.js" --include="*.ts" --include="*.vue" --include="*.jsx" --include="*.tsx" . | grep -v node_modules
-   grep -rn "password\|secret\|api_key\|private_key" --include="*.env*" --include="*.json" --include="*.yml" --include="*.yaml" . | grep -v node_modules | grep -v "\.example"
-   ```
+# --- Secrets: TruffleHog (only-verified = actually authenticates) ---
+curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh \
+  | sh -s -- -b /tmp/bin 2>/dev/null || true
+/tmp/bin/trufflehog filesystem . --only-verified --json \
+  > /tmp/vuln-scan/trufflehog.json 2>/dev/null || true
+# Also scan full git history for secrets
+/tmp/bin/trufflehog git file://. --only-verified --json \
+  > /tmp/vuln-scan/trufflehog-git.json 2>/dev/null || true
 
-4. **Assess findings.** For each potential vulnerability:
-   - Is it actually exploitable? (not just a pattern match — read the surrounding code)
-   - What's the severity? (critical / high / medium)
-   - Can you fix it without breaking functionality?
-   - Only proceed with confirmed, real vulnerabilities — not false positives
+# --- Dependencies: osv-scanner (unified CVE DB across ecosystems) ---
+curl -sSfL -o /tmp/bin/osv-scanner \
+  https://github.com/google/osv-scanner/releases/latest/download/osv-scanner_linux_amd64 2>/dev/null && \
+  chmod +x /tmp/bin/osv-scanner
+/tmp/bin/osv-scanner --format=json --recursive . \
+  > /tmp/vuln-scan/osv.json 2>/dev/null || true
 
-   If no real vulnerabilities found, log "clean audit" and exit. Don't force findings.
+# --- Smart-contract scan (if Solidity present) ---
+if ls **/*.sol >/dev/null 2>&1; then
+  pip install --quiet slither-analyzer 2>/dev/null || true
+  slither . --json /tmp/vuln-scan/slither.json --exclude-informational --exclude-low 2>/dev/null || true
+fi
 
-5. **Fix the vulnerability.** For each confirmed finding:
-   - Write the minimal fix that resolves the issue
-   - Don't refactor surrounding code
-   - Add a comment only if the fix isn't self-evident
-   - If it's a dependency issue, update the lockfile if possible
+# Record what succeeded (empty output ≠ clean, could be tool failure)
+echo "semgrep=$([ -s /tmp/vuln-scan/semgrep.json ] && echo ok || echo fail)" >  /tmp/vuln-scan/sources.txt
+echo "trufflehog=$([ -s /tmp/vuln-scan/trufflehog.json ] && echo ok || echo fail)" >> /tmp/vuln-scan/sources.txt
+echo "osv=$([ -s /tmp/vuln-scan/osv.json ] && echo ok || echo fail)"              >> /tmp/vuln-scan/sources.txt
+```
 
-6. **Create a branch and commit.**
-   ```bash
-   git checkout -b security/fix-VULN-TYPE
-   git add -A
-   git commit -m "fix(security): [description of vulnerability and fix]
+### 4. Triage — read every finding before trusting it
 
-   Vulnerability: [type — e.g. SQL injection, XSS, hardcoded secret]
-   Severity: [critical/high/medium]
-   Location: [file:line]
-   Impact: [what an attacker could do]"
-   ```
+A scanner hit is a candidate, not a vulnerability. For each candidate:
 
-7. **Push and open a PR to the original repo.**
-   ```bash
-   git push -u origin security/fix-VULN-TYPE
-   gh pr create --repo "$REPO" \
-     --title "fix(security): [short description]" \
-     --body "## Security Vulnerability Report
+1. **Open the file at the reported line** and read the surrounding 30–50 lines.
+2. **Write one sentence** describing what an attacker controls and what they achieve. If you can't, discard it.
+3. **Check the call path** — is the vulnerable function reachable from external input in production code (not tests, docs, examples)?
+4. **Severity**: critical (RCE, auth bypass, secret exposure), high (SQLi, stored XSS, SSRF, path traversal), medium (reflected XSS, weak crypto, missing rate limit).
+5. **Assign disclosure channel** per step 5.
 
-   **Type:** [vulnerability type]
-   **Severity:** [critical/high/medium]
-   **Location:** \`file:line\`
+Drop the finding if:
+- It's in `test/`, `mock/`, `fixture/`, `example/`, `demo/`, `bench/`, `docs/`
+- It's behind a feature flag not enabled by default
+- It requires attacker privileges equal to or greater than the attack yields
+- You'd be embarrassed to defend it to the maintainer
 
-   ### Description
-   [Clear explanation of the vulnerability and how it could be exploited]
+If 0 findings survive triage → log "clean audit — N candidates reviewed, 0 confirmed" and exit cleanly.
 
-   ### Fix
-   [What this PR changes and why it resolves the issue]
+### 5. Route each finding to the correct disclosure channel
 
-   ### Impact
-   [What an attacker could do without this fix]
+This is the core of the skill. Pick the channel by finding type:
 
-   ---
-   Found by [Aeon](https://github.com/aeonframework/aeon) — automated security scanner"
-   ```
+| Finding type | Channel | Why |
+|---|---|---|
+| **Dependency CVE** (osv-scanner hit) | **Public PR** bumping the dep | CVE is already public; a patch PR is net-positive |
+| **Code vulnerability** (Semgrep ERROR/WARNING, verified exploitable) | **PVR** (GitHub private advisory) | Unpatched code flaw — public disclosure creates a zero-day |
+| **Verified leaked secret** (TruffleHog verified) | **PVR** + tell maintainer to rotate | Publishing the file/line in a public PR tells attackers where to look |
+| **Smart-contract issue** (Slither high/medium) | **PVR** | On-chain exploitation is often immediate and irreversible |
+| **No PVR enabled AND no SECURITY.md** | **Private issue** to maintainer if possible, else skip and log | No safe channel = do no harm |
 
-8. **Write a report.** Save to `articles/vuln-scan-${today}.md`:
-   ```markdown
-   # Vulnerability Scan — ${today}
+#### 5a. Public PR (dependency CVEs only)
 
-   **Repo:** owner/repo (stars, language)
-   **Findings:** N vulnerabilities
+```bash
+git checkout -b security/bump-<pkg>-<cve>
+# Update lockfile/manifest
+git add -A
+git commit -m "fix(deps): bump <pkg> to patch <CVE-YYYY-NNNN>
 
-   ## Finding 1: [Type]
-   - **Severity:** critical/high/medium
-   - **File:** path:line
-   - **Description:** what's wrong
-   - **Fix:** what was changed
-   - **PR:** url
-   ```
+Advisory: <link to GHSA or NVD>
+Severity: <high/critical>
+Fixed in: <version>"
+git push -u origin HEAD
+gh pr create --repo "$REPO" \
+  --title "fix(deps): bump <pkg> to patch <CVE-YYYY-NNNN>" \
+  --body "$(cat <<EOF
+Automated dependency bump to address a disclosed CVE.
 
-9. **Notify.** Send via `./notify`:
-   ```
-   vuln-scanner: [repo] — found [N] vulnerabilities ([severity])
-   PR: [url]
-   ```
+- **CVE:** <id>
+- **Advisory:** <url>
+- **Severity:** <severity>
+- **Package:** \`<name>\` → \`<fixed-version>\`
 
-10. **Log.** Append to `memory/logs/${today}.md`.
+Detected by [osv-scanner](https://google.github.io/osv-scanner/). No code changes outside the lockfile/manifest.
+
+---
+Filed by [Aeon](https://github.com/aeonframework/aeon).
+EOF
+)"
+```
+
+#### 5b. Private Vulnerability Report (code flaws, verified secrets, contract bugs)
+
+```bash
+gh api -X POST "/repos/$REPO/security-advisories" \
+  -H "X-GitHub-Api-Version: 2026-03-10" \
+  -f summary="<short title>" \
+  -f description="$(cat <<'EOF'
+## Summary
+<one-paragraph description>
+
+## Impact
+<what an attacker can do, concretely>
+
+## Location
+`path/to/file.ext:LINE`
+
+## Proof of exploitation
+<minimal PoC or request/payload — no working exploit chains>
+
+## Suggested fix
+<specific code change or pattern>
+
+## Detected by
+Aeon + <semgrep|trufflehog|slither>
+EOF
+)" \
+  -f severity="<critical|high|medium|low>" \
+  -F cwe_ids='["CWE-89"]'  # adjust per finding
+```
+
+If `gh api` returns 404/403 on the advisories endpoint, PVR is disabled. Do **not** fall back to a public issue or PR. Instead:
+- Check `SECURITY.md` for a private contact. If present, draft an email/form submission and save to `.pending-disclosure/<repo>-<timestamp>.md` with body text — do not auto-send.
+- If no contact exists, log "no safe channel — skipped" and move on. Document your findings in the local report (step 7) but do not publish them.
+
+#### 5c. Proposed code patch (optional, paired with 5b)
+
+If you have a minimal fix, push it to **your fork only** (not a PR to upstream) and link it in the PVR description so the maintainer can cherry-pick:
+
+```bash
+git checkout -b private/fix-<slug>
+# apply fix
+git commit -m "draft: proposed patch for reported advisory"
+git push -u origin HEAD
+# DO NOT open a PR. Link the branch in the advisory body.
+```
+
+### 6. Update dedup state
+
+Append to `memory/vuln-scanned.json` (create if missing) so future runs skip this repo for 30 days:
+
+```json
+{"repo": "owner/repo", "scanned_at": "2026-04-20T16:00:00Z", "findings": <N>, "channel": "pvr|public-pr|skipped"}
+```
+
+### 7. Write local report
+
+Save to `articles/vuln-scan-${today}.md` with sections for: repo metadata, scanner sources (ok/fail per tool), candidate count, confirmed findings with severity and channel, dedup note. Do **not** include exploit details for findings disclosed via PVR — redact file/line and link to the advisory ID instead.
+
+### 8. Notify
+
+Use `./notify`. One paragraph. Lead with the verdict.
+
+```
+*Vuln Scanner — <repo>*
+<N> confirmed findings (<severity-summary>).
+Disclosed via: <PVR: advisory #123 | public PR #45 | skipped (no channel)>
+Scanners: semgrep=<ok|fail>, trufflehog=<ok|fail>, osv=<ok|fail>.
+```
+
+If the audit was clean:
+```
+*Vuln Scanner — <repo>*
+Clean audit. <M> candidates reviewed, 0 confirmed. Scanners: semgrep=ok, trufflehog=ok, osv=ok.
+```
+
+### 9. Log
+
+Append to `memory/logs/${today}.md`:
+
+```
+### vuln-scanner
+- Target: owner/repo (stars, language)
+- Candidates: N | Confirmed: M
+- Channels used: PVR (x), public PR (y), skipped (z)
+- Scanner status: semgrep=ok trufflehog=ok osv=ok
+- Advisory/PR links: [...]
+```
 
 ## Sandbox note
 
-The sandbox may block outbound curl. Use **WebFetch** as a fallback for any URL fetch. For auth-required APIs, use the pre-fetch/post-process pattern (see CLAUDE.md).
+The sandbox may block outbound curl. Use **WebFetch** as a fallback for any plain URL fetch. For anything requiring a token, use `gh api` (handles auth internally) or the pre-fetch/post-process pattern (see CLAUDE.md). Scanner binaries that fail to download → record `tool=fail` in `sources.txt` and continue; an all-scanners-fail run must report **error**, not **clean**.
 
-## Environment Variables
+## Environment variables
 
-- `GH_TOKEN` / `GITHUB_TOKEN` — Required. Needs fork + PR permissions.
+- `GH_TOKEN` / `GITHUB_TOKEN` — required. Needs `repo` + `repository_advisories:write` scopes for PVR.
 
 ## Guidelines
 
-- Only report REAL vulnerabilities. False positives damage credibility.
-- Read the code context around each finding — a grep match isn't proof.
-- Be respectful in PR descriptions. You're helping, not shaming.
-- One PR per repo per run. Bundle related fixes into a single PR.
-- Skip repos that are clearly abandoned (no commits in 1+ year).
-- Skip repos that are security research / intentionally vulnerable (e.g. DVWA, juice-shop).
-- If you're not confident a finding is real, don't file a PR. Log it and move on.
-- Never disclose vulnerabilities publicly — PRs are the responsible disclosure path.
-- Don't scan the same repo twice in 30 days (check logs).
+- **Do no harm.** If you can't route a finding through a safe channel, don't publish it.
+- **One report per repo per run.** Bundle related findings.
+- **Read the code.** A scanner hit alone is not a vulnerability.
+- **Skip intentionally vulnerable repos** (teaching tools, CTFs).
+- **Don't scan the same repo twice in 30 days** (`memory/vuln-scanned.json`).
+- **Never post exploit chains publicly.** PoCs go in the private advisory, not in a GitHub comment.
+- **Be deferential in disclosure language** — you're offering help, not grading homework.
+- **Public PRs are only for dependency bumps** addressing already-disclosed CVEs. Everything else is private.
+- **All-scanners-failed ≠ clean.** Report it as an error and do not publish anything.

--- a/skills/vuln-scanner/SKILL.md
+++ b/skills/vuln-scanner/SKILL.md
@@ -246,7 +246,9 @@ Append to `memory/logs/${today}.md`:
 
 ## Sandbox note
 
-The sandbox may block outbound curl. Use **WebFetch** as a fallback for any plain URL fetch. For anything requiring a token, use `gh api` (handles auth internally) or the pre-fetch/post-process pattern (see CLAUDE.md). Scanner binaries that fail to download → record `tool=fail` in `sources.txt` and continue; an all-scanners-fail run must report **error**, not **clean**.
+Scanner binaries (`semgrep`, `trufflehog`, `osv-scanner`, `slither`) are **not pre-installed** in the GitHub Actions sandbox, and outbound `pip install` / `curl | sh` downloads may be blocked. Operators should pre-cache them via `scripts/prefetch-vuln-scanner.sh` (runs before Claude starts, with full network access — see CLAUDE.md prefetch pattern). If any scanner binary is still missing at runtime, log `VULN_SCANNER_SKIPPED: <tool> not available`, record `tool=fail` in `sources.txt`, and continue with the remaining scanners rather than aborting the whole run.
+
+General sandbox rules: use **WebFetch** as a fallback for any plain URL fetch. For anything requiring a token, use `gh api` (handles auth internally) or the pre-fetch/post-process pattern (see CLAUDE.md). An all-scanners-fail run must report **error**, not **clean**.
 
 ## Environment variables
 


### PR DESCRIPTION
## Autoresearch result for `vuln-scanner`

**Winner: Variation B — Responsible-disclosure-first**

### Thesis

A security scanner that publishes vulnerabilities in public PRs is a zero-day publisher. Route code findings and verified secrets to GitHub **Private Vulnerability Reporting (PVR)**; reserve public PRs for **dependency CVEs already disclosed** (osv-scanner hits). Fold in Variation A's scanner upgrades (Semgrep `p/security-audit`/`p/owasp-top-ten`/`p/secrets`, TruffleHog `--only-verified`, osv-scanner) and Variation C's 30-day dedup state (`memory/vuln-scanned.json`) — so B captures most of the runner-up upside inside the disclosure-correctness frame.

### Scoring

Weights: Improvement ×3, Output ×2, Clarity/Data/Robustness ×1.5, Conventions ×1. Max = 52.5.

| Criterion (weight) | A — Better inputs | **B — Responsible disclosure** | C — Robust triage | D — Dependency-first |
|---|---|---|---|---|
| Clarity (×1.5) | 4 → 6.0 | **4.5 → 6.75** | 4 → 6.0 | 4.5 → 6.75 |
| Data quality (×1.5) | 5 → 7.5 | **4.5 → 6.75** | 3.5 → 5.25 | 4 → 6.0 |
| Output value (×2) | 3.5 → 7.0 | **5 → 10.0** | 4 → 8.0 | 4.5 → 9.0 |
| Robustness (×1.5) | 4 → 6.0 | **4.5 → 6.75** | 5 → 7.5 | 4.5 → 6.75 |
| Conventions (×1) | 5 → 5.0 | **5 → 5.0** | 5 → 5.0 | 5 → 5.0 |
| Improvement (×3) | 4 → 12.0 | **5 → 15.0** | 3.5 → 10.5 | 4 → 12.0 |
| **Total** | **43.5** | **50.25** | **42.25** | **45.5** |

### Variations considered

- **A — Better inputs.** Replace raw grep with Semgrep OSS (`p/security-audit`, `p/owasp-top-ten`, `p/secrets`), TruffleHog `--only-verified`, and osv-scanner. Semgrep's dataflow reachability reportedly cuts false positives by ~98% vs pattern-match tooling. Big data-quality win but keeps the ethically shaky public-PR-for-code-vulns path.
- **B — Responsible-disclosure-first (winner).** Routes findings by type: dep CVEs → public PR (CVE already public), code vulns / verified secrets / contract bugs → PVR via `POST /repos/{owner}/{repo}/security-advisories`, no PVR + no `SECURITY.md` → skip with log. Also includes A's scanner pipeline and C's dedup state.
- **C — Robust triage.** Multi-pass confirmation, exploitability confidence ≥4 gate, persistent `memory/vuln-scanned.json`, and scanner-status footer (`semgrep=ok|fail`). Incremental — doesn't fix the disclosure correctness gap.
- **D — Dependency-first rethink.** Drop code audit entirely; focus on osv-scanner bumps + TruffleHog verified secrets. High merge rate, near-zero FP, but narrower — misses Semgrep-class code vulns the skill could catch safely via PVR.

### Diff summary

- **Disclosure model rewritten.** `gh pr create --repo "$REPO"` for code flaws is replaced with a channel-routing table. Public PRs are now reserved for dep-CVE bumps; everything else goes through PVR (`gh api -X POST .../security-advisories`). Fallback: SECURITY.md contact drafted to `.pending-disclosure/`, never auto-sent. No safe channel → skip.
- **Scanners replace grep.** Semgrep OSS (`p/security-audit`, `p/owasp-top-ten`, `p/secrets`), TruffleHog `filesystem` + `git` with `--only-verified`, osv-scanner, and Slither for Solidity. Test/vendor/example/fixture paths excluded at scanner level.
- **Dedup state added.** `memory/vuln-scanned.json` persists repo+timestamp so future runs skip 30-day-window rescan.
- **Scanner-status reporting.** Every run records `semgrep=ok|fail trufflehog=ok|fail osv=ok|fail` and distinguishes **clean audit** (scanners ok, 0 confirmed) from **all-scanners-failed** (must not be reported as clean).
- **Triage discipline.** Each candidate requires a one-sentence attacker-model description; findings without one are dropped. Explicit skip list for teaching/CTF repos.
- **Do-no-harm default.** When a repo has neither PVR nor a `SECURITY.md`, the skill documents findings locally but publishes nothing.

### Sources

- [GitHub Private Vulnerability Reporting — docs](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability)
- [Repository security advisories REST API](https://docs.github.com/en/rest/security-advisories/repository-advisories)
- [Semgrep OSS rulesets](https://semgrep.dev/resources/semgrep-vs-github/)
- [TruffleHog — verified-secret scanning](https://github.com/trufflesecurity/trufflehog)
- [osv-scanner — unified CVE DB](https://google.github.io/osv-scanner/)

Run: `autoresearch` on `vuln-scanner` (var override).

---
Ported from aaronjmars/aeon-tmp#27.
