### PR TITLE
improve(on-chain-monitor): autoresearch evolution

### DIFF
--- a/skills/on-chain-monitor/SKILL.md
+++ b/skills/on-chain-monitor/SKILL.md
@@ -4,74 +4,204 @@ description: Monitor blockchain addresses and contracts for notable activity
 var: ""
 tags: [crypto]
 ---
-> **${var}** — Address label or chain to check. If empty, checks all watched addresses.
+<!-- autoresearch: variation B — sharper output (decoded transfers + counterparty labels + ranked USD-denominated one-liners + TL;DR lede); folds in A's Alchemy+Etherscan-v2 input path and C's persistent state + source-status footer + dedup. -->
 
-If `${var}` is set, only monitor the address with that label or on that chain.
+> **${var}** — Watch label or chain to check. Empty = all watches.
 
+If `${var}` is set, only monitor the watch with that label or watches on that chain.
 
 ## Config
 
-This skill reads watched addresses from `memory/on-chain-watches.yml`. If the file doesn't exist yet, create it or skip this skill.
+Reads `memory/on-chain-watches.yml`. If the file is missing or `watches: []`, log `ON_CHAIN_NO_CONFIG` and exit cleanly (do **not** notify — empty config is not an error).
 
 ```yaml
 # memory/on-chain-watches.yml
 watches:
   - label: My Wallet
     address: "0x1234...abcd"
-    chain: ethereum
-    rpc_url: https://eth.llamarpc.com
-    type: wallet
-    threshold: 0.1  # ETH — alert on balance changes above this
-
+    chain: ethereum          # ethereum | base | arbitrum | optimism | polygon
+    type: wallet             # wallet | contract
+    threshold_usd: 1000      # alert on transfers ≥ this USD value (default 1000)
   - label: Uniswap Pool
     address: "0xabcd...5678"
     chain: ethereum
-    rpc_url: https://eth.llamarpc.com
     type: contract
+    event_topics:            # optional — only alert on these topic0 hashes
+      - "0xddf252ad..."      # ERC20 Transfer
 ```
 
----
+Optional `memory/known-addresses.yml` — counterparty label dictionary used to humanize alerts. Lowercase keys, free-text values:
+```yaml
+labels:
+  "0x28c6c06298d514db089934071355e5743bf21d60": "Binance 14"
+  "0xa9d1e08c7793af67e9d92fe308d5697fb81d3e43": "Coinbase 10"
+  "0xe592427a0aece92de3edee1f18e0157c05861564": "Uniswap V3 Router"
+  "0x0000000000000000000000000000000000000000": "Zero (mint/burn)"
+```
 
-Read memory/MEMORY.md and memory/on-chain-watches.yml for context.
-Read the last 2 days of memory/logs/ to avoid duplicate alerts.
+## State
 
-For each entry in on-chain-watches.yml:
-1. Query the RPC endpoint for recent activity:
-   ```bash
-   # Get latest block number
-   BLOCK=$(curl -s -X POST "${rpc_url}" \
-     -H "Content-Type: application/json" \
-     -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' | jq -r '.result')
+`memory/on-chain-state.json` — per-watch state, persisted atomically after each successful run:
 
-   # Get logs for watched address (last ~256 blocks)
-   FROM_BLOCK=$(printf "0x%x" $(( 16#${BLOCK#0x} - 256 )))
-   curl -s -X POST "${rpc_url}" \
-     -H "Content-Type: application/json" \
-     -d '{"jsonrpc":"2.0","method":"eth_getLogs","params":[{"fromBlock":"'"$FROM_BLOCK"'","toBlock":"latest","address":"'"$address"'"}],"id":1}'
-   ```
-2. For wallet watches, check recent transactions:
-   ```bash
-   curl -s -X POST "${rpc_url}" \
-     -H "Content-Type: application/json" \
-     -d '{"jsonrpc":"2.0","method":"eth_getBalance","params":["'"$address"'","latest"],"id":1}'
-   ```
-3. Compare balances/events against previously logged values in memory/logs/
+```json
+{
+  "My Wallet": {
+    "last_block": 19345678,
+    "last_run": "2026-04-20T12:00:00Z",
+    "alerted_tx": ["0xabc...", "0xdef..."],
+    "median_usd_30d": 8500
+  }
+}
+```
 
-Flag as notable:
-- Balance changes > threshold defined in on-chain-watches.yml
-- Any event emission from watched contracts
-- New token transfers to/from watched wallets
+- `last_block` — start block for the next run's fetch. Initialise to `current_block − 2400` (≈ 8h ETH) on first run.
+- `alerted_tx` — tx hashes alerted in last 7 days, capped at 200. Used for cross-run dedup.
+- `median_usd_30d` — rolling median USD size of transfers at this watch; powers the `WHALE-TRANSFER` tag.
 
-If anything notable is found:
-- Send a concise alert via `./notify`:
-  ```
-  *On-Chain Alert*
-  [chain] address: event description
-  ```
-- Log the finding with current values to memory/logs/${today}.md
+Write the file via `mv` from a tempfile so a mid-run failure cannot corrupt state.
 
-If nothing notable, log "ON_CHAIN_OK" and end.
+## Steps
+
+Read `memory/MEMORY.md`, `memory/on-chain-watches.yml`, `memory/on-chain-state.json`, and the last 2 days of `memory/logs/` (for visibility only — state lives in the JSON file).
+
+For each watch (filtered by `${var}`):
+
+### 1. Fetch raw activity from `last_block` → latest
+
+**Path A — Alchemy** (preferred, if `ALCHEMY_API_KEY` set).
+
+Wallets use `alchemy_getAssetTransfers` — one call returns categorized in/out history with `value`, `asset`, `category`, `hash`, `from`, `to`, `metadata.blockTimestamp`. Run it twice per watch (once with `toAddress`, once with `fromAddress`) and merge.
+
+```bash
+curl -m 10 -s -X POST "https://${network}.g.alchemy.com/v2/${ALCHEMY_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"alchemy_getAssetTransfers","params":[{
+    "fromBlock":"0x'${from_block_hex}'",
+    "toAddress":"'${address}'",
+    "category":["external","internal","erc20","erc721","erc1155"],
+    "withMetadata":true,"excludeZeroValue":true,"maxCount":"0x32"
+  }]}'
+```
+
+Contracts use `eth_getLogs` against the same Alchemy URL (Alchemy accepts up to ~10k block ranges).
+
+Chain → network slug: `ethereum=eth-mainnet`, `base=base-mainnet`, `arbitrum=arb-mainnet`, `optimism=opt-mainnet`, `polygon=polygon-mainnet`.
+
+**Path B — Etherscan v2 unified** (fallback, if Alchemy path fails or key unset).
+
+Single endpoint, all 50+ chains via `chainid`. Works keyless at lower rate limit.
+```bash
+# wallet
+curl -m 10 -s "https://api.etherscan.io/v2/api?chainid=${chainid}&module=account&action=tokentx&address=${address}&startblock=${from_block}&endblock=99999999&sort=desc${ETHERSCAN_API_KEY:+&apikey=$ETHERSCAN_API_KEY}"
+curl -m 10 -s "https://api.etherscan.io/v2/api?chainid=${chainid}&module=account&action=txlist&address=${address}&startblock=${from_block}&endblock=99999999&sort=desc${ETHERSCAN_API_KEY:+&apikey=$ETHERSCAN_API_KEY}"
+# contract
+curl -m 10 -s "https://api.etherscan.io/v2/api?chainid=${chainid}&module=logs&action=getLogs&address=${address}&fromBlock=${from_block}&toBlock=latest${ETHERSCAN_API_KEY:+&apikey=$ETHERSCAN_API_KEY}"
+```
+
+Chain → chainid: `ethereum=1`, `base=8453`, `arbitrum=42161`, `optimism=10`, `polygon=137`.
+
+**Sandbox fallback.** Both Alchemy and Etherscan accept their key in the URL, so if `curl` fails (env-var expansion, blocked outbound), retry the exact same URL via **WebFetch**. For POSTs, WebFetch accepts the JSON body.
+
+If every path for a watch fails, mark the watch `fail` in the source footer and continue to the next — never abort the whole run.
+
+### 2. Decode every transfer
+
+Required fields per event (normalised across Alchemy / Etherscan payloads):
+
+| Field | Source |
+|-------|--------|
+| `tx_hash` | `hash` / `txHash` |
+| `block_number`, `timestamp` | `blockNum` / `metadata.blockTimestamp` |
+| `category` | `external_eth` \| `erc20` \| `erc721` \| `erc1155` \| `internal` \| `log` |
+| `direction` | `in` if `to == watch`, else `out` |
+| `token.symbol`, `token.decimals` | Alchemy returns inline; for Etherscan, use `tokenSymbol`/`tokenDecimal` fields |
+| `value_token` | human amount, e.g. `1,234,567.89 USDC` |
+| `value_usd` | `value_token × price_usd` (see step 3) |
+| `counterparty` | the non-watch address on the transfer |
+| `counterparty_label` | lookup in `known-addresses.yml`, else `null` |
+
+### 3. USD-enrich in one bulk call
+
+Collect distinct `(chain, token_contract)` pairs from decoded transfers. Bulk price via CoinGecko:
+
+```bash
+curl -m 10 -s "https://api.coingecko.com/api/v3/simple/token_price/${chain}?contract_addresses=${joined}&vs_currencies=usd${COINGECKO_API_KEY:+&x_cg_demo_api_key=$COINGECKO_API_KEY}"
+```
+
+Native ETH/MATIC/etc. use `simple/price?ids=ethereum,matic-network,...`. If CoinGecko is unreachable or returns no price for a token, set `value_usd = null` and tag the event `UNPRICED` — keep it in the log, drop it from the notification (can't meaningfully threshold without USD).
+
+### 4. Filter
+
+Drop an event if any of:
+- `value_usd < threshold_usd` (watch config, default $1000)
+- `value_usd < $0.10` (hard dust floor — prevents airdrop / phishing spam)
+- `tx_hash` already present in this watch's `alerted_tx` (cross-run dedup)
+- `category == "log"` and watch has `event_topics:` and the topic0 is not in the list
+
+### 5. Categorize surviving events
+
+Tag each event with one short label so the alert says *what kind of move it was*:
+
+| Tag | Condition |
+|-----|-----------|
+| `CEX-IN` / `CEX-OUT` | counterparty label contains an exchange name (`Binance`, `Coinbase`, `Kraken`, `OKX`, `Bybit`, `Bitfinex`) |
+| `DEX-SWAP` | counterparty label contains a router (`Uniswap`, `1inch`, `Curve`, `Sushi`, `Aerodrome`, `CoWSwap`) |
+| `BRIDGE` | counterparty label contains a bridge (`Across`, `Stargate`, `Hop`, `Synapse`, `Wormhole`, `Celer`) |
+| `MINT` / `BURN` | counterparty is `0x000…000` or the token contract itself |
+| `WHALE-TRANSFER` | `value_usd > 10 × median_usd_30d` for this watch |
+| `UNKNOWN-IN` / `UNKNOWN-OUT` | fallback — based on direction |
+
+A single event can only carry one tag; pick by priority CEX > DEX > BRIDGE > MINT/BURN > WHALE > UNKNOWN.
+
+### 6. Format the alert
+
+One notification per run. Sort all surviving events globally by `value_usd` desc; group the output by watch label (watches with zero surviving events are omitted entirely). Lead with a one-sentence TL;DR naming the single biggest move.
+
+```
+*On-Chain Alert — ${today}*
+TL;DR: My Wallet sent $1.2M USDC to Binance 14 (biggest move on any watch in 30d).
+
+*My Wallet* (ethereum)
+• CEX-OUT $1.2M USDC → Binance 14 — [tx](https://etherscan.io/tx/0x...)
+• DEX-SWAP $42k WETH → USDC via Uniswap V3 Router — [tx](https://etherscan.io/tx/0x...)
+
+*Uniswap Pool* (ethereum)
+• WHALE-TRANSFER $850k WETH out → 0x9f...a1 — [tx](https://etherscan.io/tx/0x...)
+
+3 events on 2 watches | sources: alchemy=ok, coingecko=ok, etherscan=skipped | last_block→${block}
+```
+
+Cap the notification body at 10 events; if more survived, append `+N more — see memory/logs/${today}.md`. The `./notify` call should use the explorer URL for each chain (`etherscan.io`, `basescan.org`, `arbiscan.io`, `optimistic.etherscan.io`, `polygonscan.com`).
+
+### 7. Persist state and log
+
+For each watch whose fetch **succeeded** (success ≠ "events found"):
+- `last_block ← current_block`
+- `last_run ← now` (ISO 8601 UTC)
+- `alerted_tx ← (new_tx_hashes + alerted_tx)[:200]`, purging entries > 7d old
+- `median_usd_30d ← median of all value_usd from this watch's transfers in last 30d` (read from recent logs; skip recomputation if < 5 samples)
+
+Write `memory/on-chain-state.json` atomically (tempfile + `mv`).
+
+Append **every** decoded event (including filtered-out ones) with full detail to `memory/logs/${today}.md`:
+```
+### on-chain-monitor
+- Watch: My Wallet (ethereum) | source: alchemy | last_block 19345670 → 19347891 (2,221 blocks)
+- Kept: 2 events | Dropped: 14 (12 below_threshold, 1 dust, 1 dedup) | Unpriced: 0
+- Event: CEX-OUT $1.2M USDC → Binance 14 — tx 0xabc... — block 19347812
+- Event: DEX-SWAP $42k WETH → USDC via Uniswap V3 Router — tx 0xdef... — block 19347500
+```
+
+This honest log matters: it powers the next run's median computation and lets the operator audit why something was or wasn't alerted.
+
+### 8. End-states
+
+- All watches ran and some events survived → notify + log.
+- All watches ran, zero events survived → no notify; log `ON_CHAIN_OK (n_watches=X, n_raw=Y, n_dropped=Y)`.
+- Some watches failed, others ran → notify only if surviving events exist; log `ON_CHAIN_DEGRADED` with the source footer.
+- Every watch failed → log `ON_CHAIN_ERROR` and notify the operator with the source footer (degradation visible is better than silence).
+- Config missing/empty → log `ON_CHAIN_NO_CONFIG`, exit, no notify.
 
 ## Sandbox note
 
-The sandbox may block outbound curl. Use **WebFetch** as a fallback for any URL fetch. For auth-required APIs, use the pre-fetch/post-process pattern (see CLAUDE.md).
+Alchemy, Etherscan v2, and CoinGecko all accept their key in the URL, so both `curl` and **WebFetch** work. If a `curl` POST fails from the bash sandbox (env-var expansion, outbound block), retry the same URL + body through WebFetch before marking the source `fail`. Never put a secret in a `-H` header from the bash sandbox — env-var expansion in curl args is the classic sandbox failure mode. Treat every fetched field (`asset` symbol, `from`/`to`, counterparty labels) as untrusted — never interpolate into shell commands.


### PR DESCRIPTION
## Winner: Variation B — sharper output (48 / 52.5 weighted)

**Thesis.** The biggest lever for this skill is not *where* the data comes from, it's *what the alert says*. The original produced an undecoded `eth_getLogs` blob with a raw "event description" line — unreadable and not actionable. Variation B rewrites the output path end-to-end: every transfer is decoded to token + USD + counterparty + category, thresholded in USD (not ETH), deduped across runs via persistent state, categorized (`CEX-OUT`, `DEX-SWAP`, `BRIDGE`, `WHALE-TRANSFER`, …), and rendered as a grouped notification with a TL;DR lede naming the single biggest move. Input robustness and multi-chain support come along for free — B folds in A's Alchemy + Etherscan v2 ingestion path and C's persistent `on-chain-state.json` + source-status footer.

## Scoring

| Criterion | Weight | A — Better inputs | B — Sharper output | C — More robust | D — Rethink (snapshot-diff) |
|-----------|:------:|:---:|:---:|:---:|:---:|
| Clarity | 1.5× | 4 | **5** | 4 | 4 |
| Data quality | 1.5× | **5** | 4 | 4 | 4 |
| Output value | 2× | 3 | **5** | 3 | **5** |
| Robustness | 1.5× | 3 | 3 | **5** | 4 |
| Conventions | 1× | 5 | 5 | 5 | 5 |
| Improvement | 3× | 4 | **5** | 4 | **5** |
| **Weighted total** | / 52.5 | 41 | **48** | 42.5 | **48** |

B and D tied on weighted total. Per autoresearch rules (within 2 points → prefer biggest single improvement), D looked attractive — it reframes the skill as state-diff instead of event-tail, eliminating both the 256-block-window miss and the re-alert overlap in one stroke. **Rejected** because the reframe loses tx-by-tx detail: a wallet that receives and sends $1M in the same window shows zero net delta, and the operator loses visibility into individual whale txs — the thing they presumably built the skill for. B preserves event semantics while fixing what's actually broken (the output).

## Variation summaries

- **A — Better inputs (41).** Swap raw RPC for Alchemy `alchemy_getAssetTransfers` + Etherscan v2 unified endpoint; add multi-chain network slug table; CoinGecko USD enrichment. Strong on data quality, but output format unchanged so operator still stares at a JSON-like blob.
- **B — Sharper output (48, winner).** Decode → USD-enrich → threshold → dedup → categorize → rank → TL;DR-led grouped notification with explorer links and source-status footer. Folds in A's Alchemy+Etherscan ingestion and C's persistent state + dedup + atomic writes.
- **C — More robust (42.5).** Per-chain ordered RPC fallback table (Alchemy → Ankr → LlamaRPC), 5s timeouts, atomic state writes, `ON_CHAIN_NO_CONFIG`/`DEGRADED`/`ERROR` end-states, sub-cent dust filter. Good bones but doesn't fix the output.
- **D — Rethink (48).** Reframe skill as snapshot-and-diff: Bankr portfolio for wallets, DexScreener for pools, Defillama for protocols; alert on deltas breaching USD/% thresholds. Elegant but loses tx-level detail.

## Diff summary

`skills/on-chain-monitor/SKILL.md`: full rewrite of the steps block.

- **Config**: added `threshold_usd` (replaces ETH-denominated threshold), `memory/known-addresses.yml` for counterparty labels, explicit `ON_CHAIN_NO_CONFIG` no-op on missing/empty config.
- **State**: new `memory/on-chain-state.json` with per-watch `last_block`, `last_run`, 7-day `alerted_tx` dedup, and `median_usd_30d` (powers the `WHALE-TRANSFER` tag). Atomic writes via tempfile + `mv`.
- **Input**: Alchemy `alchemy_getAssetTransfers` primary (categories: external, internal, erc20, erc721, erc1155), Etherscan v2 unified (`chainid` param, 50+ chains via one URL) as fallback, both keys-in-URL so WebFetch is a clean sandbox fallback. Keyless paths work at lower rate limits.
- **Decode**: every event normalised to `{tx_hash, category, direction, token, value_token, value_usd, counterparty, counterparty_label}`. USD-enrich via a single bulk CoinGecko call.
- **Filter**: `< threshold_usd`, `< $0.10` hard dust floor, `tx_hash` already-alerted, and optional `event_topics` allowlist.
- **Categorize**: `CEX-IN/OUT`, `DEX-SWAP`, `BRIDGE`, `MINT/BURN`, `WHALE-TRANSFER` (10× rolling median), `UNKNOWN-IN/OUT` fallback, priority-ordered.
- **Output**: grouped by watch label, sorted by USD desc, TL;DR sentence naming the biggest move, per-event one-liner `[tag] $amount token → counterparty — [tx](explorer_url)`, cap at 10 events with `+N more` overflow to log. Source-status footer (`alchemy=ok, coingecko=ok, etherscan=skipped`) distinguishes silence from failure.
- **End-states**: explicit `ON_CHAIN_OK` / `ON_CHAIN_DEGRADED` / `ON_CHAIN_ERROR` / `ON_CHAIN_NO_CONFIG`.
- **Sandbox**: explicit WebFetch retry path; bans secrets in `-H` headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Ported from aaronjmars/aeon-tmp#60.
