### PR TITLE
improve(token-alert): autoresearch evolution

### DIFF
--- a/skills/token-alert/SKILL.md
+++ b/skills/token-alert/SKILL.md
@@ -1,59 +1,145 @@
 ---
 name: Token Alert
-description: Notify on price or volume anomalies for tracked tokens
+description: Notify on per-token statistically anomalous price + volume moves (not arbitrary % thresholds)
 var: ""
 tags: [crypto]
 ---
 > **${var}** — Token symbol or CoinGecko ID. If empty, checks all tracked tokens.
 
-If `${var}` is set, only check that token.
+<!-- autoresearch: variation D — statistical baseline: replace hardcoded % thresholds with per-token z-scores (price + volume), require dual-signal confirmation, tiered output -->
 
+If `${var}` is set, only check that token.
 
 ## Config
 
-This skill reads tracked tokens from a "Tracked Tokens" section in `memory/MEMORY.md`. If the section doesn't exist yet, add it to MEMORY.md or skip this skill.
+This skill reads tracked tokens from a **"Tracked Tokens"** section in `memory/MEMORY.md`. If the section is missing, add it or exit with `TOKEN_ALERT_EMPTY — no tracked tokens`.
 
 ```markdown
 ## Tracked Tokens
-| Token | CoinGecko ID | Alert Threshold |
-|-------|-------------|-----------------|
-| ETH   | ethereum    | 10%             |
-| SOL   | solana      | 10%             |
+| Token | CoinGecko ID | Notes |
+|-------|--------------|-------|
+| ETH   | ethereum     |       |
+| SOL   | solana       |       |
 ```
+
+The `Alert Threshold` column is no longer used — thresholds are now derived per-token from 30-day statistics.
 
 ---
 
-Read memory/MEMORY.md for tracked tokens and alert thresholds.
-Read the last 2 days of memory/logs/ for previous prices to detect changes.
+Read `memory/MEMORY.md` for tracked tokens. Read the last 2 days of `memory/logs/` for prior alerts (dedup).
 
-Steps:
-1. For each token tracked in MEMORY.md (under "Tracked Tokens"):
-   - Fetch current price data using a free API:
-     ```bash
-     # CoinGecko API (works without key, but COINGECKO_API_KEY improves rate limits)
-     if [ -n "${COINGECKO_API_KEY:-}" ]; then
-       curl -s "https://pro-api.coingecko.com/api/v3/simple/price?ids=TOKEN_ID&vs_currencies=usd&include_24hr_change=true&include_24hr_vol=true" \
-         -H "x-cg-pro-api-key: $COINGECKO_API_KEY"
-     else
-       curl -s "https://api.coingecko.com/api/v3/simple/price?ids=TOKEN_ID&vs_currencies=usd&include_24hr_change=true&include_24hr_vol=true"
-     fi
-     ```
-   - Compare against last logged price in memory/logs/
-2. Alert if any of these conditions are met:
-   - Price change > 10% in 24h
-   - Volume spike > 3x average
-   - Price crosses a threshold set in MEMORY.md
-3. If any alerts triggered, send via `./notify`:
-   ```
-   *Token Alert — ${today}*
+## Why this skill alerts
 
-   TOKEN: $X.XX (up/down Y% 24h)
-   Volume: $Z (N x average)
-   Trigger: reason for alert
-   ```
-4. Log all current prices to memory/logs/${today}.md (for next comparison).
-If no anomalies detected, log "TOKEN_ALERT_OK" and end.
+A fixed 10% threshold is wrong in both directions: it floods on volatile memecoins and misses genuine anomalies on stablecoins or low-volatility large caps. Instead: for each token, compute a rolling 30-day baseline of daily log-returns and daily volume, score today's values as z-scores, and alert **only when both price and volume are anomalous** vs that token's own history. This eliminates fixed-threshold false positives and catches quiet-but-unusual moves the old skill missed.
+
+## Steps
+
+### 1. For each tracked token — fetch 30-day history + current snapshot
+
+Primary source: CoinGecko `market_chart` (free tier, 1–365 day range, daily candles).
+
+```bash
+# 30-day history: returns prices[], market_caps[], total_volumes[] arrays of [timestamp_ms, value]
+if [ -n "${COINGECKO_API_KEY:-}" ]; then
+  curl -s "https://pro-api.coingecko.com/api/v3/coins/TOKEN_ID/market_chart?vs_currency=usd&days=30&interval=daily" \
+    -H "x-cg-pro-api-key: $COINGECKO_API_KEY"
+else
+  curl -s "https://api.coingecko.com/api/v3/coins/TOKEN_ID/market_chart?vs_currency=usd&days=30&interval=daily"
+fi
+
+# Current snapshot with 24h change + 24h volume:
+curl -s "https://api.coingecko.com/api/v3/simple/price?ids=TOKEN_ID&vs_currencies=usd&include_24hr_change=true&include_24hr_vol=true&include_market_cap=true"
+```
+
+**If curl fails** (sandbox block, rate limit, 5xx): retry once with **WebFetch** on the same URLs. If WebFetch also fails, fall back to **CoinPaprika** (`https://api.coinpaprika.com/v1/tickers/{id}`) or **Binance** (`https://api.binance.com/api/v3/klines?symbol={SYMBOL}USDT&interval=1d&limit=30`) for history. Record which source served each token in a `sources:` map for the observability footer.
+
+If every source fails for a given token, skip that token and mark it `degraded` in the footer — do not abort the whole skill.
+
+### 2. Compute the per-token baseline
+
+From the 30-day history arrays, compute:
+
+- **Daily log-returns**: `r_i = ln(price_i / price_{i-1})` for the last 29 days (yields 29 return samples).
+- **Return stats**: `mean_r`, `std_r` over those 29 samples.
+- **Volume stats**: `mean_v`, `std_v` over the 30 `total_volumes` samples.
+- **Today's price-z**: `(ln(current / price_{yesterday}) - mean_r) / std_r`.
+- **Today's volume-z**: `(volume_24h - mean_v) / std_v`.
+
+Edge cases:
+- If `std_r == 0` (flat stablecoin) or the history array has fewer than 20 samples, skip the z-score logic for that token and fall back to a **simple rule**: alert only if `|24h change| > 3%` AND volume_24h > 2× mean_v. Mark the token `baseline=insufficient` in the footer.
+- Drop the most recent (partial) day from stats if CoinGecko returns a same-day bucket, to avoid contaminating the baseline with the value being scored.
+
+### 3. Decide the alert tier per token
+
+Require **dual-signal confirmation** (price AND volume both anomalous) before emitting anything. Tier by the combined severity:
+
+| Tier         | Condition                                                                    |
+|--------------|------------------------------------------------------------------------------|
+| **CRITICAL** | \|price-z\| ≥ 3.0  AND  volume-z ≥ 2.0                                       |
+| **WATCH**    | \|price-z\| ≥ 2.5  AND  volume-z ≥ 1.5  (and not CRITICAL)                   |
+| **quiet**    | anything else — do **not** alert                                             |
+
+Also compute **direction** (`↑` or `↓`) from the sign of the log-return and the **BTC-relative excess** (`token_24h_pct − btc_24h_pct`) so the reader can tell whether the move is idiosyncratic or a market-wide wave. Fetch BTC's 24h change once per run, reuse for all tokens.
+
+### 4. Dedup against the last 24h of logs
+
+Grep the last 2 days of `memory/logs/*.md` for `TOKEN_ALERT_FIRED {symbol} {tier}`. If the same token already fired at the same-or-higher tier within the last 24 hours, **suppress** it (log as suppressed-duplicate in the footer). If a WATCH has since escalated to CRITICAL, emit the new CRITICAL.
+
+### 5. Send the notification
+
+If there is at least one unsuppressed alert, fan out one message via `./notify`:
+
+```
+*Token Alert — ${today}*
+
+🔴 CRITICAL
+• ETH ↑ +12.3% ($3842) — price-z 3.1, vol-z 2.4 (vs BTC +4.2%)
+• SOL ↓ -8.7% ($184)  — price-z 2.8, vol-z 2.1 (vs BTC -2.1%)
+
+🟡 WATCH
+• LINK ↑ +4.1% ($23.1) — price-z 2.6, vol-z 1.8 (vs BTC +0.3%)
+
+sources: cg=ok(3) paprika=fallback(0) binance=fallback(0) | baseline=ok(3) insufficient(0) | suppressed=1
+```
+
+Rules for the message:
+- Omit tier sections that have no items. Never emit an empty-body notification.
+- One line per alert. No prose.
+- Cap at 8 lines of alerts total (most severe first); overflow → `+N more WATCH items` trailer.
+- Keep the whole message under ~800 chars.
+
+If nothing crossed tier thresholds, **do not notify**. Log `TOKEN_ALERT_OK` instead.
+
+### 6. Log outcomes to `memory/logs/${today}.md`
+
+Always append a section like:
+
+```
+### token-alert
+- Status: TOKEN_ALERT_OK | TOKEN_ALERT_FIRED | TOKEN_ALERT_DEGRADED | TOKEN_ALERT_EMPTY
+- Checked: ETH, SOL, LINK (n=3)
+- Prices: ETH=$3842 (+12.3%, z=3.1/2.4), SOL=$184 (-8.7%, z=2.8/2.1), LINK=$23.1 (+4.1%, z=2.6/1.8)
+- Fired: ETH CRITICAL, SOL CRITICAL, LINK WATCH
+- Suppressed: BTC WATCH (already fired WATCH within 24h)
+- Sources: cg=ok(3) paprika=0 binance=0
+- Baseline: ok=3 insufficient=0
+```
+
+Statuses:
+- `TOKEN_ALERT_OK` — tokens checked successfully, nothing met the tier thresholds.
+- `TOKEN_ALERT_FIRED` — at least one alert sent.
+- `TOKEN_ALERT_DEGRADED` — some tokens failed all sources; partial check.
+- `TOKEN_ALERT_EMPTY` — no tracked tokens configured, or every source failed for every token.
+
+The price line is **required** on every run — future invocations rely on logged prices as a secondary baseline source if the market_chart endpoint is unavailable.
 
 ## Sandbox note
 
-The sandbox may block outbound curl. Use **WebFetch** as a fallback for any URL fetch. For auth-required APIs, use the pre-fetch/post-process pattern (see CLAUDE.md).
+The sandbox may block outbound curl. For each fetch, on failure retry with **WebFetch** (bypasses the sandbox). CoinGecko, CoinPaprika, and Binance public endpoints require no auth, so no pre-fetch script is needed. If `COINGECKO_API_KEY` is set it is used for higher rate limits; no failure if absent.
+
+## Constraints
+
+- Never emit a single-signal alert (price OR volume alone). Dual-signal only.
+- Never replace the statistical baseline with a hardcoded percentage — the whole point of this skill is that volatility is per-token.
+- Keep the notification under 800 chars. If more tokens qualify, truncate, don't split.
+- Never abort the run because one token failed — degrade gracefully and report it in the footer.


### PR DESCRIPTION
## Autoresearch evolution — token-alert

### Winner: Variation D — Statistical baseline (**50.5/~52.5 weighted**)

**Thesis.** A hardcoded 10% threshold is wrong in both directions: it floods on volatile memecoins and misses genuine anomalies on low-vol majors or stablecoins. Replace it with a per-token 30-day rolling baseline of daily log-returns and daily volume, score today as a z-score, and **alert only when both price and volume are anomalous** vs that token's own history. Tier the output (CRITICAL / WATCH / quiet) by combined severity; add a 24h dedup window and multi-source fallback.

### Scoring table

| Variation | Clarity | Data | Output | Robust | Conv. | Improvement | Weighted |
|-----------|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
| A — Better inputs (markets endpoint + CoinPaprika/Binance fallback + 7d sparkline + BTC-relative) | 4 | 5 | 3.5 | 3.5 | 4 | 3.5 | **40.25** |
| B — Sharper output (severity tiers, volume-confirmed only, "top percentile of last 30d", BTC-beta) | 4 | 4 | 4.5 | 3.5 | 4 | 4 | **42.25** |
| C — More robust (fallback chain, dedup, OK/EMPTY/DEGRADED states, per-source observability) | 5 | 4 | 3 | 5 | 5 | 3 | **41** |
| **D — Statistical baseline (rethink, folds in A+B+C wins)** | 4.5 | 5 | 5 | 4.5 | 4.5 | 5 | **50.5** |

Weights: Improvement ×3, Output ×2, Clarity/Data/Robust ×1.5, Conventions ×1.

### What changed vs original

- **Threshold logic.** Dropped fixed 10% / 3× volume rule. Each token now gets a rolling 30d baseline (log-returns + volume). Alert iff `|price-z| ≥ 2.5` **and** `|vol-z| ≥ 1.5` (dual-signal confirmation). CRITICAL tier requires `|price-z| ≥ 3.0` and `vol-z ≥ 2.0`.
- **Data source.** Added CoinGecko `market_chart?days=30&interval=daily` for the baseline, kept `simple/price` for the snapshot. Added CoinPaprika and Binance `klines` as fallback chain when CoinGecko fails. Each per-token source is tracked in an observability footer.
- **Cold-start safety.** If <20 samples or `std_r == 0` (stablecoin), falls back to a `|24h| > 3%` + `vol > 2× mean` rule and logs `baseline=insufficient` rather than emitting noise.
- **Output.** Tiered notification (CRITICAL / WATCH), one line per alert with direction arrow, price, z-scores, and BTC-relative excess so the reader can tell idiosyncratic vs market-wide moves. Omits empty tier sections; caps at 8 lines; sources/baseline/suppressed footer for observability.
- **Dedup.** Greps last 2 days of logs for `TOKEN_ALERT_FIRED {sym} {tier}`; suppresses same-or-lower-tier repeats within 24h; escalates WATCH → CRITICAL if severity jumped.
- **Status codes.** Logs one of `TOKEN_ALERT_OK | TOKEN_ALERT_FIRED | TOKEN_ALERT_DEGRADED | TOKEN_ALERT_EMPTY` plus structured price/z-score line every run — future invocations can use this logged history as a secondary baseline source.

### Runners-up

- **B — Sharper output (42.25).** "Top percentile of last 30d" + severity tiers + BTC-beta adjustment. Folded into D as the tier thresholds and the BTC-relative excess column.
- **C — More robust (41).** Fallback chain + per-source observability + OK/DEGRADED/EMPTY states. Folded into D as the source fallback order, footer, and status codes.
- **A — Better inputs (40.25).** Multi-source markets endpoint + BTC-relative context. Folded into D via the `market_chart` 30d history fetch and the CoinPaprika/Binance fallbacks.

### Risks / trade-offs

- Requires 30d of daily candles per token per run (1 extra request per tracked token). Well within CoinGecko free-tier 10k/month for any reasonable tracked-tokens list.
- Statistical baseline needs history; stablecoins or brand-new tokens hit the insufficient-baseline path on day one. Handled via the fallback rule rather than silent skip.
- Dual-signal requirement is conservative by design — will miss headline-driven spikes that occur without volume confirmation. This is intentional: the previous skill's false-positive rate is the stated problem.

---
Ported from aaronjmars/aeon-tmp#41.
