### PR TITLE
improve(push-recap): autoresearch evolution

### DIFF
--- a/skills/push-recap/SKILL.md
+++ b/skills/push-recap/SKILL.md
@@ -1,127 +1,233 @@
 ---
 name: push-recap
-description: Daily deep-dive recap of all pushes — reads diffs, explains what changed and why
+description: Daily deep-dive recap of all pushes — reads diffs, ranks impact, separates user-visible shipments from internal work, delivers a verdict
 var: ""
 tags: [dev]
 ---
+<!-- autoresearch: variation B — sharper output via verdict line, user-visible/internal split, impact ranking, significance-gated notification -->
+
 > **${var}** — Repo (owner/repo) to recap. If empty, recaps all watched repos.
 
 If `${var}` is set, only recap that repo (owner/repo format).
 
 ## Config
 
-This skill reads repos from `memory/watched-repos.md`. If the file doesn't exist yet, create it or skip this skill.
+Reads repos from `memory/watched-repos.md`. If the file doesn't exist, bootstrap it with the repo from `git remote get-url origin` (one line: `owner/repo`) and continue. If bootstrap fails, notify `push-recap: no watched repos configured` and stop.
 
----
+Read `memory/MEMORY.md` and the last 2 days of `memory/logs/` for context.
 
-Read memory/MEMORY.md and the last 2 days of memory/logs/ for context.
-Read memory/watched-repos.md for the list of repos to scan.
+## The thesis
+
+A flat chronological list of commits hides the answer readers actually want: **what shipped to users today, what's internal churn, and what's stuck**. This skill ranks commits by impact, separates user-visible work from maintenance, and leads with a one-line verdict. Noisy days get suppressed instead of flooding the channel.
 
 ## Steps
 
-1. **Fetch push events** for each watched repo from the last 24 hours:
-   ```bash
-   gh api repos/owner/repo/events --jq '[.[] | select(.type == "PushEvent") | {actor: .actor.login, created_at: .created_at, ref: .payload.ref, commits: [.payload.commits[] | {sha: .sha[0:7], message: .message, author: .author.name}]}]' --paginate
-   ```
+### 1. Gate on signal
 
-2. **Fetch commits** directly as a supplement (catches force-pushes, rebases, etc.):
-   ```bash
-   gh api repos/owner/repo/commits -X GET -f since="$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-24H +%Y-%m-%dT%H:%M:%SZ)" --jq '.[] | {sha: .sha[0:7], full_sha: .sha, message: .commit.message, author: .commit.author.name, date: .commit.author.date}' --paginate
-   ```
+Fetch push events + commits for each watched repo from the last 24h:
 
-3. **If no commits found** across all watched repos: log "PUSH_RECAP_QUIET" to `memory/logs/${today}.md` and **stop here — do NOT send any notification**.
+```bash
+SINCE="$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-24H +%Y-%m-%dT%H:%M:%SZ)"
 
-4. **Deduplicate** commits by SHA across both sources.
+gh api repos/OWNER/REPO/events --jq '[.[] | select(.type == "PushEvent") | {actor: .actor.login, created_at: .created_at, ref: .payload.ref, commits: [.payload.commits[] | {sha: .sha[0:7], message: .message, author: .author.name}]}]' --paginate
 
-5. **Read the actual diffs** for each commit to understand what changed:
-   ```bash
-   gh api repos/owner/repo/commits/FULL_SHA --jq '{files: [.files[] | {filename: .filename, status: .status, additions: .additions, deletions: .deletions, patch: .patch}]}'
-   ```
-   Read ALL commits in detail. If there are more than 15, read the 15 most significant (by lines changed) and summarize the rest.
+gh api repos/OWNER/REPO/commits -X GET -f since="$SINCE" --jq '.[] | {sha: .sha[0:7], full_sha: .sha, message: .commit.message, author: .commit.author.name, date: .commit.author.date}' --paginate
+```
 
-6. **Analyze and explain** each commit thoroughly:
-   - Read the actual patch content — don't just repeat the commit message
-   - What files were changed and what the diff actually shows
-   - What feature, fix, or improvement this represents in plain language
-   - How it fits into the broader project direction
-   - Any notable patterns (new dependencies, architecture changes, refactors, new APIs)
-   - If a commit touches multiple areas, break it down by area
+Also pull **merged PRs** in the same window (they anchor themes better than raw commits):
 
-7. **Group commits by theme** — don't just list them chronologically. Cluster related commits together under descriptive headings (e.g. "New token tracking system", "Dashboard UX overhaul", "CI/CD improvements").
+```bash
+gh pr list --repo OWNER/REPO --state merged --search "merged:>=$SINCE" --json number,title,author,mergedAt,mergeCommit,additions,deletions,files,body,labels --limit 50
+```
 
-8. **Write a deep recap** to `articles/push-recap-${today}.md`:
-   ```markdown
-   # Push Recap — ${today}
+**Bot filter.** Drop commits whose author matches `dependabot[bot]`, `renovate[bot]`, `github-actions[bot]`, `*-bot`, or whose message starts with `chore(deps):` **unless** they touch files outside `package*.json`/`*.lock`/`.github/`. Note the dropped count — you'll surface it in the footer.
 
-   ## Overview
-   [2-3 sentence summary: X commits by Y authors. What was the main thrust of today's work? What moved forward?]
+**Significance gate.** After bot-filtering, if the remaining set is all empty across every watched repo: log `PUSH_RECAP_QUIET` to `memory/logs/${today}.md` and **stop — send no notification, write no article**.
 
-   **Stats:** X files changed, +Y/-Z lines across N commits
+If any fetch errors (non-empty `stderr`, rate-limit hit, 5xx), record the repo under `errors[]` and continue with partial data. If **every** fetch fails, log `PUSH_RECAP_ERROR` with the per-repo reasons and notify `push-recap: all sources failed — [reasons]` then stop.
 
-   ---
+### 2. Classify every commit (user-visible vs internal)
 
-   ## owner/repo
+For each commit, read the diff:
 
-   ### [Theme 1: e.g. "New Feature: Token Price Tracking"]
-   **Summary:** [2-3 sentences explaining what this group of changes accomplishes]
+```bash
+gh api repos/OWNER/REPO/commits/FULL_SHA --jq '{files: [.files[] | {filename, status, additions, deletions, patch}]}'
+```
 
-   **Commits:**
-   - `abc1234` — [commit message]
-     - Changed `src/token.ts`: Added new `fetchPrice()` function that calls GeckoTerminal API, parses OHLCV response, and caches results (+85 lines)
-     - Changed `src/config.ts`: Added `tokenContract` and `chain` fields to the config schema (+12 lines)
-     - New file `src/types/token.ts`: Type definitions for price data, pool info, and trade history (+45 lines)
+If `patch` is `null` for any file (diff too large), note it and fall back to `{filename, status, additions, deletions}` only.
 
-   - `def5678` — [commit message]
-     - Changed `src/notify.ts`: Extended notification template to include price formatting with delta arrows (+23, -4 lines)
+Classify by file paths touched. A commit is **user-visible** if it touches any of:
+- Product source paths (`src/`, `app/`, `lib/`, `pkg/`, `cmd/`, `components/`, `pages/`, `api/`, `routes/`, `handlers/`, `public/`)
+- New public surface: new file with `export`, new HTTP route, new CLI flag, new config key, new migration, new schema field
+- UI strings, copy, templates, public docs
+- Release/version files (`package.json` version bump, `CHANGELOG.md`, `VERSION`)
 
-   **Impact:** [What does this enable? What's the user-facing or developer-facing outcome?]
+A commit is **internal** if it *only* touches: `tests/`, `__tests__/`, `*.test.*`, `.github/`, `ci/`, `scripts/`, `docs/internal/`, `.vscode/`, lockfiles, dotfiles, or is a pure dependency bump.
 
-   ### [Theme 2: e.g. "Bug Fixes & Hardening"]
-   **Summary:** [...]
+A commit is **infra** if it *only* touches CI/CD, Docker, Terraform, workflow files. Infra is a third bucket — not user-visible, not internal engineering churn, but worth calling out separately.
 
-   **Commits:**
-   - `ghi9012` — [commit message]
-     - Changed `src/worker.ts`: Fixed race condition in concurrent skill execution — added mutex lock around memory file writes (+18, -3 lines)
-     - The bug was causing corrupted log entries when two skills ran in the same cron window
+### 3. Rank impact
 
-   **Impact:** [...]
+Compute an impact score per commit:
 
-   ### [Theme 3 if applicable]
-   ...
+```
+impact = (additions + deletions) × user_visible_multiplier × breadth_multiplier
+  user_visible_multiplier = 2.0 if user-visible, 1.2 if infra, 1.0 if internal
+  breadth_multiplier = 1 + 0.2 × min(files_touched, 5)
+```
 
-   ---
+Read diffs in full for the **top 10 by impact** plus every commit linked to a merged PR. For the rest, skim filename + stats only.
 
-   ## Developer Notes
-   - **New dependencies:** [any added packages, with versions]
-   - **Breaking changes:** [any API or config changes that affect other parts]
-   - **Architecture shifts:** [any structural changes worth noting]
-   - **Tech debt:** [any TODOs introduced or shortcuts taken]
+### 4. Write the verdict
 
-   ## What's Next
-   - [Based on today's commits, what's the likely next step?]
-   - [Any open threads or incomplete work visible in the diffs?]
-   - [Branches created but not merged?]
-   ```
+After ranking, produce a **one-line verdict** that describes today in ≤12 words. Pick exactly one shape:
+- `SHIPPING — <user-visible thing that went out>`
+- `BUILDING — <feature in progress, not yet user-visible>`
+- `HARDENING — <bugs/robustness work dominates>`
+- `REFACTORING — <internal restructuring dominates>`
+- `MAINTAINING — <deps, CI, chore dominate>`
+- `MIXED — <two-thread summary>`
 
-9. **Log** to `memory/logs/${today}.md` (repos covered, commit count, article path). **Do this before sending the notification.**
+The verdict must be specific (name the thing, not "various improvements").
 
-10. **Send a detailed notification** via `./notify`:
-   ```
-   *Push Recap — ${today}*
-   [repo] — X commits by Y authors
+### 5. Group by theme, then by audience
 
-   [Theme 1]: [2-sentence explanation of what changed and why it matters]
+Cluster commits into 2-4 themes. **Within each theme**, split into subsections:
+- **Shipped to users** — user-visible commits. Lead with these.
+- **Under the hood** — internal refactors/tests that support the user-visible work.
+- **Infra** — CI/CD/deploy changes tied to the theme.
 
-   [Theme 2]: [2-sentence explanation]
+If a theme has no user-visible commits, label it `Internal: <theme>` and push it below user-visible themes in the article.
 
-   [Theme 3 if applicable]: [2-sentence explanation]
+### 6. Write the deep recap
 
-   Key changes:
-   - [most impactful file/feature change with specific detail]
-   - [second most impactful]
-   - [third most impactful]
+Write to `articles/push-recap-${today}.md`:
 
-   Stats: X files changed, +Y/-Z lines
-   Full recap: [link to articles/push-recap-${today}.md in THIS repo — get the repo name from `git remote get-url origin`, not the watched repo]
-   ```
-   The notification should give someone a full picture without needing to click through. Include actual substance — what was built, what was fixed, what it means — not just commit message summaries.
+```markdown
+# Push Recap — ${today}
+
+## Verdict
+> <one-line verdict>
+
+**Shape:** X user-visible commits · Y internal · Z infra · N bot-filtered
+**Volume:** X files changed, +Y/-Z lines across N commits by M authors
+**Merged PRs:** <count> (<#num> <title>; <#num> <title>...)
+
+---
+
+## Top impact today
+1. `abc1234` — <commit message>. <one sentence: what the diff actually shows and who notices>. (<files> files, +X/-Y)
+2. `def5678` — <commit message>. <one sentence>. (<files> files, +X/-Y)
+3. `ghi9012` — <commit message>. <one sentence>. (<files> files, +X/-Y)
+
+---
+
+## owner/repo
+
+### [Theme 1 — descriptive name]
+
+**What this is:** <2 sentences stating the user-facing or developer-facing outcome — not the commit messages repeated>.
+
+**Shipped to users**
+- `abc1234` — <message>
+  - `path/to/file.ts`: <what the patch actually introduces in plain language> (+85/−4)
+  - `new/file.ts`: <what this new file contains> (+45/−0)
+- `def5678` — <message>
+  - `path/to/other.ts`: <specific change> (+23/−4)
+
+**Under the hood** *(only if present)*
+- `ghi9012` — <message>: <one-liner>
+
+### [Theme 2 — descriptive name]
+...
+
+### Internal: [Theme 3] *(only if any purely-internal theme exists)*
+...
+
+---
+
+## Developer notes
+- **New dependencies:** <list with versions, or "none">
+- **Breaking changes:** <API/config/schema changes that ripple, or "none">
+- **New public surface:** <new routes, CLI flags, config keys, exported functions — the things that show up in docs>
+- **Tech debt added:** <new TODOs/FIXMEs introduced in the diff, or "none">
+
+## Open threads
+- <branches pushed but not merged, with PR link if any>
+- <incomplete work visible in diffs — stubbed functions, commented-out blocks, TODO comments added>
+
+## Sources
+<per-repo status line — see step 8>
+```
+
+Keep it substantive. If there are fewer than 3 user-visible commits, drop the `Top impact today` header and merge those commits into the theme section — don't pad.
+
+### 7. Log before notifying
+
+Append to `memory/logs/${today}.md`:
+
+```
+### push-recap
+- Repos: <list>
+- Commits: <total> (user-visible: X, internal: Y, infra: Z, bot-filtered: B)
+- Merged PRs: <count>
+- Verdict: <the one-line verdict>
+- Article: articles/push-recap-${today}.md
+- Sources: <per-repo ok/error/empty>
+```
+
+### 8. Notify with significance gating
+
+**Skip the notification entirely** if all of the following are true (log `PUSH_RECAP_LOW_SIGNAL` and stop):
+- Zero user-visible commits
+- ≤3 internal commits
+- Zero merged PRs
+
+Otherwise send via `./notify`:
+
+```
+*Push Recap — ${today}*
+<repo> — <verdict>
+
+Shipped to users:
+• <top user-visible commit, specific sentence>
+• <second>
+• <third — omit if fewer than 3 user-visible>
+
+Under the hood:
+• <top internal change worth mentioning, or omit this block if noise>
+
+Shape: X user-visible · Y internal · Z infra · N bot-filtered · P merged PRs
+Volume: X files, +Y/-Z lines
+
+Full recap: https://github.com/$(git remote get-url origin | sed -E 's|.*github.com[:/]([^/]+/[^/.]+).*|\1|')/blob/main/articles/push-recap-${today}.md
+```
+
+The notification must let a reader know what shipped without clicking through. Names and numbers, not "various improvements." Each bullet must cite at least one: specific file, specific feature, specific user impact.
+
+## Source-status footer (required in article)
+
+End every article with:
+
+```
+## Sources
+- OWNER/REPO: <ok | rate-limited | partial (<reason>) | empty | error (<reason>)>
+- gh api events: <ok | fail>
+- gh api commits: <ok | fail>
+- gh pr list: <ok | fail>
+- bot-filtered: <count>
+- diff-truncated: <count>
+```
+
+This distinguishes `PUSH_RECAP_QUIET` (real empty) from `PUSH_RECAP_ERROR` (all fetches failed) from `PUSH_RECAP_PARTIAL` (some repos fetched, some didn't) in future-you's debugging.
+
+## Sandbox note
+
+`gh api` and `gh pr list` handle auth internally and work in the sandbox. If a call returns a rate-limit error (403 with `X-RateLimit-Remaining: 0`), record it in the source-status footer and continue with what you have. For large diffs where the `patch` field is `null`, fall back to filename + additions/deletions stats. Never use raw `curl` against the GitHub API — always `gh api`.
+
+## Constraints
+
+- Do not repeat the commit message verbatim as "what changed" — read the patch and state what the code now does.
+- Do not invent user impact. If the diff only shows internals, say "internal: <what>", not "improves user experience by <speculation>".
+- Do not pad the notification with boilerplate when the day was quiet — the gate exists so the channel stays high-signal.
+- Do not skip the source-status footer even on successful runs.


### PR DESCRIPTION
## Autoresearch — push-recap

### Winning variation: B — Sharper output
**Thesis:** A flat chronological list of commits hides the answer readers actually want — *what shipped to users, what's internal churn, what's stuck*. The original groups commits by theme but weighs every commit equally, has no verdict line, no user-visible vs internal split, and sends a notification every day regardless of signal. Biggest lever is making the output decision-ready with ranked impact + audience split + significance gating.

### Scoring (weighted, /52.5)

| Criterion | Weight | A | B | C | D |
|---|---|---|---|---|---|
| Clarity | 1.5× | 4 | 5 | 4 | 3 |
| Data quality | 1.5× | 5 | 4.5 | 4 | 3.5 |
| Output value | 2× | 4 | 5 | 3.5 | 4 |
| Robustness | 1.5× | 3.5 | 4 | 5 | 3 |
| Conventions | 1× | 4.5 | 4.5 | 4.5 | 4 |
| Improvement | 3× | 3.5 | 4.5 | 3 | 4 |
| **Total** | | **41.75** | **48.25** | **40** | **38.25** |

### Variations considered

**A — Better inputs (41.75):** Add merged-PR window query as theme anchors, closed-issue linkage, release/tag awareness, bot author filter (`dependabot[bot]`, `renovate[bot]`, `*-bot`, `chore(deps):` that only touch lockfiles), PR review comments as "why" signal. Best data but doesn't fix the output-structure weakness.

**B — Sharper output (48.25) ← WINNER:** One-line verdict (`SHIPPING|BUILDING|HARDENING|REFACTORING|MAINTAINING|MIXED — <specific thing>`), classify every commit as user-visible / internal / infra from touched paths, impact score `(additions+deletions) × audience_multiplier × breadth_multiplier`, lead article with "Top impact today" top-3, split every theme into *Shipped to users* / *Under the hood* / *Infra*, **significance gate** that skips the notification when zero user-visible + ≤3 internal + zero merged PRs (logs `PUSH_RECAP_LOW_SIGNAL`).

**C — More robust (40):** Bootstrap `memory/watched-repos.md` from `git remote get-url origin` if missing, per-repo status table, rate-limit pre-check via `gh api rate_limit`, diff-truncation fallback (null `patch` → stats-only), persistent SHA dedup state, `PUSH_RECAP_QUIET` vs `PUSH_RECAP_ERROR` vs `PUSH_RECAP_PARTIAL` distinction. Solid but lower ceiling than B.

**D — Rethink: shipment-first (38.25):** Pivot from commit-level to *shipment detection* — infer user-facing artifacts (new files, new public exports, new routes/CLI flags/config keys, schema changes) and group commits by the shipment they build. Right instinct but loses the "internal" commits entirely, which matter for context; B folds the shipment signal in via the classification rules.

### What landed in the winner
- **B's core:** verdict line, three-way audience split (user-visible / internal / infra) with explicit path rules, impact scoring with breadth multiplier, top-impact section, significance-gated notification
- **Folded from A:** `gh pr list --state merged --search "merged:>=$SINCE"` as theme anchors, bot-author filter list + `chore(deps):` lockfile-only filter
- **Folded from C:** bootstrap `memory/watched-repos.md` on missing, per-repo status footer, `PUSH_RECAP_QUIET` / `PUSH_RECAP_ERROR` / `PUSH_RECAP_PARTIAL` / `PUSH_RECAP_LOW_SIGNAL` log codes, diff-truncation fallback when `patch` is null
- **Folded from D:** shipment-signal rules ("new public surface: new export, new HTTP route, new CLI flag, new config key, new migration") feed directly into the user-visible classifier

### Diff summary
`skills/push-recap/SKILL.md`: +188 / −82. Replaces single "group by theme" output with verdict → top-impact → audience-split themes → developer notes → open threads → source-status. Adds bot filter, significance gate, merged-PR query, bootstrap logic, truncation fallback, and explicit constraints against paraphrasing commit messages / inventing user impact / padding notifications on quiet days.

### Constraints preserved
- Frontmatter (`name`, `description`, `var`, `tags`) unchanged in shape
- No new secrets / env vars
- Core purpose preserved (daily deep-dive recap via `gh api` + diff reading)
- Still logs to `memory/logs/${today}.md`, still notifies via `./notify`
- Still writes to `articles/push-recap-${today}.md`

---
Ported from aaronjmars/aeon-tmp#61.
