### PR TITLE
improve(market-context-refresh): autoresearch evolution

### DIFF
--- a/skills/market-context-refresh/SKILL.md
+++ b/skills/market-context-refresh/SKILL.md
@@ -8,125 +8,243 @@ permissions:
 tags: [crypto]
 ---
 
-Refresh `memory/topics/market-context.md` with current market data. This file is used as context by token-pick, narrative-tracker, and other skills — it must stay current.
+<!-- autoresearch: variation B — sharper output: lead with a Market Take (regime + conviction), show deltas vs prior snapshot, classify narrative phase with evidence, emit decision-ready context for downstream skills rather than a data dump -->
+
+Refresh `memory/topics/market-context.md` with **decision-ready** crypto context. This file is read by token-pick, narrative-tracker, and other skills — it must be current *and* actionable. A data dump is a failure; the reader should know the regime and what to do differently today within 10 seconds.
 
 Read `memory/MEMORY.md` for prior context.
 
 ## Sandbox note
 
-The sandbox may block curl. For every curl call below, if it fails or returns empty, use **WebFetch** for the same URL (omit the API key header — free tier works). WebFetch is a built-in tool that works reliably in the sandbox.
+The sandbox may block curl. For every curl call below, if it fails or returns empty, use **WebFetch** for the same URL (omit API key headers — free tiers work). Every source lists an explicit fallback. If a primary AND its fallback both fail, mark the row `fail` in the Source Status footer and use the last known value from the prior `memory/topics/market-context.md` (do not fabricate).
 
 ## Steps
 
-1. **Fetch macro crypto data from CoinGecko:**
-   ```bash
-   # BTC and ETH prices with 24h change
-   curl -s "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin,ethereum&vs_currencies=usd&include_24hr_change=true" \
-     ${COINGECKO_API_KEY:+-H "x-cg-pro-api-key: $COINGECKO_API_KEY"}
+### 1. Load prior snapshot (for deltas and preserve-on-failure)
 
-   # Top 20 by market cap (to track TVL leaders and movers)
-   curl -s "https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&order=market_cap_desc&per_page=20&page=1&sparkline=false&price_change_percentage=24h,7d" \
-     ${COINGECKO_API_KEY:+-H "x-cg-pro-api-key: $COINGECKO_API_KEY"}
+Read the existing `memory/topics/market-context.md` if present. Extract (for delta computation later):
+- BTC price, ETH price, Total mcap, BTC dominance, Total TVL, Fear & Greed value
+- The full **Token Picks Made** table (never truncate — rebuild the new file with this table intact)
 
-   # Global market stats (total market cap, volume, dominance)
-   curl -s "https://api.coingecko.com/api/v3/global" \
-     ${COINGECKO_API_KEY:+-H "x-cg-pro-api-key: $COINGECKO_API_KEY"}
+If the file doesn't exist, treat all deltas as `n/a` on the first run.
 
-   # Trending coins
-   curl -s "https://api.coingecko.com/api/v3/search/trending" \
-     ${COINGECKO_API_KEY:+-H "x-cg-pro-api-key: $COINGECKO_API_KEY"}
-   ```
-   **Fallback:** If curl fails, use WebFetch for each URL (without the API key header).
+### 2. Fetch macro crypto data (CoinGecko)
 
-2. **Fetch DeFi data:**
-   Use WebSearch for current DeFi stats: "DeFi TVL today $(date +%Y)", "top DeFi protocols TVL", "DEX volume today". Look for:
-   - Total TVL (DeFiLlama)
-   - Top 5 protocols by TVL
-   - DEX 24h volume
-   - Stablecoin market caps (USDT, USDC, USDe, USDS)
+```bash
+# Simple price for BTC, ETH, SOL + 24h change
+curl -s "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin,ethereum,solana&vs_currencies=usd&include_24hr_change=true&include_market_cap=true" \
+  ${COINGECKO_API_KEY:+-H "x-cg-pro-api-key: $COINGECKO_API_KEY"}
 
-3. **Fetch prediction market highlights from Polymarket:**
-   ```bash
-   # Top by 24h volume
-   curl -s "https://gamma-api.polymarket.com/markets?closed=false&order=volume24hr&ascending=false&limit=10"
+# Top 20 by mcap (movers + trend)
+curl -s "https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&order=market_cap_desc&per_page=20&page=1&sparkline=false&price_change_percentage=24h,7d" \
+  ${COINGECKO_API_KEY:+-H "x-cg-pro-api-key: $COINGECKO_API_KEY"}
 
-   # Highest liquidity
-   curl -s "https://gamma-api.polymarket.com/markets?closed=false&order=liquidity&ascending=false&limit=10"
-   ```
-   **Fallback:** If curl fails, use WebFetch for the same URLs.
-   Pull top 3-5 markets: question, current YES%, 24h volume, liquidity. Note any notable shifts.
+# Global stats (total mcap, volume, dominance)
+curl -s "https://api.coingecko.com/api/v3/global" \
+  ${COINGECKO_API_KEY:+-H "x-cg-pro-api-key: $COINGECKO_API_KEY"}
 
-4. **Scan for macro signals.** Use WebSearch for:
-   - "crypto market today ${today}"
-   - "BTC price analysis ${today}"
-   - Any major regulatory, macro, or geopolitical events affecting markets
+# Trending coins
+curl -s "https://api.coingecko.com/api/v3/search/trending" \
+  ${COINGECKO_API_KEY:+-H "x-cg-pro-api-key: $COINGECKO_API_KEY"}
+```
+**Fallback:** WebFetch the same URLs without the API key header.
 
-5. **Identify key narratives currently running.** Based on trending coins and web search: which 3-5 meta-narratives are driving price action right now? (e.g., AI tokens, DePIN, RWA, memecoins, restaking)
+From `/coins/markets` compute **breadth**: how many of the top 20 are green on 24h vs 7d. Breadth is a regime signal — 18/20 green = risk-on, 4/20 green = risk-off.
 
-6. **Write the updated market-context.md.** Overwrite `memory/topics/market-context.md` completely:
-   ```markdown
-   # Market Context (as of ${today})
+### 3. Fetch DeFi data (DeFiLlama — free, no key required)
 
-   ## Macro
-   - BTC $X (±X% 24h) — [one-line observation]
-   - ETH $X (±X% 24h) — [one-line observation]
-   - Total market cap: $XB (±X% 24h)
-   - BTC dominance: X%
-   - Total DeFi TVL: ~$XB
-   - DEX volume 24h: $XB
-   - Stablecoins: USDT $XB, USDC $XB, [others if notable]
+Replace the prior WebSearch approach with DeFiLlama's open REST API:
 
-   ## Top DeFi Protocols (by TVL)
-   - [Protocol]: $XB (±X% 7d)
-   - [Protocol]: $XB (±X% 7d)
-   - [Protocol]: $XB (±X% 7d)
-   - [Protocol]: $XB (±X% 7d)
-   - [Protocol]: $XB (±X% 7d)
+```bash
+# All protocols (pick top 5 by tvl, include change_7d)
+curl -s "https://api.llama.fi/protocols"
 
-   ## Trending Coins
-   - [COIN]: [why trending, price context]
-   - [COIN]: [why trending, price context]
-   - [COIN]: [why trending, price context]
+# Chains by TVL (for chain-level flow)
+curl -s "https://api.llama.fi/v2/chains"
 
-   ## Active Narratives
-   - [Narrative]: [what's driving it, phase: emerging/rising/peak/fading]
-   - [Narrative]: [what's driving it, phase]
-   - [Narrative]: [what's driving it, phase]
+# DEX volume overview
+curl -s "https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true"
 
-   ## Prediction Markets (top by volume)
-   | Market | YES% | Volume 24h | Liquidity |
-   |--------|------|------------|-----------|
-   | [question] | X% | $Xm | $Xm |
-   | [question] | X% | $Xm | $Xm |
-   | [question] | X% | $Xm | $Xm |
+# Stablecoins (total mcap + top issuers)
+curl -s "https://stablecoins.llama.fi/stablecoins?includePrices=true"
+```
+**Fallback:** WebFetch the same URLs. If both fail, mark `defillama=fail` in the Source Status footer and carry the prior file's DeFi numbers.
 
-   ## Token Picks Made
-   [Keep existing rows — do not delete history. Append new picks from recent logs if not already present.]
-   | Date | Token | Price | Thesis |
-   |------|-------|-------|--------|
-   ```
-   Preserve the Token Picks table from the prior file. Do not truncate history.
+Extract:
+- Total DeFi TVL (sum of chains) and **7d delta**
+- Top 5 protocols by TVL with `change_7d`
+- Top 3 chains by TVL with `change_7d` (flow-of-capital signal)
+- DEX 24h volume (from `totalDataChart` or `total24h`)
+- Top 4 stablecoins by mcap (USDT, USDC, USDe, USDS, DAI — whichever lead) and combined mcap
 
-7. **Log to `memory/logs/${today}.md`:**
-   ```
-   ## Market Context Refresh
-   - BTC: $X (±X%), ETH: $X (±X%)
-   - Top narrative: [name]
-   - Polymarket highlight: "[question]" YES X%
-   - Updated memory/topics/market-context.md
-   ```
+### 4. Fetch sentiment — Fear & Greed Index
 
-8. **Send notification via `./notify`** (concise, under 500 chars):
-   ```
-   market context refreshed — ${today}
+```bash
+curl -s "https://api.alternative.me/fng/?limit=2"
+```
+Returns today's value (0-100) and yesterday's. Classification buckets: 0-24 Extreme Fear, 25-49 Fear, 50-74 Greed, 75-100 Extreme Greed. **Fallback:** WebFetch the same URL.
 
-   BTC $X (±X%) / ETH $X (±X%)
-   TVL ~$XB | DEX vol $XB
-   top narrative: [name]
-   hot market: "[polymarket question]" YES X%
-   ```
+### 5. Fetch prediction markets (Polymarket Gamma)
+
+```bash
+curl -s "https://gamma-api.polymarket.com/markets?closed=false&order=volume24hr&ascending=false&limit=10"
+curl -s "https://gamma-api.polymarket.com/markets?closed=false&order=liquidity&ascending=false&limit=10"
+```
+**Fallback:** WebFetch the same URLs.
+
+For each market: `outcomes` and `outcomePrices` are JSON-encoded arrays that map 1:1. YES% = `parseFloat(outcomePrices[0]) * 100` (first element is always YES). Skip any market where the YES% is <3% or >97% (effectively settled — no signal).
+
+### 6. Scan for macro catalysts (WebSearch)
+
+Only two queries — noise is expensive here. Use WebSearch for:
+- `crypto market today ${today} macro catalyst`
+- `BTC ETF flows ${today}` (institutional flow signal)
+
+Keep only items that would change a trader's positioning today. Discard recap/explainer articles.
+
+### 7. Compute the Market Take (the headline)
+
+This is the core output — everything above is input to this line.
+
+Score the regime using these inputs:
+- **BTC 24h%** (±2% threshold)
+- **Breadth** (top-20 green count)
+- **Fear & Greed** (today vs yesterday)
+- **BTC dominance 24h change** (from `/global`)
+- **TVL 7d delta** (DefiLlama)
+- **DEX volume** vs the prior snapshot's DEX volume
+
+Assign one regime label:
+- **risk-on** — BTC up, breadth >14/20, F&G ≥55 and rising, TVL up 7d
+- **risk-off** — BTC down, breadth <7/20, F&G ≤45 and falling
+- **rotation** — BTC flat or dominance falling while breadth high (alts outperforming)
+- **chop** — no single signal dominates; small moves, flat F&G
+- **capitulation / squeeze** — only if BTC ±5%+ in 24h with F&G extreme
+
+Also emit **conviction** in {high, medium, low} based on how many signals agree.
+
+### 8. Classify active narratives with phase + evidence
+
+For each of 3-5 current meta-narratives (derived from trending coins + top movers + macro catalyst scan), assign a phase and a one-line evidence anchor:
+
+- **emerging** — new mentions, early accumulation (e.g. "3 of top trending, no mcap leader yet")
+- **rising** — strong 7d momentum, growing breadth (e.g. "sector +X% 7d, N tokens in top-20 movers")
+- **peak** — saturated attention, funding hot, breadth topping (e.g. "every feed hit, 24h volume 3x 7d avg")
+- **fading** — mindshare dropping, 7d red (e.g. "was 5 top movers last week, now 1")
+
+No narrative without an evidence anchor. If you cannot point to a number or concrete signal, don't include it.
+
+### 9. Write the updated market-context.md
+
+Overwrite `memory/topics/market-context.md` with this exact structure. **Lead with the Take** so downstream skills get the conclusion in the first ~150 chars:
+
+```markdown
+# Market Context (as of ${today})
+
+> **Take:** [regime] — [one-sentence why, citing 2 concrete numbers]. Conviction: [high|medium|low].
+
+## Signal Snapshot
+- BTC $X (±X% 24h, ±X% 7d) · dominance X% (±X pp 24h)
+- ETH $X (±X% 24h, ±X% 7d) · ETH/BTC X.XXX
+- SOL $X (±X% 24h, ±X% 7d)
+- Total mcap $XT (±X% 24h) · DEX vol $XB 24h
+- Breadth: N/20 green 24h · N/20 green 7d
+- Fear & Greed: X (label) — yesterday X
+
+## What Changed Since Last Refresh
+- [Delta or event 1 — e.g. "F&G jumped 12 pts into Greed, first time in 14 days"]
+- [Delta 2]
+- [Delta 3]
+Only real deltas. If no material change, write: "Quiet — all majors within ±1%, regime unchanged."
+
+## Active Narratives
+- **[Narrative]** — phase: [emerging|rising|peak|fading]. Evidence: [concrete signal].
+- **[Narrative]** — phase: [...]. Evidence: [...].
+- **[Narrative]** — phase: [...]. Evidence: [...].
+
+## Top DeFi Protocols (TVL, 7d change)
+- [Protocol]: $XB ([+/-X%])
+- [Protocol]: $XB ([+/-X%])
+- [Protocol]: $XB ([+/-X%])
+- [Protocol]: $XB ([+/-X%])
+- [Protocol]: $XB ([+/-X%])
+
+## Chain Flow (top 3 by TVL, 7d)
+- [Chain]: $XB ([+/-X%])
+- [Chain]: $XB ([+/-X%])
+- [Chain]: $XB ([+/-X%])
+
+## Stablecoins
+Total: $XB (±X% 7d). USDT $XB · USDC $XB · [next two] · combined share of mcap X%.
+
+## Trending (CoinGecko)
+- [COIN] — [why trending, price + 24h%]
+- [COIN] — [...]
+- [COIN] — [...]
+
+## Prediction Markets (Polymarket, top by 24h vol)
+| Market | YES% | 24h Vol | Liquidity |
+|--------|------|---------|-----------|
+| [question] | X% | $Xm | $Xm |
+| [question] | X% | $Xm | $Xm |
+| [question] | X% | $Xm | $Xm |
+
+## Macro Catalysts (next 48h)
+- [Catalyst + positioning implication]
+- [...]
+Omit this section entirely if nothing material. Do not pad with generic headlines.
+
+## Implications for Downstream Skills
+- **token-pick:** [e.g. "favor [narrative] exposure; avoid [sector] on weak breadth"]
+- **narrative-tracker:** [e.g. "monitor [narrative] for phase transition emerging→rising"]
+Keep to 1-2 lines per skill. Only write implications that follow from the Take and deltas — don't generate generic advice.
+
+## Token Picks Made
+| Date | Token | Price | Thesis |
+|------|-------|-------|--------|
+[Rebuild verbatim from the prior file. Do not truncate or reorder. Append any new picks found in the last 7 days of memory/logs/ that aren't already in the table.]
+
+---
+*Sources — btc/eth: CoinGecko · defi: DeFiLlama · sentiment: alternative.me · markets: Polymarket*
+*Source status: coingecko=[ok|fail] defillama=[ok|fail] fng=[ok|fail] polymarket=[ok|fail] websearch=[ok|fail]*
+```
+
+**Preserve-on-failure rule:** If 3+ sources fail, **do not overwrite** `market-context.md`. Instead, append a one-line staleness note to the existing file's Source Status line (`last attempt ${today} failed: sources [...]`) and exit cleanly. A stale-but-valid file is strictly better than a broken one.
+
+### 10. Log to `memory/logs/${today}.md`
+
+```
+## Market Context Refresh
+- Regime: [take] (conviction [level])
+- BTC: $X (±X%), ETH: $X (±X%), F&G: X ([label])
+- Breadth: N/20 green
+- Top narrative: [name] ([phase])
+- Polymarket highlight: "[question]" YES X%
+- Source status: [status string]
+- Updated memory/topics/market-context.md
+```
+
+### 11. Send notification via `./notify` (under 500 chars)
+
+```
+market context — ${today}
+
+take: [regime] (conviction [level])
+BTC $X (±X%) / ETH $X (±X%) · F&G X ([label])
+breadth N/20 · TVL $XB (±X% 7d)
+top narrative: [name] ([phase])
+hot market: "[polymarket q]" YES X%
+```
 
 ## Environment Variables
 
-- `COINGECKO_API_KEY` — CoinGecko Pro API key (optional, increases rate limits)
-- Notification channels configured via repo secrets (see CLAUDE.md)
+- `COINGECKO_API_KEY` — CoinGecko Pro API key (optional, increases rate limits; not required)
+- Notification channels via repo secrets (see CLAUDE.md)
+
+## Constraints
+
+- **No data-dump output.** If the file has no Take or the Take is a tautology ("market moved"), the run failed the quality bar.
+- **No fabricated numbers.** If a source fails and there's no prior value, write `n/a` — never guess.
+- **Preserve token-picks history.** Never truncate the Token Picks Made table.
+- **Concrete evidence only.** Every narrative phase claim must cite a number or signal; otherwise drop the narrative.
+- **Deltas must be real.** "What Changed" only lists material moves (≥±1% BTC, ≥±5 F&G, ≥±2% TVL, or a new regime label). No filler.

--- a/skills/market-context-refresh/SKILL.md
+++ b/skills/market-context-refresh/SKILL.md
@@ -106,6 +106,21 @@ Keep only items that would change a trader's positioning today. Discard recap/ex
 
 This is the core output — everything above is input to this line.
 
+**Market Take format (exactly 3 lines)** — this is the concrete template the rest of the file leads with:
+
+```
+Take: <regime> — <one-sentence why, citing 2 concrete numbers>.
+Conviction: <high | medium | low> — <which signals agree; which disagree>.
+Evidence: <one sentence naming the single strongest datum behind this call>.
+```
+
+Example:
+```
+Take: risk-on — BTC +3.1% 24h with 17/20 top-cap majors green.
+Conviction: high — F&G, breadth, and 7d TVL all point up; only BTC dominance disagrees (flat).
+Evidence: DEX 24h volume $7.8B, highest since March and +42% vs 7d avg.
+```
+
 Score the regime using these inputs:
 - **BTC 24h%** (±2% threshold)
 - **Breadth** (top-20 green count)
@@ -245,6 +260,6 @@ hot market: "[polymarket q]" YES X%
 
 - **No data-dump output.** If the file has no Take or the Take is a tautology ("market moved"), the run failed the quality bar.
 - **No fabricated numbers.** If a source fails and there's no prior value, write `n/a` — never guess.
-- **Preserve token-picks history.** Never truncate the Token Picks Made table.
+- **Preserve token-picks history.** "Never truncate" applies specifically to the **Token Picks Made** table: when overwriting `market-context.md`, copy the existing Token Picks Made table verbatim into the new version before adding new rows. The rest of the file is overwritten; only this table is carried forward. Never drop rows, never reorder them.
 - **Concrete evidence only.** Every narrative phase claim must cite a number or signal; otherwise drop the narrative.
 - **Deltas must be real.** "What Changed" only lists material moves (≥±1% BTC, ≥±5 F&G, ≥±2% TVL, or a new regime label). No filler.


### PR DESCRIPTION
## Autoresearch — market-context-refresh

Evolved `skills/market-context-refresh/SKILL.md` by generating 4 variations, scoring against a rubric, and picking the winner.

### Winner: Variation B — Sharper, decision-ready output

**Thesis:** The original is a data dump. Downstream skills (token-pick, narrative-tracker) need a regime call and deltas, not a bag of numbers. The biggest lever is reframing the output to lead with a one-line "Market Take" (regime + conviction), forcing deltas vs the prior snapshot, and requiring each narrative claim to cite concrete evidence. Quality bar: within 10 seconds, a reader should know the regime and what to do differently today.

### Key changes vs original

1. **Data source upgrade (folded in from A).** Replace WebSearch-for-DeFi with DeFiLlama's free REST API (`/protocols`, `/v2/chains`, `/overview/dexs`, `stablecoins.llama.fi/stablecoins`) — structured, reliable, no key required. Also adds:
   - Alternative.me Fear & Greed Index as a regime input.
   - CoinGecko top-20 **breadth** (green count) as a regime input.
   - Explicit Polymarket parsing rule (outcomePrices decimal → YES%, skip near-settled markets).
2. **Output thesis (B, the core change).**
   - First line is a **Take**: regime (risk-on / risk-off / rotation / chop / capitulation / squeeze) + conviction (high/medium/low) + one-sentence why.
   - **Signal Snapshot** compresses BTC/ETH/SOL + dominance + breadth + F&G into 6 lines.
   - **What Changed Since Last Refresh** surfaces only material deltas vs the previous file (BTC ≥±1%, F&G ≥±5, TVL ≥±2%, or a regime change). Writes "Quiet — regime unchanged" when nothing matters.
   - **Active Narratives** must cite a concrete evidence anchor (a number or signal). No evidence → drop the narrative.
   - **Implications for Downstream Skills** — 1-2 lines of positioning guidance aimed at token-pick / narrative-tracker.
3. **Robustness (folded in from C).**
   - Source-status footer (`coingecko=ok defillama=fail …`) logged in the file itself.
   - **Preserve-on-failure rule:** if ≥3 sources fail, do *not* overwrite — append staleness line and exit. A stale valid file beats a broken one.
   - Token Picks table explicitly preserved verbatim across refreshes.
4. **Constraints.** Explicit quality bar: no data-dump, no fabricated numbers, deltas must be real.

### Scoring

Weighted: Improvement ×3, Output value ×2, Clarity ×1.5, Data quality ×1.5, Robustness ×1.5, Conventions ×1. Max 50.

| Criterion (weight) | A — Better inputs | B — Sharper output | C — More robust | D — Rethink |
|---|---|---|---|---|
| Clarity (1.5x) | 5 | 5 | 5 | 4 |
| Data quality (1.5x) | 5 | 4 | 4 | 4 |
| Output value (2x) | 4 | 5 | 3 | 5 |
| Robustness (1.5x) | 4 | 4 | 5 | 3 |
| Conventions (1x) | 5 | 5 | 5 | 4 |
| Improvement (3x) | 4 | 5 | 3 | 4 |
| **Weighted total** | **46** | **49.5** | **41** | **42.5** |

### Variations considered

- **A — Better inputs (46).** Replace WebSearch-for-DeFi with DeFiLlama REST; add Alternative.me F&G; CoinGecko `/derivatives` for funding; structured Polymarket parsing. Strong data-quality lift but leaves the data-dump output in place.
- **B — Sharper output (49.5, winner).** Market Take + deltas + evidence-anchored narratives + downstream implications. Captures A's source upgrade and C's preserve-on-failure as supporting moves, but the core thesis is decision-ready output.
- **C — More robust (41).** Source-status table, fallback cascade, explicit `MARKET_CONTEXT_DEGRADED` mode, persistent history snapshot for deltas. Valuable hardening but small output-value delta.
- **D — Rethink (42.5).** Regime classifier as the whole frame — output is entirely a decision brief with implications for downstream skills. High ceiling but higher ambiguity risk; too far from the original's "living context file" role, and B captures ~80% of the value with a safer reframing.

### Why B, not D

Close on raw numbers, but B makes the biggest single *concrete* improvement (leading Take + deltas + evidence gates) while preserving the file's role as a reference artifact. D's regime-only output would require changes to token-pick / narrative-tracker to stay useful — out of scope for a single-skill evolution.

### Fold-ins (capture runner-up upside without scope creep)

- From **A**: DeFiLlama REST endpoints (Step 3), Fear & Greed (Step 4), breadth metric (Step 2).
- From **C**: source-status footer, preserve-on-failure rule, explicit token-picks preservation.
- From **D**: the "Take" label vocabulary (risk-on / rotation / chop / capitulation) and the "Implications for Downstream Skills" section.

### Diff summary

`skills/market-context-refresh/SKILL.md` — 1 file, +229 / −111. Frontmatter unchanged. Sandbox/fallback pattern preserved and strengthened. No new required env vars (COINGECKO_API_KEY remains optional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Ported from aaronjmars/aeon-tmp#48.
