### PR TITLE
improve(skill-health): autoresearch evolution

### DIFF
--- a/skills/skill-health/SKILL.md
+++ b/skills/skill-health/SKILL.md
@@ -63,6 +63,8 @@ Group non-HEALTHY skills by shared `api_host` OR shared `last_error` signature. 
 
 ### 4. Reconcile with memory/issues/
 
+**Precondition guard:** only perform issue filing/resolution if `memory/issues/INDEX.md` already exists. If it is missing, the operator has not opted into the issue-tracker contract yet — log `SKILL_HEALTH_ISSUE_TRACKER_MISSING` to `memory/logs/${today}.md`, skip this entire step (and the reconciliation side of step 5), and continue with classification + notification only. Do **not** auto-create `INDEX.md`.
+
 For each CRITICAL or FLAPPING skill, check if an open issue already exists with this skill in `affected_skills` AND a matching `root_cause` signature:
 
 - **Open issue exists, same root cause** → do nothing (no new file, no notification for this skill).

--- a/skills/skill-health/SKILL.md
+++ b/skills/skill-health/SKILL.md
@@ -1,102 +1,182 @@
 ---
 name: Skill Health
-description: Audit skill quality metrics, detect API degradation, and report health trends
+description: Audit skill metrics, file/resolve issues in memory/issues/, and notify on state change only
 var: ""
 tags: [meta]
 ---
 > **${var}** — Skill name to check. If empty, checks all scheduled skills.
 
+<!-- autoresearch: variation C — more robust: memory/issues integration per CLAUDE.md health-skill contract, state-change-gated notifications, graceful missing-data; folds in B's TL;DR+action-directives+top-5 and A's skill-runs fallback -->
+
 If `${var}` is set, only check that specific skill.
+
+## Purpose
+
+Audit skill quality metrics, detect API degradation, **file issues for new failures and resolve them when skills recover**, and notify only when fleet health state actually changes.
 
 ## Data sources
 
-1. **`memory/cron-state.json`** — Per-skill quality metrics:
-   ```json
-   {
-     "skill-name": {
-       "last_status": "success|failed|dispatched",
-       "last_success": "ISO timestamp",
-       "last_failed": "ISO timestamp",
-       "total_runs": 10,
-       "total_successes": 8,
-       "total_failures": 2,
-       "consecutive_failures": 0,
-       "success_rate": 0.80,
-       "last_quality_score": 4,
-       "last_error": "error signature text"
-     }
-   }
-   ```
-
-2. **`memory/skill-health/*.json`** — Per-skill quality analysis (written by post-run Haiku analysis):
-   ```json
-   {
-     "skill": "digest",
-     "last_analyzed": "ISO timestamp",
-     "quality_score": 4,
-     "assessment": "one-line quality summary",
-     "flags": ["api_error", "stale_data", ...],
-     "avg_score": 3.8,
-     "history": [{"date": "2026-04-08", "score": 4}, ...]
-   }
-   ```
-
-3. **`aeon.yml`** — Enabled skills and their schedules.
+1. **`memory/cron-state.json`** — Per-skill quality metrics (as before).
+2. **`memory/skill-health/*.json`** — Per-skill quality analysis (Haiku post-run).
+3. **`memory/skill-health/last-report.json`** — Last run's classification snapshot (this skill writes it). Used to dedup notifications and detect flapping.
+4. **`aeon.yml`** — Enabled skills and schedules.
+5. **`memory/issues/INDEX.md`** and `memory/issues/ISS-*.md` — Open issues tracker. Check before filing, update on recovery.
+6. **`./scripts/skill-runs --hours 168 --failures --json`** — Fallback source for failures that never wrote to cron-state (sandbox blocks, etc.). Run once, parse JSON.
+7. **`memory/logs/YYYY-MM-DD.md`** (last 3 days) — Grep for `SKILL_*_ERROR` or `EMPTY` signatures keyed to skills missing from skill-health/*.json.
 
 ## Steps
 
-1. Read `aeon.yml` for all enabled skills with schedules.
-2. Read `memory/cron-state.json` for quality metrics.
-3. Read all files in `memory/skill-health/` for quality trends.
+### 1. Gather state
 
-4. For each enabled skill, classify its health:
+- Parse `aeon.yml` → list of enabled skills with schedules. If `${var}` set, filter to just that skill.
+- Load `memory/cron-state.json` (if missing or unparseable, treat as empty — first run, not failure).
+- Load every `memory/skill-health/*.json` (except `last-report.json`).
+- Load `memory/skill-health/last-report.json` if present → `prev_report`. If missing, `prev_report = {}`.
+- Run `./scripts/skill-runs --hours 168 --failures --json 2>/dev/null || echo '{}'` → extract any skill with failures in the last 7d that isn't in cron-state (sandbox-blocked state writes).
+- Parse `memory/issues/INDEX.md` → extract open issues with `detected_by: skill-health` and their affected skills. If missing, treat as empty.
 
-   **CRITICAL** (consecutive_failures >= 3):
-   - Likely API degradation or persistent config issue
-   - Report the skill, failure count, and `last_error` signature
-   - If multiple skills share the same error signature, flag as systemic (e.g. "3 crypto skills failing with rate_limit — CoinGecko API may be down")
+### 2. Classify each enabled skill
 
-   **DEGRADED** (success_rate < 0.6 OR avg quality score < 2.5):
-   - Skill runs but produces poor output
-   - Report success rate, average quality score, and recent flags
+For each enabled skill, assign one status using the **first matching rule**:
 
-   **WARNING** (success_rate < 0.8 OR consecutive_failures >= 1):
-   - Occasional issues worth monitoring
-   - Report recent failure and error if available
+| Status | Trigger |
+|---|---|
+| **CRITICAL** | `consecutive_failures >= 3` OR (status==failed AND days_since_last_success >= 3) |
+| **DEGRADED** | `success_rate < 0.6` OR (latest `skill-health/*.json` avg_score < 2.5 over ≥3 runs) |
+| **FLAPPING** | 3+ status transitions (success↔failed) in last 7 days per cron-state history *or* `skill-runs` output |
+| **WARNING** | `success_rate < 0.8` OR `consecutive_failures >= 1` |
+| **HEALTHY** | `success_rate >= 0.8` AND `consecutive_failures == 0` AND (no skill-health data OR avg_score >= 3) |
+| **NO DATA** | no entry in cron-state AND never seen in skill-runs |
 
-   **HEALTHY** (success_rate >= 0.8 AND no consecutive failures AND avg score >= 3):
-   - Working well
+Compute **severity score** for sorting: `consecutive_failures × (1 + days_since_last_success/7)`. Ties broken by days_since_last_success desc.
 
-   **NO DATA** (no entry in cron-state.json or total_runs == 0):
-   - Never been dispatched by the scheduler
+For each CRITICAL/DEGRADED/FLAPPING skill, record:
+- `last_error` (from cron-state or nearest log signature)
+- `api_host` if the error clearly names one (e.g. `api.coingecko.com`, `api.github.com`)
+- `suggested_action` — one of: `FIX CONFIG` (missing secret, bad arg), `WAIT-API` (rate limit, 5xx, timeout on third-party host), `INVESTIGATE` (unrecognised error), `DISPATCH-SKILL` (NO DATA but scheduled — scheduler gap)
 
-5. Detect API degradation patterns:
-   - Group skills by their external API dependencies (crypto skills use CoinGecko/Alchemy, research skills use web APIs, etc.)
-   - If 2+ skills in the same group are CRITICAL or DEGRADED, flag the shared dependency
-   - Check `last_error` fields for common patterns: "rate limit", "403", "timeout", "connection refused"
+### 3. Detect systemic patterns
 
-6. Check for quality trends:
-   - Any skill whose avg_score dropped by > 1 point over the last 10 runs
-   - Any skill with recurring flags (same flag in 3+ consecutive analyses)
+Group non-HEALTHY skills by shared `api_host` OR shared `last_error` signature. If ≥2 skills share one:
+- Emit a single `SYSTEMIC:` callout (e.g. `SYSTEMIC: 3 skills failing on api.coingecko.com (rate_limit)`).
+- Do **not** duplicate the same error across per-skill rows — reference the systemic line.
 
-7. Format the health report:
+### 4. Reconcile with memory/issues/
+
+For each CRITICAL or FLAPPING skill, check if an open issue already exists with this skill in `affected_skills` AND a matching `root_cause` signature:
+
+- **Open issue exists, same root cause** → do nothing (no new file, no notification for this skill).
+- **Open issue exists, different root cause** → append a note to the existing ISS file's body: `Update YYYY-MM-DD: new signature: <error>`. Do not file a new issue.
+- **No open issue** → file a new one (see below).
+
+For each skill now HEALTHY whose name appears in any open issue's `affected_skills`:
+- Remove it from that issue's `affected_skills`. If the list becomes empty, set `status: resolved`, set `resolved_at: <now ISO>`, and move the row from Open to Resolved in INDEX.md.
+
+**Filing a new issue:**
+1. Find next ID: scan `memory/issues/ISS-*.md`, take max `NNN`, add 1. Format as zero-padded 3 digits (`ISS-042`).
+2. Write `memory/issues/ISS-NNN.md` with YAML frontmatter:
+   ```yaml
+   ---
+   id: ISS-NNN
+   title: <skill> <concise failure>
+   status: open
+   severity: critical | high | medium | low   # critical=CRITICAL status, high=FLAPPING, medium=DEGRADED
+   category: rate-limit | timeout | missing-secret | config | api-change | sandbox-limitation | unknown
+   detected_by: skill-health
+   detected_at: <ISO timestamp>
+   affected_skills: [<skill>, ...]    # may grow later
+   root_cause: <error signature, 1 line>
+   fix_pr: null
+   ---
+   
+   ## What happened
+   <2-3 line summary>
+   
+   ## Signal
+   - consecutive_failures: N
+   - days_since_last_success: N
+   - last_error: "<error>"
+   - related skills: <list or "none">
    ```
-   *Skill Health — ${today}*
+3. Append a row to `memory/issues/INDEX.md` under **Open**: `| ISS-NNN | title | severity | category | YYYY-MM-DD | skill-a, skill-b |`.
 
-   🔴 CRITICAL (N):
-   skill-a: 5 consecutive failures — "rate limit exceeded" (CoinGecko)
-   skill-b: 3 consecutive failures — "timeout"
+All issue writes must be atomic per file — never partial updates mid-run.
 
-   ⚠️ API DEGRADATION: CoinGecko skills (token-alert, trending-coins) — shared failure pattern
+### 5. Decide whether to notify
 
-   🟡 DEGRADED (N):
-   skill-c: 45% success rate, avg quality 2.1
+Build a stable signature from the current classification: sorted list of `CRITICAL+FLAPPING+DEGRADED skill names + SYSTEMIC callouts`. SHA-256 it → `current_hash`.
 
-   🟢 HEALTHY (N): skill-d, skill-e, skill-f, ...
-   ⚪ NO DATA (N): skill-g, skill-h
-   ```
+- If `current_hash == prev_report.hash` AND `now - prev_report.last_notified_at < 24h` → **do not notify**. State unchanged.
+- Otherwise → **notify** (there's new signal or the daily reminder cadence elapsed).
 
-8. Send via `./notify` if any skills are CRITICAL or DEGRADED.
-9. Log to memory/logs/${today}.md.
+Always write `memory/skill-health/last-report.json`:
+```json
+{
+  "hash": "<current_hash>",
+  "last_notified_at": "<ISO if notified this run, else previous value>",
+  "last_run_at": "<ISO now>",
+  "classification": { "critical": [...], "degraded": [...], "flapping": [...], "warning": [...], "healthy_count": N, "no_data": [...] }
+}
+```
 
-If all skills healthy, log "SKILL_HEALTH_OK" and end.
+### 6. Format the report
+
+**Top line:** `HEALTH: OK` | `HEALTH: WARNING(W)` | `HEALTH: DEGRADED(D)` | `HEALTH: CRITICAL(C)` — most severe wins.
+
+**Body (notify-channel format, max 1 message):**
+
+```
+*Skill Health — ${today}*
+HEALTH: CRITICAL(2)  [systemic: api.coingecko.com rate_limit — 3 skills]
+
+🔴 CRITICAL
+- token-movers — 5 fails, 3d down — WAIT-API (rate_limit) → ISS-042
+- defi-monitor — 4 fails, 2d down — WAIT-API (rate_limit) → ISS-042
+
+🟡 DEGRADED / FLAPPING
+- digest — 52% success (14d), avg quality 2.1 — INVESTIGATE → ISS-043
+
+⚪ NO DATA (2): skill-x, skill-y — DISPATCH-SKILL
+🟢 HEALTHY: 34
+
+Open issues: 2 · Resolved this run: 1 (rss-digest)
+```
+
+Rules for formatting:
+- Cap per-section rows at 5; collapse the rest as `+N more — see memory/issues/INDEX.md`.
+- Omit HEALTHY list (count only). Omit any empty section.
+- Always end with `Open issues: X · Resolved this run: Y`.
+- If NO CRITICAL/DEGRADED/FLAPPING and no new/resolved issues → body is just `HEALTH: OK — N skills healthy`.
+
+### 7. Notify and log
+
+- If the gate in step 5 said notify → `./notify "<report body>"`. Update `last_notified_at` in last-report.json to now.
+- If gate said skip → do not call `./notify`. Log to memory/logs/${today}.md:
+  ```
+  ### skill-health
+  - SKILL_HEALTH_NOOP — state unchanged since <prev_run_at>, hash=<short>
+  ```
+
+On notify, log to memory/logs/${today}.md:
+```
+### skill-health
+- HEALTH: <OK|WARNING|DEGRADED|CRITICAL>
+- filed: [ISS-NNN, ...]
+- resolved: [ISS-NNN, ...]
+- open: N
+- systemic: <pattern or none>
+```
+
+If all skills healthy, the body-only shortcut from step 6 still fires (once per 24h, per gate) so the operator gets confirmation the audit actually ran — but suppress if last-report.json shows a notify <24h ago with the same OK hash.
+
+## Sandbox note
+
+The sandbox may block outbound `curl`. This skill does not fetch URLs directly — all data is local or via `gh` / `./scripts/skill-runs` (which uses `gh api`). No curl fallback needed. If `./scripts/skill-runs` fails, log `SKILL_HEALTH_PARTIAL — skill-runs unavailable` and continue with cron-state only.
+
+## Constraints
+
+- Never file two open issues for the same `(skill, root_cause)` pair — always check INDEX.md first.
+- Never edit a Resolved issue. If a previously-resolved issue re-fires, file a new ISS with a pointer (`related: ISS-NNN`) in the body.
+- Do not notify on pure HEALTHY runs more than once per 24h.
+- If `${var}` is set (single-skill mode), skip INDEX.md updates only if the single skill is HEALTHY — otherwise file/resolve as normal.
+- Never touch `memory/issues/INDEX.md` Resolved section except to move rows into it; never delete rows.


### PR DESCRIPTION
## Winning variation
**C — More robust** · **51/52.5** weighted

Closes a documented gap in `CLAUDE.md`: *"Health skills (skill-health, skill-evals, heartbeat, self-review) file issues. Repair skills (skill-repair, autoresearch) close them."* The prior skill-health only emitted notifications and never touched `memory/issues/`.

### Thesis
The biggest lever for this skill isn't better input sources — it's fulfilling its role as the issue-tracker producer for the fleet. Add `memory/issues/` integration (file new ISS-NNN.md for new CRITICAL/FLAPPING, close on recovery), gate notifications on state change via a SHA-256 hash + 24h cadence to kill channel spam, and graceful missing-data handling so first runs aren't failures. Fold in B's output sharpening (TL;DR `HEALTH: OK|WARNING|DEGRADED|CRITICAL` verdict, per-item action directives, top-5 cap, HEALTHY as count) and A's `./scripts/skill-runs` fallback as cheap upside.

### Key changes vs original
- **Issue tracker integration** per CLAUDE.md contract: files `ISS-NNN.md` with YAML frontmatter for each new CRITICAL/FLAPPING, appends to `INDEX.md` Open table, resolves issues when affected skills recover (moves rows Open → Resolved).
- **Dedup**: stable SHA-256 hash of classification + `last-report.json` snapshot → skips notification when state unchanged and last notify <24h ago. Kills "same digest 3 days in a row" noise.
- **New status `FLAPPING`**: 3+ status transitions in 7d. Previously invisible.
- **Severity score** `consecutive_failures × (1 + days_since_success/7)` for deterministic sorting; top-5 cap per section with `+N more → INDEX.md` overflow.
- **Action directives** per item: `FIX CONFIG` / `WAIT-API` / `INVESTIGATE` / `DISPATCH-SKILL`. Operator knows what to do without re-reading the skill.
- **Graceful missing-data**: missing `cron-state.json` / `skill-health/*.json` / `INDEX.md` treated as empty, not as failures.
- **`./scripts/skill-runs --hours 168 --failures --json`** fallback catches failures that never wrote to cron-state (sandbox blocks).
- HEALTHY list dropped (count only). `SYSTEMIC:` callout dedups shared-host errors across per-skill rows.

### Scoring table

| Criterion (weight) | A — Better inputs | B — Sharper output | **C — More robust** | D — Rethink (root-cause clustering) |
|---|---|---|---|---|
| Clarity (×1.5) | 4 | 5 | **5** | 3 |
| Data quality (×1.5) | 5 | 3 | **4** | 4 |
| Output value (×2) | 3 | 5 | **5** | 5 |
| Robustness (×1.5) | 3 | 3 | **5** | 3 |
| Conventions (×1) | 3 | 4 | **5** | 3 |
| Improvement (×3) | 3 | 4 | **5** | 4 |
| **Weighted total /52.5** | 36 | 42.5 | **51** | 40 |

### Variation summaries (what was considered)

- **A — Better inputs** (36): `./scripts/skill-runs --hours 168 --failures`, grep `memory/logs/` last 7d for error signatures, `gh pr list` for in-flight autoresearch/skill-repair branches, auto-cluster API deps by grepping skill URLs instead of hardcoded groups. Good data hygiene but doesn't address the biggest gap (no issue filing).
- **B — Sharper output** (42.5): TL;DR verdict line, severity scoring, top-5 cap, per-item action directives, drop HEALTHY list. Strong output improvement; folded into C.
- **C — More robust** *(winner, 51)*: `memory/issues/` integration + state-change notification gating + FLAPPING + graceful missing-data. Folds in B's sharpening and A's skill-runs fallback.
- **D — Rethink: root-cause clustering** (40): group failures by error signature + shared host instead of by skill, SLO-style error-budget phrasing, collapsed root-cause view. Elegant for multi-skill systemic issues but loses per-skill signal and doesn't address the issue-tracker gap.

### Diff summary
`skills/skill-health/SKILL.md`: +151 / −71. Adds data-source list (items 3, 5, 6, 7), classification rules table with FLAPPING + severity score, step 4 (`Reconcile with memory/issues/`), step 5 (state-change notification gating with `last-report.json`), step 6 (sharpened output format with TL;DR + action directives + top-5 cap), rewritten Constraints section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Ported from aaronjmars/aeon-tmp#43.
