### PR TITLE
improve(monitor-polymarket): autoresearch evolution

### DIFF
--- a/skills/monitor-polymarket/SKILL.md
+++ b/skills/monitor-polymarket/SKILL.md
@@ -1,146 +1,160 @@
 ---
 name: Monitor Polymarket
-description: Monitor specific prediction markets for 24h price moves, volume changes, and fresh comments
+description: Monitor prediction markets with a trader's lens — orderbook microstructure, conviction scoring, action-tiered output
 var: ""
 tags: [crypto]
 ---
-> **${var}** — Event slug to monitor (e.g. "us-x-iran-ceasefire-by"). If empty, reads the watchlist from `skills/monitor-polymarket/watchlist.md`.
+<!-- autoresearch: variation D — trader's lens reframe: orderbook microstructure + conviction scoring + action-tiered output -->
 
-Read `memory/MEMORY.md` for context.
-Read the last 2 days of `memory/logs/` to compare against previous readings and flag changes.
+> **${var}** — Event slug to monitor (e.g. "us-x-iran-ceasefire-by"). If empty, reads `skills/monitor-polymarket/watchlist.md`. If that's also empty, auto-discover the top 5 open events by 24h volume.
 
-## Watchlist
+Read `memory/MEMORY.md` for context. Read yesterday's entry in `memory/logs/` for this skill (if present) so you can dedup alerts and observe day-over-day drift.
 
-The default watchlist lives at `skills/monitor-polymarket/watchlist.md`. Each line is an event slug. Add or remove slugs to change what gets monitored.
+## Thesis
 
-If `${var}` is set, monitor only that single event (useful for ad-hoc checks).
+A flat table of 24h moves trains readers to ignore the skill. What matters to a trader is **conviction** — is this move backed by volume, tight spreads, and orderbook weight, or is it drift on a thin book? Every market earns a score and lands in one of three tiers — **CONVICTION / WATCH / IGNORE** — so the reader's attention is spent, not sprayed.
 
 ## Steps
 
-### 1. Load watchlist
+### 1. Resolve the watchlist
 
 ```bash
 if [ -n "${var}" ]; then
   SLUGS="${var}"
+  DISCOVERED="no"
 else
-  # Read watchlist file, one slug per line, skip comments and blanks
-  SLUGS=$(grep -v '^#' skills/monitor-polymarket/watchlist.md | grep -v '^$')
+  SLUGS=$(grep -Ev '^(#|$)' skills/monitor-polymarket/watchlist.md || true)
+  DISCOVERED="no"
+  if [ -z "$SLUGS" ]; then
+    DISCOVERED="yes"
+    curl -s "https://gamma-api.polymarket.com/events?active=true&closed=false&order=volume24hr&ascending=false&limit=5" > .pm-events.json
+    SLUGS=$(python3 -c 'import json; [print(e["slug"]) for e in json.load(open(".pm-events.json"))]')
+  fi
 fi
 ```
 
-### 2. For each event, fetch markets and price history
+If any `curl` returns empty/non-zero, retry with **WebFetch** on the same URL (sandbox fallback).
 
-For each event slug in the watchlist:
+### 2. For each event, pull the full signal stack
 
-**a) Get the event and its markets:**
-```bash
-curl -s "https://gamma-api.polymarket.com/events?slug=$SLUG&limit=1"
+Run these fetches per slug and record per-source status (`ok|fail`) for the footer:
+
+**a) Event + markets** — `https://gamma-api.polymarket.com/events?slug=$SLUG&limit=1`
+Capture event `id`, `title`, and each market's `id`, `question`, `closed`, `outcomePrices`, `volume24hr`, `volumeNum`, `liquidityNum`, `clobTokenIds`. **Skip closed markets** — they've already resolved.
+
+**b) 24h price history** — `https://clob.polymarket.com/prices-history?market=$YES_TOKEN&interval=1d&fidelity=60`
+(`YES_TOKEN` = `json.loads(clobTokenIds)[0]`.) Compute: `open`, `close`, `high`, `low`, **24h change in pp** (close − open, ×100), intraday range width.
+
+If the history is empty, mark the market `DATA_MISSING` and continue — do not drop the event.
+
+**c) Orderbook microstructure** (per YES token):
+- Spread — `https://clob.polymarket.com/spread?token_id=$YES_TOKEN` → width in pp
+- Midpoint — `https://clob.polymarket.com/midpoint?token_id=$YES_TOKEN`
+- Book — `https://clob.polymarket.com/book?token_id=$YES_TOKEN` → compute **depth imbalance** = (Σ top-5 bid sizes − Σ top-5 ask sizes) / (Σ top-5 bid + Σ top-5 ask). Positive = buy-side pressure, negative = sell-side.
+
+Spread interpretation: `<2pp` tight (high confidence), `2–5pp` moderate, `>5pp` wide (uncertainty / info vacuum).
+
+**d) Comments** — fetch both top-by-reactions and latest:
+```
+https://gamma-api.polymarket.com/comments?parent_entity_type=Event&parent_entity_id=$EVENT_ID&limit=10&order=reactionCount&ascending=false
+https://gamma-api.polymarket.com/comments?parent_entity_type=Event&parent_entity_id=$EVENT_ID&limit=10&order=createdAt&ascending=false
+```
+(`parent_entity_type` is case-sensitive — `Event`, not `event`.) Each comment has `body`, `profile.username` (may be null → use `anon`), `reactionCount`, `createdAt`. Count how many comments landed in the last 24h vs the prior 6 days (from the latest feed) — that's your comment-burst baseline.
+
+### 3. Score each open market — Conviction Index (0–10)
+
+| Input | Contribution |
+|-------|--------------|
+| **Magnitude** | \|24h chg\| ≥ 5pp → +3 · 2–5pp → +1.5 · <2pp → 0 |
+| **Volume backing** | volume24hr ≥ $500k → +2 · $100k–500k → +1 · <$100k → 0 |
+| **Liquidity** | liquidityNum ≥ $200k → +1 · <$50k → −1 (thin-book penalty) |
+| **Spread** | <2pp → +2 · 2–5pp → +1 · >5pp → 0 |
+| **Depth imbalance** | \|imb\| > 0.3 **aligned** with the move direction → +2 |
+| **Comment activity** | last-24h comment count ≥ 5× the prior-6-day daily avg, or ≥ 10 new → +1 |
+
+Clamp to 0–10. Tiering:
+- **CONVICTION** (score ≥ 7): real move backed by book + volume + tight spread
+- **WATCH** (4–6.99): mixed signals, worth tracking
+- **IGNORE** (<4): noise / thin-book drift / no real information
+
+### 4. Detect divergences (high-value flags)
+
+Scan every market (including WATCH/IGNORE) for:
+- **Comment burst before move** — ≥5 new comments in the hour(s) preceding a ≥3pp move → *possible insider chatter*
+- **Price without volume** — ≥3pp change but volume24hr < $50k → *likely drift, discount it*
+- **Spread stress** — spread > 2× the implied volatility estimate from the 24h range (rough proxy: range/24 hours) → *uncertainty arriving*
+- **Volume without price** — volume24hr ≥ 2× (volumeNum / 30) baseline AND \|24h chg\| < 1pp → *potential accumulation*
+
+### 5. Dedup against yesterday
+
+Read yesterday's `memory/logs/` entry for this skill. If a market tagged CONVICTION yesterday is again CONVICTION today with the same direction and magnitude within ±1pp, demote to WATCH and append `(already flagged 24h ago)` to the line. This stops the skill from screaming the same signal daily.
+
+### 6. Build the report
+
+Open with a one-line verdict — pick one: `all quiet`, `one conviction move`, `multi-market action`, `orderbook stress`, `divergence day`.
+
+Then per tier (omit empty tiers):
+
+```
+*CONVICTION — [N markets]*
+[Event Title] › [market question]
+  YES [X.X%] ([+/-X.Xpp], $[X]m 24h vol, spread [Xpp], depth [+0.XX / -0.XX])
+  why: [one line naming which inputs earned the score]
+  comment: "[most illuminating comment — not most popular]" — [@user]
+
+*WATCH — [N markets]*
+[same structure, shorter — one line per market when possible]
+
+*DIVERGENCES*
+- [event] › [market]: [flag name] — [one line]
+- ...
+
+*sources: gamma=[ok|fail], clob_history=[ok|fail], clob_book=[ok|fail], comments=[ok|fail] | discovered=[yes|no]*
 ```
 
-The response contains the event `id`, `title`, and a `markets` array. Each market has:
-- `id`, `question`, `slug`, `closed`
-- `outcomePrices` — JSON array, index 0 = YES price (0.0–1.0)
-- `volume24hr`, `volumeNum`, `liquidityNum`
-- `clobTokenIds` — JSON array, index 0 = YES token, index 1 = NO token
+**Comment selection rule** — prefer comments that *explain* the move (name-drops, numbers, events, reasoning) over emoji/hype. If no comment is substantive, write `no substantive comments`.
 
-**Skip closed markets** — they've already resolved.
+### 7. Notify
 
-**b) Get 24h price history for each open market:**
-```bash
-# YES token is index 0 of clobTokenIds
-TOKEN_ID=$(echo "$CLOB_TOKEN_IDS" | python3 -c "import json,sys; print(json.loads(sys.stdin.read())[0])")
-curl -s "https://clob.polymarket.com/prices-history?market=$TOKEN_ID&interval=1d&fidelity=60"
-```
+Send via `./notify` (≤4000 chars — aggressively trim the WATCH tier if needed; CONVICTION + DIVERGENCES must survive).
 
-Response: `{ "history": [{ "t": unix_timestamp, "p": "price_string" }, ...] }`
-
-**c) Calculate 24h stats for each market:**
-- **Open / Close** — first and last price in the history
-- **Change** — close minus open, in percentage points (e.g. +4.0pp)
-- **High / Low** — intraday range
-- **Volume** — `volume24hr` from the market data
-- **Direction** — classify as: surging (>+5pp), rising (+2 to +5pp), stable (-2 to +2pp), falling (-5 to -2pp), crashing (<-5pp)
-
-### 3. Fetch comments
-
-For each event, get top comments and latest comments:
-
-```bash
-EVENT_ID=... # from step 2a
-
-# Top comments by reactions
-curl -s "https://gamma-api.polymarket.com/comments?parent_entity_type=Event&parent_entity_id=$EVENT_ID&limit=10&order=reactionCount&ascending=false"
-
-# Latest comments (last 24h chatter)
-curl -s "https://gamma-api.polymarket.com/comments?parent_entity_type=Event&parent_entity_id=$EVENT_ID&limit=10&order=createdAt&ascending=false"
-```
-
-**Important:** `parent_entity_type` must be `Event` (capital E).
-
-Each comment has: `body`, `profile.username` (often null → use "anon"), `reactionCount`, `createdAt`.
-
-From the combined results, pick the **3 most interesting comments** per event:
-- New comments from the last 24h get priority (they react to recent moves)
-- High-reaction comments that are still relevant
-- Contrarian takes, insider-sounding analysis, whale callouts, humor
-
-### 4. Build the report
-
-For each event, produce a summary block:
-
-```
-**[Event Title]** (event_id: N)
-
-| Market | YES | 24h Chg | High/Low | 24h Vol |
-|--------|-----|---------|----------|---------|
-| [question] | XX.X% | +X.Xpp ▲ | XX–XX% | $X.Xm |
-| [question] | XX.X% | -X.Xpp ▼ | XX–XX% | $X.Xm |
-...
-
-Biggest mover: "[question]" — [direction] from X% to Y%
-
-Comments:
-- [user/anon]: "[comment excerpt]" (X upvotes)
-- [user/anon]: "[comment excerpt]"
-- [user/anon]: "[comment excerpt]"
-```
-
-Flag any market that moved more than **5 percentage points** in 24h — these are the ones worth paying attention to.
-
-### 5. Notify
-
-Send via `./notify` (under 4000 chars):
+All-IGNORE case:
 ```
 polymarket monitor — ${today}
-
-[Event Title]
-[market] YES X% (chg pp) $Xm vol
-[market] YES X% (chg pp) $Xm vol
-biggest mover: [market] — [direction]
-top comment: "[excerpt]"
-
-[next event...]
-
-alerts: [list any markets that moved >5pp]
+all quiet — N markets tracked, no conviction-tier signals
+[sources line]
 ```
 
-If no markets moved significantly, say so — "all quiet" is useful signal too.
+All sources failed:
+```
+MONITOR_POLYMARKET_DEGRADED — sources: [status line]
+```
 
-### 6. Log
+### 8. Log
 
 Append to `memory/logs/${today}.md`:
 ```
 ## Monitor Polymarket
-- **Events monitored:** N
-- **Markets tracked:** N (M open, K closed)
-- **Biggest mover:** "[question]" — X% → Y% (+/-Zpp)
-- **Alert markets (>5pp move):** [list or "none"]
-- **Top comment:** "[excerpt]"
-- **Notification sent:** yes
+- **Verdict:** [one-line verdict]
+- **Events:** N ([from watchlist|auto-discovered])
+- **Markets:** N open / K closed / D data-missing
+- **CONVICTION:** [list market questions or "none"]
+- **WATCH:** [count]
+- **Divergences:** [list or "none"]
+- **Dedup demotions:** [count]
+- **Sources:** gamma=..., clob_history=..., clob_book=..., comments=...
+- **Notification:** sent|degraded|suppressed
 ```
 
-If a market has moved dramatically or a new trend is forming, also note it in `memory/MEMORY.md` for future reference.
+If a market appears in CONVICTION for the first time, add a one-line entry under a `## Polymarket Watch` section in `memory/MEMORY.md` so future runs can track persistence.
 
 ## Sandbox note
 
-The sandbox may block outbound curl. Use **WebFetch** as a fallback for any URL fetch. For auth-required APIs, use the pre-fetch/post-process pattern (see CLAUDE.md).
+All endpoints used here are public (no auth). For each `curl`, if it returns non-zero or empty JSON, retry the same URL with **WebFetch** and record the recovered source as `ok` in the footer. If both curl and WebFetch fail, record `fail` — never silently omit a failure.
+
+## Constraints
+
+- Do not alert on IGNORE-tier markets even if raw 24h change exceeds 5pp — thin-book drift is exactly what the Conviction Index exists to filter.
+- Always include the sources status line; observability beats cleanliness.
+- Comment quotes: strip newlines, clip to ≤140 chars, escape any markdown that could break the notification.
+- Do not change the `var` semantics (single slug) or the tags without strong justification.


### PR DESCRIPTION
## Winner: Variation D — Trader's lens reframe

**Thesis:** A flat table of 24h moves trains readers to ignore the skill. What matters is *conviction* — whether a move is backed by volume, tight spreads, and orderbook weight, or is drift on a thin book. Every market earns a 0–10 score and lands in **CONVICTION / WATCH / IGNORE**, so the reader's attention is spent, not sprayed. Orderbook microstructure (spread, depth imbalance via `clob.polymarket.com/spread`, `/midpoint`, `/book`) is the new signal dimension the original was missing.

## Scoring

| Variation | Clarity ×1.5 | Data ×1.5 | Output ×2 | Robust ×1.5 | Conv ×1 | Impr ×3 | **Total /50** |
|---|---|---|---|---|---|---|---|
| Original baseline | 4 | 3 | 3 | 2 | 5 | 3 | 38.0 |
| A — Better inputs | 4 | 5 | 3.5 | 4 | 5 | 4 | 43.5 |
| B — Sharper output | 4.5 | 3.5 | 5 | 3.5 | 5 | 4.5 | 45.75 |
| C — More robust | 4.5 | 3 | 3.5 | 5 | 5 | 3.5 | 41.25 |
| **D — Trader's lens** | **3.5** | **5** | **5** | **3** | **4.5** | **5** | **46.75** |

## What the variations considered

- **A — Better inputs:** add CLOB `/spread`, `/book`, `/midpoint`; auto-discover top-volume events when watchlist is empty; precise `startTs`/`endTs` windows; multi-horizon price history.
- **B — Sharper output:** rank markets by significance × volume × liquidity; one-line verdict at top; day-over-day delta from yesterday's log; comment selection by *explanatory* value, not popularity.
- **C — More robust:** empty-watchlist fallback; graceful closed-market handling; WebFetch fallback per source; per-source status footer (`gamma=ok|fail`, `clob=ok|fail`); alert dedup vs. yesterday.
- **D — Trader's lens (winner):** folds A's orderbook endpoints + auto-discovery and C's status footer + dedup into a trader-grade conviction framework with divergence detection (comment-burst-before-move, price-without-volume, spread stress, volume-without-price).

## Diff summary

- **New signal stack:** adds `/spread`, `/midpoint`, `/book` calls per YES token; computes depth imbalance from top-5 bid/ask sizes.
- **Conviction Index:** 0–10 scoring across magnitude, volume, liquidity, spread, depth imbalance, comment activity → CONVICTION / WATCH / IGNORE tiers.
- **Divergence scanner:** four flags (insider-chatter proxy, drift, spread stress, accumulation) surface asymmetric signals the tiering alone misses.
- **Auto-discovery:** when the watchlist is empty, pulls the top 5 open events by 24h volume.
- **Sources footer:** explicit per-endpoint `ok|fail` line so silent failures can't hide behind empty output; `MONITOR_POLYMARKET_DEGRADED` marker when everything fails.
- **Dedup against yesterday's log:** repeat CONVICTION with unchanged direction/magnitude demotes to WATCH — stops same-signal-every-day alert fatigue.
- **Comment selection rule:** prefer explanatory comments (name-drops, numbers, reasoning) over emoji/hype.

## Constraints preserved

- Frontmatter (`name`, `description`, `var`, `tags`) unchanged in shape.
- `var` semantics unchanged — still a single event slug.
- Memory/logging/notify conventions intact.
- No new env vars introduced; all endpoints remain public, no-auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Ported from aaronjmars/aeon-tmp#36.
