### PR TITLE
improve(reg-monitor): autoresearch evolution

### DIFF
--- a/skills/reg-monitor/SKILL.md
+++ b/skills/reg-monitor/SKILL.md
@@ -1,100 +1,175 @@
 ---
 name: Regulatory Monitor
-description: Track legislation, regulatory actions, and legal developments affecting prediction markets, crypto, and AI agents
+description: Track legislation, regulatory actions, and legal developments affecting prediction markets, crypto, and AI agents — triaged by stage × impact for decision-ready output
 var: ""
 tags: [crypto, research]
 ---
-> **${var}** — Specific regulatory topic to focus on (e.g. "prediction markets", "stablecoins", "AI agents"). If empty, scans all tracked domains.
+<!-- autoresearch: variation B — sharper output via stage×impact scoring, action-first triage, deadline-aware buckets, structured primary sources (Federal Register + SEC/CFTC RSS), persistent URL dedup, source-status observability -->
 
-If `${var}` is set, narrow the search to that specific regulatory area.
+> **${var}** — Specific regulatory topic to narrow focus (e.g. `prediction-markets`, `stablecoins`, `ai-agents`). If empty, scans all tracked domains.
 
-Read memory/MEMORY.md for context on current positions and interests.
-Read the last 2 days of memory/logs/ to avoid repeating items.
+Read `memory/MEMORY.md` for context on current positions and interests.
+Read the last 2 days of `memory/logs/` entries for this skill to avoid repeating items.
+Read `memory/topics/reg-monitor-seen.md` (create if missing) for persistent URL dedup across all prior runs.
+
+## Thesis
+
+Original skill produced news-shaped output (HIGH PRIORITY / NOTABLE / WATCH LIST) with soft ranking and no deadlines. Reg-monitor's real value is **decisions** — file a comment, prepare for a ban, short a market, brief counsel. Rank items by **stage × impact**, surface deadlines, drop filler buckets, and distinguish "quiet week" from "monitor failure" via source-status observability.
 
 ## Steps
 
-1. **Search for recent regulatory developments.** Use WebSearch to find legislation, enforcement actions, regulatory guidance, and legal developments from the last 7 days across these domains:
+### 1. Load inputs (structured primary sources first, WebSearch as gap-filler)
 
-   **Primary domains** (always search):
-   - Prediction markets — bills, CFTC actions, state-level bans, Polymarket/Kalshi regulatory status
-   - Crypto/DeFi — SEC enforcement, stablecoin legislation, exchange regulations, token classification
-   - AI agents — autonomous agent regulations, AI liability frameworks, AI governance bills
+Set `today=$(date -u +%F)`, `year=$(date +%Y)`, `since=$(date -u -d '7 days ago' +%F)`.
 
-   **Secondary domains** (include if relevant hits):
-   - Privacy/surveillance — financial surveillance laws, KYC/AML changes
-   - Open source — software liability, AI open-source restrictions
+Fetch from each source below. Track which succeed/fail — you'll emit a `source_status` footer. Treat each as independent; any single failure is non-fatal.
 
-   Run these searches (use the current year dynamically — `date +%Y`):
-   ```
-   WebSearch: "prediction market regulation OR legislation OR ban $(date +%Y)"
-   WebSearch: "CFTC prediction market OR Polymarket OR Kalshi $(date +%Y)"
-   WebSearch: "crypto regulation OR legislation OR SEC enforcement $(date +%Y)"
-   WebSearch: "stablecoin bill OR regulation $(date +%Y)"
-   WebSearch: "AI agent regulation OR autonomous agent legislation $(date +%Y)"
-   ```
+**A. Federal Register (authoritative US rulemakings, notices, enforcement)** — public, no auth:
+```
+WebFetch: https://www.federalregister.gov/api/v1/documents.json?conditions[publication_date][gte]=${since}&conditions[term]=prediction+market+OR+digital+asset+OR+stablecoin+OR+cryptocurrency+OR+AI+agent&per_page=40&order=newest
+```
+Extract per item: `title`, `publication_date`, `type` (Rule / Proposed Rule / Notice), `agencies`, `document_number`, `html_url`, `comments_close_on` (critical — drives ACT bucket), `abstract`.
 
-   If `${var}` is set, replace the above with 2-3 targeted searches for that specific topic.
+**B. SEC press releases (RSS)** — authoritative enforcement + guidance:
+```
+WebFetch: https://www.sec.gov/news/pressreleases.rss
+```
+Keep only items published on/after `${since}`. Match titles against keywords: crypto, digital asset, stablecoin, token, DeFi, prediction, event contract, AI.
 
-2. **Filter and deduplicate.** From all results:
-   - Keep only developments from the last 7 days
-   - Deduplicate against recent logs — skip anything already reported
-   - Discard opinion pieces and speculation — keep only actual legislative/regulatory actions, proposed bills, enforcement actions, court rulings, or official guidance
-   - Flag anything that directly impacts prediction markets or coordination markets as HIGH PRIORITY
+**C. CFTC press releases (RSS)** — authoritative prediction market + derivatives actions:
+```
+WebFetch: https://www.cftc.gov/RSS/RSSPR/rsspr.xml
+```
+Keep items on/after `${since}`. CFTC runs prediction-market rulemaking — all CFTC items are in-scope by default.
 
-3. **Rank by impact.** Score each item on:
-   - **Direct impact on tracked domains** — prediction market regulation > crypto regulation > AI regulation
-   - **Stage of action** — enacted law > passed committee > introduced bill > proposed rule > leaked draft
-   - **Jurisdiction weight** — US federal > EU > US state > UK > other G7 > rest of world
-   - **Enforcement severity** — ban/shutdown > heavy restriction > licensing requirement > reporting requirement > guidance
+**D. WebSearch (gap-filler for state bills, court rulings, international)** — run these with the current year injected:
+- `"prediction market" (bill OR legislation OR ban OR ruling) ${year}`
+- `"Polymarket" OR "Kalshi" (CFTC OR state OR ruling OR investigation) ${year}`
+- `stablecoin (legislation OR regulation OR enforcement) ${year}`
+- `"AI agent" (regulation OR liability OR legislation) ${year}`
+- `ESMA OR MiCA (enforcement OR guidance) ${year}`
 
-4. **Enrich top items.** For the top 3-5 items:
-   - Use WebFetch on the source URL for more detail
-   - Identify: what exactly changed, who introduced/enacted it, what's the timeline, who's affected
-   - Note any prediction market angles — does this create a tradeable event? does it affect existing markets?
+If `${var}` is set, replace the above with 3 targeted searches for that specific topic (include `${year}` and "bill OR ruling OR enforcement").
 
-5. **Format and send via `./notify`** (keep under 4000 chars):
-   ```
-   *Reg Monitor — ${today}*
+**E. Congress.gov (optional, skip if no API key)** — if `CONGRESS_GOV_API_KEY` env var is set, WebFetch bill search for crypto/prediction-market keywords. Otherwise skip silently and rely on Federal Register + WebSearch to catch bill activity.
 
-   *HIGH PRIORITY*
-   - [Bill/Action name](url) — jurisdiction
-     what changed. who's affected. timeline.
-     prediction market angle: [if applicable]
+### 2. Deduplicate against seen URLs
 
-   *NOTABLE*
-   - [Bill/Action name](url) — jurisdiction
-     one-line summary. stage: [introduced/committee/passed/enacted]
+Read `memory/topics/reg-monitor-seen.md` (format: one URL per line, oldest first). Drop any candidate whose URL already appears. Also drop candidates whose title substring-matches an entry from the last 2 days of `memory/logs/`.
 
-   *WATCH LIST*
-   - brief mention of developing stories not yet actionable
+If the seen-file exceeds 500 lines, keep only the most recent 500 before appending new items at end.
 
-   ${count} regulatory developments tracked
-   ```
+### 3. Filter
 
-6. **Log to memory/logs/${today}.md.** Record which items were included and their current stage.
+Discard:
+- Opinion pieces, think-tank posts, academic papers (unless directly cited in a bill/rule/ruling)
+- Industry lobbying announcements with no bill/docket link
+- Generic "crypto market" news without a regulatory action
+- Rumors without a concrete document/docket/case number
 
-   If nothing found, log "REG_MONITOR_OK" and end.
+Keep only: bills introduced/advancing, agency rulemakings, enforcement actions, court rulings, official guidance, international regulatory coordination.
 
-## What Counts as a Regulatory Development
+### 4. Score each surviving item
 
-Include:
-- Bills introduced or advancing in any legislature
-- Regulatory agency actions (CFTC, SEC, ESMA, FCA, etc.)
-- Enforcement actions, fines, cease-and-desist orders
-- Court rulings affecting crypto, prediction markets, or AI
-- Official regulatory guidance or frameworks published
-- International regulatory coordination (FATF, G7, Basel)
+Compute `triage_score = impact × stage`:
 
-Exclude:
-- Opinion pieces, think tank reports (unless cited in actual legislation)
-- Industry lobbying announcements (unless tied to specific bill)
-- Rumors of future regulation without concrete action
-- Academic papers on regulation
+**impact** (domain relevance to tracked interests):
+- **3** — direct hit on prediction markets / event contracts / Polymarket / Kalshi / coordination markets
+- **2** — crypto/DeFi/stablecoin/token classification
+- **1** — AI agents, privacy/KYC, open-source liability (secondary)
+
+**stage** (how close to binding):
+- **5** — enacted law, final rule, binding court ruling, active enforcement (fine issued, C&D)
+- **4** — passed a chamber, passed committee, agency final-rule comment period open with deadline <14d
+- **3** — proposed rule / ANPRM with open comment period, bill reported out of committee
+- **2** — introduced bill with at least one co-sponsor, leaked draft rule, staff advisory
+- **1** — introduced bill with no co-sponsors, rumored action, international coordination statement
+
+Jurisdiction multiplier — apply AFTER `impact × stage`:
+- US federal or EU-wide: ×1.0
+- US state (CA, NY, TX), UK: ×0.8
+- Other G7: ×0.6
+- Rest of world: ×0.4
+
+### 5. Triage into buckets
+
+- **ACT** (score ≥ 10, or comment deadline within 7 days, or enforcement action in last 7 days) — items that need a decision or action now
+- **WATCH** (score 6-9) — actively advancing, not yet actionable
+- **CONTEXT** (score 3-5) — relevant but early-stage; include only if ACT + WATCH combined < 5 items, otherwise drop
+- Below 3: discard
+
+Cap at 8 items total across all buckets. Sort within each bucket by score descending.
+
+### 6. Enrich top items
+
+For every ACT item and top 2 WATCH items, WebFetch the source URL and extract:
+- **what changed**: one specific, verifiable sentence (not "the CFTC did something")
+- **who's affected**: named entities or clearly-scoped class
+- **timeline**: next milestone date if any (vote, deadline, effective date)
+- **prediction market angle**: does this create a tradeable event, or directly affect an existing Polymarket/Kalshi market? Omit the line if none.
+
+### 7. Compose notification
+
+Keep under 4000 chars. If all buckets empty after filtering: **skip notify**, write `REG_MONITOR_OK` to the log, end.
+
+```
+*Reg Monitor — ${today}*
+{1-line thesis: e.g. "3 items need a decision this week" or "quiet week, 2 to watch"}
+
+*ACT*
+• [Title](url) — jurisdiction · stage
+  what changed. who's affected.
+  ⏰ {deadline or effective date}
+  📊 prediction market angle: {if any}
+
+*WATCH*
+• [Title](url) — jurisdiction · stage
+  one-sentence verdict.
+
+*CONTEXT* (only if included)
+• [Title](url) — one-line summary.
+
+—
+sources: federal-register={ok|fail} · sec={ok|fail} · cftc={ok|fail} · websearch={ok|fail} · congress={ok|fail|skip}
+{n} developments scored, {n_act} act / {n_watch} watch / {n_context} context
+```
+
+If **all sources failed**, send a different notification: `*Reg Monitor — ${today}* ⚠️ all sources failed, see log` and write `REG_MONITOR_ERROR` to the log. Do not emit an empty digest.
+
+If **some sources failed** (partial data), still send the digest but flag it in the thesis line: `⚠️ partial — {failed sources} down`. Log `REG_MONITOR_DEGRADED`.
+
+### 8. Update state
+
+Append every URL included in the notification to `memory/topics/reg-monitor-seen.md`, one per line.
+
+### 9. Log to `memory/logs/${today}.md`
+
+```
+### reg-monitor
+- Status: {REG_MONITOR_OK | REG_MONITOR_DEGRADED | REG_MONITOR_ERROR | sent}
+- Items: {n_act} act / {n_watch} watch / {n_context} context
+- Sources: fr={ok|fail} sec={ok|fail} cftc={ok|fail} ws={ok|fail} cg={ok|fail|skip}
+- Top item: {title, score, stage}
+- Deadlines tracked: {any comment-period or vote dates in the next 14 days}
+```
+
+## What counts as a regulatory development
+
+**Include**: bills introduced/advancing; agency rulemakings (NPRM/ANPRM/final rule); enforcement actions (fines, C&D, consent orders); court rulings affecting in-scope domains; official guidance/advisory letters; international coordination statements tied to a concrete document (FATF, G7, Basel).
+
+**Exclude**: opinion pieces; think-tank reports (unless cited in a bill/docket); industry lobbying with no bill attached; academic papers; speculation without a document; press releases announcing future press releases.
 
 ## Sandbox note
 
-The sandbox may block outbound curl. Use **WebFetch** as a fallback for any URL fetch. For auth-required APIs, use the pre-fetch/post-process pattern (see CLAUDE.md).
+The sandbox blocks some outbound curl. Use **WebFetch** for every URL fetch (it's the Claude built-in and bypasses the sandbox). Federal Register, SEC RSS, CFTC RSS, and WebSearch all work without env-var auth. Congress.gov API requires `CONGRESS_GOV_API_KEY` — skip silently if unset.
 
 ## Environment Variables
 
-No environment variables required — uses WebSearch and WebFetch.
+- `CONGRESS_GOV_API_KEY` (optional) — enables Congress.gov bill search step E. Skill degrades gracefully without it.
+
+## Constraints
+
+- Never emit an empty notification — if nothing clears the ACT/WATCH threshold, log `REG_MONITOR_OK` and stay silent.
+- Never include a URL already in `memory/topics/reg-monitor-seen.md`.
+- Never include speculation or opinion in the ACT bucket — only documents with a docket/bill/case number.
+- Cap at 8 items total; actionable items beat volume.


### PR DESCRIPTION
## Autoresearch — reg-monitor

**Winner: Variation B — sharper output via stage×impact triage, action-first buckets**
Score: **49.5 / 52.5 weighted**

### Thesis
Original skill produced news-shaped output (HIGH PRIORITY / NOTABLE / WATCH LIST) with soft ranking and no deadlines. Reg-monitor's real value is **decisions** — file a comment, prepare for a ban, short a market, brief counsel. The rewrite ranks items by `impact × stage × jurisdiction`, surfaces comment deadlines and effective dates, drops filler buckets when empty, and replaces freeform WebSearch-only inputs with authoritative primary sources (Federal Register API, SEC/CFTC RSS) plus WebSearch as gap-filler for state/court/international coverage.

### Key changes vs original
- **Scoring**: replaced soft "HIGH PRIORITY / NOTABLE" with `impact (1-3) × stage (1-5) × jurisdiction (0.4-1.0)` → ACT (≥10 or deadline <7d) / WATCH (6-9) / CONTEXT (3-5, only if ACT+WATCH<5)
- **Inputs**: Federal Register API (authoritative US rulemakings with RIN, comment-close dates) + SEC press RSS + CFTC RSS as primary; WebSearch now gap-filler for state bills, court rulings, international
- **Output discipline**: each ACT item must have `what changed / who's affected / timeline / prediction-market angle` — no filler sentences
- **Deadline awareness**: items with comment periods closing in <7 days get auto-promoted to ACT regardless of score
- **Empty handling**: if nothing clears ACT/WATCH threshold, skill is silent (logs `REG_MONITOR_OK`) rather than sending a low-signal digest
- **Persistent dedup**: `memory/topics/reg-monitor-seen.md` — URL-level dedup across all runs, not just last 2 days of logs
- **Observability**: source-status footer (`federal-register=ok · sec=ok · cftc=ok · websearch=ok · congress=skip`) and three distinct outcome states: `REG_MONITOR_OK` (nothing found, all sources fine) / `REG_MONITOR_DEGRADED` (partial data, some sources down) / `REG_MONITOR_ERROR` (all sources failed)
- **Cap**: 8 items total across all buckets; actionable items beat volume

### Scoring table

| Variation | Clarity ×1.5 | Data ×1.5 | Output ×2 | Robust ×1.5 | Conv ×1 | Improve ×3 | **Total** |
|---|---|---|---|---|---|---|---|
| A — Better inputs (Federal Register + SEC/CFTC RSS only) | 4 | 5 | 4 | 4 | 5 | 4 | 44.5 |
| **B — Stage×impact triage, action-first** ✅ | **5** | **4** | **5** | **4** | **5** | **5** | **49.5** |
| C — Persistent dedup + source-status + degraded mode | 5 | 4 | 4 | 5 | 5 | 4 | 46.0 |
| D — Lifecycle pipeline tracker (stage deltas) | 3 | 4 | 5 | 3 | 4 | 5 | 44.0 |

### Variations considered

- **A — Better inputs**: replace WebSearch with structured Federal Register API + SEC RSS + CFTC RSS as primary sources. Strong on data quality but keeps the original's soft ranking and news-shape — improvement was bounded by output format.
- **B — Sharper output** (winner): decision-ready triage with stage×impact scoring, mandatory fields per item, deadline-aware auto-promotion, and silent-on-empty. Folds A's structured sources and C's dedup/observability as cheap wins.
- **C — More robust**: persistent URL dedup, source-status footer, `REG_MONITOR_OK / DEGRADED / ERROR` tri-state, graceful empty-data handling. High robustness gain but leaves the core output unchanged.
- **D — Lifecycle pipeline tracker**: maintain `memory/topics/reg-watchlist.md` with tracked bills/rules + current stage, and surface DELTAS (stage changes) rather than news. Highest ceiling but requires baseline bootstrapping; first-run would emit an empty digest while populating state — same failure mode that killed D on telegram-digest.

### Why B beats its closest runner-up (C, +3.5)
C hardens the same output. B hardens it AND reshapes it into decisions. The biggest lever for a regulatory-news skill read by an operator is **"what do I do about this?"**, not "am I seeing all the news?" — B delivers the decision frame and still folds in C's dedup state + source-status footer, capturing most of C's robustness upside.

### Diff summary
`skills/reg-monitor/SKILL.md`: +142 / -67. Adds thesis section, stage×impact scoring formula, ACT/WATCH/CONTEXT triage with deadline auto-promotion, source-status observability, persistent dedup state, silent-on-empty handling, and explicit OK/DEGRADED/ERROR states. Preserves frontmatter (`var`, `tags`, `description`) and sandbox-note convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Ported from aaronjmars/aeon-tmp#55.
