### PR TITLE
improve(treasury-info): autoresearch evolution

### DIFF
--- a/skills/treasury-info/SKILL.md
+++ b/skills/treasury-info/SKILL.md
@@ -10,9 +10,9 @@ tags: [crypto]
 
 If `${var}` is set, only check the wallet with that label (exact match, case-insensitive).
 
-## Config
+## Configuration
 
-Reads watched addresses from `memory/on-chain-watches.yml`. Format:
+Reads watched addresses from `memory/on-chain-watches.yml` (auto-created on first run if missing — see Bootstrap below). Minimal schema:
 
 ```yaml
 watches:
@@ -20,6 +20,7 @@ watches:
     address: "0x1234...abcd"
     chain: base            # base, ethereum, optimism, arbitrum, polygon, solana
     type: wallet           # only type:wallet is processed here
+protocols: []              # reserved for future protocol-level watches; safe to omit
 ```
 
 ### Bootstrap (file missing)

--- a/skills/treasury-info/SKILL.md
+++ b/skills/treasury-info/SKILL.md
@@ -1,105 +1,177 @@
 ---
 name: Treasury Info
-description: Show holdings overview for a wallet using Bankr API with block explorer fallback
+description: Decision-ready treasury overview — verdict, concentration, depegs, significant changes
 var: ""
 tags: [crypto]
 ---
+<!-- autoresearch: variation B — sharper output via verdict + concentration + depeg flags + significance-gated deltas, folding in Alchemy Portfolio API (from A), source-status footer + bootstrap (from C), and "what changed" lede (from D) -->
+
 > **${var}** — Wallet label to check. If empty, checks all watched wallets.
 
-If `${var}` is set, only check the wallet with that label.
-
+If `${var}` is set, only check the wallet with that label (exact match, case-insensitive).
 
 ## Config
 
-This skill reads watched addresses from `memory/on-chain-watches.yml`. If the file doesn't exist yet, create it or skip this skill.
+Reads watched addresses from `memory/on-chain-watches.yml`. Format:
 
 ```yaml
-# memory/on-chain-watches.yml
 watches:
   - label: Treasury
     address: "0x1234...abcd"
-    chain: base
-    rpc_url: https://base.llamarpc.com
-    type: wallet
+    chain: base            # base, ethereum, optimism, arbitrum, polygon, solana
+    type: wallet           # only type:wallet is processed here
 ```
 
-### Bankr API (preferred)
+### Bootstrap (file missing)
 
-Set the `BANKR_API_KEY` secret (prefixed `bk_`). The Bankr portfolio endpoint returns token balances, USD values, PnL, and NFTs across chains — one call covers everything.
+If `memory/on-chain-watches.yml` does not exist:
+1. Create it with a commented-out template (label/address/chain placeholders, no real addresses).
+2. Send **one** `./notify` message: "treasury-info: no watches configured — edit memory/on-chain-watches.yml to enable."
+3. Log `TREASURY_INFO_NO_CONFIG` to `memory/logs/${today}.md` and exit 0.
 
-If `BANKR_API_KEY` is not set, the skill falls back to direct RPC + CoinGecko.
+If the file exists but has zero `type: wallet` entries: log `TREASURY_INFO_OK — no wallets configured` and exit 0 without notifying.
 
----
+### Required / optional secrets
 
-Read memory/MEMORY.md and memory/on-chain-watches.yml for watched addresses.
-Read the last 2 days of memory/logs/ to compare against previous snapshots.
+| Secret | Purpose | Fallback if missing |
+|---|---|---|
+| `ALCHEMY_API_KEY` | Primary balances + metadata (EVM + Solana) | Direct public RPC + hard-coded token list |
+| `BANKR_API_KEY` | PnL enrichment only | Skip PnL lines |
+| `COINGECKO_API_KEY` | Price backstop / 24h change | Public CoinGecko (lower rate limit) |
 
-Steps:
+## Data flow
 
-1. **Load watches** — parse `memory/on-chain-watches.yml`. Filter to `type: wallet` entries. If `${var}` is set, match by label.
+Read `memory/MEMORY.md` for context. Read the most recent per-wallet snapshot from `memory/topics/treasury-snapshots.md` (see step 5) to compute deltas.
 
-2. **Fetch holdings** — for each wallet, try Bankr first, then fall back:
+### 1. Load watches
 
-   **Path A — Bankr API** (if `BANKR_API_KEY` is set):
-   ```bash
-   curl -s "https://api.bankr.bot/wallet/portfolio?include=pnl&showLowValueTokens=false" \
-     -H "X-API-Key: ${BANKR_API_KEY}"
-   ```
-   This returns balances grouped by chain with token symbols, amounts, USD values, and PnL.
+Parse `memory/on-chain-watches.yml`. Keep only `type: wallet`. If `${var}` set, filter to matching label (case-insensitive exact match). If no wallets remain after filtering, log `TREASURY_INFO_OK — no matching wallet for '${var}'` and exit 0.
 
-   If the Bankr wallet address matches a watched address, use the response directly.
-   If querying a different wallet, use the Agent API:
-   ```bash
-   # Submit prompt
-   JOB=$(curl -s -X POST "https://api.bankr.bot/agent/prompt" \
-     -H "X-API-Key: ${BANKR_API_KEY}" \
-     -H "Content-Type: application/json" \
-     -d '{"prompt":"Show full token balances for wallet '"${address}"' on '"${chain}"'"}' \
-     | jq -r '.jobId')
+### 2. Fetch balances (per wallet)
 
-   # Poll for result (max 30s, 3s intervals)
-   for i in $(seq 1 10); do
-     RESULT=$(curl -s "https://api.bankr.bot/agent/job/${JOB}" \
-       -H "X-API-Key: ${BANKR_API_KEY}")
-     STATUS=$(echo "$RESULT" | jq -r '.status')
-     if [ "$STATUS" = "completed" ]; then break; fi
-     sleep 3
-   done
-   ```
+Try sources in order; record which one succeeded into a `source` field for the footer.
 
-   **Path B — RPC + CoinGecko fallback** (no Bankr key):
-   - Get native balance via `eth_getBalance` (EVM) or equivalent RPC call.
-   - For ERC-20 tokens, query known token contracts with `balanceOf(address)` via `eth_call`.
-   - Look up USD prices from CoinGecko:
-     ```bash
-     curl -s "https://api.coingecko.com/api/v3/simple/price?ids=${coin_ids}&vs_currencies=usd&include_24hr_change=true"
-     ```
-   - For Solana wallets, use the Solana RPC `getBalance` and `getTokenAccountsByOwner` methods.
+**Primary — Alchemy Portfolio API** (if `ALCHEMY_API_KEY` set):
+```
+POST https://api.g.alchemy.com/data/v1/${ALCHEMY_API_KEY}/assets/tokens/by-address
+Body: {"addresses":[{"address":"0x…","networks":["base-mainnet"]}],"withMetadata":true,"withPrices":true}
+```
+One call returns token balances, decimals, symbols, and USD values across EVM chains. For `chain: solana`, use `solana-mainnet` in `networks` — the same endpoint supports SPL tokens.
 
-3. **Format treasury overview**:
-   ```
-   *Treasury Overview — ${today}*
+**Fallback — public RPC + CoinGecko**:
+- Native balance: `eth_getBalance` on a public RPC (e.g. `https://base.llamarpc.com`, `https://eth.llamarpc.com`).
+- ERC-20s: only the subset listed in `memory/topics/known-tokens.md` (if that file exists) via `eth_call` → `balanceOf`.
+- Prices + 24h change: `https://api.coingecko.com/api/v3/simple/price?ids=…&vs_currencies=usd&include_24hr_change=true`.
 
-   *Label* (chain)
-   Total Value: $X,XXX.XX
+**Enrichment — Bankr PnL** (if `BANKR_API_KEY` set and the wallet address matches the key owner): call `GET https://api.bankr.bot/wallet/portfolio?include=pnl&showLowValueTokens=false` with header `X-API-Key: ${BANKR_API_KEY}`. Merge `pnl` fields into the balance list by token symbol. Skip entirely if it times out after 15s — never block on it.
 
-   Holdings:
-   - TOKEN1: amount ($value) [+/-% 24h]
-   - TOKEN2: amount ($value) [+/-% 24h]
-   - ...
+Sandbox note: if curl fails, retry the same URL once via **WebFetch**. For auth-required calls, use the pre-fetch pattern — write `scripts/prefetch-treasury.sh` that curls Alchemy/Bankr with env access and caches JSON under `.treasury-cache/${label}.json`; the skill reads the cache.
 
-   Top 5 by value shown. N tokens below $1 hidden.
+### 3. Classify holdings
 
-   Change since last check: +/- $X.XX
-   ```
-   Include PnL data if available from Bankr. Compare total value against the last logged snapshot.
+For each token in the response, bucket into:
+- **stables** — symbol in `{USDC, USDT, DAI, FRAX, USDe, USDS, PYUSD, TUSD, LUSD, GHO, crvUSD}`.
+- **majors** — symbol in `{ETH, WETH, stETH, wstETH, rETH, cbETH, SOL, BTC, WBTC, cbBTC, tBTC}`.
+- **longtail** — everything else with USD value ≥ $1.
+- **dust** — USD value < $1 (counted, not shown).
 
-4. **Send** via `./notify`.
+### 4. Compute per-wallet signals
 
-5. **Log** current totals and per-token balances to `memory/logs/${today}.md` so future runs can track changes over time.
+For each wallet compute:
 
-If no watched wallets configured, send nothing. Log "TREASURY_INFO_OK — no wallets configured" and end.
+- **Total USD value** = sum across all non-dust tokens.
+- **Category shares** = stables / majors / longtail / dust as % of total.
+- **Concentration** = largest single non-stable position as % of total. Flag if > 60%.
+- **Depegs** = any stablecoin priced outside [$0.98, $1.02]. Flag with current price.
+- **Significant tokens** = tokens passing either gate:
+  - ≥ 1% of total portfolio value, OR
+  - |24h price change| ≥ 10% AND ≥ $100 absolute value.
+- **Delta vs last snapshot** (only if a prior snapshot exists for this wallet in `memory/topics/treasury-snapshots.md`):
+  - Total value delta (absolute + %)
+  - New tokens: appeared this run, weren't in last snapshot, ≥ $100 value
+  - Removed tokens: in last snapshot ≥ $100 value, now < $1
+  - Large moves: per-token balance change ≥ 20% AND ≥ $500 absolute
+
+Derive a **verdict** (one line):
+- `ACCUMULATING` — total value up ≥ 5% since last snapshot
+- `BLEEDING` — total value down ≥ 5% since last snapshot
+- `SHIFTING` — total value within ±5% but category shares moved ≥ 10 percentage points
+- `STABLE` — otherwise
+
+### 5. Persist snapshot
+
+Append to `memory/topics/treasury-snapshots.md` (create the file on first run) under a dated section:
+```
+## ${today} ${wallet.label} (${wallet.chain})
+total_usd: 12345.67
+stables_pct: 42
+majors_pct: 35
+longtail_pct: 23
+top: USDC=5200, ETH=4100, cbBTC=1800, AERO=900, PEPE=300
+source: alchemy
+```
+Keep the last 30 entries per wallet — older ones can be pruned in-place.
+
+### 6. Format notification
+
+Build one message per run (all wallets combined if `${var}` is empty, else one wallet):
+
+```
+*Treasury — ${today}*
+Verdict: ACCUMULATING  (+6.2% / +$X,XXX since 2026-04-18)
+
+*${label}* (${chain}) — $12,345.67
+stables 42% · majors 35% · longtail 23%
+
+What changed
+  • ETH +0.8 (+$1,900, balance +12%)
+  • USDC −$1,200 (−8%)
+  • new: AERO $900
+
+Significant holdings
+  • USDC     5,200  ( 42%)   $1.00
+  • ETH      1.25   ( 33%)   $3,280  +2.1% 24h
+  • cbBTC    0.025  ( 15%)   $1,800  +0.4% 24h
+  • AERO     800    (  7%)   $1.13   −12% 24h   ⚠ moved
+  3 dust positions hidden.
+
+Flags
+  ⚠ concentration: USDC 42% (stables — ok)
+  ⚠ depeg: none
+
+Takeaway: stables 42% — room to deploy if conviction is there.
+
+sources: alchemy=ok bankr=skip coingecko=ok
+```
+
+Rules for the message body:
+- Skip the "What changed" block entirely on first run (no prior snapshot). Write `first snapshot — baseline saved.` instead.
+- Skip "Flags" lines that have nothing to report (don't print "depeg: none" if there was no near-miss). Only keep a flag line if it's actually flagged OR a near-miss worth noting.
+- Omit the "Takeaway" line when there's nothing specific to say — don't pad.
+- Keep the whole message under 1500 chars; truncate the significant-holdings list to top 8 before any omission.
+
+### 7. Send and log
+
+Send via `./notify`. Then log to `memory/logs/${today}.md`:
+
+```
+### treasury-info
+- Wallets: 2 (Treasury-base, Ops-ethereum)
+- Verdict: ACCUMULATING (+6.2%)
+- Flags: concentration-stables=ok, depegs=none
+- Sources: alchemy=ok bankr=skip coingecko=ok
+- PR: n/a
+```
+
+If every source failed for every wallet, notify `TREASURY_INFO_ERROR — all sources failed (alchemy=fail, coingecko=fail)` and log the same line. Do not guess values.
 
 ## Sandbox note
 
-The sandbox may block outbound curl. Use **WebFetch** as a fallback for any URL fetch. For auth-required APIs, use the pre-fetch/post-process pattern (see CLAUDE.md).
+Sandbox may block outbound curl or env-var expansion in headers. Use **WebFetch** for auth-free URLs (public RPC, public CoinGecko). For `ALCHEMY_API_KEY` / `BANKR_API_KEY`, prefer the pre-fetch pattern: `scripts/prefetch-treasury.sh` runs before Claude with full env access, caches JSON under `.treasury-cache/`, and the skill reads the cache. See CLAUDE.md § Sandbox Limitations.
+
+## Constraints
+
+- Never invent balances or prices. If a source fails, report the failure in the footer; don't fall back to last-snapshot values as if they were current.
+- Don't notify on first run beyond the baseline message — readers shouldn't get a "0% change" page on day one.
+- Respect `${var}`: when set, only process that wallet and only persist that wallet's snapshot.
+- Preserve token decimals correctly when computing balance deltas (integer math on raw units, divide at the end).


### PR DESCRIPTION
## Winner: Variation B — Sharper output (46.5 / 52.5)

**Thesis**: a treasury update is only useful if it tells the reader what to do next. The original emits a flat "Top 5 by value" snapshot with no verdict, no category view, no risk flags, and no significance gating on changes. Biggest lever is turning the output into a decision-ready page: one-line verdict → category decomposition (stables/majors/longtail with %) → concentration & depeg flags → significance-gated token list → delta vs last snapshot → one actionable takeaway. Upstream, the brittle Bankr Agent-job polling path is replaced with Alchemy Portfolio API (works for any wallet across EVM + Solana in one call). Bankr is kept as PnL-only enrichment.

## Scoring

| Criterion (weight) | A — inputs | **B — output** | C — robust | D — flow-first |
|---|---|---|---|---|
| Clarity (1.5x) | 4 | 4 | 4 | 3 |
| Data quality (1.5x) | 5 | 4 | 4 | 4 |
| Output value (2x) | 3 | **5** | 3 | 5 |
| Robustness (1.5x) | 3 | 3 | 5 | 3 |
| Conventions (1x) | 5 | 5 | 5 | 5 |
| Improvement (3x) | 4 | **5** | 3 | 5 |
| **Weighted total / 52.5** | 41 | **46.5** | 39.5 | 45 |

## Variations considered

- **A — Better inputs (41)**: replace Bankr Agent polling with Alchemy Portfolio API (single call, any wallet, EVM + Solana). Bankr becomes PnL-only. CoinGecko is price backstop. Pre-fetch pattern under `scripts/prefetch-treasury.sh`. Strong on data quality but doesn't fix what the reader sees.
- **B — Sharper output (46.5) ← winner**: verdict + categories + concentration + depeg + significance gates. Folds in A's Alchemy primary path, C's source-status footer + bootstrap-on-missing-config, and D's "What changed" section as the lede against the prior snapshot.
- **C — More robust (39.5)**: bootstrap missing config, per-wallet status, source-status footer, persistent dedup for first-time tokens, timeout guards on Bankr polling. Solid engineering but doesn't change what the operator actually reads.
- **D — Rethink / flow-first (45)**: lead with *what changed* (new tokens, large in/outflows, stablecoin rotations, concentration shifts) rather than a snapshot. Skip notification entirely when delta is negligible. Right impulse, but loses the baseline view operators still want at a glance — B captures the same delta framing without sacrificing the snapshot.

## Key changes in the winning SKILL.md

- **Lede**: `Verdict: ACCUMULATING / BLEEDING / SHIFTING / STABLE` computed from total-value and category-share deltas vs last snapshot.
- **Categories**: stables / majors / longtail / dust with %. Concentration flag at >60% single non-stable. Depeg flag for any stable outside [\$0.98, \$1.02].
- **Significance gating**: only print a token if ≥1% of total OR (|24h|≥10% AND value≥\$100). Dust (<\$1) counted, not shown.
- **"What changed"**: new tokens, removed tokens, balance changes ≥20% AND ≥\$500. Skipped on first run; replaced with a baseline message.
- **Alchemy Portfolio API** as primary source (one call, EVM + Solana with SPL). Bankr becomes PnL enrichment only and is skipped on timeout. Public RPC + CoinGecko fallback for the auth-free path. WebFetch fallback for sandbox blocks; pre-fetch pattern for auth-required calls.
- **Bootstrap**: missing `memory/on-chain-watches.yml` creates a template, sends one notify, logs `TREASURY_INFO_NO_CONFIG`, exits 0. Missing config no longer silently does nothing.
- **Source-status footer**: `sources: alchemy=ok bankr=skip coingecko=ok` so the operator can distinguish `TREASURY_INFO_OK` (quiet run) from `TREASURY_INFO_ERROR` (every source failed).
- **Snapshot persistence**: `memory/topics/treasury-snapshots.md` keeps the last 30 dated entries per wallet for delta computation.

## Constraints honored

- No new secrets — uses only `ALCHEMY_API_KEY`, `BANKR_API_KEY`, `COINGECKO_API_KEY` which are already in `aeon.yml`.
- Tags (`[crypto]`) and `var` semantics preserved.
- Core purpose preserved: a treasury overview, just one that's readable and decision-ready instead of a flat balance dump.

---
Ported from aaronjmars/aeon-tmp#57.
