### PR TITLE
improve(daily-routine): autoresearch evolution

### DIFF
--- a/skills/daily-routine/SKILL.md
+++ b/skills/daily-routine/SKILL.md
@@ -1,89 +1,163 @@
 ---
 name: Daily Routine
-description: Morning briefing combining token movers, tweet roundup, paper pick, GitHub issues, and HN digest
+description: Priority-ranked morning briefing — ledes the single most important thing, caps each section, omits empty ones
 var: ""
 tags: [news]
 ---
-> **${var}** — Area to emphasize (e.g. "crypto", "AI", "security"). If empty, covers all areas equally.
+<!-- autoresearch: variation B — priority-driven curation with "why now" per item, source-status footer, dedup against last 2 days -->
 
-This skill is designed to run as part of a chain (see `chains:` in `aeon.yml`). When chained, prior step outputs (token-movers, paper-pick, github-issues, hn-digest) are provided in the chain context above. Use those outputs directly — do not re-run the sub-skills.
+> **${var}** — Area to emphasize (e.g. "crypto", "AI", "security"). If set, ranks items touching that area higher and biases tweet topic selection. If empty, weights topics from MEMORY.md "Next Priorities" equally.
 
-If running standalone (no chain context provided), fall back to reading each sub-skill and executing it inline:
-- Read `skills/token-movers/SKILL.md` and execute its steps
-- Read `skills/paper-pick/SKILL.md` and execute its steps
-- Read `skills/github-issues/SKILL.md` and execute its steps
-- Read `skills/hn-digest/SKILL.md` and execute its steps
+Read `memory/MEMORY.md` for goals, tracked items, and "Next Priorities".
+Read the last 2 days of `memory/logs/` to extract already-seen token symbols, tweet URLs, paper titles/arXiv IDs, HN item IDs, GH issue URLs — use them for dedup.
 
-Read memory/MEMORY.md for context.
-Read the last 2 days of memory/logs/ to avoid repeating items.
+This skill is designed to run as part of a chain (see `chains:` in `aeon.yml`). When chained, prior step outputs — `.outputs/token-movers.md`, `.outputs/paper-pick.md`, `.outputs/github-issues.md`, `.outputs/hacker-news-digest.md` — appear in the chain context. **Use those outputs directly — do not re-run the sub-skills.**
+
+If running standalone and the chain outputs are absent, produce a lightweight version per source rather than re-executing the full sub-skills (see §4 Standalone fallback). Never re-execute a sub-skill inline — that wastes tokens and runtime.
 
 ---
 
-## Tweet Roundup
+## 1. Gather inputs
 
-Search X for the latest chatter across topics relevant to your interests. Use the X.AI API if `XAI_API_KEY` is set:
+For each source, record its status as one of: `ok` (content present), `empty` (ran but nothing to report), `fail` (no output / error), `skip` (standalone fallback produced a stub).
+
+- **token-movers**: read `.outputs/token-movers.md` if present
+- **paper-pick**: read `.outputs/paper-pick.md` if present
+- **github-issues**: read `.outputs/github-issues.md` if present
+- **hn-digest**: read `.outputs/hacker-news-digest.md` if present
+- **tweet roundup**: see §2
+
+Treat a zero-byte or stub file (e.g. "No items today") as `empty`, not `ok`. A missing file is `fail`.
+
+## 2. Tweet roundup (topic selection from MEMORY.md)
+
+Pick 2-4 tweet topics in this priority order:
+1. If `${var}` is set, its area is topic #1.
+2. Add up to 3 more topics drawn from MEMORY.md "Next Priorities" and "About This Repo" interests. If MEMORY.md is bare, fall back to: `crypto`, `AI`, `developer tools`.
+
+Dedup tweet URLs against the last 2 days of logs before including them.
+
+Prefer the X.AI API if `XAI_API_KEY` is set:
 
 ```bash
 FROM_DATE=$(date -u -d "yesterday" +%Y-%m-%d 2>/dev/null || date -u -v-1d +%Y-%m-%d)
 TO_DATE=$(date -u +%Y-%m-%d)
 
-# Customize these topics to your interests
-for TOPIC in "crypto OR bitcoin OR ethereum OR DeFi" "artificial intelligence OR AI agents OR LLM" "programming OR open source OR developer tools"; do
+# Replace TOPICS with your selected 2-4 topics
+for TOPIC in "${TOPICS[@]}"; do
   curl -s -X POST "https://api.x.ai/v1/responses" \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $XAI_API_KEY" \
     -d '{
       "model": "grok-4-1-fast",
-      "input": [{"role": "user", "content": "Search X for the latest popular tweets about: '"$TOPIC"' from '"$FROM_DATE"' to '"$TO_DATE"'. Return the 3-5 most interesting or viral tweets. For each: @handle, a one-line summary of what they said, and the direct link (https://x.com/username/status/ID). Skip low-engagement noise."}],
+      "input": [{"role": "user", "content": "Search X for tweets about: '"$TOPIC"' from '"$FROM_DATE"' to '"$TO_DATE"'. Return the 3 most interesting, high-signal tweets (min ~200 likes or ~50 retweets — skip low-engagement noise and reply chains). For each: @handle, one-line summary of the actual insight/claim (not a paraphrase), engagement counts (likes/rt/replies), and direct link. Ignore shitposts and engagement bait."}],
       "tools": [{"type": "x_search", "from_date": "'"$FROM_DATE"'", "to_date": "'"$TO_DATE"'"}]
     }'
 done
 ```
 
-If `XAI_API_KEY` is not set, fall back to WebSearch for each topic and summarize the top 3-5 results per topic instead.
+If `XAI_API_KEY` is unset or every call fails, fall back to WebSearch per topic; mark the tweet source as `skip` if the fallback also produces nothing usable.
 
-For each topic, write 2-3 bullet points capturing the gist. Include links.
+From all collected tweets across topics, keep **at most 5 total** — the ones that best carry an insight (a claim, number, named entity, or concrete observation). Drop pure reactions and paraphrases. For each kept tweet, write one line: `@handle — what they actually said [link]`.
 
----
+## 3. Rank, curate, and draft
 
-## Format & Send
+For every candidate item (token row, tweet, paper, issue, HN story), score:
 
-Combine everything (chain context outputs + tweet roundup) into a single notification via `./notify` (keep under 4000 chars):
+- **leverage** (1-3): does it plausibly change a decision the operator cares about? (MEMORY.md priorities + tracked items)
+- **urgency** (1-3): why today — new, breaking, a deadline, an unlock, or a cliff? A paper from last week that just trended today is a 2; a CVE published this morning is a 3.
+
+Compute `score = leverage × urgency`. Keep items with `score ≥ 4`. Within each section, sort by score (desc) and apply the caps below.
+
+| Section | Cap | Notes |
+|---|---|---|
+| Winners (24h) | 5 | Collapse to 3 if any loser or repeat symbol from last 2 days |
+| Losers (24h) | 5 | Same collapse rule |
+| Tweet roundup | 5 total | Grouped by topic in output |
+| Paper of the day | 1 | Skip if chain output is `empty` — do not invent |
+| GitHub issues | 4 | Omit issues already in last-2-days logs |
+| HN digest | 4 | Dedup HN item IDs against last 2 days |
+
+**Omit empty or failed sections entirely.** Do not emit "No items today" stubs — they burn characters that the kept sections need.
+
+**Write the lede last.** After curation, draft a ≤2-line "Today's take" that names the single most important thing across all sections and why it matters now. If nothing scored ≥ 6 (leverage 3 × urgency 2, or 2 × 3), write a one-line "quiet morning — no high-leverage signal".
+
+**Why-now lines.** For each kept item except token rows, add one trailing line ≤12 words explaining why it earned space today. No filler ("interesting development"); a concrete hook (a name, number, or claim).
+
+## 4. Standalone fallback (no chain outputs)
+
+If ALL four chain outputs are missing, do NOT re-run the sub-skills. Instead, assemble a lightweight version:
+
+- **token-movers**: one `curl`/WebFetch to CoinGecko `/coins/markets?vs_currency=usd&order=market_cap_desc&per_page=100&price_change_percentage=24h`. Pick top 5 gainers and top 5 losers by 24h %. Mark source `skip`.
+- **paper-pick**: WebSearch `"arxiv.org" 2026-04-20 <focus area>` and take 1 paper with title + 1-line "why read".
+- **github-issues**: `gh api repos/${WATCHED}/issues?state=open&sort=updated&per_page=10` for watched repos from `memory/watched-repos.md` (skip if the file is absent) — include up to 4.
+- **hn-digest**: WebFetch `https://hn.algolia.com/api/v1/search?tags=front_page&numericFilters=points>100` and include top 4 matching MEMORY.md interests.
+- **tweet roundup**: same as §2 above (this step is independent of the chain).
+
+Standalone output is a `DEGRADED` build — prepend `*⚠ degraded — standalone fallback*` below the lede.
+
+## 5. Format and send
+
+Target: single notification via `./notify`, **≤ 4000 chars**. Build the message, measure, trim, send.
+
+Layout (omit any section that is empty/failed):
 
 ```
 *Daily Routine — ${today}*
+_Today's take:_ <≤2 lines, one concrete call>
 
-*Top 10 Winners (24h)*
-1. SYMBOL: $price (+X%)
+*Winners 24h*
+1. SYMBOL — $price (+X%) [link]
 ...
 
-*Top 10 Losers (24h)*
-1. SYMBOL: $price (-X%)
+*Losers 24h*
+1. SYMBOL — $price (-X%) [link]
 ...
 
-*Tweet Roundup*
-*Crypto:* gist of what's happening
-*AI:* gist
-*Dev:* gist
-
-*Paper of the Day*
-"Title" — why you should read it [link]
-
-*GitHub Issues*
-- repo: #N title (or "No new issues")
-
-*HN Digest*
-1. [Title](url) (Xpts) — summary
-   [Discuss](hn_link)
+*Tweets*
+• @handle — insight [link]
 ...
+
+*Paper*
+"Title" — why read in one line [link]
+
+*GitHub*
+- owner/repo#N — title — why now [link]
+...
+
+*Hacker News*
+1. [Title](url) (Xpts) — why now [HN]
+...
+
+_sources: token-movers=ok|empty|fail|skip, paper-pick=..., github-issues=..., hn-digest=..., tweets=ok|skip|fail_
 ```
 
-If the combined message exceeds 4000 chars, trim the HN and tweet sections first — token data and paper pick are highest priority.
+**Trim order if over 4000 chars** (drop from the bottom):
+1. Tweets (drop to 3, then drop section)
+2. HN (drop to 2, then drop section)
+3. GitHub issues (drop to 2, then drop section)
+4. Losers (drop to 3)
+5. Paper
+6. Winners (drop to 3)
+
+The lede and source-status footer always stay.
+
+## 6. Log
+
+Append to `memory/logs/${today}.md` under `### daily-routine`:
+- Section counts (e.g. `winners=5 losers=3 tweets=4 paper=1 github=2 hn=3`)
+- Source statuses (same as footer)
+- The lede
+- Every tweet URL, paper arXiv ID / title, HN item ID, and GitHub issue URL that was included — future runs dedup against these
+- `DAILY_ROUTINE_OK` if at least 2 sections shipped with content, else `DAILY_ROUTINE_DEGRADED`, else `DAILY_ROUTINE_EMPTY` if everything was empty/fail
 
 ## Sandbox note
 
-The sandbox may block outbound curl. Use **WebFetch** as a fallback for any URL fetch. For auth-required APIs, use the pre-fetch/post-process pattern (see CLAUDE.md).
+The sandbox may block outbound `curl`. Use **WebFetch** as a fallback for any URL fetch. For auth-required APIs (X.AI), rely on pre-fetch or post-process patterns (see CLAUDE.md). If `curl` to x.ai returns a sandbox error, try WebFetch the same endpoint; if that also fails, mark `tweets=fail` and continue — never block the briefing on one source.
 
-## Log
+## Constraints
 
-Log everything to memory/logs/${today}.md.
+- Never invent items. If `paper-pick` output is empty or a stub, omit the Paper section.
+- Never re-execute sub-skills inline — the chain already did that work or the standalone fallback handles it lightly.
+- The lede must be grounded in a specific item actually included below it — no generic framing.
+- Dedup applies to tweet URLs, paper arXiv IDs / titles, HN item IDs, GitHub issue URLs, and token symbols appearing 2+ days in a row.


### PR DESCRIPTION
## Autoresearch — daily-routine

**Winner**: Variation B (48/52.5 weighted) — priority-driven curation with "why now" per item, source-status footer, dedup against last 2 days.

### Thesis
`daily-routine` aggregates 5 fixed sections without ranking, hardcodes tweet topics, and treats a missing chain output the same as an empty one. The biggest lever is **ruthless curation plus observability**: lede with the single most important thing, rank every candidate by leverage × urgency, cap each section, omit empty ones, expose per-source status in a footer, and dedup against the last 2 days of logs.

Variation B folds in:
- From A — MEMORY.md-driven tweet topic selection and explicit engagement threshold in the X.AI prompt.
- From C — source-status footer distinguishing `ok / empty / fail / skip`, dedup against last 2 days, `DAILY_ROUTINE_DEGRADED` marker, lightweight standalone fallback (instead of re-executing sub-skills).

### Scoring table

| Variation | Clarity | Data | Output | Robust | Conv | Improv | Weighted |
|-----------|---------|------|--------|--------|------|--------|----------|
| A — Better inputs (MEMORY-driven topics, engagement gate, GH trending, macro lede) | 4 | 5 | 3 | 3 | 4 | 3 | 37 |
| **B — Sharper output (priority ranking, caps, why-now, source-status, omit empty)** | 4 | 4 | 5 | 4 | 5 | 5 | **48** |
| C — More robust (empty/fail distinction, dedup, DEGRADED mode, light fallback) | 4 | 3 | 3 | 5 | 4 | 3 | 37 |
| D — Rethink ("what needs attention today" — attention items over sections) | 3 | 4 | 4 | 3 | 4 | 4 | 39 |

Weights: Improvement ×3, Output value ×2, Clarity/Data/Robustness ×1.5, Conventions ×1. Max = 52.5.

### Key diff

- **New**: `Today's take` lede (≤2 lines, must ground in a concrete item below).
- **New**: Leverage × urgency scoring (1-3 each), keep items with score ≥ 4, sorted desc.
- **New**: Per-section caps (Winners/Losers 5, Tweets 5 total across all topics, Paper 1, GH 4, HN 4).
- **New**: "Why now" line (≤12 words) per kept item except token rows.
- **New**: Omit empty/failed sections entirely — no "No items today" stubs.
- **New**: Source-status footer `token-movers=ok|empty|fail|skip, ...`.
- **New**: Priority-ordered trim sequence under 4000 chars (tweets → HN → GH → losers → paper → winners). Lede and footer always stay.
- **New**: MEMORY.md-driven tweet topics (`${var}` first, then Next Priorities; falls back to crypto/AI/dev only if MEMORY is bare).
- **Changed**: Standalone fallback no longer re-executes the 4 sub-skills inline — it assembles a lightweight version per source (CoinGecko curl, WebSearch for arxiv, `gh api` for watched-repos, HN Algolia search) and tags the build `DEGRADED`.
- **New**: Dedup against last 2 days' logs (tweet URLs, paper arXiv IDs, HN item IDs, GH issue URLs, repeat token symbols).
- **New**: Log records structured status (`DAILY_ROUTINE_OK|DEGRADED|EMPTY`) plus every URL/ID included so next-day dedup works.

### Runners-up summary

- **A** (37) — strong data diversity but doesn't fix the bloat problem; B absorbs its two strongest changes (MEMORY-driven topics, engagement threshold).
- **C** (37) — best robustness story but doesn't move the output-quality needle; B absorbs its source-status/dedup/fallback wins.
- **D** (39) — the most creative reframe (decision-first attention queue) but loses the predictability users want from a 7 AM briefing, and adds interpretive risk (what counts as "attention"?).

### Constraints preserved

- Frontmatter format (name, description, var, tags) unchanged.
- Core purpose preserved — still a chain-consumer with standalone fallback that emits one notification.
- No new env vars introduced (XAI_API_KEY already used).
- `var` semantics refined (emphasis area still) — now actually consumed in tweet topic selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Ported from aaronjmars/aeon-tmp#33.
