### PR TITLE
improve(agent-buzz): autoresearch evolution

### DIFF
--- a/skills/agent-buzz/SKILL.md
+++ b/skills/agent-buzz/SKILL.md
@@ -1,72 +1,132 @@
 ---
 name: Agent Buzz
-description: Top 10 tweets by influence mentioning AI agents
+description: Curated AI-agent tweets, clustered into narratives with insight summaries
 var: ""
 tags: [social]
 ---
-> **${var}** — Specific project or topic to prioritize in the search (e.g. "MyProject", "MCP protocol"). If empty, searches AI agents broadly.
+<!-- autoresearch: variation B — sharper output via clustering, signal score, insight extraction, and skip-gates -->
 
-Read memory/MEMORY.md for context.
-Read the last 2 days of memory/logs/ to avoid repeating tweets.
+> **${var}** — Specific project or topic to prioritize (e.g. "MCP protocol", "browser-use"). If empty, searches AI agents broadly.
+
+Read `memory/MEMORY.md` for context.
+Read the last 3 days of `memory/logs/` — extract every `https://x.com/.../status/<id>` URL already posted by this skill and treat those IDs as a dedup set.
+
+## Goal
+
+Publish a curated, narrative-aware read on what the AI-agent scene on X talked about in the last 24h. **Curation, not aggregation.** Better to ship 6 high-signal tweets in 2 clusters than 10 tweets of mixed noise.
 
 ## Steps
 
-1. Search X for high-engagement tweets about AI agents using the X.AI API:
-   ```bash
-   FROM_DATE=$(date -u -d "2 days ago" +%Y-%m-%d 2>/dev/null || date -u -v-2d +%Y-%m-%d)
-   TO_DATE=$(date -u +%Y-%m-%d)
+### 1. Fetch candidates
 
-   # Search AI agents broadly
-   curl -s -X POST "https://api.x.ai/v1/responses" \
-     -H "Content-Type: application/json" \
-     -H "Authorization: Bearer $XAI_API_KEY" \
-     -d '{
-       "model": "grok-4-1-fast",
-       "input": [{"role": "user", "content": "Search X for the most viral and influential tweets from '"$FROM_DATE"' to '"$TO_DATE"' mentioning AI agents, autonomous agents, agent frameworks, agent protocols, or agentic AI. Rank by influence — prioritize accounts with large followings, high engagement (likes, retweets, quote tweets), and people who are builders/founders/researchers in the space. Return the top 15 tweets. For each: @handle, follower count if visible, a one-line summary of what they said, engagement stats if available, and the direct link (https://x.com/username/status/ID)."}],
-       "tools": [{"type": "x_search", "from_date": "'"$FROM_DATE"'", "to_date": "'"$TO_DATE"'"}]
-     }'
-   ```
+```bash
+FROM_DATE=$(date -u -d "1 day ago" +%Y-%m-%d 2>/dev/null || date -u -v-1d +%Y-%m-%d)
+TO_DATE=$(date -u +%Y-%m-%d)
+```
 
-   If `${var}` is set, also search for that specific project/topic and prioritize those results:
-   ```bash
-   curl -s -X POST "https://api.x.ai/v1/responses" \
-     -H "Content-Type: application/json" \
-     -H "Authorization: Bearer $XAI_API_KEY" \
-     -d '{
-       "model": "grok-4-1-fast",
-       "input": [{"role": "user", "content": "Search X for all tweets from '"$FROM_DATE"' to '"$TO_DATE"' mentioning '"${var}"'. Return every tweet you find with @handle, summary, engagement, and direct link (https://x.com/username/status/ID)."}],
-       "tools": [{"type": "x_search", "from_date": "'"$FROM_DATE"'", "to_date": "'"$TO_DATE"'"}]
-     }'
-   ```
+Issue one primary x_search call. The response for each tweet **must include** explicit engagement counts (likes, retweets, replies) and follower count if visible — without these numbers the signal scoring in step 3 cannot run.
 
-   If `XAI_API_KEY` is not set or the curl command fails (sandbox blocking, network errors), fall back to WebSearch. **IMPORTANT:** Always include "today" or "past 24 hours" and the current date in your search query to force fresh results — e.g. `"AI agents twitter today ${today}"`. Discard any results older than 48 hours. Summarize what you find.
+```bash
+curl -s -X POST "https://api.x.ai/v1/responses" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $XAI_API_KEY" \
+  -d '{
+    "model": "grok-4-1-fast",
+    "input": [{"role": "user", "content": "Search X from '"$FROM_DATE"' to '"$TO_DATE"' for tweets in the AI-agents conversation: autonomous agents, agent frameworks, MCP / agent protocols, agent products, agent benchmarks, agent research papers. Return up to 40 candidates. For EACH candidate you MUST return: @handle, follower_count (integer or null), role_guess (builder|founder|researcher|investor|commentator|anon), one-line claim (what they actually said — not a paraphrase, the thesis), likes (int), retweets (int), replies (int), posted_at (ISO), direct_link (https://x.com/username/status/ID). Prefer builders/founders/researchers. Skip obvious engagement-farming threads (\"RT if you agree\", reply-guy pileons, giveaways)."}],
+    "tools": [{"type": "x_search", "from_date": "'"$FROM_DATE"'", "to_date": "'"$TO_DATE"'"}]
+  }'
+```
 
-2. Merge both result sets (if `${var}` was searched). Deduplicate against recent logs. Rank by influence:
-   - Follower count / account credibility (builders > commentators > anons)
-   - Engagement (likes, RTs, quote tweets)
-   - Substance (actual insight > hype > shilling)
+If `${var}` is set, also issue a second call constrained to that topic with the same return schema; merge results.
 
-3. Pick the top 10 tweets.
+**Fallback chain** (fire in order, stop at first success):
+1. curl to X.AI as above.
+2. WebFetch the same X.AI endpoint (bypasses sandbox env-var blocking for some requests).
+3. WebSearch with a forced-fresh query: `"AI agents twitter today ${today}"` — discard anything >48h old, expect degraded metadata.
 
-4. Send via `./notify` (under 4000 chars):
-   ```
-   *Agent Buzz — ${today}*
+Record which source succeeded — you will print it in the output footer.
 
-   1. @handle — one-line summary
-      [link](https://x.com/...)
+### 2. Skip-gates (before clustering)
 
-   2. @handle — one-line summary
-      [link](https://x.com/...)
+Drop any candidate that matches ANY of:
+- **Dup**: `status/<id>` already in the 3-day dedup set from step 0.
+- **Engagement-farming**: poll threads, "bookmark this", "drop a 🔥", reply-guy pileons with <follower_count/10 likes.
+- **Self-promo only**: pure product shill with no claim, no benchmark, no datapoint. Launch tweets are fine IF they include a concrete capability claim or number.
+- **Staleness**: `posted_at` older than 30h.
+- **Anon + low engagement**: role_guess=anon AND (likes+retweets) < 200.
 
-   ...
-   ```
+### 3. Signal scoring
 
-5. Log to memory/logs/${today}.md.
-   If nothing found, log "AGENT_BUZZ_OK" and end.
+Compute `signal = likes + 2*retweets + replies`, then apply modifiers:
+- × 1.3 if role_guess ∈ {builder, founder, researcher}
+- × 0.7 if the claim is a pure hot-take with no concrete referent (no named project, number, paper, or bench)
+- × 0.5 if near-duplicate of another surviving candidate (same claim, different author) — keep the higher-scored one only
+
+### 4. Narrative clustering
+
+Group surviving candidates into **2–4 narrative clusters**. A cluster is a shared thesis, not a shared keyword — e.g. "MCP vendor lock-in debate" not "MCP". Name each cluster in ≤5 words. If one cluster would hold >60% of tweets, split it. If a tweet fits no cluster, drop it unless its signal is exceptional (top 3 overall).
+
+Target output: **2–4 clusters, 2–3 tweets each, 6–9 total tweets** (strictly ≤10).
+
+### 5. Insight extraction
+
+For each selected tweet, write a one-line **insight** (≤20 words). An insight:
+- States the actual claim or datapoint, not a paraphrase of the tweet text.
+- If the tweet is an opinion, states *what they're arguing against* (the contrast is the signal).
+- If the tweet announces a thing, states *what's new vs. prior art* (not "X launched").
+
+**Anti-hype lint** — if your insight contains any of these, rewrite it:
+`game-changing`, `revolutionary`, `mind-blowing`, `wild`, `huge`, `massive`, `unreal`, `insane`, vague "AI agents are evolving", "the future of X".
+
+### 6. Conversation-shape lead
+
+Write one opening sentence (≤25 words) that names what the conversation was actually *about* today. Examples of shape:
+- "Mostly protocol debate — MCP vs. A2A — with two concrete launches on the side."
+- "Quiet builder day: three benchmark drops, no drama."
+- "Funding announcements dominated; the technical thread was about tool-use cost."
+
+If you cannot characterize the shape in one honest sentence, the clustering is wrong — redo step 4.
+
+### 7. Notify
+
+Send via `./notify` (under 4000 chars):
+
+```
+*Agent Buzz — ${today}*
+_<conversation-shape one-liner>_
+
+**<Cluster 1 name>**
+• @handle — <insight>
+  <link>
+• @handle — <insight>
+  <link>
+
+**<Cluster 2 name>**
+• @handle — <insight>
+  <link>
+
+<!-- _src: xai|webfetch|websearch · candidates: N → kept: M_ -->
+```
+
+Keep the footer on the message — it's a single line, and it's how future self-audits debug empty days.
+
+### 8. Log and exit
+
+Append to `memory/logs/${today}.md` under `### agent-buzz`:
+- source used, candidate count, kept count
+- cluster names
+- every selected `https://x.com/.../status/<id>` URL on its own line (for tomorrow's dedup)
+
+**Status codes** (log exactly one):
+- `AGENT_BUZZ_OK` — notification sent with ≥1 cluster.
+- `AGENT_BUZZ_EMPTY` — fetch succeeded but nothing survived skip-gates. Send a short notify: `Agent Buzz — ${today}: quiet day, no survivors.` Do not fabricate.
+- `AGENT_BUZZ_ERROR` — all three sources in the fallback chain failed. Notify: `Agent Buzz — ${today}: all sources failed (${error summary}).` Log the specific failure per source.
+
+Never pad the output to hit 10 tweets. 6 good > 10 mid.
 
 ## Sandbox note
 
-The sandbox may block outbound curl. Use **WebFetch** as a fallback for any URL fetch. For auth-required APIs, use the pre-fetch/post-process pattern (see CLAUDE.md).
+The sandbox may block outbound curl. Use **WebFetch** as a fallback for any URL fetch. For auth-required APIs, use the pre-fetch/post-process pattern (see CLAUDE.md). The three-step fallback chain in step 1 is the applied version of this.
 
 ## Environment Variables Required
-- `XAI_API_KEY` — X.AI API key for Grok x_search
+- `XAI_API_KEY` — X.AI API key for Grok x_search. If unset, the chain starts at step 2 (WebSearch).


### PR DESCRIPTION
## Autoresearch — agent-buzz

**Winner: Variation B — Sharper output** (48.75 weighted)

### Thesis
The original produces a flat top-10 tweet list with paraphrase-style summaries, no narrative structure, and no skip-gates against engagement-farming or shill content. The biggest lever is curation, not fetching. Cluster surviving tweets into 2–4 shared-thesis narratives, rank by a transparent signal formula (`likes + 2×rt + replies` with builder/hot-take/near-dup modifiers), replace paraphrase with insight extraction (the actual claim or contrast), lead with a one-line conversation shape, and enforce skip-gates up front.

### Scoring

| Criterion | Weight | A (Better inputs) | B (Sharper output) | C (More robust) | D (Author leaderboard) |
|---|---|---|---|---|---|
| Clarity | 1.5× | 4 | **4.5** | 4 | 3.5 |
| Data quality | 1.5× | **5** | 4 | 4 | 4 |
| Output value | 2× | 4 | **5** | 3.5 | 4 |
| Robustness | 1.5× | 3.5 | 4 | **5** | 3 |
| Conventions | 1× | 5 | 5 | 5 | 4.5 |
| Improvement | 3× | 4 | **5** | 3.5 | 3.5 |
| **Weighted total** | | 43.75 | **48.75** | 42 | 38.75 |

### Variation summaries

- **A — Better inputs**: 3 parallel x_search angles (builders / launches / debates) + explicit engagement counts + builder-role tagging + min-engagement filter. Strong recall, same output structure.
- **B — Sharper output** ✅ **winner**: Cluster into 2–4 narratives, signal score with modifiers, insight-not-paraphrase, anti-hype lint, conversation-shape lead, skip-gates (dup / farm / shill / stale / low-engagement anon).
- **C — More robust**: X.AI → WebFetch → WebSearch fallback chain, source-status footer, 3-day persistent dedup, AGENT_BUZZ_EMPTY vs AGENT_BUZZ_ERROR. Incremental reliability gain.
- **D — Author leaderboard rethink**: Top 5 voices × their best 1–2 takes instead of a flat tweet list. Good for ongoing trend tracking; loses one-hit viral moments; narrower use case.

### What B folded in from the runners-up
- **From A**: explicit engagement counts (`likes`, `retweets`, `replies`, `follower_count`) returned per candidate — required for the signal scorer.
- **From C**: three-step fallback chain, source-status footer in the notification, `AGENT_BUZZ_OK` / `AGENT_BUZZ_EMPTY` / `AGENT_BUZZ_ERROR` state codes, 3-day URL dedup against `memory/logs/`.

### Diff summary
- Frontmatter description rewritten; tags/var/name preserved.
- 8 numbered steps (was 5): fetch → skip-gates → signal score → cluster → insight → conversation shape → notify → log/exit.
- Max output capped at 10 tweets but target is 6–9 across 2–4 clusters. Explicit "never pad to 10".
- Notification format changed from numbered list to cluster-headed bullets with conversation-shape italic lead and source-status HTML-comment footer.
- Added skip-gates, anti-hype lint, three status codes, explicit fallback chain.

---
Ported from aaronjmars/aeon-tmp#31.
