### PR TITLE
improve(repo-pulse): autoresearch evolution

### DIFF
--- a/skills/repo-pulse/SKILL.md
+++ b/skills/repo-pulse/SKILL.md
@@ -1,91 +1,163 @@
 ---
 name: repo-pulse
-description: Daily report on new stars, forks, and traffic for watched repos
+description: Daily report on new stars, forks, and releases for watched repos — with notable-stargazer enrichment and a one-line growth verdict
 var: ""
 tags: [dev]
 ---
-> **${var}** — Repo (owner/repo) to check. If empty, checks all watched repos.
+<!-- autoresearch: variation B — sharper output: /events primary input + notable-stargazer enrichment + QUIET/STEADY/ACTIVE/SURGE verdict -->
+> **${var}** — Repo (`owner/repo`) to check. If empty, checks all watched repos.
 
 ## Config
 
-This skill reads repos from `memory/watched-repos.md`. Skip any repo whose name ends with "-aeon" or contains "aeon-agent" — those are agent repos, not project repos.
+Reads repos from `memory/watched-repos.md`. Skip any repo whose name ends with `-aeon` or contains `aeon-agent` — those are agent repos, not project repos.
 
----
+If `${var}` is set and matches `owner/repo`, check only that repo.
 
-Read memory/MEMORY.md and the last 3 days of memory/logs/ for previous star/fork counts to calculate deltas.
-Read memory/watched-repos.md for the list of repos to track.
+## Context
+
+Read `memory/MEMORY.md` and the last **7 days** of `memory/logs/` for previous `stargazers_count` / `forks_count` per repo. Parse lines matching `**owner/repo**: stargazers_count=N, forks_count=M` to reconstruct a per-day series — you'll need it for the rolling-average baseline used in step 5.
 
 ## Steps
 
-1. **Fetch repo stats** for each watched repo:
-   ```bash
-   gh api repos/owner/repo --jq '{stargazers_count, forks_count, watchers_count, open_issues_count, subscribers_count}'
-   ```
+### 1. Compute the 24h cutoff FIRST
 
-2. **Compute the 24h cutoff timestamp** FIRST — this is critical:
-   ```bash
-   CUTOFF=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-24H +%Y-%m-%dT%H:%M:%SZ)
-   ```
-   Use this `$CUTOFF` for ALL time filtering below. Do NOT use "today's date" — use exactly 24 hours ago from now.
+```bash
+CUTOFF=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-24H +%Y-%m-%dT%H:%M:%SZ)
+export CUTOFF
+```
+All time filtering uses exactly this timestamp — never "today's date" or "since midnight".
 
-3. **Fetch the most recent stargazers** — efficiently, without downloading all pages:
-   ```bash
-   # Calculate the last page (100 per page) to avoid fetching all stargazers
-   STARS=$(gh api repos/owner/repo --jq '.stargazers_count')
-   LAST_PAGE=$(( (STARS + 99) / 100 ))
-   # Fetch only the last 2 pages (covers up to 200 most recent stars)
-   PREV_PAGE=$(( LAST_PAGE > 1 ? LAST_PAGE - 1 : 1 ))
-   gh api "repos/owner/repo/stargazers?per_page=100&page=$PREV_PAGE" -H "Accept: application/vnd.github.star+json" --jq '.[] | {user: .user.login, starred_at: .starred_at}'
-   gh api "repos/owner/repo/stargazers?per_page=100&page=$LAST_PAGE" -H "Accept: application/vnd.github.star+json" --jq '.[] | {user: .user.login, starred_at: .starred_at}'
-   ```
-   Combine the results from both pages, deduplicate by user, and keep only entries where `starred_at` >= `$CUTOFF` (24 hours ago). NOT "since midnight today" — since exactly 24 hours ago.
+### 2. Fetch current counts (1 call per repo)
 
-   **Why not `--paginate`?** The stargazers API returns oldest-first. Using `--paginate` fetches ALL pages (O(N) API calls as stars grow). Fetching only the last 2 pages is O(1) and covers up to 200 recent stars — more than enough for 24h changes.
+```bash
+gh api repos/owner/repo --jq '{stargazers_count, forks_count, subscribers_count}'
+```
+If this call returns non-2xx (404, 403, rate limit), record `source=fail` with the reason and continue to the next repo. Do **not** abort the batch.
 
-4. **Fetch recent forks** (sorted by newest):
-   ```bash
-   gh api "repos/owner/repo/forks?sort=newest&per_page=10" --jq '.[] | {owner: .owner.login, created_at: .created_at, full_name: .full_name}'
-   ```
-   Keep only forks where `created_at` >= `$CUTOFF`.
+### 3. Fetch recent events — primary input
 
-5. **Determine if there's activity to report.** Check BOTH:
-   - **New stargazers from step 3**: any with `starred_at` >= the 24h cutoff
-   - **New forks from step 4**: any with `created_at` >= the 24h cutoff
+One call per repo covers stargazers, forks, **and releases** for the last ~90 days, newest-first:
 
-   **Send a notification if ANY of these are true:**
-   - At least 1 new stargazer in the last 24h (unstars don't cancel this out)
-   - At least 1 new fork in the last 24h
-   - First run (no previous data in logs)
+```bash
+gh api "repos/owner/repo/events?per_page=100" \
+  --jq '[.[] | select(.created_at >= env.CUTOFF) | {type, actor: .actor.login, created_at, tag: (.payload.release.tag_name // null), action: (.payload.action // null)}]'
+```
 
-   Only log "REPO_PULSE_QUIET" and skip notification if ZERO new stargazers AND ZERO new forks since the 24h cutoff.
+Parse the filtered events:
+- `WatchEvent` → new stargazer (`actor`). Deduplicate by actor (GitHub only fires one per user).
+- `ForkEvent` → new fork. Fork URL = `github.com/{actor}/{repo}`.
+- `ReleaseEvent` with `action == "published"` → new release (`tag`).
 
-6. **Send notification** via `./notify`:
-   ```
-   *Repo Pulse — ${today}*
-   [owner/repo]
+Record `source=events` for this repo.
 
-   Stars: X total (+N new)
-   Forks: Y total (+N new)
+**Why `/events` over paginated stargazers?** One call instead of two, and it captures forks + releases in the same response. Events API returns 300 events over 10 pages for up to 90 days — more than enough for a 24h window on typical repos.
 
-   New stargazers:
-   github.com/user1 | github.com/user2 | github.com/user3
+### 4. Fallback (rate limit or error)
 
-   New forks:
-   github.com/user1/repo | github.com/user2/repo
-   ```
+If step 3 returns non-2xx, fall back to the stargazers two-last-pages technique (events emptiness is NOT a fallback trigger — empty genuinely means no activity):
 
-   Format rules:
-   - List stargazers on one line separated by ` | ` (not one per line)
-   - Same for forks
-   - Omit "New stargazers" section entirely if there are none
-   - Omit "New forks" section entirely if there are none
-   - Do NOT include traffic data, watchers, or open issues
+```bash
+STARS=$(gh api repos/owner/repo --jq '.stargazers_count')
+LAST_PAGE=$(( (STARS + 99) / 100 ))
+PREV_PAGE=$(( LAST_PAGE > 1 ? LAST_PAGE - 1 : 1 ))
+gh api "repos/owner/repo/stargazers?per_page=100&page=$PREV_PAGE" \
+  -H "Accept: application/vnd.github.star+json" \
+  --jq '.[] | select(.starred_at >= env.CUTOFF) | {user: .user.login, starred_at}'
+gh api "repos/owner/repo/stargazers?per_page=100&page=$LAST_PAGE" \
+  -H "Accept: application/vnd.github.star+json" \
+  --jq '.[] | select(.starred_at >= env.CUTOFF) | {user: .user.login, starred_at}'
+```
+Deduplicate by user. Forks in the fallback path come from:
+```bash
+gh api "repos/owner/repo/forks?sort=newest&per_page=10" \
+  --jq '.[] | select(.created_at >= env.CUTOFF) | {owner: .owner.login, full_name, created_at}'
+```
+Record `source=stargazers-fallback` for this repo. Releases are skipped in fallback (not critical).
 
-7. **Log** to `memory/logs/${today}.md` — ALWAYS include the exact current counts so the next run can calculate deltas:
-   ```
-   ## Repo Pulse
-   - **owner/repo**: stargazers_count=X, forks_count=Y
-   - **New stars (24h):** N
-   - **New forks (24h):** N
-   - **Notification sent:** yes/no
-   ```
+### 5. Enrich stargazers and compute the verdict
+
+**Notable-stargazer lookup** — for each new stargazer in the 24h window, cap **10** lookups per repo to respect rate limits:
+```bash
+gh api users/{login} --jq '{login, followers, public_repos, bio}'
+```
+Mark as **notable** if `followers >= 100` OR `public_repos >= 20`. Logins ending in `[bot]` or `-bot` are never notable and are excluded from the handle list entirely.
+
+**Growth verdict** — reconstruct the last 7 days of `stargazers_count` from logs and compute per-day deltas. Let `avg7` = mean of the available daily deltas (use `avg7 = 1` if fewer than 3 days are logged). Let `today_stars` = new stargazers in the last 24h.
+
+| Verdict | Rule (first matching row wins) |
+|---------|--------------------------------|
+| `SURGE` | `today_stars >= 10` OR `today_stars > 3 * avg7` |
+| `ACTIVE` | `today_stars > 1.5 * avg7` |
+| `STEADY` | `today_stars >= 1` OR any new fork OR any new release |
+| `QUIET` | zero stars, zero forks, zero releases in 24h |
+
+Record the rule that fired so it shows up in the log.
+
+### 6. Decide whether to notify
+
+Send a notification if ANY of:
+- ≥1 new stargazer in the last 24h (unstars do not cancel this)
+- ≥1 new fork
+- ≥1 new release
+- First run for this repo (no previous count in logs)
+
+Otherwise print `REPO_PULSE_QUIET` and skip `./notify`.
+
+### 7. Notification — via `./notify`
+
+Format (omit any empty section entirely):
+```
+*Repo Pulse — ${today}* — [VERDICT]
+[owner/repo] — stars X (+N) · forks Y (+M) · releases +R
+
+Notable new stargazers:
+github.com/user1 (1.2k followers) | github.com/user2 (450 followers)
+
+Other new stargazers:
+github.com/user3 | github.com/user4
+
+New forks:
+github.com/user5/repo | github.com/user6/repo
+
+New releases:
+v1.2.3 | v1.2.4
+
+Source: events
+```
+
+Rules:
+- `[VERDICT]` is uppercased, in square brackets, on the header line.
+- Handles joined by ` | ` on **one line** — never one per line.
+- Round follower counts: `<1000` → raw number, `1000+` → `1.2k` form.
+- Omit `Notable new stargazers`, `Other new stargazers`, `New forks`, `New releases`, or `Source` lines if they would be empty.
+- **Never include traffic, watchers, or open issues** — they don't belong in a pulse.
+- One message per repo if multiple repos have activity. Batch into a single message only when combined length stays under 1500 chars.
+
+### 8. Log to `memory/logs/${today}.md`
+
+Always include the exact current counts so tomorrow's run can compute deltas:
+```
+## Repo Pulse
+- **owner/repo**: stargazers_count=X, forks_count=Y, source=events
+- **New stars (24h):** N (verdict=ACTIVE, avg7=1.4)
+- **New forks (24h):** M
+- **New releases (24h):** R
+- **Notable stargazers:** user1(1200), user2(450)
+- **Notification sent:** yes
+```
+If the repo lookup failed, log:
+```
+- **owner/repo:** FAILED (<reason>) — counts unchanged
+```
+
+## Sandbox note
+
+- `gh api` handles auth internally; prefer it over curl.
+- `/repos/{owner}/{repo}/traffic/*` endpoints require **admin** permission and return 403 for the default workflow `GITHUB_TOKEN`. Do **not** attempt them from this skill.
+- If `gh api` fails on one repo, log the failure and continue — never abort the whole batch.
+
+## Constraints
+
+- A day with zero stars, zero forks, zero releases is `QUIET` — print `REPO_PULSE_QUIET` and do not notify.
+- Never promote a bot account to "notable", even if it clears the follower threshold.
+- Keep the verdict vocabulary fixed to `QUIET / STEADY / ACTIVE / SURGE` so downstream skills can grep for it.


### PR DESCRIPTION
## Winner: Variation B — sharper output (49.5/52.5 weighted)

**Thesis:** a flat `+3 stars` count is not actionable — the reader can't tell if that's above or below baseline for the repo, or whether a notable developer is behind it. The biggest lever is enriching the notification itself: a one-line growth **verdict** (`QUIET / STEADY / ACTIVE / SURGE`) derived from today vs. a 7-day rolling baseline, plus per-new-stargazer follower lookup to surface "notable" accounts.

B folds in A's `/events` single-call input (efficiency win) and C's per-repo error isolation + source-status footer (cheap robustness wins) on top of the output thesis.

## Scoring

| Criterion (weight) | A — Better inputs | B — Sharper output | C — More robust | D — Rethink velocity |
|--------------------|-------------------|--------------------|-----------------|----------------------|
| Clarity (1.5×) | 5 | 4 | 4 | 4 |
| Data quality (1.5×) | 5 | 5 | 4 | 4 |
| Output value (2×) | 4 | **5** | 3 | 4 |
| Robustness (1.5×) | 4 | 4 | 5 | 3 |
| Conventions (1×) | 5 | 5 | 5 | 5 |
| Improvement (3×) | 4 | **5** | 3 | 3 |
| **Weighted total** | 46 | **49.5** | 39.5 | 38.5 |

## Variations considered

- **A — Better inputs (46):** swap 2× paginated stargazers call for single `/events` call (stars + forks + releases in one request), stargazers-pagination kept as fallback. Best efficiency win but doesn't change the output.
- **B — Sharper output (49.5) — winner:** same `/events` input as A + per-stargazer follower lookup (≥100 followers or ≥20 public repos → "notable") + 4-tier verdict from today vs. 7d-rolling delta. Verdict appears as `[VERDICT]` tag in the header.
- **C — More robust (39.5):** layered source chain (events → stargazers-fallback → counts-only), per-repo try/catch, `source=...` footer, `REPO_PULSE_OK/DEGRADED/QUIET` markers. Robustness only — no output enrichment.
- **D — Rethink velocity (38.5):** signal-or-suppress framing — only notify above 1.5× baseline or ≥5 stars, suppress quiet days beyond first run. Interesting philosophical shift but risks under-alerting on the current low-volume repo (1–2 stars/day) where every star is a signal.

## Diff summary

- `Data sources`: paginated `/stargazers` (2 calls) → `/events?per_page=100` (1 call, also captures forks + releases). Stargazers-pagination kept as rate-limit fallback only.
- `Output`: adds `[QUIET/STEADY/ACTIVE/SURGE]` header tag, "Notable new stargazers" subsection with follower counts, combined `stars X (+N) · forks Y (+M) · releases +R` header line, and a `Source:` footer.
- `Robustness`: explicit per-repo error isolation — one failed lookup no longer aborts the batch.
- `Traffic`: explicitly removed from the scope (traffic endpoints require admin permission and return 403 for the default workflow token — attempting them is noise).
- `Log schema`: adds `verdict=`, `avg7=`, `source=`, notable stargazer list; keeps the grep-able `stargazers_count=N, forks_count=M` line so future runs can still reconstruct deltas.

## Test plan

- [ ] Enable `repo-pulse` in `aeon.yml` on a dry-run schedule
- [ ] Verify `/events` call returns for a repo with known recent activity (e.g., `aaronjmars/aeon`)
- [ ] Verify follower enrichment caps at 10 lookups per repo
- [ ] Verify `QUIET` day prints `REPO_PULSE_QUIET` and skips `./notify`
- [ ] Verify per-repo failure doesn't abort the batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Ported from aaronjmars/aeon-tmp#50.
