### PR TITLE
improve(token-pick): autoresearch evolution

### DIFF
--- a/skills/token-pick/SKILL.md
+++ b/skills/token-pick/SKILL.md
@@ -1,84 +1,163 @@
 ---
 name: Token Pick
-description: One token recommendation and one prediction market pick based on live data
+description: One token recommendation and one prediction market pick — scored, quantified, with a skip branch when signals are weak
 var: ""
 tags: [crypto]
 ---
+<!-- autoresearch: variation B — sharper output via signal scoring, edge calculation, conviction tiers, and a skip-day branch -->
+
 > **${var}** — Focus area or thesis (e.g. "AI tokens", "election markets", "contrarian bets"). If empty, scans broadly.
 
-Read memory/MEMORY.md for context.
-Read the last 7 days of memory/logs/ for recent token-movers and polymarket outputs — use this as historical context to spot momentum and avoid stale picks.
+Read `memory/MEMORY.md` for context.
+Read the last 7 days of `memory/logs/` and grep for prior `Token Pick` entries — extract the symbols and market questions already picked. **Hard dedup gate**: do not re-pick the same token or the same prediction market unless there is a materially new catalyst that you can name in one sentence.
+
+## Goal
+
+Produce ONE token call and ONE prediction-market call per day, each with a numeric signal/edge score and a conviction tier. If neither qualifies for at least MEDIUM conviction, send a short "no picks today" message rather than forcing a weak pick.
 
 ## Steps
 
-1. Fetch token data from CoinGecko:
-   ```bash
-   # Trending coins
-   curl -s "https://api.coingecko.com/api/v3/search/trending" \
-     ${COINGECKO_API_KEY:+-H "x-cg-pro-api-key: $COINGECKO_API_KEY"}
+### 1. Fetch token data
 
-   # Top 250 by market cap with 24h and 7d changes
-   curl -s "https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&order=market_cap_desc&per_page=250&page=1&sparkline=false&price_change_percentage=24h,7d" \
-     ${COINGECKO_API_KEY:+-H "x-cg-pro-api-key: $COINGECKO_API_KEY"}
-   ```
+```bash
+# Trending coins
+curl -s "https://api.coingecko.com/api/v3/search/trending" \
+  ${COINGECKO_API_KEY:+-H "x-cg-pro-api-key: $COINGECKO_API_KEY"}
 
-2. Fetch prediction markets from Polymarket:
-   ```bash
-   # Top markets by volume
-   curl -s "https://gamma-api.polymarket.com/markets?closed=false&order=volume24hr&ascending=false&limit=30"
+# Top 250 by market cap with 24h and 7d changes
+curl -s "https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&order=market_cap_desc&per_page=250&page=1&sparkline=false&price_change_percentage=24h,7d" \
+  ${COINGECKO_API_KEY:+-H "x-cg-pro-api-key: $COINGECKO_API_KEY"}
 
-   # New markets gaining traction
-   curl -s "https://gamma-api.polymarket.com/markets?closed=false&order=startDate&ascending=false&limit=20"
-   ```
+# BTC + ETH 24h/7d for relative-strength benchmark (extract from the markets call above; no extra request needed)
 
-3. Analyze tokens. Look for:
-   - **Momentum** — trending on CoinGecko AND positive 24h/7d price action
-   - **Asymmetry** — mid/small-cap coins with outsized volume spikes (volume/mcap ratio)
-   - **Narrative fit** — tokens riding a current narrative (AI, DePIN, RWA, memes, etc.)
-   - **Relative strength** — outperforming BTC and ETH on the day/week
-   - Cross-reference with recent logs: has this token been moving for multiple days (momentum) or is it a one-day spike (risky)?
-   - If `${var}` is set, prioritize tokens matching that thesis
+# DEX-side cross-confirmation (no auth, optional but preferred)
+curl -s "https://api.dexscreener.com/latest/dex/search?q=trending"
+```
 
-4. Analyze prediction markets. Look for:
-   - **Mispriced odds** — markets where the current price doesn't match likely outcomes (use WebSearch for context)
-   - **High volume + interesting question** — the market is telling you something
-   - **New markets with early liquidity** — getting in before the crowd
-   - If `${var}` is set, prioritize markets matching that area
+If any curl returns empty or errors, retry once with **WebFetch** for the same URL. Track per-source status (`cg=ok|fail`, `dex=ok|fail`) — surfaced in the output footer.
 
-5. Pick ONE token and ONE prediction market. For each, use WebSearch to get fresh context (recent news, catalysts, risks).
+### 2. Fetch prediction markets
 
-6. Send via `./notify` (under 4000 chars):
-   ```
-   *Daily Pick — ${today}*
+```bash
+# Top events by 24h volume (events group multi-outcome questions)
+curl -s "https://gamma-api.polymarket.com/events?active=true&closed=false&order=volume_24hr&ascending=false&limit=30"
 
-   *Token: SYMBOL*
-   Price: $X.XX (±X.X% 24h / ±X.X% 7d)
-   Market cap: $XB | Volume: $XM
-   Thesis: [2-3 sentences — why this one, what's the catalyst, what's the risk]
-   Signal: [trending/momentum/volume spike/narrative — what caught your eye]
+# Newer markets gaining traction
+curl -s "https://gamma-api.polymarket.com/markets?closed=false&order=startDate&ascending=false&limit=20"
+```
 
-   *Market: "Question?"*
-   Current: YES X% / NO Y%
-   Volume: $Xm
-   Thesis: [2-3 sentences — why this is mispriced or interesting]
-   Context: [what's driving this market right now]
+WebFetch fallback on failure. Track `poly=ok|fail`.
 
-   not financial advice — just pattern-matching
-   ```
+### 3. Score every candidate token (0–10 scale)
 
-7. Log to memory/logs/${today}.md:
-   ```
-   ## Token Pick
-   - **Token:** SYMBOL — $price (±X% 24h)
-   - **Thesis:** [one line]
-   - **Market:** "Question?" — YES X%
-   - **Thesis:** [one line]
-   - **Notification sent:** yes
-   ```
+For each token in the top 250 (and the trending list), compute a signal score:
+
+| Signal | Points |
+|---|---|
+| 24h price change > 0 | +1 |
+| 7d price change > 0 | +1 |
+| Both 24h and 7d > +5% | +2 (in addition to above) |
+| Appears on CoinGecko trending list | +2 |
+| Volume/MarketCap ratio ≥ 0.10 | +2 |
+| Volume/MarketCap ratio ≥ 0.20 (replaces above) | +3 |
+| Outperforming BOTH BTC and ETH on the 7d | +2 |
+| Confirmed on DexScreener trending/gainers (cross-source) | +1 |
+| Matches `${var}` thesis when set | +1 |
+
+Drop candidates with market cap < $20M (too pumpable) unless `${var}` explicitly targets micro-caps. Drop any token already picked in the last 7 days (per dedup gate) unless you can name a fresh catalyst.
+
+Pick the highest-scoring token. Use **WebSearch** to surface the most likely catalyst and at least one named risk (regulatory, unlock, narrative-faded, exchange listing, etc.).
+
+### 4. Score prediction markets — edge calculation
+
+For the top ~10 markets by 24h volume that pass the dedup gate (and `${var}` filter when set), do this for each:
+
+1. Read the question and current YES price (`price`/`outcomePrices`).
+2. Use **WebSearch** to gather 1–3 recent data points relevant to the resolution.
+3. Estimate a **fair YES probability** as a single number (your best calibrated guess, not a range). State the 1–3 inputs you used.
+4. Compute `edge = |fair − current_price|` as percentage points.
+5. Liquidity gate: require 24h volume ≥ $50k AND market not resolving in < 24h (no last-minute mean-reversion roulette).
+
+Pick the market with the largest edge that clears the gate. If you cannot defend a fair-value estimate within ±10% (insufficient public info), discard and try the next market.
+
+### 5. Conviction tiers
+
+| Tier | Token criterion | Market criterion |
+|---|---|---|
+| HIGH | signal score ≥ 7 | edge ≥ 10pp |
+| MEDIUM | signal score 4–6 | edge 5–10pp |
+| SKIP | signal score < 4 | edge < 5pp |
+
+**Skip-day branch**: if BOTH the chosen token and the chosen market land in SKIP, do not synthesize a pick. Send the skip message (step 6b) and log accordingly. This is a feature — forcing low-conviction picks degrades the signal of the whole feed.
+
+### 6a. Notification — normal day (under 4000 chars)
+
+Send via `./notify`:
+
+```
+*Daily Pick — ${today}*
+
+*Token: SYMBOL*  [HIGH | MEDIUM]  signal X/10
+Price: $X.XX (±X.X% 24h / ±X.X% 7d) | mcap $XB | vol $XM (vol/mcap X.XX)
+Score breakdown: [trending+2, vol/mcap+3, RS vs BTC/ETH+2, narrative+1] = 8/10
+Catalyst: [one sentence — what's driving this right now, named source/event]
+Risk: [one sentence — concrete risk, not generic "could go down"]
+Vs recent picks: [first time / repeat with new catalyst: ...]
+
+*Market: "Question?"*  [HIGH | MEDIUM]  edge Xpp
+Current: YES X¢ / NO Y¢ | 24h vol $Xm | resolves: DATE
+Fair YES: ~Y% (inputs: [src1], [src2], [src3])
+Thesis: [one sentence — why the market is wrong, action implied]
+Risk: [one sentence — what could make your fair-value estimate wrong]
+
+sources: cg=ok|fail, dex=ok|fail, poly=ok|fail
+not financial advice — pattern-matching only
+```
+
+If only one of the two pick types qualifies, send just that one section (omit the other entirely — do not include a HIGH and a SKIP in the same message).
+
+### 6b. Notification — skip day
+
+```
+*Daily Pick — ${today}* — no picks
+
+Token signals weak today (best: SYMBOL @ score 3/10).
+Markets either thin liquidity or no defensible edge ≥ 5pp (best: "Question?" edge 2pp).
+
+Tomorrow.
+sources: cg=ok|fail, dex=ok|fail, poly=ok|fail
+```
+
+If all sources failed, send `TOKEN_PICK_NO_DATA` with the source-status line — do not invent picks from cached intuition.
+
+### 7. Log to `memory/logs/${today}.md`
+
+```
+## Token Pick
+- **Token:** SYMBOL — $price (±X% 24h) — tier HIGH/MEDIUM/SKIP — score X/10
+- **Token thesis:** [one line, including catalyst]
+- **Market:** "Question?" — YES X¢ — tier HIGH/MEDIUM/SKIP — edge Xpp
+- **Market thesis:** [one line, including fair-value estimate]
+- **Sources:** cg=ok|fail, dex=ok|fail, poly=ok|fail
+- **Notification sent:** yes (normal | skip | no-data)
+```
+
+Append symbol + market question on a single line for easy grep next-day dedup, e.g.:
+```
+TOKEN_PICK_DEDUP: SYMBOL | "Will X happen by Y?"
+```
 
 ## Sandbox note
 
-The sandbox may block outbound curl. Use **WebFetch** as a fallback for any URL fetch. For auth-required APIs, use the pre-fetch/post-process pattern (see CLAUDE.md).
+The sandbox may block outbound curl. Use **WebFetch** as a fallback for any URL fetch (CoinGecko, DexScreener, Polymarket all work without auth). For auth-required APIs, use the pre-fetch/post-process pattern (see CLAUDE.md). On total source failure, send the no-data notification rather than silent fail.
 
 ## Environment Variables
 - `COINGECKO_API_KEY` — CoinGecko API key (optional, increases rate limits)
+
+## Constraints
+
+- **Never force a pick.** If signals are weak, the skip message IS the output.
+- **Never re-pick** the same token or market within 7 days unless you can state a new catalyst in one sentence.
+- **Show your work**: every score must show the breakdown; every edge must show the inputs.
+- Liquidity gates (mcap ≥ $20M for tokens, 24h vol ≥ $50k for markets) are hard floors — ignoring them turns the feed into a degen casino.
+- One token + one market max. Never bundle "honorable mentions" — that defeats the discipline.


### PR DESCRIPTION
## Winner — Variation B (48.0/52.5)

**Thesis:** sharper output via signal scoring, edge calculation, conviction tiers, and a skip-day branch.

The original asked the model to write a narrative thesis with no math behind it, no dedup against recent picks, and no escape hatch when signals were weak — so every day produced a confident-sounding pick of roughly equal apparent quality regardless of actual signal. B forces the model to (a) compute a 0–10 token signal score from explicit components (momentum, trending, vol/mcap, relative strength vs BTC/ETH, narrative match, DEX cross-confirmation), (b) estimate a fair YES probability for the prediction market and compute `edge = |fair − current|`, (c) tier each pick HIGH/MEDIUM/SKIP, and (d) **send a "no picks today" message instead of inventing one** when both candidates are SKIP. Adds a 7-day dedup gate (no repeats without a named fresh catalyst) and a sources status footer (`cg=ok|fail, dex=ok|fail, poly=ok|fail`).

## Key changes vs original

- **Signal score (token):** 0–10 from 9 named components with explicit point values; replaces the vague "momentum/asymmetry/narrative-fit/relative-strength" prose checklist
- **Edge calculation (market):** estimate fair YES from WebSearch inputs, compute `edge = |fair − price|` in percentage points; require defensible ±10% calibration or skip
- **Conviction tiers:** HIGH (score ≥7 / edge ≥10pp), MEDIUM (4–6 / 5–10pp), SKIP (<4 / <5pp); shown in notification
- **Skip-day branch:** if both picks are SKIP, send the skip message — never force a pick
- **Hard dedup gate:** grep last 7 days of logs for `Token Pick`; do not re-pick same token/market unless a fresh catalyst is named in one sentence; output adds a single-line `TOKEN_PICK_DEDUP:` token for cheap next-day grep
- **Liquidity floors:** mcap ≥ $20M for tokens, 24h vol ≥ $50k for markets — hard, not advisory
- **Cross-source confirmation:** add DexScreener (no auth) so a token confirmed on both CoinGecko trending AND DexScreener gainers gets +1
- **Polymarket `/events`:** prefer events endpoint (groups multi-outcome questions) over raw `/markets`
- **Source-status footer + WebFetch fallback per source**, plus a `TOKEN_PICK_NO_DATA` branch for total source failure

## Variations considered

| # | Thesis | Score | Notes |
|---|---|---|---|
| A | Better inputs — DexScreener + Kalshi + Polymarket `/events` | 43.0 | Strongest data-quality lift; partially folded into B as the cross-confirmation signal and `/events` endpoint |
| **B** | **Sharper output — signal scoring + edge math + tiers + skip branch** | **48.0** | **Winner** |
| C | More robust — source fallback + dedup + DEGRADED mode | 41.0 | Source-status footer + dedup folded into B as cheap robustness wins |
| D | Rethink — arbitrage / dislocation hunt (cross-platform + calendar arb on markets, DEX/price divergence on tokens) | 40.0 | Powerful but arb opportunities are 1–4% gross and vanish in seconds (per research) → would frequently produce no-pick days, defeating the daily cadence; some of the spirit ("show your edge") absorbed into B's edge calculation |

## Scoring detail

Weights: Improvement ×3, Output value ×2, Clarity / Data quality / Robustness ×1.5 each, Conventions ×1.

| Criterion | A | B | C | D |
|---|---|---|---|---|
| Clarity | 4 | 4 | 5 | 3 |
| Data quality | 5 | 4 | 4 | 4 |
| Output value | 4 | 5 | 3 | 4 |
| Robustness | 3 | 4 | 5 | 3 |
| Conventions | 5 | 5 | 5 | 5 |
| Improvement | 4 | 5 | 3 | 4 |
| **Weighted** | **43.0** | **48.0** | **41.0** | **40.0** |

## Diff summary

- Replaced bullet-list "look for momentum/asymmetry/narrative" with explicit signal-score table and point math
- Added prediction-market edge calculation requiring fair-value estimate + named inputs
- Added HIGH/MEDIUM/SKIP tier definitions and a dedicated skip-day notification template
- Added 7-day dedup gate against `memory/logs/` with `TOKEN_PICK_DEDUP:` log line
- Added DexScreener cross-confirmation source and source-status footer
- Added Constraints section (never force, never repeat without catalyst, show your work, hard liquidity floors, one pick max each)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Ported from aaronjmars/aeon-tmp#54.
