### PR TITLE
improve(token-report): autoresearch evolution

### DIFF
--- a/skills/token-report/SKILL.md
+++ b/skills/token-report/SKILL.md
@@ -54,6 +54,8 @@ Use DexScreener for two things only:
 
 If DexScreener fails, continue with GT only (`ds=fail` in footer). Never abort on DS failure.
 
+**Low-liquidity pair addendum:** the 3% deviation threshold above is calibrated for liquid pairs. On thin pairs it produces false `ds=divergent` flags from harmless tick noise. **If the pair's 24h volume is below $100k, raise the DS deviation threshold to 10% instead of 3%** before flagging `ds=divergent`. The deep-pool-wins rule still applies when the larger threshold is exceeded.
+
 ### 3. Compute true deltas
 
 From the `TOKEN_REPORT_STATE:` key=value lines in prior logs, load:

--- a/skills/token-report/SKILL.md
+++ b/skills/token-report/SKILL.md
@@ -4,6 +4,8 @@ description: Daily price performance report for the project's token — price, v
 var: ""
 tags: [crypto]
 ---
+<!-- autoresearch: variation B — verdict-first template, threshold-based classification, true deltas from persistent STATE log, skip-when-empty sections -->
+
 > **${var}** — Token contract address. If empty, uses tracked token from MEMORY.md.
 
 ## Config
@@ -17,108 +19,183 @@ This skill reads the token to track from the "Tracked Token" section in `memory/
 | AEON  | 0xbf8e... | base |
 ```
 
----
+If no tracked token is configured and `${var}` is empty, abort silently — no article, no notification.
 
-Read memory/MEMORY.md for the tracked token.
-Read the last 7 days of memory/logs/ for previous price data to show trends.
+Read the last 30 days of `memory/logs/*.md` for prior `TOKEN_REPORT_STATE:` lines (written in step 8). These are the authoritative source of 1d / 7d / 30d deltas, because a stored price yesterday beats an API window that shifts under you.
+
+## Thesis
+
+A daily token report is only useful if it tells the reader *what changed and whether it matters*. Snapshots of price, volume, and liquidity are table-stakes; the value is in the verdict. Every section below must either sharpen the verdict or be dropped. No filler, no "N/A", no "no specific context" sentences.
 
 ## Steps
 
-1. **Fetch token info** from GeckoTerminal (free, no API key needed):
-   ```bash
-   # Token metadata + price
-   curl -s "https://api.geckoterminal.com/api/v2/networks/base/tokens/CONTRACT_ADDRESS"
-   ```
+### 1. Fetch core market data (GeckoTerminal — primary)
 
-2. **Fetch pool data** for the token (top liquidity pools):
-   ```bash
-   # Top pools for this token
-   curl -s "https://api.geckoterminal.com/api/v2/networks/base/tokens/CONTRACT_ADDRESS/pools?page=1"
-   ```
+```bash
+curl -s "https://api.geckoterminal.com/api/v2/networks/base/tokens/CONTRACT_ADDRESS"
+curl -s "https://api.geckoterminal.com/api/v2/networks/base/tokens/CONTRACT_ADDRESS/pools?page=1"
+# Top pool address from the pools response:
+curl -s "https://api.geckoterminal.com/api/v2/networks/base/pools/POOL_ADDRESS/ohlcv/day?aggregate=1&limit=30"
+curl -s "https://api.geckoterminal.com/api/v2/networks/base/pools/POOL_ADDRESS/ohlcv/hour?aggregate=1&limit=24"
+curl -s "https://api.geckoterminal.com/api/v2/networks/base/pools/POOL_ADDRESS/trades"
+```
 
-3. **Fetch OHLCV data** for trend analysis:
-   ```bash
-   # Get the top pool address from step 2, then fetch candles
-   # Daily candles for the last 30 days
-   curl -s "https://api.geckoterminal.com/api/v2/networks/base/pools/POOL_ADDRESS/ohlcv/day?aggregate=1&limit=30"
+If curl fails (sandbox block), retry each URL with **WebFetch**. If the token endpoint returns no data or 404 after both paths, go to step 9 with `TOKEN_REPORT_NO_DATA` — do not notify, do not write an article.
 
-   # Hourly candles for the last 24h
-   curl -s "https://api.geckoterminal.com/api/v2/networks/base/pools/POOL_ADDRESS/ohlcv/hour?aggregate=1&limit=24"
-   ```
+### 2. Cross-check with DexScreener (sanity + alt signal)
 
-4. **Fetch recent trades** for activity signal:
-   ```bash
-   curl -s "https://api.geckoterminal.com/api/v2/networks/base/pools/POOL_ADDRESS/trades"
-   ```
+```bash
+curl -s "https://api.dexscreener.com/latest/dex/tokens/CONTRACT_ADDRESS"
+```
 
-5. **Search for social sentiment** (optional — requires XAI_API_KEY):
-   If `XAI_API_KEY` is set, search X for mentions of $TOKEN in the last 24h:
-   ```bash
-   curl -s -X POST "https://api.x.ai/v1/responses" \
-     -H "Content-Type: application/json" \
-     -H "Authorization: Bearer $XAI_API_KEY" \
-     -d '{
-       "model": "grok-4-1-fast",
-       "input": [{"role": "user", "content": "Search X for $TOKEN_SYMBOL in the last 24 hours. Return the 5 most notable tweets with @handle and summary."}],
-       "tools": [{"type": "x_search"}]
-     }'
-   ```
-   If `XAI_API_KEY` is not set, skip social sentiment and note it in the report.
+Use DexScreener for two things only:
+- **Price sanity:** if DS price deviates >3% from GT price on the deepest-liquidity pair, mark `ds=divergent` in the sources footer and trust the deeper pool. Do not average.
+- **Boost/trending flag:** if the pair is `boosted` or on `trending`, add one sentence to the Context section.
 
-6. **Compile the daily report**:
-   ```markdown
-   # Token Report — ${today}
+If DexScreener fails, continue with GT only (`ds=fail` in footer). Never abort on DS failure.
 
-   ## $TOKEN Performance
+### 3. Compute true deltas
 
-   | Metric | Value | 24h Change |
-   |--------|-------|------------|
-   | Price | $X.XXXX | +/-Y.Y% |
-   | Liquidity | $X.XK | — |
-   | 24h Volume | $X.XK | — |
-   | 24h Buys/Sells | X / Y | — |
-   | 24h High/Low | $X.XX / $X.XX | — |
-   | FDV | $X.XM | — |
+From the `TOKEN_REPORT_STATE:` key=value lines in prior logs, load:
+- **1d-ago price, liquidity, volume_24h, buys, sells, whales** (yesterday's run)
+- **7d-ago price**
+- **30d-ago price** (fall back to GT daily OHLCV close if missing)
 
-   ## Trend
-   - **24h:** [price action summary from hourly candles]
-   - **7-day:** +/-X.X% ([rallying, consolidating, pulling back, etc.])
-   - **30-day:** +/-X.X% ([context])
+For each:
+- If prior value exists, compute pct delta against it.
+- If prior is missing, compute from OHLCV candles and mark the figure `(~7d)` or `(~30d)` to signal the fallback source.
 
-   ## Volume & Liquidity
-   [Is volume increasing/decreasing? Any notable large trades? Buy/sell ratio?]
+Derived signals:
+- **Liq Δ 24h:** pct change vs yesterday's stored liquidity.
+- **Vol ratio:** today's 24h volume ÷ mean(last 7 days of 24h volume). Report as `Z.Z×`.
+- **Buy/sell shift:** (today_buys/today_sells) vs yesterday's ratio. Report both.
+- **Whale trades 24h:** count of single trades with `volume_in_usd >= 1000` in the trades feed. List the top 3 with direction and size in the "What changed" section if ≥1 exists.
 
-   ## Social Pulse
-   [Key mentions, sentiment, notable tweets — or "XAI_API_KEY not set, social data unavailable"]
+### 4. Classify the day (one verdict)
 
-   ## Context
-   [1-2 sentences connecting price action to any known events — repo updates, market conditions]
+Pick exactly one label from the table. Thresholds use *today's true deltas* from step 3. Evaluate top-to-bottom; the first row whose trigger fully matches wins.
 
-   ---
-   *Data: GeckoTerminal | Chain: Base*
-   *Contract: CONTRACT_ADDRESS*
-   ```
+| Label | Trigger |
+|-------|---------|
+| `BREAKOUT` | Δprice ≥ +10% AND vol ratio ≥ 2.0 |
+| `BREAKDOWN` | Δprice ≤ −10% AND vol ratio ≥ 2.0 |
+| `RALLYING` | +3% ≤ Δprice < +10% AND vol ratio ≥ 1.0 |
+| `SLIDING` | −10% < Δprice ≤ −3% AND vol ratio ≥ 1.0 |
+| `ACCUMULATING` | abs(Δprice) < 3% AND buy/sell ratio ≥ 1.3 AND whale buys ≥ 1 |
+| `DISTRIBUTING` | abs(Δprice) < 3% AND buy/sell ratio ≤ 0.7 AND whale sells ≥ 1 |
+| `QUIET` | vol ratio < 0.5 AND whale trades = 0 |
+| `CONSOLIDATING` | (everything else) |
 
-7. **Save** to `articles/token-report-${today}.md`
+Do not freelance labels. The verdict drives the lede, the TL;DR, and the notification.
 
-8. **Send notification** via `./notify`:
-   ```
-   *$TOKEN Daily — ${today}*
+### 5. Compile the report
 
-   Price: $X.XXXX (Y.Y% 24h)
-   Liquidity: $X.XK | 24h Vol: $X.XK
-   Buys/Sells: X/Y
-   7d: +/-X.X% | 30d: +/-X.X%
+Save to `articles/token-report-${today}.md`:
 
-   [1-sentence summary]
+```markdown
+# $TOKEN — ${today}
 
-   Chart: https://www.geckoterminal.com/base/pools/POOL_ADDRESS
-   ```
+**Verdict:** [LABEL] — [≤18 words, citing the 1–2 numbers that drove the label]
 
-9. **Log** to `memory/logs/${today}.md` including the current price (for trend comparison in future runs).
+## 24h at a glance
 
-**Important:** If the GeckoTerminal API returns no data (token not found, API error, empty response), log "TOKEN_REPORT_NO_DATA" to memory and **do NOT send any notification**. Do not notify about failures or empty results.
+| Metric | Now | 24h Δ | vs 7d avg |
+|--------|-----|-------|-----------|
+| Price | $X.XXXX | ±Y.Y% | — |
+| Liquidity | $X.XK | ±Y.Y% | — |
+| Volume (24h) | $X.XK | — | Z.Z× |
+| Buys / Sells | X / Y | ratio Z.ZZ (yest Z.ZZ) | — |
+| Whale trades (≥$1k) | N | — | — |
+| FDV | $X.XM | — | — |
+
+## Trend
+- **7d:** ±X.X% ([one phrase: rallying, range-bound, rolling over, etc.])
+- **30d:** ±X.X% ([one phrase])
+
+## What changed
+[2–4 sentences. Name the specific deltas that matter and the verdict they produced. If whale trades exist, list the top 3 as `buy $1.2K @ $0.0042 · 11:03 UTC`. If liquidity moved >5%, name the pool and the $ amount. Tie every sentence back to the verdict. No filler.]
+
+## Social Pulse
+[Only include if XAI_API_KEY is set AND x_search returns ≥2 tweets with ≥10 engagement. Lead with a one-line read of the conversation shape, then quote 1–3 tweets with @handle + engagement counts. Otherwise OMIT this section entirely.]
+
+## Context
+[Only include when there is a genuine link to known activity: a recent repo release, a broader market regime shift, a boost/trending flag, an on-chain event. If none, OMIT. Never write "no specific context".]
+
+---
+*Chart: https://www.geckoterminal.com/base/pools/POOL_ADDRESS*
+*Contract: CONTRACT_ADDRESS | Chain: Base*
+*Sources: gt=ok · ds=[ok|fail|divergent] · xai=[ok|skip|fail]*
+```
+
+**Section discipline:**
+- If Social Pulse or Context has no real content, drop the section — do not write placeholder text.
+- Never round in a way that flips a sign or crosses a threshold (e.g. don't render `−0.05%` as `0.0%`).
+- Every number in the report traces to an API response or a delta computed in step 3. Do not invent figures.
+
+### 6. Social sentiment (conditional)
+
+If `XAI_API_KEY` is set:
+
+```bash
+curl -s -X POST "https://api.x.ai/v1/responses" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $XAI_API_KEY" \
+  -d '{
+    "model": "grok-4-1-fast",
+    "input": [{"role": "user", "content": "Search X for $TOKEN_SYMBOL or CONTRACT_ADDRESS mentions in the last 24 hours with at least 10 likes. Return up to 5 notable tweets with @handle, engagement counts, and a one-line summary of the claim or vibe. Exclude obvious bots and generic shill posts."}],
+    "tools": [{"type": "x_search"}]
+  }'
+```
+
+If the response has fewer than 2 tweets that clear the engagement bar, skip the Social Pulse section and set `xai=skip` in the footer. On API error, set `xai=fail` and skip. If `XAI_API_KEY` is not set, set `xai=skip`.
+
+### 7. Save article
+
+Write the compiled report to `articles/token-report-${today}.md`.
+
+### 8. State log (powers tomorrow's deltas)
+
+Append to `memory/logs/${today}.md`:
+
+```
+### token-report
+- Verdict: [LABEL]
+- TOKEN_REPORT_STATE: price=X.XXXX liquidity=XXXX.XX volume_24h=XXXX.XX buys=N sells=N whales=N pool=POOL_ADDRESS
+- 24h: ±X.X% | 7d: ±X.X% | 30d: ±X.X%
+- Article: articles/token-report-${today}.md
+- Sources: gt=ok ds=[ok|fail|divergent] xai=[ok|skip|fail]
+```
+
+The `TOKEN_REPORT_STATE:` line is a contract — step 3 of the next run parses it with a key=value split. Keep the keys, order, and numeric formats stable. No currency symbols, no thousands separators.
+
+### 9. Notify
+
+Lead with the verdict, not raw numbers. One short paragraph plus metrics.
+
+```
+*$TOKEN — [LABEL]*
+
+[One sentence citing the driving number(s).]
+
+Price $X.XXXX (±Y.Y% 24h) | Liq $X.XK (±Z.Z%) | Vol $X.XK (W.W× 7d)
+Buys/Sells X/Y (ratio Z.ZZ) | Whales: N
+
+Chart: https://www.geckoterminal.com/base/pools/POOL_ADDRESS
+```
+
+**Skip rules:**
+- `TOKEN_REPORT_NO_DATA` (step 1 bailout): log only, **no notification, no article**.
+- `QUIET` verdict with whales=0 AND abs(Δprice 24h) <1%: send a single-line notification `$TOKEN quiet — $X.XXXX flat, vol $X.XK.` (no table). This confirms the skill ran without pinging channels with filler on dead days.
+- Any other verdict: full notification above.
 
 ## Sandbox note
 
-The sandbox may block outbound curl. Use **WebFetch** as a fallback for any URL fetch. For auth-required APIs, use the pre-fetch/post-process pattern (see CLAUDE.md).
+The sandbox may block outbound curl. For any URL fetch that fails, retry with **WebFetch** as a fallback — GeckoTerminal, DexScreener, and api.x.ai are all public or token-auth'd via header, so no pre-fetch / post-process plumbing is needed.
+
+## Constraints
+
+- Never invent numbers. Every figure traces to an API response or a computed delta.
+- Never write filler sections. Drop them.
+- Verdict must come from the step-4 table — no freelance labels.
+- On `TOKEN_REPORT_NO_DATA`, exit silently. No notification about the failure.
+- Preserve the `TOKEN_REPORT_STATE:` log line schema — tomorrow's run depends on it.


### PR DESCRIPTION
## Winning variation: B — Sharper output (49.5 / 52.5)

**Thesis:** The original skill is a competent snapshot — it dumps price, volume, liquidity, and a buys/sells count into a templated table every day. The report runs fine on days when something interesting happens *and* on days when nothing does, so the reader has to do the "so what" synthesis themselves. The biggest lever is not more data or more robustness — it's making the skill commit to a verdict. Variation B forces that by (1) classifying the day with a threshold table (BREAKOUT / BREAKDOWN / RALLYING / SLIDING / ACCUMULATING / DISTRIBUTING / CONSOLIDATING / QUIET), (2) leading every output (article, notification, log) with the verdict and a ≤18-word "why" citing the driving numbers, (3) computing **true** 1d/7d/30d deltas from a persistent `TOKEN_REPORT_STATE:` log line rather than trusting the API's sliding 24h window, and (4) skipping Social Pulse and Context sections entirely when they have no real content instead of writing "N/A" or filler.

## Key changes

- **Verdict-first template** with 8-label threshold table; classification is deterministic, not freelanced.
- **Persistent state contract** — every run writes `TOKEN_REPORT_STATE: price=… liquidity=… volume_24h=… buys=… sells=… whales=… pool=…` to the daily log. Tomorrow's run parses it for authoritative deltas. OHLCV is fallback-only.
- **DexScreener cross-check** (folded in from Variation A) — sanity-checks GT price; flags `ds=divergent` when >3% off; surfaces boost/trending status for Context.
- **Skip-empty-sections discipline** — Social Pulse, Context, even table rows get dropped instead of padded with "N/A" or "no notable activity".
- **Whale trades** — count of single trades ≥$1K from the GT trades feed; top 3 listed in "What changed" when present.
- **Two notification modes** — full report for active verdicts; single-line quiet ping when `QUIET` + whales=0 + abs(Δprice) <1%, so the channel isn't flooded with filler on dead days.
- **Sources footer** (folded in from C) — `gt=ok · ds=[ok|fail|divergent] · xai=[ok|skip|fail]` for observability.
- **Hardened social prompt** — XAI query now requires ≥10 likes and explicitly filters bots/shill.

## Scoring

Weights: Improvement ×3, Output value ×2, Clarity/Data quality/Robustness ×1.5, Conventions ×1. Max = 52.5.

| Criterion | A | B | C | D |
|-----------|--:|--:|--:|--:|
| Clarity (×1.5) | 4 | **5** | 4 | 3 |
| Data quality (×1.5) | **5** | 4 | 4 | 4 |
| Output value (×2) | 3 | **5** | 3 | **5** |
| Robustness (×1.5) | 4 | 4 | **5** | 3 |
| Conventions (×1) | 5 | 5 | 5 | 5 |
| Improvement (×3) | 3 | **5** | 3 | 4 |
| **Weighted total** | 39.5 | **49.5** | 39.5 | 42 |

## Variations considered

- **A — Better inputs (39.5):** DexScreener cross-check, holder count + top-10 concentration, multi-pool aggregation, multi-angle XAI queries. More sources but same "data dump" framing — the report still doesn't commit to a read.
- **B — Sharper output (49.5):** *Winner.* Verdict-first template, threshold classifier, true deltas from persistent state, skip-empty discipline. Biggest single-lever improvement.
- **C — More robust (39.5):** GT→DS fallback chain, partial-data modes (OK / PARTIAL / NO_DATA), explicit WebFetch retries, schema-versioned state, rate-limit awareness. Improves reliability but doesn't change the reading experience.
- **D — Rethink (42):** Reframe as change-detection + narrative tracker with a rolling 14-day state buffer and threshold-gated reports. Strong thesis but drifts from "daily report" mandate and the regime-detection rules carry more miscalibration risk than B's simpler classifier.

## Folded upside from runners-up

- **From A:** DexScreener sanity-check on price and boost/trending flag.
- **From C:** `sources=` observability footer and explicit `ds=[ok|fail|divergent]` / `xai=[ok|skip|fail]` states; strict `TOKEN_REPORT_NO_DATA` silent-exit kept.
- **From D:** The `QUIET` label and single-line quiet ping capture D's "don't ping on dead days" insight without abandoning the daily-report contract.

## Diff summary

- `skills/token-report/SKILL.md` — full rewrite (175 insertions / 98 deletions). Core workflow preserved; frontmatter unchanged; no new env vars required.

---
Ported from aaronjmars/aeon-tmp#39.
