### PR TITLE
improve(monitor-runners): autoresearch evolution

### DIFF
--- a/skills/monitor-runners/SKILL.md
+++ b/skills/monitor-runners/SKILL.md
@@ -4,138 +4,206 @@ description: Find the top 5 tokens that ran hardest in the past 24h across major
 var: ""
 tags: [crypto]
 ---
-> **${var}** — Filter by chain (e.g. "solana", "eth", "base", "bsc"). If empty, scans all major networks.
+<!-- autoresearch: variation B — sharper output via composite Runner Score, actionable tags, session verdict, repeat-runner delta -->
+
+> **${var}** — Filter by chain (e.g. "solana", "eth", "base", "bsc", "arbitrum"). If empty, scans all major networks.
 
 Read `memory/MEMORY.md` for context.
-Read the last 2 days of `memory/logs/` to see if any of these tokens were flagged before (repeat runners are interesting).
+Read the last 2 days of `memory/logs/` to find any tokens previously flagged as runners — **repeat runners across days are the real signal**.
+
+## Why this skill exists
+
+A flat "top 5 by 24h %" list is dominated by micro-cap meme coins with <$50k liquidity. That output trains the operator to ignore it. The biggest lever is **ranking by a composite Runner Score and tagging each pick with an actionable category** — so the operator can tell at a glance which picks are serious (deep-liq, sustained momentum) vs speculative (micro-cap, brand-new pool).
 
 ## Data Source
 
-GeckoTerminal API (free, no API key). Docs: https://api.geckoterminal.com/api/v2
+GeckoTerminal API (free, no API key). Docs: https://apiguide.geckoterminal.com
 
-Key endpoints:
-- `GET /networks/trending_pools?page=1` — trending pools across all networks
-- `GET /networks/{network}/trending_pools?page=1` — per-network trending pools
-- `GET /networks/{network}/new_pools?page=1` — newly created pools
+Endpoints used:
+- `GET /networks/trending_pools?page=1` — trending pools across all networks (the % movers)
+- `GET /networks/{network}/trending_pools?page=1` — per-network trending
+- `GET /networks/{network}/pools?page=1&sort=h24_volume_usd_desc` — volume leaders (catches runners that aren't on the trending list yet)
+- `GET /networks/new_pools?page=1` — newly created pools (brand-new breakouts)
 
 Each pool object includes:
 - `attributes.name` — pool name (e.g. "TOKEN / SOL")
 - `attributes.price_change_percentage.{m5,m15,m30,h1,h6,h24}` — price changes
 - `attributes.volume_usd.{m5,m15,m30,h1,h6,h24}` — volume
 - `attributes.market_cap_usd` / `attributes.fdv_usd` — market cap
-- `attributes.transactions.h24.{buys,sells}` — transaction counts
+- `attributes.transactions.h24.{buys,sells,buyers,sellers}` — activity
 - `attributes.pool_created_at` — pool creation timestamp
 - `attributes.reserve_in_usd` — liquidity
 - `relationships.network.data.id` — chain name
+- `relationships.base_token.data.id` — base token address (for dedup)
 
 ## Steps
 
-### 1. Fetch trending pools from multiple networks
-
-Pull trending pools from global + individual chains sequentially:
+### 1. Fetch data (sequential, rate-limit aware)
 
 ```bash
 TMPDIR=$(mktemp -d)
+TODAY=$(date -u +%Y-%m-%d)
 
-# Fetch sequentially with 1s delay to avoid GeckoTerminal 429 rate limits
-for NETWORK in "" solana eth base bsc arbitrum; do
-  if [ -z "$NETWORK" ]; then
-    URL="https://api.geckoterminal.com/api/v2/networks/trending_pools?page=1"
-    OUT="$TMPDIR/global.json"
-  else
-    URL="https://api.geckoterminal.com/api/v2/networks/${NETWORK}/trending_pools?page=1"
-    OUT="$TMPDIR/${NETWORK}.json"
-  fi
-  curl -s "$URL" > "$OUT"
-  # If 429, wait 2s and retry once
-  if grep -q '"status":"429"' "$OUT" 2>/dev/null; then
-    sleep 2
-    curl -s "$URL" > "$OUT"
-  fi
+# Networks to scan. If ${var} is set, restrict to that one.
+if [ -n "${var}" ]; then
+  NETWORKS="${var}"
+else
+  NETWORKS="solana eth base bsc arbitrum"
+fi
+
+fetch_with_backoff() {
+  local url="$1" out="$2"
+  for delay in 0 2 4; do
+    [ $delay -gt 0 ] && sleep $delay
+    curl -s --max-time 15 "$url" > "$out"
+    if ! grep -q '"status":"429"' "$out" 2>/dev/null && [ -s "$out" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Global trending
+fetch_with_backoff "https://api.geckoterminal.com/api/v2/networks/trending_pools?page=1" "$TMPDIR/global.json" \
+  && GLOBAL_OK=1 || GLOBAL_OK=0
+sleep 1
+
+# Per-network trending + volume leaders
+for N in $NETWORKS; do
+  fetch_with_backoff "https://api.geckoterminal.com/api/v2/networks/${N}/trending_pools?page=1" "$TMPDIR/${N}-trend.json" \
+    && eval "${N}_TREND_OK=1" || eval "${N}_TREND_OK=0"
+  sleep 1
+  fetch_with_backoff "https://api.geckoterminal.com/api/v2/networks/${N}/pools?page=1&sort=h24_volume_usd_desc" "$TMPDIR/${N}-vol.json" \
+    && eval "${N}_VOL_OK=1" || eval "${N}_VOL_OK=0"
   sleep 1
 done
+
+# New pools (for BREAKOUT tagging)
+fetch_with_backoff "https://api.geckoterminal.com/api/v2/networks/new_pools?page=1" "$TMPDIR/new.json" \
+  && NEW_OK=1 || NEW_OK=0
 ```
 
-If `${var}` is set to a specific chain, only fetch that chain's trending pools.
+**Sandbox fallback:** if `curl` fails for any URL (file is empty or has `"status":"429"` after retries), retry that URL with **WebFetch** using the same URL. Parse the JSON response body.
 
-Also fetch new pools to catch tokens that just launched and are already running:
-```bash
-curl -s "https://api.geckoterminal.com/api/v2/networks/new_pools?page=1" > "$TMPDIR/new.json"
+### 2. Merge, dedupe, gate
+
+From every fetched file, extract all pool objects. Then:
+
+1. **Dedupe** by `relationships.base_token.data.id` — keep the highest-volume pool per token (same token may have multiple pools across DEXes).
+2. **Gate on quality** — drop a pool if ANY of:
+   - `volume_usd.h24 < 50000` (too thin to be a real runner)
+   - `price_change_percentage.h24 <= 0` (we want runners, not dumps)
+   - `reserve_in_usd < 10000` (liquidity floor)
+   - `transactions.h24.sells / transactions.h24.buys > 10` (dumping pattern)
+   - `transactions.h24.buys / transactions.h24.sells > 50` (honeypot pattern — nobody can sell)
+   - pool_created < 1h ago AND `volume_usd.h24 < 100000` (too new to judge)
+   - `price_change_percentage.h24 > 10000` (>100x — almost certainly a rug-in-progress)
+
+Record the count of pre-gate and post-gate pools for the log.
+
+### 3. Score each surviving pool
+
+Compute a **Runner Score** (0-100) per pool. Use simple normalized components so the math is transparent:
+
+```
+pct_pts  = clamp(price_change_percentage.h24 / 500, 0, 1)        # 500% maps to full
+vol_pts  = clamp(log10(volume_usd.h24 + 1) / 7, 0, 1)             # $10m vol = full
+liq_pts  = clamp(log10(reserve_in_usd + 1) / 6, 0, 1)             # $1m liq = full
+mom_pts  = clamp((price_change_percentage.h1 + 50) / 100, 0, 1)   # +50% h1 = full, -50% = 0
+skew_pts = clamp(buys / (buys + sells), 0, 1)                     # 0.5 = neutral
+
+runner_score = 40*pct_pts + 25*vol_pts + 15*liq_pts + 10*mom_pts + 10*skew_pts
 ```
 
-### 2. Merge, dedupe, and rank
+This weights absolute move (40%) + liquidity-adjusted volume (25%) + liquidity depth (15%) + live momentum (10%) + buy pressure (10%). Pct_pts is clamped to avoid meme-coin moonshots flooding the ranking.
 
-From all fetched data:
+### 4. Tag each pool (exactly one tag)
 
-1. **Dedupe** by pool address — same pool can appear in global + per-network results
-2. **Filter** to positive 24h movers only (we want runners, not dumps)
-3. **Sort** by `price_change_percentage.h24` descending
-4. **Apply quality filters** — skip pools that look like obvious rugs or noise:
-   - Skip if 24h volume < $50,000 (too thin)
-   - Skip if pool created < 1 hour ago and no meaningful volume (too new to judge)
-   - Skip if buy/sell ratio is extreme (>10:1 sells = probably dumping)
-   - Flag but don't skip if mcap is null/zero (might be very new)
+Apply tags in priority order — first match wins:
 
-### 3. Select the top 5 runners
+| Tag | Condition |
+|-----|-----------|
+| **DEEP-LIQ** | `reserve_in_usd >= 1_000_000` AND `volume_usd.h24 >= 1_000_000` |
+| **BREAKOUT** | `pool_created_at` within last 48h AND `volume_usd.h24 >= 250_000` |
+| **CONTINUATION** | `price_change_percentage.h1 > 2` AND `price_change_percentage.h24 > 50` |
+| **REVERSAL** | `price_change_percentage.h1 < -5` AND `price_change_percentage.h24 > 0` (fading) |
+| **MICRO-SPEC** | everything else (default — small-cap speculation) |
 
-Pick the **5 tokens with the largest 24h price increase** that pass the quality filters.
+### 5. Select the top 5 + session verdict
 
-For each runner, collect:
-- **Token name** and pair (e.g. "TOKEN / SOL")
-- **Chain** (solana, eth, base, etc.)
-- **24h change** — the big number
-- **1h change** — is it still running or cooling off?
-- **5m change** — real-time momentum
-- **24h volume** — how much money flowed through
-- **Market cap / FDV** — size context
-- **Buy/sell ratio** — demand signal
-- **Pool age** — when was the pool created
-- **Liquidity** (reserve_in_usd) — how much is backing it
+Rank by Runner Score descending, take top 5.
 
-### 4. Analyze each runner
+Compute a session verdict from the tag distribution among the top 5:
 
-For each of the 5, write a quick assessment:
-- **Momentum** — is it accelerating (1h > 0 and 5m > 0) or fading?
-- **Volume** — proportional to mcap? Over-traded is suspicious, under-traded means thin.
-- **Buy pressure** — more buys than sells = continued demand
-- **Age** — brand new (<24h) = speculative; older = something changed
-- **Risk** — low liquidity, no mcap data, extreme moves (>1000%) = high risk
+- **STRONG** — ≥2 DEEP-LIQ picks (real money moving)
+- **MIXED** — 1 DEEP-LIQ OR ≥2 CONTINUATION (signal but speculative)
+- **SPECULATIVE** — majority MICRO-SPEC/BREAKOUT (retail casino)
+- **SLEEPY** — fewer than 5 pools survived the quality gate
 
-### 5. Notify
+### 6. Cross-reference prior days
 
-Send via `./notify` (under 4000 chars). No leading spaces on any line:
+From the last 2 days of `memory/logs/`, extract any token names flagged under `## Monitor Runners`. For each of today's top 5, mark **★ repeat** if the token name appears in either prior day's log. Sustained runners across multiple days deserve extra attention.
+
+### 7. Notify
+
+Send via `./notify` (under 4000 chars, no leading spaces). Format:
+
 ```
-*runners — ${today}*
+*runners — ${TODAY}* — verdict: STRONG
 
-1. TOKEN (chain) +X,XXX% 24h
-vol $Xm | fdv $Xm | still running / cooling off — [1-2 sentence analysis]
+1. [TAG] TOKEN (chain) +X% 24h ★ repeat
+vol $X.Xm | liq $X.Xm | fdv $Xm | h1 +X% | buys:sells X:Y
+— [one-line actionable take: e.g. "sustained multi-day momentum with deep liquidity — watch for continuation"]
 
-2. TOKEN (chain) +XXX% 24h
-vol $Xm | fdv $Xm | momentum note — [1-2 sentence analysis]
+2. [TAG] TOKEN (chain) +X% 24h
+vol $Xm | liq $Xk | fdv $Xm | h1 -X% | buys:sells X:Y
+— [one-line take]
 
 3. ...
 4. ...
 5. ...
 
-vibe: [one line on overall market mood]
+sources: gt-global=ok gt-{networks}=ok/fail
+vibe: [one-line read on overall tape mood]
 ```
 
-### 6. Log
+**Formatting rules:**
+- Format dollar values human-readable: `$2.3m`, `$450k`, `$75k`. Never show raw dollar amounts with comma separators.
+- Format percentages: `+347%` (no decimals unless <10%, then `+4.2%`).
+- If `market_cap_usd` is null, show `fdv $Xm (no mcap)`.
+- Include the ★ repeat marker only for tokens appearing in prior days' logs.
+- The one-line take MUST say something the operator can act on — not a restatement of the numbers. Good: "clean breakout, pool <24h old but already $500k liq locked". Bad: "price went up a lot with high volume".
 
-Append to `memory/logs/${today}.md`:
+**Edge cases:**
+- If verdict is **SLEEPY** (<5 pools passed): send a short note instead — `*runners — ${TODAY}* — sleepy session, only N pools cleared quality gate. Skipping top-5.` Include the 1-2 survivors if any.
+- If ALL sources failed (every `*_OK=0`): send `*runners — ${TODAY}* — MONITOR_RUNNERS_ERROR, all GeckoTerminal endpoints failed. Check sandbox/rate-limits.` and skip the rest.
+
+### 8. Log
+
+Append to `memory/logs/${TODAY}.md`:
+
 ```
 ## Monitor Runners
-- **Networks scanned:** N
-- **Positive movers found:** N
+- **Networks scanned:** N (list)
+- **Source status:** gt-global=ok|fail, per-network: ...
+- **Pools pre-gate:** N / **post-gate:** N
+- **Verdict:** STRONG|MIXED|SPECULATIVE|SLEEPY
 - **Top 5:**
-  1. TOKEN (chain) +X% — $Xm vol, $Xm mcap — [momentum note]
+  1. [TAG] TOKEN (chain) +X% — score XX, vol $Xm, liq $Xk — [one-line take]
   2. ...
-- **Repeat runners from previous days:** [list any or "none"]
-- **Notification sent:** yes
+- **Repeat runners (seen in prior 2 days):** [list or "none"]
+- **Gate rejections breakdown:** thin-vol=N, dumping=N, honeypot=N, too-new=N, rug-like=N
+- **Notification sent:** yes|no (reason if no)
 ```
 
-If any token appears as a runner on multiple days in a row, flag it in `memory/MEMORY.md` — sustained momentum is notable.
+If a token appears as a runner on **3 days in a row**, flag it in `memory/MEMORY.md` under "Active topics" — sustained multi-day runners are worth a deeper look.
 
 ## Sandbox note
 
-The sandbox may block outbound curl. Use **WebFetch** as a fallback for any URL fetch. For auth-required APIs, use the pre-fetch/post-process pattern (see CLAUDE.md).
+The sandbox may block outbound curl. Use **WebFetch** as a fallback for any URL fetch — for each URL that `curl` fails, call WebFetch on the same URL and parse the JSON body. GeckoTerminal requires no auth so no pre-fetch pattern needed.
+
+## Constraints
+
+- Never recommend trades. This is pure observation — "watch", "monitor", "interesting" are fine; "buy", "ape", "enter" are not.
+- Don't inflate the list. If only 3 pools pass the gate, publish 3 — don't backfill with low-quality picks.
+- The Runner Score math is deterministic — if two runs on the same data produce different top-5s, something is wrong.


### PR DESCRIPTION
## Autoresearch — monitor-runners

**Winner: Variation B (45.5/52.5) — sharper output via composite Runner Score, actionable tags, session verdict, repeat-runner delta**

### Thesis
A flat "top 5 by 24h %" list is dominated by micro-cap meme coins with <$50k liquidity. That trains the operator to ignore the output. The biggest lever is ranking by a composite Runner Score (pct + vol + liq + momentum + buy skew) and tagging each pick with an actionable category (DEEP-LIQ / BREAKOUT / CONTINUATION / REVERSAL / MICRO-SPEC) — so the operator can tell at a glance which picks are serious vs speculative.

### Scoring (1-5 per criterion, weighted)

| Criterion | Weight | Orig | A | B | C | D |
|-----------|-------:|-----:|--:|--:|--:|--:|
| Clarity | 1.5 | 4 | 3.5 | **4.5** | 4 | 3.5 |
| Data quality | 1.5 | 3.5 | **4.5** | 4 | 4 | 3.5 |
| Output value | 2 | 3 | 3.5 | **4.75** | 3 | 4 |
| Robustness | 1.5 | 3 | 3 | 3.5 | **4.5** | 3 |
| Conventions | 1 | 4.5 | 4 | 4.5 | 4.5 | 4 |
| Improvement | 3 | — | 3.5 | **4.75** | 3 | 3.5 |
| **Total (of 52.5)** | | — | 39.5 | **45.5** | 38.25 | 37.5 |

### Variations considered
- **A — Better inputs (39.5):** add DexScreener trending/boosted + GeckoTerminal `order=h24_volume_usd_desc` volume-leader pass + cross-source dedup. Good source diversity but output still a flat list.
- **B — Sharper output (45.5, WINNER):** composite Runner Score + 5 actionable tags + session verdict + repeat-runner markers from prior logs + human-readable formatting + actionable one-line take per pick.
- **C — More robust (38.25):** exponential backoff, source-status footer, persistent dedup state, graceful empty/error branches. Incremental reliability wins but no output lever.
- **D — Rethink anomaly-first (37.5):** volume-anomaly / awakening / skew-flip categories instead of top-5. Compelling reframe but depends on a 7-day baseline that doesn't exist — same blocker that sunk D in treasury-info autoresearch.

### What B folds in from the runners-up
- From A: the `sort=h24_volume_usd_desc` volume-leader fetch pass (catches runners not yet on trending list) + expanded network coverage via `${var}` override
- From C: source-status footer (`gt-global=ok gt-base=fail`), exponential backoff on 429, MONITOR_RUNNERS_ERROR / SLEEPY / OK state split, graceful empty-data notify
- From D: cross-day delta framing (★ repeat markers from last 2 days of logs, 3-day-streak flag into MEMORY.md)

### Key changes in the diff
1. **Runner Score** (deterministic 0-100): 40% pct_change + 25% log10(volume) + 15% log10(liquidity) + 10% h1 momentum + 10% buy/sell skew
2. **Tags** applied in priority order: DEEP-LIQ (≥$1m liq + ≥$1m vol) → BREAKOUT (pool <48h + ≥$250k vol) → CONTINUATION (h1>2% AND h24>50%) → REVERSAL (h1<-5% but h24>0) → MICRO-SPEC (default)
3. **Session verdict** from tag mix: STRONG / MIXED / SPECULATIVE / SLEEPY
4. **Quality gates** tightened: honeypot filter (buys/sells >50:1), rug-like filter (h24 >10000%), liquidity floor ($10k reserve)
5. **Repeat-runner detection** via last 2 days of `memory/logs/`; 3-day streak promotes to MEMORY.md active topics
6. **Output format**: human-readable dollars (`$2.3m` not `$2,341,000`), per-item one-line actionable take, source-status footer
7. **No trade recommendations** constraint — observation only ("watch", "monitor"), not "buy"/"ape"

### What's preserved
- Frontmatter (`name`, `description`, `var`, `tags`) unchanged
- Same single data source (GeckoTerminal, no API key, no new secrets)
- Same notify → log → MEMORY.md promotion flow
- Same sandbox WebFetch fallback pattern

---
Ported from aaronjmars/aeon-tmp#64.
