### PR TITLE
improve(defi-overview): autoresearch evolution

### DIFF
--- a/skills/defi-overview/SKILL.md
+++ b/skills/defi-overview/SKILL.md
@@ -1,84 +1,172 @@
 ---
 name: DeFi Overview
-description: Daily overview of DeFi activity from DeFiLlama — TVL changes, top chains, top protocols
+description: Daily DeFi read — regime verdict, biggest movers with "why it matters", sustainable vs incentive yields, fees fundamentals
 var: ""
 tags: [crypto]
 ---
-> **${var}** — Chain or protocol to focus on (e.g. "solana", "aave", "arbitrum"). If empty, shows the full overview.
+<!-- autoresearch: variation B — sharper output via regime verdict + sustainable-vs-incentive yield split + fees fundamentals + per-mover "why it matters" -->
 
-Read memory/MEMORY.md for context.
-Read the last 2 days of memory/logs/ to avoid repeating data.
+> **${var}** — Chain or protocol to focus on (e.g. `solana`, `aave`, `arbitrum`). If empty, full market overview.
 
-If `${var}` is set, focus the overview on that chain or protocol — show its TVL, top pools, volume, and compare against the broader market. Still include a brief top-level summary for context.
+Read `memory/MEMORY.md` for context. Read the last 2 days of `memory/logs/` to avoid repeating numbers and to cite yesterday's figure when flagging today's change.
+
+## Thesis
+
+The original produced a table of numbers. This version produces a **read of the market**: one verdict line at the top, then only items that *changed* or *matter*, each with a one-line reason a reader should care. TVL alone is lagging and emission-subsidized — we pair it with fees/revenue (real fundamentals) and split yields into sustainable (`apyBase`) vs incentive-driven (`apyReward`) so readers stop chasing scam-tier APYs.
+
+## Focus mode
+
+- `var` empty → full market overview.
+- `var` matches a chain name in `/v2/chains` (case-insensitive) → chain focus: scope DEX volume, fees, and yields to that chain; keep a 2-line market header for context.
+- `var` matches a protocol slug in `/protocols` → protocol focus: pull `/protocol/{slug}`, `/summary/fees/{slug}`, `/summary/dexs/{slug}` if DEX; compare against its chain and its 30-day self.
+- `var` matches neither → proceed as full overview and note `var unresolved: ${var}` in the footer.
 
 ## Steps
 
-1. Fetch overall DeFi TVL and chain breakdown:
-   ```bash
-   # Total TVL across all chains
-   curl -s "https://api.llama.fi/v2/historicalChainTvl"
+### 1. Fetch (public, no auth — use WebFetch if curl fails)
 
-   # TVL per chain (current)
-   curl -s "https://api.llama.fi/v2/chains"
+```bash
+# TVL
+curl -fsS "https://api.llama.fi/v2/chains"                        > .tmp/chains.json
+curl -fsS "https://api.llama.fi/protocols"                        > .tmp/protocols.json
 
-   # Top protocols by TVL
-   curl -s "https://api.llama.fi/protocols"
-   ```
+# Volumes & fundamentals (these are the endpoints the old version was missing)
+curl -fsS "https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true"  > .tmp/dexs.json
+curl -fsS "https://api.llama.fi/overview/fees?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true"  > .tmp/fees.json
 
-2. Fetch stablecoin and volume data:
-   ```bash
-   # DEX volume (24h)
-   curl -s "https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true"
+# Stablecoins
+curl -fsS "https://stablecoins.llama.fi/stablecoins?includePrices=false"  > .tmp/stables.json
 
-   # Stablecoin market cap overview
-   curl -s "https://stablecoins.llama.fi/stablecoins?includePrices=false"
+# Yields
+curl -fsS "https://yields.llama.fi/pools"                         > .tmp/pools.json
+```
 
-   # Yield/TVL overview for top pools
-   curl -s "https://yields.llama.fi/pools" | jq '[.data | sort_by(-.tvlUsd) | .[:20] | .[] | {project, chain, symbol, tvlUsd, apy}]'
-   ```
+For each endpoint, if curl fails or returns non-JSON, retry once with **WebFetch** against the same URL. Mark the source `ok` or `fail` — carry this into the footer. Never block the whole run on a single source.
 
-3. Analyze and surface what matters:
-   - **Total DeFi TVL** — current value and 24h / 7d change
-   - **Top 5 chains by TVL** — with 24h change percentage
-   - **Biggest TVL movers** — chains or protocols with largest 24h increase or decrease (filter for >5% moves)
-   - **Top 5 protocols by TVL** — with 24h change
-   - **DEX volume** — total 24h volume, top 3 DEXes
-   - **Stablecoin market cap** — total and any notable shifts
-   - **Top yields** — 3 highest APY pools with >$10M TVL (skip scam-tier APYs)
+`/protocols` and `/v2/chains` already include `change_1d` / `change_7d` / `tvl` — use these directly, do not diff manually. `/overview/dexs` and `/overview/fees` return `total24h`, `total7d`, `change_1d`, `change_7d`, `change_1m`, `protocols[]`.
 
-4. Compare against yesterday's log if available — flag anything that changed significantly.
+If `var` is a chain, additionally fetch `/overview/dexs/{chain}` and `/overview/fees/{chain}` and filter pools by `chain == var`.
 
-5. Send via `./notify` (under 4000 chars):
-   ```
-   *DeFi Overview — ${today}*
+### 2. Compute the verdict (ONE line, leads the message)
 
-   *TVL:* $X.XXB (±X.X% 24h)
+Score three dimensions from the last 24h:
 
-   *Top Chains*
-   1. Ethereum: $XXB (+X.X%)
-   2. Solana: $XXB (+X.X%)
-   ...
+- `tvl_d = overall TVL change_1d` (sum across `/v2/chains`)
+- `vol_d = DEX volume change_1d` (from `/overview/dexs`)
+- `stable_d = stablecoin supply change_1d` (sum from `/stablecoins`)
 
-   *Biggest Movers*
-   ↑ Chain/Protocol: +XX% ($XB → $XB)
-   ↓ Chain/Protocol: -XX% ($XB → $XB)
+Verdict rules (pick the first that matches):
+- All three > +2% → **Risk-on** — capital flowing in across TVL, volume, and stables.
+- Two of three < −2% → **Risk-off** — capital unwinding.
+- `|tvl_d| < 1% AND |vol_d| < 5%` → **Sideways** — no conviction; grind day.
+- Otherwise → **Mixed** — describe the split in ≤12 words (e.g. "TVL drifting up on steady volume, stables flat").
 
-   *Top Protocols*
-   1. Lido: $XXB (+X.X%)
-   2. AAVE: $XXB (+X.X%)
-   ...
+### 3. Pick what goes in the message
 
-   *DEX Volume (24h):* $X.XB
-   Top: Uniswap $XB, Jupiter $XB, ...
+Each section caps at 3 items. **Drop any section whose best item fails its inclusion rule** — don't pad.
 
-   *Stables:* $XXXB total
+**Top chains** (3 items): rank by TVL; show `change_1d` only if `|change_1d| >= 1%`, otherwise suppress the delta.
 
-   *Top Yields (>$10M TVL)*
-   Pool — X.X% APY ($XM TVL)
-   ```
+**Movers — chains** (1 up, 1 down): filter `|change_1d| >= 5% AND tvl >= $500M`. Require a ≤15-word "why" grounded in what you observed (unlock, points program, bridge activity, depeg, exploit, launch). If you can't name a cause from the data or memory, write `"no obvious catalyst"` — do not invent one.
+
+**Movers — protocols** (1 up, 1 down): filter `|change_1d| >= 10% AND tvl >= $100M`. Same "why" rule.
+
+**Fundamentals — fees leaders** (top 3 by 24h fees from `/overview/fees`): include `change_1d` in fees vs 7d average. This replaces the old "top protocols by TVL" padding — fees > TVL for real demand.
+
+**Fundamentals — fees-beating-TVL** (up to 2): protocols where `fees change_7d > +20% AND TVL change_7d < +5%`. These are where real demand is outpacing emission-subsidized capital. Skip section if none.
+
+**DEX volume**: 24h total + top 3 DEXes with `change_1d`.
+
+**Stablecoins**: total supply + any single stablecoin with `|change_1d| >= 1%` (usually only notable shifts survive).
+
+**Yields** — split into two sub-sections, **each with a hard filter**:
+
+- **Real yield (sustainable)** — 3 pools max. Filter:
+  `apyBase > 0 AND apyReward_share < 0.5 AND outlier == false AND predictions.binnedConfidence >= 2 AND apyMean30d >= apy * 0.5 AND tvlUsd >= $10M`.
+  Rank by `apyBase` descending.
+- **Incentive yield (points / emissions)** — 2 pools max. Filter:
+  `apyReward > 0 AND outlier == false AND tvlUsd >= $25M`. Tag with the reward token symbol. Rank by `apy` descending.
+
+If zero pools survive either filter, omit that sub-section and note it in the footer (`real_yield=0` etc.) — this is itself a signal.
+
+### 4. Compare against yesterday's log
+
+Read `memory/logs/${yesterday}.md`. If a mover appears today whose direction flipped (e.g. chain was top gainer yesterday, now top loser), prepend `↔` and note the reversal in its "why" line. If a yield pool from yesterday's Real-yield list is missing today, check whether it failed a filter (outlier flipped, APY collapsed) — this is worth one line under Yields.
+
+### 5. Notify
+
+Send via `./notify` (single call, under 4000 chars, plain markdown). Template:
+
+```
+*DeFi — ${today}* — <Verdict>: <≤12-word regime read>
+
+*TVL:* $X.XXT (+X.X% 24h, +X.X% 7d)
+
+*Top chains*
+1. Ethereum — $XXXB (+X.X%)
+2. Solana — $XXB (+X.X%)
+3. Tron — $XXB
+
+*Movers*
+↑ Sui +12% ($1.8B → $2.0B) — <≤15-word why>
+↓ Base −7%  ($9.2B → $8.6B) — <≤15-word why>
+↑ Pendle +18% ($4.0B → $4.7B) — <≤15-word why>
+↓ Ethena −11% ($5.1B → $4.5B) — <≤15-word why>
+
+*Fees leaders (24h)*
+1. Tether — $XXM (+X% vs 7d avg)
+2. Circle — $XXM (flat)
+3. Uniswap — $XXM (−X%)
+
+*Fees beating TVL*
+• Hyperliquid — fees +42% / TVL +3% (7d) — demand outrunning deposits
+• <second if any>
+
+*DEX vol (24h):* $X.XB (+X%)  top: Uniswap $XB, PancakeSwap $XB, Jupiter $XB
+
+*Stables:* $XXXB (+0.X%)  — USDe +1.2% only notable single-issuer move
+
+*Real yield (sustainable, ≥$10M, filtered)*
+• stETH (Lido, ETH) — 3.2% apyBase ($21B TVL)
+• sUSDS (Sky, ETH) — 6.1% apyBase ($2.1B TVL)
+• GHO savings (Aave, ETH) — 7.0% apyBase ($400M TVL)
+
+*Incentive yield (points / emissions, ≥$25M)*
+• <pool> — 18% apy via $XYZ rewards ($80M TVL)
+• <pool> — 14% apy via $ABC rewards ($60M TVL)
+
+_sources: llama_tvl=ok  llama_dex=ok  llama_fees=ok  llama_stables=ok  llama_yields=ok  | var: ${var:-none}_
+```
+
+Edit rules before sending:
+- Any mover with `"no obvious catalyst"` stays — do not invent causes.
+- Drop any section whose filter produced no items, except write one line explaining (e.g. `_no real-yield pools cleared filter today — apyMean30d gates tightened_`).
+- If ≥2 sources are `fail`, prefix the title with `[DEGRADED]` and note which in the footer.
+- If all sources fail, send a single line `DEFI_OVERVIEW_ERROR: all DeFiLlama endpoints failed` and stop.
+
+### 6. Log
+
+Append to `memory/logs/${today}.md`:
+
+```
+### defi-overview
+- Var: ${var:-none}
+- Verdict: <Risk-on|Risk-off|Sideways|Mixed> — <regime read>
+- TVL: $X.XXT (+X.X% 24h)
+- Top mover up: <chain/protocol> +X%
+- Top mover down: <chain/protocol> −X%
+- Fees leader: <protocol> $XXM
+- Real-yield count: N   Incentive-yield count: N
+- Sources: tvl=ok dex=ok fees=ok stables=ok yields=ok
+```
 
 ## Sandbox note
 
-The sandbox may block outbound curl. Use **WebFetch** as a fallback for any URL fetch. For auth-required APIs, use the pre-fetch/post-process pattern (see CLAUDE.md).
+The sandbox may block outbound curl for `*.llama.fi`. For every endpoint, if curl fails or returns a non-JSON body, retry once with **WebFetch** against the same URL before marking the source `fail`. All DeFiLlama endpoints used here are public and unauthenticated — no pre-fetch/post-process needed.
 
-6. Log to memory/logs/${today}.md.
+## Constraints
+
+- Never invent a catalyst in the "why" line. `"no obvious catalyst"` is a valid answer.
+- Never show an APY without its filter verdict (real vs incentive). No unlabeled yields.
+- Drop empty sections rather than padding with low-conviction items.
+- Keep the notification under 4000 chars — trim lowest-signal sections first (in order: Stablecoins, DEX top-3, Top chains #3).


### PR DESCRIPTION
## Autoresearch result for `defi-overview`

**Winner: Variation B — Sharper output** (48 / 50 weighted)

Thesis: the original produces a table of numbers. Biggest lever for value isn't adding more sources — it's forcing a market *read*. This version leads with a single-line regime verdict, demands a ≤15-word "why it matters" per mover (with "no obvious catalyst" as an explicit valid answer, no fabrication), splits yields into sustainable (`apyBase`) vs incentive-driven (`apyReward`) with hard programmatic filters, and adds the fees/revenue fundamentals the original ignored entirely.

### Scoring

| Criterion | Weight | A — Better inputs | B — Sharper output | C — More robust | D — Rethink (fundamentals-first) |
|---|---|---|---|---|---|
| Clarity | 1.5× | 4 | **5** | 4 | 3 |
| Data quality | 1.5× | **5** | 4 | 3 | **5** |
| Output value | 2× | 4 | **5** | 3 | **5** |
| Robustness | 1.5× | 3 | 3 | **5** | 3 |
| Conventions | 1× | 5 | 5 | 5 | 4 |
| Improvement | 3× | 4 | **5** | 3 | 4 |
| **Total** | | 43 | **48** | 38 | 42.5 |

### Variation summaries

- **A — Better inputs (43):** adds `/overview/fees` endpoints, uses `change_1d` / `change_7d` fields directly, formalizes a programmatic scam-APY filter (`outlier=false AND binnedConfidence>=2 AND apyMean30d >= apy*0.5 AND tvlUsd>=10M`), properly wires `${var}` to chain-scoped / protocol-scoped endpoints.
- **B — Sharper output (48) — WINNER:** 1-line regime verdict at top (Risk-on / Risk-off / Sideways / Mixed from TVL Δ + DEX vol Δ + stables Δ); yields split into Real vs Incentive sub-sections with hard filters; Fundamentals section (fees leaders + fees-beating-TVL); ≤15-word "why it matters" per mover, no invented catalysts; drop empty sections rather than pad.
- **C — More robust (38):** per-endpoint WebFetch fallback, source-status footer, `DEFI_OVERVIEW_DEGRADED` / `DEFI_OVERVIEW_EMPTY` / `DEFI_OVERVIEW_ERROR` branches, cached prev-run data for day-over-day compare. Rejected as standalone — the skill isn't failing (cron-state shows 46/46 successes on autoresearch; defi-overview is disabled but has no recorded failures).
- **D — Rethink (42.5):** invert the frame — TVL is lagging, lead with fees-grew-but-TVL-didn't, stablecoin mint/redeem migration, only show pools where `apyBase > apyReward`. Clarity dropped because the structure is less conventional and loses useful TVL baseline context.

B was picked over D (48 vs 42.5) because B keeps the overview structure readers expect while upgrading what each section contains. B folds in **A's `/overview/fees` endpoint and programmatic yield filters** and **C's source-status footer + DEGRADED/ERROR branches** as cheap upside on top of the output-discipline thesis, capturing most of the runner-up value.

### Key changes in the winning SKILL.md

- 1-line regime verdict lead: `*DeFi — ${today}* — Risk-on: capital flowing across TVL, volume, stables.`
- Yields split: **Real yield** (sustainable, `apyBase` dominant, `apyMean30d >= apy*0.5`, non-outlier, `binnedConfidence >= 2`, `tvlUsd >= $10M`) vs **Incentive yield** (tagged with reward token).
- New **Fundamentals** section from `/overview/fees`: fees leaders + protocols where fees grew 7d but TVL didn't.
- Movers now require a ≤15-word "why it matters" and `"no obvious catalyst"` is an explicit valid answer.
- `${var}` wired to `/overview/dexs/{chain}`, `/overview/fees/{chain}`, `/summary/fees/{protocol}`, etc.
- Trim priority encoded (cut Stablecoins → DEX top-3 → Top chains #3 first) so the 4000-char cap is deterministic.

### Diff summary

`skills/defi-overview/SKILL.md`: +143 / −55. Frontmatter preserved (name, description, var, tags). New sections: Thesis, Focus mode, Verdict rules, Fundamentals, Real vs Incentive yield, Constraints. Sandbox note retained and strengthened (retry-once WebFetch fallback per endpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Ported from aaronjmars/aeon-tmp#58.
