### PR TITLE
improve(evening-recap): autoresearch evolution

### DIFF
--- a/skills/evening-recap/SKILL.md
+++ b/skills/evening-recap/SKILL.md
@@ -4,9 +4,14 @@ description: End-of-day operational summary — what Aeon shipped, what failed, 
 var: ""
 tags: [meta]
 ---
-> **${var}** — Optional date override (YYYY-MM-DD). If empty, recaps today.
+<!-- autoresearch: variation B — reframe recap around tomorrow's decisions, lead with a TL;DR verdict, mandate links, cap to top items; folds in A's cron-state cross-check for silent failures and C's parser fix + source-health awareness -->
+> **${var}** — Optional date override (YYYY-MM-DD). If empty, recaps today (UTC).
 
-Read memory/MEMORY.md for context and open issues.
+Read memory/MEMORY.md for context and `memory/issues/INDEX.md` for open issues.
+
+## Goal
+
+The recap is not a log dump — the operator can read the log themselves. Its job is to deliver a verdict on the shape of the day and surface the calls that need a human. Lead with a one-sentence TL;DR; cap headlines; demand a URL on every shipped item; and never print empty sections.
 
 ## Steps
 
@@ -15,53 +20,78 @@ Read memory/MEMORY.md for context and open issues.
    TODAY=${var:-$(date -u +%Y-%m-%d)}
    ```
 
-2. **Read today's activity log.**
-   Read `memory/logs/${TODAY}.md`. If it doesn't exist, log "No activity log for ${TODAY}" and exit.
+2. **Read today's activity log.** Open `memory/logs/${TODAY}.md`.
+   - Treat **both** `## ` and `### ` as skill-entry headers (existing logs use both styles — `### autoresearch`, `## Changelog Skill`). Capture each heading text as the skill name and the body until the next heading.
+   - If the file is missing or whitespace-only, mark `log=missing` and continue to step 3 — silent failures may still need reporting before exiting.
 
-3. **Extract key metrics from the log.** Count and collect:
-   - Skills that ran (every `## ` header is one skill run)
-   - Content produced: articles written, tweet drafts, explainers, ideas
-   - Issues filed or resolved (check for ISS- references)
-   - Failures or errors (look for "failed", "blocked", "error", "timeout", "zero output")
-   - Anything flagged as needing follow-up
+3. **Cross-check `memory/cron-state.json` for silent failures.** Load it as JSON. For each skill present:
+   - `consecutive_failures ≥ 1` and `last_status != "success"` → silent failure (force into Blockers regardless of log content).
+   - `last_success` date == TODAY but no log entry for that skill → "ran without logging" (low-severity Blocker).
+   - If the file is missing or unparseable, record `cron-state=unavailable` and skip the cross-check (do not abort).
 
-4. **Check open issues** from `memory/issues/INDEX.md` — note any that appear in today's log.
+4. **Deduplicate repeat runs.** If the same skill appears N>1 times in the log, fold into one entry labeled `skill ×N`. Keep the most informative run's headline (the one with a PR/URL or the longest body); collapse the rest to `+K more`.
 
-5. **Write and send the recap notification** via `./notify`. Format:
+5. **Extract every artifact link.** For each entry, capture every URL or file path in the body (PR link, run URL, `articles/...` path, `dashboard/outputs/...` path, ISS-NNN reference). An entry with no concrete artifact is "talk, not ship" — demote it to the Notable tier.
+
+6. **Score and tier each entry on leverage.** What matters for tomorrow's decisions:
+   - **Headlines (top tier, cap 5):** new PR opened, change merged, new article shipped, issue resolved or newly filed, new failure pattern.
+   - **Notable (mid tier, cap 5):** routine successful runs, repeat outputs, expected cron firings, talk-not-ship entries.
+   - **Skip:** pure noise (heartbeat OK with nothing flagged, dedup-only runs, "no new items" reports). Collapse to a count for the footer.
+
+7. **Identify decisions for tomorrow.** Re-scan the day for items that need a *human call*:
+   - Failing skills past their retry budget (cron-state `consecutive_failures ≥ 2`).
+   - PRs awaiting merge for >24h (use `gh pr list --state open --json number,title,url,createdAt` if `gh` is available; skip if not).
+   - Open issues from `memory/issues/INDEX.md` mentioned in today's log without resolution.
+   - Conflicting outputs across skills.
+   List as concrete asks naming the target ("merge PR #N", "decide whether ISS-007 is wontfix"). If none, omit the section.
+
+8. **Write the TL;DR last.** After steps 2–7, write one sentence that takes a stance on the shape of the day. Examples:
+   - "heavy ship day — 5 evolution PRs filed and 0 failures"
+   - "quiet — only crons fired, nothing shipped"
+   - "two regressions opened, one resolved; net negative"
+   - "first failure of `fetch-tweets` in a week — investigate before tomorrow's run"
+   No hedging, no "today saw...", no "various activity occurred".
+
+9. **Compose and send the recap via `./notify`.**
 
    ```
    *Evening Recap — ${TODAY}*
+   _TL;DR: <one-sentence verdict from step 8>_
 
-   *What ran:* N skills
+   *Headlines:*
+   - [skill] — [one-line outcome] · <URL>
+   - ...
 
-   *Shipped:*
-   - [concrete output 1 — keep to one line]
-   - [concrete output 2]
-   ...
+   *Notable:*  (omit section if empty)
+   - [skill ×N] — [one-line]
+   - ...
 
-   *Issues:*
-   - [any new issues filed, or "none"]
+   *Decisions for tomorrow:*  (omit if empty)
+   - [specific ask, named target]
 
-   *Blockers:*
-   - [any failures or errors, or "clean"]
+   *Blockers:*  (omit if empty)
+   - [skill] — [error in ≤8 words] · <run URL if available>
 
-   *Follow-up:*
-   - [anything flagged for attention, or "none"]
+   _+M routine runs collapsed · sources: log=[ok|missing|empty] cron-state=[ok|unavailable]_
    ```
 
-   Rules:
-   - Keep under 2000 chars
-   - Each bullet is one line — no sub-bullets
-   - Skip sections that are empty (don't include "Follow-up: none" if there's nothing)
-   - Lead with what actually shipped, not what was attempted
+   **Hard rules:**
+   - ≤2000 chars total.
+   - **Every Headline bullet must include a URL.** No URL → demote to Notable.
+   - TL;DR is mandatory and must take a stance.
+   - Never print "none" or "clean" — omit the section instead.
+   - Always include the source-health footer line so future-you can debug "why was this recap empty".
+   - Lead with shipped artifacts, not skills attempted.
+   - **Empty-day exit:** if `log=missing` AND no silent failures AND no decisions, send a single line `*Evening Recap — ${TODAY}*: quiet day, no activity recorded · sources: log=missing cron-state=ok` and stop.
 
-6. **Log to memory.**
-   Append to `memory/logs/${TODAY}.md`:
-   ```
-   ## Evening Recap
-   - Recap sent for ${TODAY}: N skills, M outputs, K issues
-   ```
+10. **Log to memory.** Append to `memory/logs/${TODAY}.md` (create the file if it didn't exist):
+    ```
+    ## Evening Recap
+    - Sent for ${TODAY}: H headlines, N notable, B blockers, D decisions queued, M collapsed
+    - TL;DR: <copy the one-sentence verdict>
+    - Sources: log=X cron-state=Y
+    ```
 
 ## Sandbox note
 
-`./notify` uses `.pending-notify/` fallback — recap delivery is reliable even if curl is blocked.
+All inputs are local file reads (logs, issues index, cron-state). `gh pr list` runs through the GitHub CLI and is sandbox-friendly — if it fails, treat the source as unavailable and skip the PR-staleness check. `./notify` writes to `.pending-notify/` when outbound HTTP is blocked, so delivery is reliable.


### PR DESCRIPTION
## Autoresearch — `evening-recap`

Skill evolved by the autoresearch meta-skill. Generated 4 distinct variations against the original, scored each on the standard rubric, and selected the winner.

### Winner: Variation B — Sharper output (decision-first reframe)

**Thesis.** The recap is not a log dump — the operator can read the log themselves. Its job is to deliver a verdict on the day's shape and surface the calls that need a human. The original aggregated bullets under fixed sections (Shipped/Issues/Blockers/Follow-up) without ranking, link discipline, or a stance.

**Key changes:**
- One-sentence **TL;DR verdict** is mandatory and must take a position (no hedging, no "various activity").
- **Headlines are capped at 5** and **must include a URL** — no link → demoted to Notable.
- New **Decisions for tomorrow** section names concrete asks ("merge PR #N", "decide whether ISS-007 is wontfix"). Omitted if empty.
- **Tiered scoring** (Headlines / Notable / Skip-collapse) replaces flat bullet lists.
- **Empty sections are dropped** — never prints "none" or "clean".
- **Parser fix** from variation C: recognizes both `## ` and `### ` as skill-entry headers (existing logs use both — the original parser missed all `### autoresearch` entries from today's log).
- **Silent-failure cross-check** from variation A: loads `memory/cron-state.json` and forces skills with `consecutive_failures ≥ 1` into Blockers regardless of log content.
- **Source-health footer** so future-you can debug "why was this recap empty".

### Scoring (1-5, weighted)

| Criterion (weight) | A: Better inputs | B: Sharper output | C: More robust | D: Rethink (baseline) |
|---|---|---|---|---|
| Clarity (1.5×) | 4 | 5 | 4 | 3 |
| Data quality (1.5×) | 5 | 3 | 4 | 3 |
| Output value (2×) | 4 | 5 | 3 | 4 |
| Robustness (1.5×) | 5 | 3 | 5 | 3 |
| Conventions (1×) | 5 | 5 | 5 | 4 |
| Improvement (3×) | 4 | 5 | 3 | 3 |
| **Weighted total** | **46** | **46.5** | **39.5** | **34.5** |

A and B were within 0.5. Per the rubric tiebreak (prefer the bigger single improvement on close scores), B's reframe wins. Folded A's cron-state cross-check and C's parser/source-health into B as quality gates so the runner-up upside isn't lost.

### All 4 variations considered

- **A — Better inputs (multi-source corroboration).** Layer recap on log + `cron-state.json` + `gh run list` + `git log` + artifact directories. Cross-checks reveal silent failures (workflow ran, no log entry). Strong data quality and robustness; output structure stays conventional.
- **B — Sharper output (decision-first, capped, link-mandatory). [WINNER]** Reframe around tomorrow's decisions. TL;DR verdict, tiered headlines, link mandate, decisions section. Highest perceived improvement and output value; absorbs A's silent-failure check and C's parser fix.
- **C — More robust (parser fix + source-health).** Defensive states for missing/empty logs, dedup, cross-check vs. cron-state, source-health footer. Highest robustness but smallest perceived improvement (bug fixes only visible when something breaks).
- **D — Rethink: today vs 7-day baseline.** Compute medians across the prior 7 daily logs, surface the largest deviation as "today's tell". Creative reframe but operationally premature — only 2 log files exist today, so the baseline is degenerate; would produce noise until 2+ weeks of history accumulate.

### Diff summary

`skills/evening-recap/SKILL.md` — 66 insertions, 36 deletions. Frontmatter unchanged. New `## Goal` section frames the thesis. Steps expanded from 6 to 10, with explicit cron-state cross-check, deduplication, leverage tiering, decisions extraction, and TL;DR-last composition. Sandbox note updated to cover `gh pr list` fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Ported from aaronjmars/aeon-tmp#40.
