### PR TITLE
improve(auto-merge): autoresearch evolution

### DIFF
--- a/skills/auto-merge/SKILL.md
+++ b/skills/auto-merge/SKILL.md
@@ -4,44 +4,78 @@ description: Automatically merge open PRs that have passing CI, no blocking revi
 var: ""
 tags: [dev, meta]
 ---
-> **${var}** — Repo (owner/repo) to target. If empty, uses all watched repos.
+<!-- autoresearch: variation C — safety-hardened (author allowlist, size cap, UNKNOWN retry, fork block, dry-run mode) so an autonomous agent with merge credentials cannot accidentally ship a hostile or oversized PR -->
 
-Merge open PRs that are fully green: all status checks SUCCESS or NEUTRAL, no CHANGES_REQUESTED review decisions, and mergeable state MERGEABLE. Cap at MAX_AUTO_MERGE merges per run (default: 3).
+> **${var}** — Repo (owner/repo) to target. If empty, uses every repo in memory/watched-repos.md.
+> Env: `AUTO_MERGE_DRY_RUN=1` logs intent without merging. `MAX_AUTO_MERGE=N` caps merges per run (default 3).
+
+Merge open PRs that are fully green **and** pass an explicit safety policy. The policy exists because this skill runs autonomously with write access — a bug in the gate is a bug that ships to main.
 
 Read memory/MEMORY.md and memory/watched-repos.md for repos to target.
 Read the last 2 days of memory/logs/ to avoid re-logging PRs already merged.
 
+## Safety policy
+
+A PR merges only when every one of the following holds:
+
+- **Author allowlist**: `author.login` is one of `dependabot[bot]`, `renovate[bot]`, `github-actions[bot]`, OR appears under a `## Trusted Authors` section in memory/watched-repos.md. No allowlist → only the three bot logins are eligible.
+- **Size cap**: `additions + deletions ≤ 500`. Override by applying the label `auto-merge-large` on the PR.
+- **Base branch**: `baseRefName` is `main` or `master`. Refuse any other target.
+- **Not a fork**: `isCrossRepository == false` (fork CI can be tampered with).
+- **Not draft**: `isDraft == false`.
+- **Not already queued**: `autoMergeRequest == null` (avoid fighting GitHub's native auto-merge if a human enabled it).
+- **No opt-out label**: none of {`do-not-merge`, `wip`, `hold`, `needs-review`, `blocked`} present.
+- **Mergeable state**: `mergeStateStatus == "CLEAN"` (this is stricter than `mergeable == "MERGEABLE"` — CLEAN additionally requires branch-protection gates to be satisfied).
+- **Reviews**: `reviewDecision != "CHANGES_REQUESTED"`.
+- **Checks**: every entry in `statusCheckRollup` has `conclusion` in `{SUCCESS, NEUTRAL, SKIPPED}`. Any `FAILURE`, `TIMED_OUT`, `CANCELLED`, `PENDING`, or `null` conclusion disqualifies the PR.
+
 ## Steps
 
-1. **List open PRs** on each watched repo:
+1. **List open PRs** for each watched repo with the full field set:
    ```bash
-   gh pr list -R owner/repo --state open --json number,title,mergeable,reviewDecision,statusCheckRollup
+   gh pr list -R owner/repo --state open --json number,title,author,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,autoMergeRequest,isCrossRepository,labels,additions,deletions,baseRefName
    ```
 
-2. **Filter to mergeable PRs** — a PR is mergeable only when ALL of the following are true:
-   - `mergeable == "MERGEABLE"` (no conflicts)
-   - `reviewDecision` is not `"CHANGES_REQUESTED"` (no blocking reviews)
-   - All entries in `statusCheckRollup` have `conclusion` of `"SUCCESS"`, `"NEUTRAL"`, or `"SKIPPED"` — skip any PR with a `"FAILURE"` or `"PENDING"` check
-
-3. **Log skipped PRs** — for each PR that does NOT qualify, record the reason (conflicts, pending CI, changes requested) in memory/logs/${today}.md without sending a notification.
-
-4. **Merge up to MAX_AUTO_MERGE PRs** (default 3) per run. For each qualifying PR:
+2. **Handle UNKNOWN state** — GitHub computes `mergeStateStatus` lazily. If a PR returns `UNKNOWN`, sleep 3 seconds and re-query once:
    ```bash
-   gh pr merge NUMBER -R owner/repo --squash --delete-branch
+   sleep 3 && gh pr view NUMBER -R owner/repo --json mergeStateStatus,mergeable,statusCheckRollup
    ```
-   Record the PR number, title, and result SHA in memory/logs/${today}.md.
+   If still UNKNOWN after the retry, skip the PR with reason `UNKNOWN-persistent` and let the next run retry.
 
-5. **Send a notification** only if at least one PR was merged:
+3. **Apply the safety policy** to each PR. Record a verdict for every PR: either `MERGE` or `SKIP:<specific-reason>`. Reasons must name the failing gate — e.g. `SKIP:author-not-allowlisted:contributor123`, `SKIP:size-cap:823-lines`, `SKIP:mergeStateStatus=BEHIND`, `SKIP:label:do-not-merge`, `SKIP:check-failed:lint`. Vague reasons like `SKIP:not-ready` are not acceptable.
+
+4. **Merge qualifying PRs**, up to MAX_AUTO_MERGE (default 3):
+   - If `AUTO_MERGE_DRY_RUN=1`, log `DRY_RUN:would-merge #N` and continue — **do NOT** invoke merge.
+   - Otherwise:
+     ```bash
+     gh pr merge NUMBER -R owner/repo --squash --delete-branch
+     ```
+     If the merge fails (non-zero exit), capture stderr and log `MERGE_FAIL #N: <stderr>`. A failed merge does NOT count toward the cap — continue to the next qualifying PR.
+
+5. **Send a notification** only when at least one real (non-dry-run) merge succeeded:
    ```
    *Auto Merge — ${today}*
    Merged N PR(s) on owner/repo:
-   - #123: PR title (squash merged)
-   - #124: PR title (squash merged)
+   - #123: PR title (+45/-12, by @author) — squash merged abc1234
    Queue cleared. Self-improve cycle unblocked.
    ```
-   If no PRs were merged (all blocked by CI, conflicts, or reviews), do NOT send a notification — just log the reasons.
+   No merges → no notification, just a log entry.
 
-6. **Log summary** to memory/logs/${today}.md:
-   - Merged PRs: list number + title
-   - Skipped PRs: list number + reason
-   - If nothing was merged: log "AUTO_MERGE_SKIP: no qualifying PRs" and end.
+6. **Log to memory/logs/${today}.md** under an `### auto-merge` heading:
+   - `Mode`: live | dry-run
+   - `Repo(s)`: list
+   - `Merged`: `#N title @author +A-D SHA` per line
+   - `Skipped`: `#N SKIP:<reason>` per line
+   - `Totals`: `merged=X qualified=Y considered=Z`
+   - If zero qualified, include a verdict breakdown: `AUTO_MERGE_SKIP: 0/Z qualifying (behind=B blocked=L failing=F draft=D author-blocked=A size-blocked=S)`
+
+## Sandbox note
+
+`gh` authenticates via the workflow's GITHUB_TOKEN — no curl needed. If `gh pr merge` fails with `Resource not accessible by integration`, the workflow token lacks merge permission on that repo; log once and notify at most once per 7 days (check memory/logs/ for prior notification) to avoid alert spam.
+
+## Constraints
+
+- Never merge a PR whose author is not allowlisted, even if every other gate is green.
+- Never bypass the size cap without the explicit `auto-merge-large` label (set by a human, not a bot).
+- Never auto-retry a `MERGE_FAIL` within the same run — if the first merge attempt fails, log and move on.
+- Do not modify PR state other than merging (no comments, no label edits, no branch updates).


### PR DESCRIPTION
## Winner: Variation C — Safety-hardened policy (50.5 / 52.5)

**Thesis**: the original gates on `mergeable==MERGEABLE` + no-CHANGES_REQUESTED + all-checks-green and merges anything that passes. For an autonomous agent with merge credentials, the biggest practical risk isn't a check-then-merge race — it's that the gate lets through a PR from an untrusted author, a 5000-line refactor, or a branch targeting something other than `main`. C hardens the gate.

### Key changes
- **Author allowlist**: `dependabot[bot]`, `renovate[bot]`, `github-actions[bot]`, plus logins under `## Trusted Authors` in `memory/watched-repos.md`. Everyone else is rejected.
- **Size cap**: `additions + deletions ≤ 500`; override requires human-applied `auto-merge-large` label.
- **Stricter state gate**: `mergeStateStatus == CLEAN` (encodes branch protection) replaces `mergeable == MERGEABLE` (which only catches conflicts).
- **UNKNOWN handling**: sleep 3s + single re-query, then skip — GitHub computes mergeability lazily.
- **Base-branch check**: must target `main` or `master`.
- **Fork rejection**: `isCrossRepository == false`.
- **Already-queued guard**: skip if GitHub's native auto-merge is already enabled by a human.
- **Opt-out labels**: `do-not-merge`, `wip`, `hold`, `needs-review`, `blocked`.
- **`AUTO_MERGE_DRY_RUN=1`** mode for safe testing without touching PRs.
- **Per-PR merge failures** captured and logged; do not abort the loop.
- **Specific skip reasons**: `SKIP:size-cap:823-lines`, not `SKIP:not-ready`.

## Scoring rubric

| Variation | Clarity | Data quality | Output value | Robustness | Conventions | Improvement | **Weighted (max 52.5)** |
|-----------|---------|--------------|--------------|------------|-------------|-------------|--------------------------|
| A — Better inputs | 5 | 5 | 3 | 4 | 5 | 4 | 44 |
| B — Sharper output | 4 | 4 | 5 | 3 | 4 | 3 | 39.5 |
| **C — More robust** | **5** | **5** | **4** | **5** | **5** | **5** | **50.5** |
| D — Rethink (native `--auto`) | 4 | 5 | 4 | 5 | 5 | 5 | 49 |

Weights: Improvement ×3, Output value ×2, Clarity/Data/Robustness ×1.5, Conventions ×1.

## All variation summaries

- **A — Better inputs**: richer `gh pr list --json` (mergeStateStatus, isDraft, autoMergeRequest, isCrossRepository, labels, additions/deletions, baseRefName), use `mergeStateStatus=CLEAN` as primary gate, UNKNOWN retry, label opt-out, fork rejection. Score 44.
- **B — Sharper output**: classify every PR into a verdict (MERGE/BEHIND/BLOCKED/FAILING/PENDING/CONFLICTS/DRAFT/CHANGES_REQUESTED), emit a verdict table every run, alert when queue is stuck ≥24h even with zero merges. Score 39.5.
- **C — More robust** *(winner)*: full safety policy (allowlist, size cap, base-branch check, fork block, opt-out labels, draft/autoMerge guards), UNKNOWN retry, `AUTO_MERGE_DRY_RUN` mode, per-PR merge-failure capture, specific skip reasons. Score 50.5.
- **D — Rethink**: pivot to GitHub's native `gh pr merge --auto` — enqueue eligible PRs and let GitHub atomically merge them once all gates pass. Eliminates the check-then-merge race. Same policy allowlist as C. Score 49.

## Tiebreaker note

C and D are within 2 points. The rubric favors the biggest practical single improvement in that case. For this repo's usage (nightly 2 PM UTC, CI long settled), the check-then-merge race is theoretical; the allowlist + size-cap + dry-run prevents a real catastrophe class (runaway merge of a hostile PR). C wins.

## Diff summary

`skills/auto-merge/SKILL.md`: +56 / −22. Original 47 lines → new 76 lines. Adds Safety policy section, UNKNOWN retry, dry-run mode, specific skip-reason requirement, size cap, author allowlist, and a constraints block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Ported from aaronjmars/aeon-tmp#38.
