### PR TITLE
improve(paper-digest): autoresearch evolution

### DIFF
--- a/skills/paper-digest/SKILL.md
+++ b/skills/paper-digest/SKILL.md
@@ -50,8 +50,10 @@ Deduplicate the pool by arXiv ID. Drop any ID already shipped in the last 7 days
 
 Drop a paper unless it passes at least one of:
 - Direct keyword match to a tracked topic in title or abstract
-- ≥5 HF upvotes (community signal overrides topic match)
+- ≥**5** HF upvotes (community signal overrides topic match) — *`5` is a tunable threshold; adjust if HF upvote distributions shift or if the digest is consistently over/under-selecting. Values of 3–10 are reasonable.*
 - Published in last 14 days AND author or lab is listed in MEMORY.md
+
+**HF fallback**: if the Hugging Face API fails (curl + WebFetch both error) or returns an empty result set across every topic, skip the upvote gate entirely and fall back to **arXiv recent: top 5 from `cs.LG` and top 5 from `cs.AI` submitted in the last 7 days, sorted by `submittedDate` descending**. Note `(HF unavailable — arXiv-only fallback)` in the digest header.
 
 Also drop if ANY of:
 - Survey/review with no new empirical result (unless a tracked topic explicitly tracks surveys)

--- a/skills/paper-digest/SKILL.md
+++ b/skills/paper-digest/SKILL.md
@@ -4,69 +4,129 @@ description: Find and summarize new papers matching tracked research interests
 var: ""
 tags: [research]
 ---
+<!-- autoresearch: variation B — signal-first output: skip-gate low-signal papers, enforce "what's new / so what" sentences, lead with a one-line verdict, ship fewer than 5 rather than pad -->
+
 > **${var}** — Research topic to search. If empty, uses topics from MEMORY.md.
 
-If `${var}` is set, search papers on that topic instead of using MEMORY.md topics.
+## 0. Config check
 
+If `${var}` is set, treat it as the only topic (skip MEMORY.md topic parsing).
 
-Read memory/MEMORY.md for tracked research topics and interests.
-Read the last 7 days of memory/logs/ to avoid covering papers already reported.
+Otherwise read `memory/MEMORY.md` for tracked topics — look for `## Interests`, `## Research topics`, or `## Tracked topics`. Accept bullet lists or comma-separated lines.
 
-For each topic area in MEMORY.md:
-1. Search Hugging Face Papers API (free, no key needed, arXiv-indexed papers with community signal):
-   ```bash
-   curl -s "https://huggingface.co/api/papers/search?q=TOPIC&limit=10"
-   ```
-   Response is a JSON array. Each entry has:
-   - `paper.id` — arXiv ID (use for links: `https://arxiv.org/abs/{id}`, PDF: `https://arxiv.org/pdf/{id}`)
-   - `paper.title`, `paper.summary` (abstract), `paper.authors[].name`
-   - `paper.publishedAt` — publication date
-   - `paper.upvotes` — community upvotes (higher = more notable)
+If no topics are configured AND `${var}` is empty, abort:
+- Log `PAPER_DIGEST_NO_TOPICS` to `memory/logs/${today}.md` with a note
+- Notify once via `./notify`: `paper-digest: no topics configured. Add ## Interests bullets to memory/MEMORY.md or pass var="topic".`
+- Exit. An empty digest is worse than a skip.
 
-2. Also check today's trending papers for serendipitous finds:
-   ```bash
-   curl -s "https://huggingface.co/api/daily_papers?limit=15"
-   ```
-   Daily papers also include `paper.ai_summary` and `paper.ai_keywords[]` — use these to quickly assess relevance to tracked topics.
+Read the last 7 days of `memory/logs/` → extract arXiv IDs already shipped (search for patterns like `arxiv.org/abs/XXXX.XXXXX` or explicit dedup lists). Treat these as skip keys.
 
-3. Score each paper for relevance:
-   - Direct keyword match to MEMORY.md interests = high
-   - Related field or methodology = medium
-   - High upvotes (>10) on Hugging Face = boost score
-   - Tangential = skip
+## 1. Gather candidate pool
 
-Select the top 5 most relevant papers across all topics.
+For each topic, fetch from two independent sources:
 
-For each selected paper:
-- Use the abstract from the API response (`paper.summary`)
-- Write a 2-3 sentence summary: what they found, why it matters, connection to other work
-- Note upvote count as a signal of community interest
+**Hugging Face Papers** (community signal):
+```bash
+curl -s "https://huggingface.co/api/papers/search?q=${TOPIC}&limit=15"
+```
+Fields used: `paper.id` (arXiv ID), `title`, `summary` (abstract), `authors[].name`, `publishedAt`, `upvotes`.
 
-Format as a weekly briefing and save to articles/paper-digest-${today}.md:
+**arXiv API** (recency + breadth, last 14 days):
+```bash
+FROM=$(date -u -d '14 days ago' +%Y%m%d0000)
+TO=$(date -u +%Y%m%d2359)
+curl -s "https://export.arxiv.org/api/query?search_query=all:${TOPIC}+AND+submittedDate:[${FROM}+TO+${TO}]&sortBy=submittedDate&sortOrder=descending&max_results=15"
+```
+Parse the Atom XML: `<entry>` → `<id>` (URL with arXiv ID), `<title>`, `<summary>`, `<author><name>`, `<published>`. Space between calls (arXiv asks for ≥3s between requests).
+
+Also fetch HF daily trending once for serendipity:
+```bash
+curl -s "https://huggingface.co/api/daily_papers?limit=15"
+```
+
+Deduplicate the pool by arXiv ID. Drop any ID already shipped in the last 7 days of logs.
+
+## 2. Skip-gate (drop before summarizing)
+
+Drop a paper unless it passes at least one of:
+- Direct keyword match to a tracked topic in title or abstract
+- ≥5 HF upvotes (community signal overrides topic match)
+- Published in last 14 days AND author or lab is listed in MEMORY.md
+
+Also drop if ANY of:
+- Survey/review with no new empirical result (unless a tracked topic explicitly tracks surveys)
+- Pure leaderboard/benchmark-number paper with no method novelty
+- Abstract looks like an extended previous work (`v2`, `v3` — check arXiv version)
+- Already in the 7-day log dedup set
+
+## 3. Rank survivors
+
+Signal score = `(upvotes * 2) + (1 if ≥1 citation and <30d old) + (2 if tracked-topic keyword in title)`. Ties broken by `publishedAt` descending.
+
+## 4. Select — fewer is better
+
+Pick up to 5, but **only include a paper if you can write a non-generic "so-what" sentence**. If signal is thin, ship 3, or 2. If the pool is genuinely empty after the skip-gate, ship zero and write a one-line "no new papers of substance this cycle" digest — padding is worse than brevity.
+
+## 5. Summarize — required moves and banned phrases
+
+For each selected paper, write two sentences:
+
+- **What's new** (1 sentence): the concrete method or result, named specifically. Must cite at least one of: a number, a dataset/benchmark name, a mechanism, or a delta vs. a named prior system. Not "proposes a novel approach".
+- **So what** (1 sentence): why a reader tracking *this specific topic* should care *this week*. Must reference a tracked interest explicitly OR name a paper/approach it supersedes, replicates, or contradicts.
+
+**Banned** (rewrite or drop the paper):
+- "This paper proposes", "We introduce", "In this work we..."
+- "Novel", "state-of-the-art" without a number
+- "Could have implications" / "may be useful for" / "opens avenues"
+- Generic "advances the field" / "improves performance"
+
+Self-edit pass: re-read each summary. If "what's new" could apply to 5+ other papers in the field, rewrite or drop the paper.
+
+## 6. Output
+
+Save to `articles/paper-digest-${today}.md`:
 ```markdown
 # Paper Digest — ${today}
+> **Verdict:** <one line: shape of the week, e.g. "3 solid LLM agent results, 1 surprising RL finding, no new alignment work worth reading">
+> Pool: HF ${n_hf} + arXiv ${n_arxiv} → ${n_deduped} deduped → ${n_shipped} shipped
 
-## Topic Area
-1. **Paper Title** — Authors (Year) · ↑upvotes
-   Summary of key findings and implications.
-   [Paper](https://arxiv.org/abs/ID) | [PDF](https://arxiv.org/pdf/ID)
+## ${topic_or_cluster}
+1. **Title** — First Author et al. (2026) · ↑${upvotes}
+   **What's new:** specific method + number/delta.
+   **So what:** connection to tracked interest or paper superseded.
+   [abs](https://arxiv.org/abs/ID) | [pdf](https://arxiv.org/pdf/ID)
 
 2. ...
 ```
 
-Send abbreviated version via `./notify` (under 4000 chars):
+Send abbreviated version via `./notify` (<4000 chars) — keep the verdict line:
 ```
 *Paper Digest — ${today}*
-5 new papers across [topics]
+${verdict}
 
-1. "Title" — key finding
+1. "Title" — what's new in ≤12 words (↑${upvotes})
 2. ...
 
-Full briefing: articles/paper-digest-${today}.md
+Full: articles/paper-digest-${today}.md
 ```
 
-Log what you did to memory/logs/${today}.md.
+## 7. Log
+
+Append to `memory/logs/${today}.md`:
+```
+### paper-digest
+- Verdict: <verdict line>
+- Shipped: <arXiv IDs, comma-separated>  <!-- used for next-cycle dedup -->
+- Pool: hf=${n_hf}, arxiv=${n_arxiv} → deduped=${n_deduped} → skip-gated=${n_dropped} → shipped=${n_shipped}
+```
 
 ## Sandbox note
 
-The sandbox may block outbound curl. Use **WebFetch** as a fallback for any URL fetch. For auth-required APIs, use the pre-fetch/post-process pattern (see CLAUDE.md).
+Curl may be blocked. For any failed fetch, retry with **WebFetch** against the same URL. If HF and arXiv both fail for every topic, notify `PAPER_DIGEST_ERROR — all sources unreachable`, log, and exit without writing a digest. If only one source works, proceed and note `(partial: 1/2 sources)` in the digest header.
+
+## Constraints
+
+- Never ship a paper without a specific "what's new" sentence (number, name, or delta).
+- Never pad to reach 5 — cap is 5, but fewer is better.
+- Never ship a paper that doesn't tie to a tracked topic — the whole point is filtering.
+- Never re-ship an arXiv ID that appears in the last 7 days of logs.


### PR DESCRIPTION
## Autoresearch — paper-digest

**Winner:** Variation B — Sharper output (signal-first discipline)
**Score:** 48.75 / 52.5 weighted

### Thesis
The original produces a generic list of 5 papers with 2-3 sentence summaries — no filter for noise, no signal discipline, and silently produces an empty/useless digest against a fresh MEMORY.md. The biggest lever isn't more sources; it's forcing each summary to earn its place: a specific "what's new" sentence (number / name / delta) and a "so what" sentence that ties to a tracked interest. Ship 3 good papers, not 5 padded ones.

### Scoring

| Criterion (weight) | A: Better inputs | B: Sharper output | C: More robust | D: Rethink thematic |
|---|---|---|---|---|
| Clarity (×1.5) | 4 (6.0) | **4.5 (6.75)** | 4 (6.0) | 3.5 (5.25) |
| Data quality (×1.5) | **5 (7.5)** | 4.5 (6.75) | 4 (6.0) | 4 (6.0) |
| Output value (×2) | 3.5 (7.0) | **5 (10.0)** | 3.5 (7.0) | 4.5 (9.0) |
| Robustness (×1.5) | 3.5 (5.25) | 4 (6.0) | **5 (7.5)** | 3 (4.5) |
| Conventions (×1) | 5 (5.0) | 5 (5.0) | 5 (5.0) | 4 (4.0) |
| Improvement (×3) | 4 (12.0) | **4.75 (14.25)** | 3.5 (10.5) | 4 (12.0) |
| **Total** | 42.75 | **48.75** | 42.0 | 40.75 |

### Variations considered

- **A — Better inputs (42.75):** multi-source ingestion (HF Papers + arXiv date-range + Semantic Scholar bulk), cross-source dedup by arXiv ID, 14-day recency filter, default topics if MEMORY.md is empty. Strong on data quality but doesn't fix the output noise problem.
- **B — Sharper output (48.75, winner):** skip-gate (drop papers lacking topic match / upvotes / recency / novelty), mandatory "what's new" with number/delta and "so what" tied to tracked interest, banned-phrase list, self-edit pass, one-line verdict at top, abort on empty topics (no more silently-useless digests), ship <5 rather than pad.
- **C — More robust (42.0):** fallback chain, explicit states (`PAPER_DIGEST_OK / EMPTY / DEGRADED / ERROR`), persistent dedup via 7-day log scan, source-status footer. Solid reliability wins but lower output lift.
- **D — Rethink thematic (40.75):** cluster papers into 2-3 thematic threads and lead with a meta-narrative ("two groups independently report X"). High-ceiling reframe but higher execution variance — hard to cluster 5 papers into coherent threads on thin cycles.

### What changed (diff summary)

**Added:**
- Empty-topics guard: if MEMORY.md has no `## Interests` / `## Research topics` section and `${var}` is empty, abort with a one-time `PAPER_DIGEST_NO_TOPICS` notify instead of producing a useless digest.
- arXiv API source with 14-day `submittedDate:[FROM+TO+TO]` filter, alongside HF Papers + HF daily trending.
- Skip-gate section: explicit drop rules (missing topic match / low upvotes / surveys-without-novelty / benchmark-only / already-logged).
- Signal scoring: `(upvotes * 2) + citation bonus + (2 if tracked-topic keyword in title)`.
- "What's new" / "So what" two-sentence structure with specificity requirements (must cite number, dataset, mechanism, or delta).
- Banned-phrase list + self-edit pass (rewrite or drop if summary could apply to 5+ other papers).
- One-line verdict at top of digest ("3 solid LLM agent results, 1 surprising RL finding, no new alignment work worth reading").
- "Fewer is better": allow 3 or 2 papers (or zero with one-liner) rather than pad to 5.
- Persistent dedup against the last 7 days of `memory/logs/` by arXiv ID.
- Pool observability line: `hf=N, arxiv=N → deduped=N → skip-gated=N → shipped=N`.

**Preserved:** frontmatter (name, description, var, tags), HF Papers as primary source, `${var}` override, notify/log conventions, sandbox WebFetch fallback pattern.

### Runners-up contribution

B folds in:
- From A: arXiv API as second source with 14-day recency filter, cross-source dedup by arXiv ID
- From C: persistent dedup via log scan, explicit error state (`PAPER_DIGEST_ERROR`), partial-source degraded note (`partial: 1/2 sources`)
- Adjacent to D: the verdict line at the top captures the "shape of the week" insight without committing to the harder thread-clustering execution

🤖 Generated by autoresearch skill

---
Ported from aaronjmars/aeon-tmp#37.
