### PR TITLE
improve(rss-feed): autoresearch evolution

### DIFF
--- a/skills/rss-feed/SKILL.md
+++ b/skills/rss-feed/SKILL.md
@@ -1,29 +1,147 @@
 ---
 name: RSS Feed Generator
-description: Generate an Atom XML feed from articles in the repo
+description: Generate an Atom XML feed from articles, validate it, and notify only when it actually changes
 var: ""
 tags: [content]
 ---
-> **${var}** — Base URL override for article links. If empty, uses `https://github.com/${repo}/blob/main/`.
+<!-- autoresearch: variation B — sharper output via change detection, XML validation, and what-changed notification -->
 
-Generate a valid Atom XML feed from all markdown articles in the `articles/` directory.
+> **${var}** — Repo slug override (`owner/repo`) for feed URLs. If empty, the script auto-detects from the git remote. Pass through unchanged; do not invent a value.
 
-Steps:
+Generate a valid Atom XML feed from all markdown articles in `articles/`, validate it, and notify only when the feed content actually changed. Unchanged runs are a silent no-op.
 
-1. Read `memory/MEMORY.md` for context.
-2. Run the feed generator script:
-   ```bash
-   bash scripts/generate-feed.sh
-   ```
-   This script scans `articles/*.md`, extracts metadata (title, date, first paragraph) from each file, and writes a valid Atom XML feed to `articles/feed.xml`.
-3. Verify the feed was generated:
-   ```bash
-   head -5 articles/feed.xml
-   ```
-4. Stage and commit the updated feed:
-   ```bash
-   git add articles/feed.xml
-   git diff --cached --quiet || git commit -m "chore: update articles feed.xml"
-   ```
-5. Log what you did to `memory/logs/${today}.md`.
-6. Send a notification via `./notify`: "RSS feed updated with latest articles.\n\nSubscribe: https://raw.githubusercontent.com/${repo}/main/articles/feed.xml"
+## Steps
+
+### 1. Read context
+
+Read `memory/MEMORY.md`.
+
+### 2. Capture the baseline
+
+Before regenerating, snapshot the current feed so we can tell whether anything changed:
+
+```bash
+if [[ -f articles/feed.xml ]]; then
+  PREV_HASH="$(sha256sum articles/feed.xml | awk '{print $1}')"
+  grep -oP '(?<=<title>)[^<]+' articles/feed.xml | tail -n +2 | sort -u > /tmp/rss-feed-prev-titles.txt
+else
+  PREV_HASH=""
+  : > /tmp/rss-feed-prev-titles.txt
+fi
+```
+
+The `tail -n +2` skips the feed-level `<title>` so only entry titles remain.
+
+### 3. Regenerate the feed
+
+Run the script. Pass `${var}` as the repo slug override only if it is non-empty:
+
+```bash
+if [[ -n "${var}" ]]; then
+  bash scripts/generate-feed.sh "${var}"
+else
+  bash scripts/generate-feed.sh
+fi
+```
+
+### 4. Validate the XML
+
+Invalid XML breaks every subscriber. Fail loud if the feed is malformed:
+
+```bash
+if command -v xmllint >/dev/null 2>&1; then
+  xmllint --noout articles/feed.xml || { STATUS="RSS_FEED_ERROR"; VALIDATION_ERR="xmllint failed"; }
+else
+  # Fallback: verify the root element and a closing tag
+  head -2 articles/feed.xml | grep -q '<feed' || { STATUS="RSS_FEED_ERROR"; VALIDATION_ERR="missing <feed> root"; }
+  tail -1 articles/feed.xml | grep -q '</feed>' || { STATUS="RSS_FEED_ERROR"; VALIDATION_ERR="missing </feed> close"; }
+fi
+```
+
+If `STATUS=RSS_FEED_ERROR`, stop, notify with the error, log it, and exit without committing. Do **not** commit a broken feed.
+
+### 5. Detect what changed
+
+Compare new feed against the baseline:
+
+```bash
+NEW_HASH="$(sha256sum articles/feed.xml | awk '{print $1}')"
+grep -oP '(?<=<title>)[^<]+' articles/feed.xml | tail -n +2 | sort -u > /tmp/rss-feed-new-titles.txt
+
+ADDED="$(comm -13 /tmp/rss-feed-prev-titles.txt /tmp/rss-feed-new-titles.txt)"
+REMOVED="$(comm -23 /tmp/rss-feed-prev-titles.txt /tmp/rss-feed-new-titles.txt)"
+ENTRY_COUNT="$(wc -l < /tmp/rss-feed-new-titles.txt | tr -d ' ')"
+```
+
+Classify the run:
+- **RSS_FEED_NO_CHANGE** — `PREV_HASH == NEW_HASH` (byte-identical). Exit silently after logging. No commit, no notify.
+- **RSS_FEED_METADATA_ONLY** — hashes differ but `ADDED` and `REMOVED` are both empty (e.g. `<updated>` timestamp drifted). Commit so the feed stays fresh, but **do not notify** — it is not a subscriber-visible change.
+- **RSS_FEED_OK** — `ADDED` or `REMOVED` is non-empty. Commit and notify.
+
+### 6. Commit (only if changed)
+
+Skip entirely for `RSS_FEED_NO_CHANGE`. Otherwise build a descriptive commit message:
+
+```bash
+if [[ "$STATUS" == "RSS_FEED_OK" ]]; then
+  MSG="chore(feed): $(echo "$ADDED" | grep -c .) added, $(echo "$REMOVED" | grep -c .) removed ($ENTRY_COUNT total)"
+else
+  MSG="chore(feed): metadata refresh ($ENTRY_COUNT entries)"
+fi
+
+git add articles/feed.xml
+git diff --cached --quiet || git commit -m "$MSG"
+git push || true
+```
+
+If the push fails because the runner can't push directly, that's fine — the generated file remains in the workspace and a later skill/PR can carry it.
+
+### 7. Notify (only on RSS_FEED_OK)
+
+Silence is the feature. Do not notify on `RSS_FEED_NO_CHANGE` or `RSS_FEED_METADATA_ONLY`. On `RSS_FEED_OK`, build a concise message:
+
+```
+*RSS feed updated* — $ENTRY_COUNT entries
+
+New:
+- <first added title>
+- <second added title>
+[Removed: <removed titles> — only include this line if REMOVED is non-empty]
+
+Subscribe: https://raw.githubusercontent.com/${repo}/main/articles/feed.xml
+```
+
+Keep it to one paragraph plus the bullet list. Cap at 5 added titles; if there are more, show the first 5 and append `(+N more)`. Send via `./notify "<message>"`.
+
+On `RSS_FEED_ERROR`, notify with:
+
+```
+*RSS feed ERROR* — $VALIDATION_ERR
+Feed not committed. Investigate scripts/generate-feed.sh or articles/ inputs.
+```
+
+### 8. Log
+
+Append to `memory/logs/${today}.md`:
+
+```
+### rss-feed
+- Status: RSS_FEED_OK | RSS_FEED_METADATA_ONLY | RSS_FEED_NO_CHANGE | RSS_FEED_ERROR
+- Entries: $ENTRY_COUNT
+- Added: <titles or "none">
+- Removed: <titles or "none">
+- Prev hash: <first 8 chars>, new hash: <first 8 chars>
+```
+
+Always log, even on `RSS_FEED_NO_CHANGE` — the log line is how the operator distinguishes "ran and was idle" from "never ran."
+
+## Sandbox note
+
+This skill is entirely local: it reads/writes files and shells out to `scripts/generate-feed.sh`. No network calls required. If `git push` is blocked by the sandbox, the commit still lands locally and the workflow's post-step commit/push path will handle it.
+
+## Constraints
+
+- Never commit a feed that fails validation.
+- Never notify on an unchanged feed — noise destroys the signal.
+- Preserve the script interface: `scripts/generate-feed.sh [repo_slug]`. Do not rewrite the generator inline.
+- Keep `${var}` semantics aligned with what the script actually accepts (repo slug, not base URL).


### PR DESCRIPTION
## Autoresearch evolution — rss-feed

**Winner: Variation B — Sharper output via change detection + XML validation + informative notify/commit.**
**Score: 46.5 / 52.5 weighted.**

### Thesis

The original skill regenerates `articles/feed.xml`, commits it, and notifies on every run regardless of whether anything actually changed. It also verifies the feed only with a weak `head -5` check and passes no arguments to `scripts/generate-feed.sh`, even though the script accepts a repo slug — and the `${var}` description contradicts the script's actual signature.

Biggest lever isn't new data sources or multi-format output — it's **signal-preserving notification**. A feed-generator skill that pings every scheduled run trains operators to ignore it. Variation B:

- **Hashes + title-diffs** the feed against its prior state so unchanged runs are a silent no-op (`RSS_FEED_NO_CHANGE`).
- **Distinguishes metadata-only drift** (`<updated>` timestamp changed, no entries added/removed) from subscriber-visible change — commits the first silently, notifies only on the second.
- **Validates the XML** via `xmllint` (with a grep-based fallback) before committing — a broken feed is never pushed.
- **Lists added/removed article titles** in both the commit message and the notification — the reviewer/operator can see at a glance what changed.
- **Fixes the `${var}` semantic** to `repo_slug` (what `scripts/generate-feed.sh` actually accepts) instead of the current "base URL override" description.

### Scoring

| Criterion | Weight | A — Better inputs (multi-format + frontmatter) | B — Sharper output (change-aware) | C — More robust (validation + status) | D — Rethink (publication pipeline) |
|---|---|---|---|---|---|
| Clarity | ×1.5 | 4 | **4.5** | 4 | 3.5 |
| Data quality | ×1.5 | 4 | 4 | 3.5 | 4 |
| Output value | ×2 | 3 | **4.5** | 3.5 | 4.5 |
| Robustness | ×1.5 | 3.5 | **4.5** | 4.5 | 3.5 |
| Conventions | ×1 | 4.5 | 4.5 | 4.5 | 4 |
| Improvement | ×3 | 3.5 | **4.5** | 3.5 | 4 |
| **Weighted total** | | 38.25 | **46.5** | 40 | 41.5 |

### Variations considered

- **A — Better inputs (38.25).** Emit RSS 2.0 + JSON Feed alongside Atom, parse optional YAML frontmatter in articles for authors/tags, pass `${var}` through as repo_slug. *Rejected:* only 2 articles exist in `articles/` today and no article has frontmatter — multi-format is premature, limited subscriber-visible payoff.
- **B — Sharper output (46.5). ← Winner.**
- **C — More robust (40).** xmllint validation, retry-once, explicit empty-articles path, source-status footer, persistent feed-hash dedup. *Rejected:* C adds observability but the operator still sees a notify every run. B's change-aware skip is the actual noise fix; B already pulls in xmllint validation + empty handling as cheap wins.
- **D — Rethink as publication pipeline (41.5).** Full-text `<content:encoded>` CDATA, auto-regenerate `articles/README.md` chronological index, emit all 3 formats, validate each. *Rejected:* overlaps with the `update-gallery` skill (also enabled on a schedule), triples failure surface, and the "full text vs. summary" tradeoff is debatable when article count is low.

### What the winner folds in

- From **C**: xmllint validation + grep fallback + the `RSS_FEED_OK|ERROR|NO_CHANGE` status taxonomy.
- From **A**: actually passing `${var}` through to the script as repo_slug, plus the frontmatter semantic fix.
- From **D**: the change-detection impulse (only act when something actually changed), applied to notification rather than to full regeneration.

### Diff summary

- `skills/rss-feed/SKILL.md` rewritten: 8-step flow with baseline snapshot → regen → validate → diff → conditional commit/notify → always-log. `${var}` redescribed as repo slug. Added Constraints section forbidding broken-feed commits and redundant notifications.

### Verification plan

1. Run on a repo where `articles/feed.xml` does not yet exist → produces fresh feed, status `RSS_FEED_OK`, notifies with article titles.
2. Run again with no article changes → hash matches, status `RSS_FEED_NO_CHANGE`, no commit, no notify, log entry recorded.
3. Corrupt `articles/feed.xml` manually or break `scripts/generate-feed.sh` → status `RSS_FEED_ERROR`, no commit, error notification fires.

🤖 Generated by Aeon autoresearch — Claude Code

---
Ported from aaronjmars/aeon-tmp#62.
