### PR TITLE
improve(tweet-roundup): autoresearch evolution

### DIFF
--- a/skills/tweet-roundup/SKILL.md
+++ b/skills/tweet-roundup/SKILL.md
@@ -4,71 +4,126 @@ description: Gist of the latest tweets on configurable topics
 var: ""
 tags: [social]
 ---
-> **${var}** — Topic or search query to focus on (e.g. "solana", "brain-computer interfaces", "@elonmusk"). If empty, uses default topics (configurable in MEMORY.md).
 
-Read memory/MEMORY.md for context.
-Read the last 2 days of memory/logs/ to avoid repeating items.
+<!-- autoresearch: variation B — sharper output via signal scoring, sub-narrative clustering, and insight-per-item discipline -->
+
+> **${var}** — Topic or X search query (e.g. "solana", "brain-computer interfaces", "@elonmusk"). If empty, uses topics from MEMORY.md, then built-in defaults.
+
+Today is ${today}. Read memory/MEMORY.md for context.
 
 ## Steps
 
-1. Search X for the latest chatter. If `${var}` is set, search for that specific topic instead of the defaults.
+### 1. Load dedup set
 
-   **Default topics** (used when `${var}` is empty and no topics configured in MEMORY.md under a "Tweet Roundup Topics" section):
+Build `SEEN_TWEETS` (a set of URLs we've already reported) from two sources and union them:
+
+- **Persistent seen-file** (`memory/tweet-roundup-seen.txt`) — read all URLs if present.
+- **Last 3 days of `memory/logs/*.md`** — grep for lines containing `https://x.com/` to catch URLs not yet in the seen-file.
+
+### 2. Resolve topic list
+
+Priority order:
+
+1. If `${var}` is set → `TOPICS=("${var}")` (single-topic mode).
+2. Else if MEMORY.md has a `## Tweet Roundup Topics` section → use its bulleted lines, one query per line.
+3. Else use the built-in defaults:
    - `artificial intelligence OR AI agents OR LLM`
    - `crypto OR bitcoin OR DeFi`
    - `technology OR startups OR open source`
 
-   Users can customize default topics in MEMORY.md under a "Tweet Roundup Topics" section.
+### 3. Fetch per topic — with source-path observability
 
-   **First, check for pre-fetched data** (the workflow pre-fetches XAI results outside the sandbox):
-   - If `${var}` is set: read `.xai-cache/roundup-var.json`
-   - Otherwise: read `.xai-cache/roundup-*.json` files matching your configured topics
-   - If cache files exist and contain results, use that data. Extract the tweet lists from each response.
+For each topic, track `SOURCE ∈ {cache, websearch, failed}` and a per-topic candidate list.
 
-   **If no cache files exist**, try the direct API call:
-   ```bash
-   FROM_DATE=$(date -u -d "yesterday" +%Y-%m-%d 2>/dev/null || date -u -v-1d +%Y-%m-%d)
-   TO_DATE=$(date -u +%Y-%m-%d)
+**Path A — pre-fetched cache (preferred):**
 
-   # If ${var} is set, use: TOPICS=("${var}")
-   # Otherwise use the default topics listed above
-   for TOPIC in \
-     "artificial intelligence OR AI agents OR LLM" \
-     "crypto OR bitcoin OR DeFi" \
-     "technology OR startups OR open source"; do
-     curl -s -X POST "https://api.x.ai/v1/responses" \
-       -H "Content-Type: application/json" \
-       -H "Authorization: Bearer $XAI_API_KEY" \
-       -d '{
-         "model": "grok-4-1-fast",
-         "input": [{"role": "user", "content": "Search X for the latest popular tweets about: '"$TOPIC"' from '"$FROM_DATE"' to '"$TO_DATE"'. Return the 3-5 most interesting or viral tweets. IMPORTANT: For each tweet you MUST include: 1) the @handle of the person who tweeted, 2) a one-line summary of what they said, 3) the actual tweet permalink in the format https://x.com/username/status/ID — NOT the URL of any article they linked to. I want the tweet URL itself, not news article URLs. If you cannot find the exact tweet URL, still include the @handle and note the tweet link is unavailable."}],
-         "tools": [{"type": "x_search", "from_date": "'"$FROM_DATE"'", "to_date": "'"$TO_DATE"'"}]
-       }'
-   done
-   ```
-   If neither cache nor direct API works, fall back to WebSearch for each topic. **IMPORTANT:** Always include "today" or "past 24 hours" and the current date in your search query to force fresh results — e.g. `"crypto twitter today ${today}"`. Discard any results older than 48 hours. Summarize the top 3-5 results per topic.
+- Single-topic mode: read `.xai-cache/roundup-var.json`.
+- Default/MEMORY.md mode: read any matching `.xai-cache/roundup-*.json` files; match by slugified topic name if the prefetch script supports it.
 
-2. For each topic, write 2-3 bullet points capturing the gist — what people are talking about, any big news, notable takes. Every bullet MUST attribute to a specific @handle and link to the actual tweet (x.com/user/status/ID). Do NOT link to news articles — link to the tweet discussing them. If a tweet URL is unavailable, still include the @handle.
+Parse with:
+```bash
+jq -r '.output[] | select(.type == "message") | .content[] | select(.type == "output_text") | .text' .xai-cache/roundup-*.json
+```
 
-3. Send via `./notify` (under 4000 chars):
-   ```
-   *Tweet Roundup — ${today}*
+If parsing yields text, `SOURCE=cache`. Extract each tweet's `@handle`, text, engagement counts (likes/retweets/replies if present), and permalink `https://x.com/<handle>/status/<id>`.
 
-   *[Topic 1]*
-   - @handle: gist (https://x.com/handle/status/ID)
-   - ...
+**Path B — direct X.AI curl:** Skipped. The sandbox blocks env-var-authenticated curl; do not attempt.
 
-   *[Topic 2]*
-   - @handle: gist (https://x.com/handle/status/ID)
-   - ...
+**Path C — WebSearch fallback** (when cache is missing or empty):
+```
+site:x.com "<topic keywords>" after:<YESTERDAY>
+```
+Always include the word "today" and `${today}` in the query to force fresh results. Discard any result whose visible date is older than 48h. Collect up to 5 candidates per topic. Mark `SOURCE=websearch`.
 
-   *[Topic 3]*
-   - @handle: gist (https://x.com/handle/status/ID)
-   - ...
-   ```
+If both Path A and Path C return nothing for a topic, mark `SOURCE=failed`.
 
-4. Log to memory/logs/${today}.md.
+### 4. Score and filter
+
+For each candidate, require:
+- a known `@handle`
+- a tweet URL of the form `https://x.com/<handle>/status/<id>` (if missing, keep the item but mark "link unavailable")
+- posted within the last 48h
+- URL **not** in `SEEN_TWEETS`
+
+Compute `signal_score = likes + 2×retweets + replies`. If counts are unavailable (WebSearch path), use the search result rank as a weak proxy.
+
+Demote (−50% score):
+- replies to a parent tweet (we want primary posts, not threaded reactions)
+- near-duplicates of a higher-scoring tweet in the same topic (>70% text overlap or same linked URL)
+
+### 5. Curate per topic
+
+After filtering + dedup, for each topic:
+
+- **0 survivors** → drop the topic from output. Do NOT pad with filler or stale items.
+- **1–3 survivors** → list them ranked by `signal_score`, highest first.
+- **4+ survivors** → group into 2–3 sub-narratives (shared keywords, same entity, same underlying claim). Write one short line labeling each sub-narrative, then surface the top-1 tweet per narrative as the exemplar.
+
+For each reported tweet, write an **insight** — what the tweet actually asserts, claims, reveals, or argues — not a paraphrase of the headline. If a tweet is just a bare link or a low-content reaction, either skip it or write the insight of the thing it links to (and mark it as a link).
+
+Also write a one-line **conversation shape** per topic summarizing the vibe across survivors (e.g. "bullish momentum, dissenters quiet", "split opinion on X's launch", "single story dominating — Y").
+
+### 6. Notify
+
+If every topic dropped (nothing survived across all topics): log `TWEET_ROUNDUP_EMPTY` to `memory/logs/${today}.md` and **stop — do not notify**.
+
+Otherwise send via `./notify` (≤4000 chars). Format:
+
+```
+*Tweet Roundup — ${today}*
+_Source: cache:X websearch:Y failed:Z_
+
+*[Topic 1]* — _conversation shape_
+- x.com/handle — insight (signal: 12.3k) [View](https://x.com/handle/status/ID)
+- x.com/handle — insight (signal: 4.1k) [View](https://x.com/handle/status/ID)
+
+*[Topic 2]* — _conversation shape_
+- x.com/handle — insight (signal: 8k) [View](https://x.com/handle/status/ID)
+```
+
+Formatting rules:
+- Use `x.com/handle`, **never** `@handle`. On Telegram, `@handle` pings the user; `x.com/handle` links the profile cleanly.
+- Every surviving tweet gets a `[View](URL)` link. If the URL is unavailable, drop the `[View]` and say "(link unavailable)".
+- Show `signal: <score>` only when engagement counts were available (cache path). Omit silently on the WebSearch path.
+
+### 7. Persist and log
+
+- Append each reported tweet URL (one per line) to `memory/tweet-roundup-seen.txt`. Create the file if missing. This ensures these URLs stay excluded from all future runs, regardless of log rotation.
+- Log to `memory/logs/${today}.md`:
+  ```
+  ## Tweet Roundup
+  - topics: [topic1: N tweets, topic2: M tweets, topic3: 0 (dropped)]
+  - source: cache:X websearch:Y failed:Z
+  - urls: <list of reported URLs>
+  ```
 
 ## Sandbox note
 
-The sandbox may block outbound curl. Use **WebFetch** as a fallback for any URL fetch. For auth-required APIs, use the pre-fetch/post-process pattern (see CLAUDE.md).
+The sandbox blocks outbound curl with `$XAI_API_KEY` in headers — always use the pre-fetched `.xai-cache/roundup-*.json` files or the WebSearch fallback. Do not attempt direct curl to `api.x.ai` at runtime. To add a new default-topic cache file, edit `scripts/prefetch-xai.sh` (the workflow runs prefetch outside the sandbox, where env-var auth works).
+
+## Constraints
+
+- Never notify an empty roundup — silence beats filler.
+- Never `@handle` anyone in notifications (Telegram ping hazard).
+- Never report a URL already in `SEEN_TWEETS`.
+- Preserve the original skill's core purpose: a gist of the latest X chatter on configurable topics.


### PR DESCRIPTION
## Winner: Variation B — Sharper output (49.5/52.5)

**Thesis:** the biggest lever for `tweet-roundup` is curation + output discipline, not fetching. The original dumps 2–3 bullets per topic with no signal ranking, no dedup against prior runs, and uses `@handle` (which pings users on Telegram). This variation folds in signal scoring, sub-narrative clustering, insight extraction, empty-state guards, and dedup.

### Key changes
- **Persistent seen-file** (`memory/tweet-roundup-seen.txt`) + last-3-days log scan → no repeats across runs, regardless of log rotation.
- **Signal scoring:** `likes + 2×retweets + replies`, with −50% demotion for reply-tweets and near-duplicates.
- **Sub-narrative clustering** when >3 tweets survive in a topic (shared keywords/entity/claim).
- **Insight per item** — what the tweet asserts, not a paraphrase of the headline.
- **Conversation-shape line** per topic (the vibe across survivors).
- **Drop empty topics** from output (no filler/padding). If ALL topics drop → log `TWEET_ROUNDUP_EMPTY` and skip notify entirely.
- **`x.com/handle` format** in notifications (NOT `@handle` — that pings users on Telegram).
- **Source-path observability** (`_Source: cache:X websearch:Y failed:Z_`).
- **MEMORY.md topic list** support via `## Tweet Roundup Topics` section.
- **Sandbox honesty** — dropped the broken direct-curl Path B; the sandbox blocks env-var-auth curl, so only cache + WebSearch remain.

### Scoring

Weights: Improvement ×3, Output value ×2, Clarity / Data quality / Robustness ×1.5 each, Conventions ×1. Max = 52.5.

| Variation | Clarity | Data | Output | Robust | Conv | Impr | **Total** |
|---|---|---|---|---|---|---|---|
| A — Better inputs | 4 | 5 | 3.5 | 3.5 | 5 | 4 | **42.75** |
| **B — Sharper output** | **4.5** | **4** | **5** | **4.5** | **5** | **5** | **49.5** |
| C — More robust | 4 | 3.5 | 3.5 | 5 | 5 | 3.5 | **41.25** |
| D — Rethink "pulse" | 3.5 | 4 | 4.5 | 3.5 | 4.5 | 4 | **42** |

### Variation summaries

**A — Better inputs** (42.75): add prefetch entries for default topics in `scripts/prefetch-xai.sh`, MEMORY.md-configurable topic list, 48h recency window, engagement counts, multi-angle queries. Solid data-side upgrades but leaves the output format and dedup gaps untouched.

**B — Sharper output** (49.5) — **winner**: curation thesis described above. Folds in A's MEMORY.md topic list + engagement-count extraction and C's persistent seen-file + source-path footer, capturing most of the runner-up upside.

**C — More robust** (41.25): persistent seen-file, log dedup, source-path footer, partial-failure handling, empty branches. Good reliability but minimal output improvement.

**D — Rethink "pulse"** (42): replace top-N-per-topic with one digested paragraph per topic plus cross-topic convergence detection. Rejected because convergence detection needs a baseline the skill doesn't have, and the output pattern diverges from sibling skills (`fetch-tweets`, `telegram-digest`, `reply-maker`), which all stabilized on Variation B–style curation wins.

### Diff summary
- Added dedup (persistent seen-file + 3-day log scan) and a `## Constraints` section.
- Replaced flat "2–3 bullets per topic" with signal-scored + clustered curation.
- Added per-topic conversation-shape line and insight-per-item discipline.
- Replaced `@handle` format with `x.com/handle` (Telegram-safe).
- Added source-path observability and empty-state notification guard.
- Dropped broken direct-curl path; sandbox reality doc'd.

---
Ported from aaronjmars/aeon-tmp#51.
