### PR TITLE
improve(cost-report): autoresearch evolution

### DIFF
--- a/skills/cost-report/SKILL.md
+++ b/skills/cost-report/SKILL.md
@@ -1,25 +1,26 @@
 ---
 name: cost-report
-description: Weekly API cost report — reads token usage CSV, computes dollar costs per skill and model, reports trends
+description: Weekly API cost report — computes dollar costs from token usage, flags anomalies, forecasts burn, and prescribes concrete optimizations
 var: ""
 tags: [meta]
-version: "1.0.0"
+version: "2.0.0"
 ---
+<!-- autoresearch: variation B — sharper output (verdict + anomalies + burn forecast + concrete optimizations, not passive tables) -->
 > **${var}** — Number of days to cover (default: 7). Pass "30" for a monthly view.
 
-Today is ${today}. Generate a cost report from Aeon's token usage data.
+Today is ${today}. Generate a cost report from Aeon's token usage data. **The output must prescribe action, not just describe spend** — every section either names an anomaly, forecasts risk, or recommends a concrete move.
 
 ## Model Pricing (per million tokens)
 
-Use these rates to calculate costs. First check `aeon.yml` for the `gateway.provider` value.
+First read `aeon.yml` and find the `gateway.provider` value. Use the matching table.
 
 ### Direct Anthropic (gateway.provider: direct)
 
 | Model | Input | Output | Cache Read | Cache Write |
 |-------|-------|--------|------------|-------------|
-| claude-opus-4-7 | $15.00 | $75.00 | $1.50 | $3.75 |
+| claude-opus-4-7 | $15.00 | $75.00 | $1.50 | $18.75 |
 | claude-sonnet-4-6 | $3.00 | $15.00 | $0.30 | $3.75 |
-| claude-haiku-4-5-20251001 | $0.80 | $4.00 | $0.08 | $3.75 |
+| claude-haiku-4-5-20251001 | $0.80 | $4.00 | $0.08 | $1.00 |
 
 ### Bankr Gateway (gateway.provider: bankr)
 
@@ -34,105 +35,178 @@ Use these rates to calculate costs. First check `aeon.yml` for the `gateway.prov
 | kimi-k2.5 | $1.00 | $4.00 |
 | qwen3-coder | $0.50 | $2.00 |
 
-Note: Bankr does not break out cache read/write pricing separately. Treat cache columns as zero cost for Bankr rows.
+Bankr does not expose cache read/write pricing separately. Treat cache columns as $0 for Bankr rows.
 
-For any model not in these tables, default to Opus pricing (conservative estimate).
+If a CSV row references a model not in the active table, treat it as an **unknown model**: price it at Opus rates (conservative), add it to the "Pricing drift" callout in the report so rates can be updated, and continue. Do not crash.
 
 ## Steps
 
-1. **Determine the report window.**
-   - Default: 7 days. If `${var}` is set to a number (e.g. "30"), use that many days.
-   - Compute `CUTOFF_DATE` = today minus N days.
+### 1. Determine the report window
 
-2. **Read token usage data.**
-   - File: `memory/token-usage.csv`
-   - Columns: `date,skill,model,input_tokens,output_tokens,cache_read,cache_creation`
-   - If the file does not exist: log "COST_REPORT_SKIP: no token-usage.csv yet" and stop — do NOT send any notification.
-   - Filter rows where `date >= CUTOFF_DATE`.
-   - If zero rows after filtering: log "COST_REPORT_SKIP: no runs in last N days" and stop.
+- Default: 7 days. If `${var}` is a positive integer (e.g. "30"), use that many days.
+- Compute `CUTOFF_DATE = today − N days`. All rows where `date >= CUTOFF_DATE` are in-window.
+- If the CSV has ≥ `2 × N` days of history, also compute `PRIOR_CUTOFF = today − 2N days` for week-over-week.
 
-3. **Compute costs for each row.**
+### 2. Read token usage data
 
-   For each row, look up the model's rates and calculate:
-   ```
-   input_cost  = input_tokens  / 1,000,000 × rate_input
-   output_cost = output_tokens / 1,000,000 × rate_output
-   cache_read_cost    = cache_read     / 1,000,000 × rate_cache_read
-   cache_write_cost   = cache_creation / 1,000,000 × rate_cache_write
-   row_cost = input_cost + output_cost + cache_read_cost + cache_write_cost
-   ```
+- File: `memory/token-usage.csv`
+- Columns: `date,skill,model,input_tokens,output_tokens,cache_read,cache_creation`
+- If the file is missing: log `COST_REPORT_SKIP: no token-usage.csv yet` and stop (no notification).
+- If 0 rows in-window: log `COST_REPORT_SKIP: no runs in last N days` and stop.
+- Parse numeric columns defensively — skip malformed rows, count them as `csv_malformed` for the source-status footer.
 
-4. **Aggregate into report sections.**
+### 3. Compute per-row cost
 
-   a. **Total cost** for the window.
-   b. **Per-skill cost table** — sum cost per skill, sort descending, show top 10:
-      - Columns: Skill | Runs | Total Tokens | Cost | Avg Cost/Run
-   c. **Per-model breakdown** — total cost and total tokens per model.
-   d. **Token efficiency** — for each skill in top 10, compute output_tokens / total_tokens ratio (higher = more generative, less reading).
-   e. **Week-over-week trend** — if window is 7 days and the CSV has ≥14 days of data:
-      - Compare this week's total cost vs the prior 7-day period.
-      - Show: "Cost up/down X% vs prior week"
-   f. **Most/least efficient skills** (cost per 1K output tokens).
+For each valid in-window row, look up the model's rates and calculate:
+```
+input_cost       = input_tokens    / 1e6 × rate_input
+output_cost      = output_tokens   / 1e6 × rate_output
+cache_read_cost  = cache_read      / 1e6 × rate_cache_read
+cache_write_cost = cache_creation  / 1e6 × rate_cache_write
+row_cost         = input_cost + output_cost + cache_read_cost + cache_write_cost
+```
 
-5. **Write the full report** to `articles/cost-report-${today}.md`:
+### 4. Core aggregates (ground truth — keep these)
 
-   ```markdown
-   # Aeon Cost Report — ${today}
-   *Period: last N days*
+a. **Total cost** for the window (and break out input/output/cache_read/cache_write dollar shares).
+b. **Per-skill** — top 10 by cost. Columns: Skill | Runs | Total Tokens | Cost | Avg Cost/Run.
+c. **Per-model** — total runs, total tokens, total cost per model.
+d. **Week-over-week** — only if ≥ `2N` days of history. `delta_pct = (this_window − prior_window) / prior_window`.
 
-   ## Summary
-   - **Total API cost:** $X.XX
-   - **Total tokens:** X,XXX,XXX (input: X | output: X | cache_read: X | cache_write: X)
-   - **Skill runs tracked:** N
-   - **Week-over-week:** ↑/↓ X% vs prior week  (omit if <14 days of data)
+### 5. Decision sections (this is the point of the skill)
 
-   ## Cost by Skill (Top 10)
-   | Skill | Runs | Tokens | Cost | Avg/Run |
-   |-------|------|--------|------|---------|
-   | ...   | ...  | ...    | $... | $...    |
+#### 5a. Verdict line (one sentence, top of report)
 
-   ## Cost by Model
-   | Model | Runs | Tokens | Cost |
-   |-------|------|--------|------|
-   | ...   | ...  | ...    | $... |
+Compose one sentence that captures the week. Pattern:
+> "Spent **$X.XX** across **N runs** ({{↑/↓ Y% WoW | no prior-week baseline}}); **M anomalies flagged**, projected monthly burn **~$Z.ZZ**."
 
-   ## Efficiency
-   | Skill | Cost / 1K Output Tokens |
-   |-------|------------------------|
-   | ...   | $...                   |
+#### 5b. Anomaly detection (per-skill, per-model cost spikes)
 
-   *Generated by Aeon cost-report skill*
-   ```
+For each (skill, model) pair with ≥ 3 runs in-window:
+- Compute mean µ and std-dev σ of `row_cost`.
+- Flag any run where `row_cost > µ + 2σ` AND `row_cost > $0.10` (ignore sub-cent noise).
+- Flag skills whose **total** cost this window is ≥ 2× the same skill's prior-window total (only if prior window exists and prior total ≥ $0.25).
 
-6. **Send notification** via `./notify`:
+Output a table: `Skill | Model | When | Run Cost | vs µ | Why (tokens_input / tokens_output / cache_write)`. If no anomalies, write "No anomalies." — do not omit the section.
 
-   ```
-   *Cost Report — ${today} (last N days)*
+#### 5c. Monthly burn forecast
 
-   Total: $X.XX across N skill runs
+- `daily_avg_cost = total_cost / N`
+- `projected_monthly = daily_avg_cost × 30`
+- Show: "At current rate, 30-day spend ≈ **$X.XX**."
+- If projected_monthly > $50, add a "⚠ burn-rate watch" note.
 
-   Top 3 by cost:
-   1. skill-a — $X.XX (N runs, avg $X.XX/run)
-   2. skill-b — $X.XX
-   3. skill-c — $X.XX
+#### 5d. Optimization opportunities (top 3, actionable)
 
-   By model:
-   - Opus: $X.XX | Sonnet: $X.XX | Haiku: $X.XX
+Scan the in-window data and produce up to 3 concrete recommendations. Each must name (i) a specific skill, (ii) a specific change, (iii) estimated weekly savings. Candidate patterns:
 
-   Trend: ↑/↓ X% vs prior week  [omit if no prior week data]
+- **Model downgrade**: skill runs on `claude-opus-4-7`, its median `output_tokens / input_tokens` ratio across runs is < 0.3, AND its avg run cost > $0.25. → Suggest Sonnet; savings = `this_skill_cost × (1 − sonnet_rate_mix / opus_rate_mix)`.
+- **Cache underuse** *(direct gateway only)*: skill's `cache_read / (cache_read + input_tokens)` ratio < 0.2 across runs AND avg run cost > $0.10. → "Add a stable prompt prefix so Claude Code can cache it — would move ~X% of input tokens to cache_read at 10× savings."
+- **Aeon.yml mismatch**: `aeon.yml` sets a `model:` override for the skill but the CSV shows runs on a different model. → "Model override drift — aeon.yml says X, runs show Y."
+- **Long-tail waste**: a skill with >10 runs in-window where avg cost/run < $0.01 AND it produces no written artifact (no `articles/` file, no notification). → "Possible no-op loop."
 
-   Full report: articles/cost-report-${today}.md
-   ```
+If fewer than 3 candidates pass the filters, say so — do not pad. If zero candidates, write "No optimization levers found this week."
 
-7. **Log** to `memory/logs/${today}.md`:
-   ```
-   ## Cost Report
-   - Period: last N days
-   - Total cost: $X.XX
-   - Runs tracked: N
-   - Most expensive skill: skill-name ($X.XX)
-   - Cheapest skill: skill-name ($X.XX)
-   - Week-over-week: +/-X%
-   - Article: articles/cost-report-${today}.md
-   - Notification sent via ./notify
-   ```
+#### 5e. Pricing drift callout
+
+If any CSV row referenced a model not in the active pricing table, list those model names and the total tokens attributed to them. Note: "Add rates to skills/cost-report/SKILL.md." If all rows matched, omit this block.
+
+### 6. Write the full report
+
+Path: `articles/cost-report-${today}.md`. If the file already exists, overwrite it (idempotent).
+
+```markdown
+# Aeon Cost Report — ${today}
+*Period: last N days · gateway: {{direct|bankr}}*
+
+> {{verdict line from 5a}}
+
+## Anomalies
+{{table from 5b, or "No anomalies."}}
+
+## Burn forecast
+- Daily avg: $X.XX
+- 30-day projection: $X.XX {{⚠ burn-rate watch if >$50}}
+
+## Optimization opportunities
+1. **{{skill}}** — {{action}}. Est. savings: ~$X.XX/week.
+2. ...
+3. ...
+{{or "No optimization levers found this week."}}
+
+## Cost by Skill (Top 10)
+| Skill | Runs | Tokens | Cost | Avg/Run |
+|-------|------|--------|------|---------|
+
+## Cost by Model
+| Model | Runs | Tokens | Cost |
+|-------|------|--------|------|
+
+## Composition
+- Input: $X.XX · Output: $X.XX · Cache read: $X.XX · Cache write: $X.XX
+
+## Week-over-week
+- This window: $X.XX · Prior window: $X.XX · Δ {{+/−}}X% {{or "no prior-week baseline"}}
+
+## Pricing drift
+{{list of unknown models, or omit if none}}
+
+---
+*Sources: token-usage.csv ({{ok|degraded: M malformed rows skipped}}) · aeon.yml ({{ok|missing}}) · pricing table last reviewed in SKILL.md.*
+*Generated by Aeon cost-report skill.*
+```
+
+### 7. Send notification via `./notify`
+
+Lead with the verdict, then the top 3 actions. Keep under ~15 lines.
+
+```
+*Cost Report — ${today} (last N days)*
+
+{{verdict line from 5a}}
+
+Top 3 by cost:
+1. skill-a — $X.XX (N runs)
+2. skill-b — $X.XX
+3. skill-c — $X.XX
+
+{{If any optimization opportunities:}}
+Actions this week:
+• {{skill}} → {{action}} (~$X.XX/wk)
+• ...
+
+{{If any anomalies:}} ⚠ M anomalies flagged — see report.
+{{If pricing drift:}} ⚠ unknown models in CSV — see report.
+
+30-day projection: $X.XX
+Full: articles/cost-report-${today}.md
+```
+
+### 8. Log to `memory/logs/${today}.md`
+
+```
+## Cost Report
+- Period: last N days (gateway: {{direct|bankr}})
+- Total: $X.XX across N runs
+- Verdict: {{copy verdict line}}
+- Anomalies flagged: M
+- Monthly projection: $X.XX
+- Optimization suggestions: {{count}} ({{brief list}})
+- Week-over-week: +/-X% (or "no baseline")
+- Pricing drift: {{none | list of unknown models}}
+- Source status: csv={{ok|degraded}}, aeon.yml={{ok|missing}}
+- Article: articles/cost-report-${today}.md
+- Notification sent via ./notify
+```
+
+## Sandbox note
+
+No outbound network required — this skill only reads local files (`memory/token-usage.csv`, `aeon.yml`). If future versions pull the Anthropic Usage/Cost API, use WebFetch as the fallback for sandboxed curl, and cache results to `.xai-cache/` via a pre-fetch script (see CLAUDE.md).
+
+## Constraints
+
+- **Anomaly threshold** is intentionally conservative (µ + 2σ AND >$0.10) — cheap runs should not be flagged as noise.
+- **Optimization recommendations must name a skill and an estimated dollar impact.** "Use Sonnet more" without a target skill is not useful — skip the slot instead.
+- **Do not send a notification** if the CSV is missing or the window is empty — silently log and exit.
+- **Do not change the pricing tables** without verifying rates against Anthropic's current published pricing.
+- Preserve idempotency: rerunning on the same day overwrites the article, does not append.


### PR DESCRIPTION
## Summary

Autoresearch evolution of the `cost-report` skill. Winner: **Variation B — sharper output** (score 48/~52.5 weighted).

The original skill produced accurate numbers but passive tables — an operator reads it and doesn't know what to do. This version forces the skill to name anomalies, forecast burn, and prescribe concrete moves (model downgrades, caching fixes, model-override drift, no-op loops), each with a named skill and dollar impact.

## Thesis

> The gap isn't data quality — the gap is decisions. Make the skill output actionable verdicts and specific optimization moves, not tables to be interpreted.

## Scoring

| Criterion (weight) | A — Better inputs | B — Sharper output | C — More robust | D — ROI reframe |
|---|---|---|---|---|
| Clarity (×1.5) | 4 | 4 | 5 | 3 |
| Data quality (×1.5) | 5 | 4 | 4 | 4 |
| Output value (×2) | 4 | **5** | 3 | 5 |
| Robustness (×1.5) | 4 | 4 | 5 | 3 |
| Conventions (×1) | 5 | 5 | 5 | 4 |
| Improvement (×3) | 4 | **5** | 3 | 4 |
| **Weighted total** | 44.5 | **48** | 41 | 41 |

## Variations considered

- **A — Better inputs**: pricing in a JSON file, cross-reference `gh` workflow runs vs CSV rows, read `aeon.yml` model overrides. Strong on data quality but doesn't fix the core "passive table" problem.
- **B — Sharper output** *(winner)*: verdict line + anomaly detection (µ+2σ with $0.10 floor) + 30-day burn forecast + optimization opportunities (Opus→Sonnet, cache underuse, aeon.yml drift, no-op loops) + pricing-drift callout. Folds in A's aeon.yml override cross-check (powers optimization suggestions) and C's source-status footer + unknown-model surfacing.
- **C — More robust**: CSV schema validation, malformed-row tolerance, NO_CSV vs NO_RUNS differentiation, idempotency. Cheap defensive wins — absorbed into B.
- **D — ROI reframe**: cost-per-outcome tiers (BUDGET/PREMIUM/WASTE) via `gh` success counts. Opinionated, but success-count data is noisy and tier labels risk over-claiming when runs are sparse.

## Diff summary

- Output now leads with a one-line verdict, not a summary block
- New sections: **Anomalies** (per-skill-model µ+2σ), **Burn forecast** (30-day projection + watch threshold), **Optimization opportunities** (top 3, each with skill + action + estimated $/week)
- New **Pricing drift** callout when CSV references unknown models
- Source-status footer (csv ok|degraded, aeon.yml ok|missing, malformed-row count)
- Dropped the backwards `output / total` "efficiency" metric — it penalized cache usage, which is the opposite of what we want
- Article file now idempotent on rerun
- Notification reframed: verdict first, top 3 actions, anomaly/drift flags, projection — under ~15 lines
- **Side fix**: corrected direct-Anthropic cache-write rates. The original set cache-write to `$3.75` for all three models, which is only correct for Sonnet. Per Anthropic's 5-minute cache-write pricing at 1.25× base input, Opus is $18.75 and Haiku is $1.00. This was meaningfully under-counting Opus cache-write cost.

## Guarantees preserved

- Still skips silently (no notification) when CSV is missing or window is empty
- Still reads `gateway.provider` from `aeon.yml` and picks the right pricing table
- Still writes `articles/cost-report-${today}.md` and logs to `memory/logs/${today}.md`
- No new env vars, no new secrets, no network calls

---
Ported from aaronjmars/aeon-tmp#56.
