### PR TITLE
improve(vibecoding-digest): autoresearch evolution

### DIFF
--- a/skills/vibecoding-digest/SKILL.md
+++ b/skills/vibecoding-digest/SKILL.md
@@ -1,159 +1,200 @@
 ---
 name: Vibecoding Digest
-description: Monitor r/vibecoding for trending posts, interesting discussions, and notable projects shipped
+description: Decision-ready pulse of r/vibecoding — ranked by signal score, narrative-clustered, with a one-line verdict and tools leaderboard
 var: ""
 tags: [content]
 ---
-> **${var}** — Time window: "day" (default), "week", or "month". Controls the Reddit top sort period.
+<!-- autoresearch: variation B — sharper output via signal scoring + verdict + narrative clusters + tools pulse + insight discipline -->
+
+> **${var}** — Time window: `day` (default), `week`, or `month`. Controls Reddit's `?t=` sort period. Anything else → treat as `day`.
 
 Read `memory/MEMORY.md` for context.
 Read the last 2 days of `memory/logs/` to avoid repeating posts already covered.
+Load `memory/seen-vibecoding.txt` if present (one post ID per line, last 200) — dedup against it.
 
-## Data Source
+## Data source
 
-Reddit JSON API (no auth required). Append `.json` to any Reddit URL.
+Reddit JSON API (no auth). Append `.json` to any Reddit URL. Use `old.reddit.com` — it's lighter, more stable, and less likely to be JS-rate-limited than `www.reddit.com`.
 
-Key endpoints:
-- `https://www.reddit.com/r/vibecoding/top.json?t=day&limit=25` — top posts by score in time window
-- `https://www.reddit.com/r/vibecoding/hot.json?limit=25` — currently hot (trending) posts
-- `https://www.reddit.com/r/vibecoding/comments/{post_id}.json` — post detail + comments
+**User-Agent (required):** `web:aeon-vibecoding-digest:1.0 (by /u/aeonbot)` — Reddit's preferred format. Default/generic UAs get 429'd fast.
 
-**Important:** Always include header `User-Agent: aeon-bot/1.0` or Reddit will 429 you.
+Endpoints:
+- `https://old.reddit.com/r/vibecoding/top.json?t={window}&limit=30` — top by score in window
+- `https://old.reddit.com/r/vibecoding/hot.json?limit=30` — currently hot
+- `https://old.reddit.com/r/vibecoding/rising.json?limit=15` — rising (catches momentum before top)
+- `https://old.reddit.com/r/vibecoding/comments/{post_id}.json?sort=top&limit=15&depth=2` — comments
 
-Each post object (at `data.children[].data`) contains:
-- `title` — post title
-- `selftext` — post body (markdown)
-- `score` — net upvotes
-- `num_comments` — comment count
-- `upvote_ratio` — 0.0–1.0 (below 0.70 = controversial)
-- `author` — username
-- `created_utc` — unix timestamp
-- `permalink` — relative URL (prepend `https://reddit.com`)
-- `link_flair_text` — post flair/category
-- `url` — linked URL if it's a link post
+Fields to keep per post: `id`, `title`, `selftext`, `score`, `num_comments`, `upvote_ratio`, `author`, `created_utc`, `permalink`, `link_flair_text`, `is_self`, `domain`, `url`, `stickied`.
 
 ## Steps
 
-### 1. Fetch trending posts
-
-Pull both top and hot to get full picture:
+### 1. Fetch three sorts
 
 ```bash
 TIME_WINDOW="${var:-day}"
+case "$TIME_WINDOW" in day|week|month) ;; *) TIME_WINDOW="day" ;; esac
+UA="web:aeon-vibecoding-digest:1.0 (by /u/aeonbot)"
 
-# Top posts by score
-curl -s -H "User-Agent: aeon-bot/1.0" \
-  "https://www.reddit.com/r/vibecoding/top.json?t=$TIME_WINDOW&limit=25" > /tmp/vc_top.json
+mkdir -p /tmp/vc
+STATUS_TOP=fail STATUS_HOT=fail STATUS_RISING=fail
 
-# Currently hot posts (may surface rising posts not yet in top)
-curl -s -H "User-Agent: aeon-bot/1.0" \
-  "https://www.reddit.com/r/vibecoding/hot.json?limit=25" > /tmp/vc_hot.json
+curl -fsSL -H "User-Agent: $UA" \
+  "https://old.reddit.com/r/vibecoding/top.json?t=$TIME_WINDOW&limit=30" \
+  -o /tmp/vc/top.json && STATUS_TOP=ok
+
+curl -fsSL -H "User-Agent: $UA" \
+  "https://old.reddit.com/r/vibecoding/hot.json?limit=30" \
+  -o /tmp/vc/hot.json && STATUS_HOT=ok
+
+curl -fsSL -H "User-Agent: $UA" \
+  "https://old.reddit.com/r/vibecoding/rising.json?limit=15" \
+  -o /tmp/vc/rising.json && STATUS_RISING=ok
 ```
 
-### 2. Merge and dedupe
+If a curl fails, **fall back to WebFetch** on the same URL (the sandbox may block curl but not WebFetch). If all three endpoints fail after fallback, notify `VIBECODING_DIGEST_ERROR: all Reddit endpoints failed` and log to today's log; exit.
 
-Combine top + hot results. Dedupe by post ID. Skip pinned/stickied posts (`stickied: true`).
+### 2. Merge, dedupe, filter
 
-### 3. Categorize and pick the best
+- Union posts from top + hot + rising, dedupe by `id`.
+- Drop `stickied: true`.
+- Drop IDs present in `memory/seen-vibecoding.txt` or mentioned in the last 2 days of `memory/logs/`.
+- If ≥3 endpoints succeeded and <5 posts survive dedup: it's a quiet day. Go straight to step 7 with a minimal "quiet day" digest (1-line vibe + tools pulse + source footer). Do not skip the notify.
 
-Sort posts into buckets:
+### 3. Score and classify
 
-**Ship posts** — someone built and shipped something ("I built", "I shipped", "my app", "launched")
-- These are the pulse of the sub. Note what they built, what stack, user count if mentioned.
+For each surviving post, compute:
 
-**Discussion / hot takes** — opinion posts, debates, meta-commentary
-- Low upvote_ratio (<0.70) = controversial = interesting
-- High comment count relative to score = heated debate
-
-**Memes / culture** — humor, screenshots, relatable content
-- High score + high upvote_ratio = the sub's vibe distilled
-
-**Resource / tutorial** — guides, tools, workflows shared
-- Look for links, Claude Code setups, prompt strategies, tool recommendations
-
-**Select 5-8 most notable posts** across categories. Prioritize:
-1. Highest score (the sub voted — respect that)
-2. Most comments (active discussion = signal)
-3. Controversial (low ratio + many comments = spicy)
-4. Anything directly relevant to AI coding, Claude, agents, shipping fast
-
-### 4. For top 3 posts, fetch comments
-
-For the 3 most interesting posts (highest comments or most controversial), fetch the comment thread:
-
-```bash
-# post_id is the alphanumeric ID from the permalink
-curl -s -H "User-Agent: aeon-bot/1.0" \
-  "https://www.reddit.com/r/vibecoding/comments/$POST_ID.json?sort=top&limit=10"
+```
+age_hours = (now - created_utc) / 3600
+controversy_bonus = (num_comments * 2) if upvote_ratio < 0.70 else 0
+signal_score = score + (2 * num_comments) + controversy_bonus - (age_hours * 0.3)
 ```
 
-Response is an array of two listings:
-- Index 0: the post itself
-- Index 1: comments (`data.children[].data` — each has `body`, `author`, `score`, `replies`)
+Classify each post into exactly one bucket (check in order, first match wins):
 
-Pick the **2-3 best comments** per post: sharpest take, funniest reply, most useful advice.
+1. **Ship** — title or selftext contains any of: "I built", "I shipped", "I made", "launched", "my app", "my project", "we built", "we shipped", "MVP", "v1", "release", "now live". Note stack, user count, revenue if cited.
+2. **Debate** — `upvote_ratio < 0.70` AND `num_comments ≥ 20`, OR title is a question/opinion ("is", "are", "should", "why", "vs", "the problem with", "hot take", "unpopular opinion").
+3. **Tutorial** — contains: "how to", "guide", "workflow", "setup", "prompt", "tip", "tutorial", "lesson", "what I learned".
+4. **Meme** — `is_self: false` AND (domain is image host: i.redd.it, imgur, i.imgur, v.redd.it) AND (score/num_comments ratio > 20 = people upvote and move on).
+5. **Other** — everything else.
 
-### 5. Build the digest
+### 4. Pick winners
+
+Rank all posts by `signal_score` desc. Select:
+
+- **Top 5 posts** for the main list — cap 2 per bucket (so no bucket dominates unless signal demands it).
+- **Top 2 spicy threads** — highest `controversy_bonus` among Debate bucket (ratio < 0.70). If fewer than 2 exist, show what you have; don't invent drama.
+
+For those 7 posts (5 + 2), fetch the comment thread via the comments endpoint. Skip if fetch fails (log which ones).
+
+### 5. Extract signals
+
+**Verdict (one-line):** Based on bucket distribution across the top 5 posts:
+- `SHIPPING` — ≥3 Ship posts
+- `DEBATING` — ≥3 Debate posts OR ≥1 in top-2 signal
+- `LEARNING` — ≥3 Tutorial posts
+- `HYPE` — ≥3 Meme posts
+- `MIXED` — no bucket dominates
+
+**Tools pulse:** Scan all fetched posts (titles + selftext) AND all fetched comments for tool mentions. Count case-insensitive occurrences of: `Claude Code`, `Claude`, `Cursor`, `Windsurf`, `Bolt.new`, `Bolt`, `Replit`, `v0`, `Lovable`, `Codex`, `Copilot`, `ChatGPT`, `Gemini`, `Aider`, `Cline`. Output the top 6 by count — this is the community's live tool leaderboard.
+
+**Narrative clusters:** Group the top 5 posts into 1-3 themes. A theme = ≥2 posts sharing ≥2 content keywords (not stopwords). Name each theme in 2-4 words (e.g., "Claude Code vs Cursor", "revenue from vibe apps", "context-window frustration").
+
+**Insight-per-post:** For each of the 5 main posts, write a 1-line **insight** that goes beyond restating the title. What does this post reveal about the community, the tools, or the practice? If you can't exceed the title, cut the post and promote the next in rank.
+
+### 6. Build the digest
 
 ```
 ## Vibecoding Digest — ${today}
 
-### Top Posts
+**Verdict:** {SHIPPING|DEBATING|LEARNING|HYPE|MIXED} — {≤12-word rationale: what drove the verdict}
 
-1. **[title]** — u/author (score pts, N comments, ratio%)
-   [one-line summary of what it's about and why it matters]
-   https://reddit.com/r/vibecoding/...
+**Tools pulse:** 1. {tool} ({N}) · 2. {tool} ({N}) · 3. {tool} ({N}) · 4. {tool} ({N}) · 5. {tool} ({N}) · 6. {tool} ({N})
 
-2. **[title]** — u/author (score pts, N comments)
-   [summary]
+**Narratives:** {theme 1} · {theme 2} · {theme 3}
 
-... (5-8 posts)
+### Top 5
 
-### Spicy Threads
+1. **[title]** — {bucket} · {score}pts · {num_comments}c · {ratio as %}%
+   *Insight:* {what this post reveals — not a paraphrase}
+   https://reddit.com{permalink}
 
-**"[post title]"** (N comments, ratio%)
-- u/commenter: "[interesting comment excerpt]"
-- u/commenter: "[interesting comment excerpt]"
+2. ... (repeat for 5)
 
-**"[post title]"** (N comments)
-- u/commenter: "[comment excerpt]"
+### Spicy threads
 
-### Vibes
-[2-3 sentences on the overall mood of the sub today. What are vibecoding people excited about? Worried about? Shipping? Arguing about?]
+**"[post title]"** — {num_comments}c · {ratio}% upvoted
+- u/{commenter}: "{sharpest-take comment excerpt, ≤40 words}"
+- u/{commenter}: "{second best excerpt}"
+
+**"[post title]"** — {num_comments}c · {ratio}% upvoted
+- u/{commenter}: "{excerpt}"
+
+---
+_sources: top={ok|fail} hot={ok|fail} rising={ok|fail} · scanned={N} · new={N} · dedup={N}_
 ```
 
-### 6. Notify
+**Hard constraints:**
+- Every `Insight:` line must state a claim, implication, or pattern — not restate the title. Use verbs: "reveals", "suggests", "signals", "confirms", "contradicts".
+- No "lots of people are excited about X" — name the tool, cite the count.
+- Exactly 5 top posts (not 4, not 8) unless dedup left fewer — in which case cite the count in the source footer.
+- `ratio as %` = `round(upvote_ratio * 100)`.
+
+### 7. Notify
 
 Send via `./notify`:
+
 ```
 r/vibecoding — ${today}
 
-top posts:
-1. "[title]" — X pts, N comments
-2. "[title]" — X pts, N comments
-3. "[title]" — X pts, N comments
+verdict: {VERDICT} — {≤12-word rationale}
+tools: {tool1} {N} · {tool2} {N} · {tool3} {N}
 
-spicy: "[controversial post title]" (ratio% upvoted, N comments)
-best comment: "[excerpt]" — u/author
+top:
+1. "{title}" — {score}pts, {comments}c
+2. "{title}" — {score}pts, {comments}c
+3. "{title}" — {score}pts, {comments}c
 
-vibes: [one-line mood summary]
+spicy: "{controversial title}" ({ratio}%, {comments}c)
+  "{sharpest comment excerpt, ≤25 words}" — u/{author}
+
+src: top={ok|fail} hot={ok|fail} rising={ok|fail}
 ```
 
-### 7. Log
+Quiet-day fallback (<5 posts after dedup):
+```
+r/vibecoding — ${today}
+quiet day — {N} posts after dedup
+tools pulse: {tool1} {N} · {tool2} {N} · {tool3} {N}
+src: top={ok|fail} hot={ok|fail} rising={ok|fail}
+```
+
+### 8. Log and persist
 
 Append to `memory/logs/${today}.md`:
 ```
 ## Vibecoding Digest
-- **Posts scanned:** N
-- **Top post:** "[title]" — X score, N comments
-- **Most controversial:** "[title]" — ratio% upvoted
-- **Themes:** theme1, theme2, theme3
-- **Vibes:** [one-line]
+- **Window:** {day|week|month}
+- **Verdict:** {VERDICT} ({rationale})
+- **Top post:** "{title}" — {score}pts, {comments}c (signal {score})
+- **Most controversial:** "{title}" — {ratio}% upvoted, {comments}c
+- **Tools pulse (top 3):** {tool1}={N}, {tool2}={N}, {tool3}={N}
+- **Narratives:** {theme1}, {theme2}, {theme3}
+- **Sources:** top={ok|fail} hot={ok|fail} rising={ok|fail}
+- **Scanned / new / dedup:** {S} / {N} / {D}
 - **Notification sent:** yes
 ```
 
-If any post contains a strong take or insight relevant to topics tracked in MEMORY.md, note it there.
+Append the post IDs of everything in the top 5 + spicy threads to `memory/seen-vibecoding.txt` (create if missing). Keep only the last 200 lines.
+
+If any post surfaces a take or insight relevant to topics tracked in `MEMORY.md` (e.g., specific tool regressions, new workflows worth reading), note it there under the appropriate topic.
 
 ## Sandbox note
 
-The sandbox may block outbound curl. Use **WebFetch** as a fallback for any URL fetch. For auth-required APIs, use the pre-fetch/post-process pattern (see CLAUDE.md).
+The sandbox may block outbound curl. If curl fails, use **WebFetch** on the same URL as a fallback — WebFetch bypasses the sandbox. If all three Reddit endpoints fail even via WebFetch, emit `VIBECODING_DIGEST_ERROR` to notify, log the failure, and exit. No auth is required, so no pre-fetch/post-process pattern is needed.
+
+## Output codes
+
+- `VIBECODING_DIGEST_OK` — normal run, ≥5 posts after dedup.
+- `VIBECODING_DIGEST_QUIET` — <5 posts after dedup but ≥1 source succeeded.
+- `VIBECODING_DIGEST_ERROR` — all sources failed or 0 posts total.


### PR DESCRIPTION
## Winner: Variation B — Sharper output (49.5/50)

**Thesis:** Original emits a flat "Top Posts + Spicy Threads + Vibes" list with no ranking rationale, no verdict, no narrative structure, and a vague "Vibes" filler section. Biggest lever is decision-ready output: signal-scored ranking, one-line verdict on the day (SHIPPING/DEBATING/LEARNING/HYPE/MIXED), tools leaderboard (count mentions of Claude Code / Cursor / Bolt / Replit / Windsurf / Codex across posts + comments — this IS the pulse), narrative clustering of the top posts, and a mandatory per-post insight line that goes beyond the title. "Vibes" is cut.

## Scoring table

| Variation | Clarity | Data | Output | Robust | Conv | **Improv (3x)** | **Total** |
|-----------|---------|------|--------|--------|------|-----------------|-----------|
| A — Better inputs | 4 | 5 | 3 | 3 | 4 | 3 | **37.0** |
| **B — Sharper output** | **5** | **4** | **5** | **4** | **5** | **5** | **49.5** |
| C — More robust | 4 | 4 | 3 | 5 | 5 | 3 | 39.5 |
| D — Rethink pulse | 4 | 4 | 5 | 3 | 4 | 4 | 42.5 |

*Weights: Improvement 3x, Output 2x, Clarity/Data/Robust 1.5x, Conv 1x.*

## Variation summaries

- **A — Better inputs (37):** Multi-sort ingestion (top + hot + rising), proper User-Agent `web:aeon-vibecoding-digest:1.0 (by /u/aeonbot)`, old.reddit.com for stability, optional cross-sub (r/ClaudeAI, r/cursor), richer field parsing. More data into the same flat template — feeds the ceiling without raising it.
- **B — Sharper output (49.5, WINNER):** Signal score = `score + 2*comments + controversy_bonus - age_hours*0.3`; verdict line; tools pulse leaderboard; narrative clusters (≥2 posts + ≥2 shared keywords = theme); insight-per-post discipline (cut the post if its insight is just a paraphrase); source-status footer; drops vague "Vibes" for data-grounded verdict.
- **C — More robust (39.5):** Fallback chain curl → WebFetch → graceful exit, persistent `memory/seen-vibecoding.txt` dedup, VIBECODING_DIGEST_OK/QUIET/ERROR codes, 429 handling, empty-day "quiet day" notify with minimal pulse. Reliability ceiling without changing output ceiling.
- **D — Rethink pulse (42.5):** Reframe from "top posts" to Tools Pulse + Ships + Pains + Hottest Take (4 sections, ~7 items). More actionable but loses the post artifacts readers actually click, and yesterday-vs-today delta requires a baseline that doesn't exist on first run.

## What B folds in from the runners-up

- **From A:** three-sort ingestion (top + hot + rising), proper `web:aeon-vibecoding-digest:1.0 (by /u/aeonbot)` User-Agent per Reddit's documented format, old.reddit.com as primary (lighter + less JS-rate-limited), var normalization (day/week/month, else → day).
- **From C:** `memory/seen-vibecoding.txt` persistent dedup (last 200 IDs), source-status footer `top={ok|fail} hot={ok|fail} rising={ok|fail}`, quiet-day fallback notify (<5 posts after dedup), explicit `VIBECODING_DIGEST_OK/QUIET/ERROR` output codes, curl → WebFetch fallback.
- **From D:** tools pulse section as a first-class output block (leaderboard of Claude Code / Cursor / Bolt / Replit / Windsurf / Codex / Copilot / ChatGPT / Gemini / Aider / Cline mentions across posts + comments) — this captures D's core thesis without abandoning the post digest.

## Diff summary

- Replaces 5-8 post "Top Posts" list with **signal-scored top 5** ranked by `score + 2*comments + controversy_bonus - age_hours*0.3`, capped at 2 per bucket.
- New **Verdict line** at the top: SHIPPING / DEBATING / LEARNING / HYPE / MIXED with ≤12-word rationale.
- New **Tools pulse** leaderboard (top 6 by mention count across posts + comments).
- New **Narratives** line — 1-3 themes grouping the top 5.
- Posts classified into explicit buckets (Ship / Debate / Tutorial / Meme / Other) via deterministic keyword rules.
- **Insight-per-post is now mandatory** — must state a claim/implication/pattern with verbs like "reveals/suggests/signals/confirms/contradicts", not restate the title. Cut the post if you can't exceed the title.
- Drops the vague "Vibes" section (the verdict + tools pulse + narratives carry that signal with data behind it).
- **Data:** adds `rising.json`, switches to `old.reddit.com`, proper User-Agent format, var normalization.
- **Robustness:** curl → WebFetch fallback, source-status footer, `memory/seen-vibecoding.txt` persistent dedup, quiet-day notify path, `VIBECODING_DIGEST_OK/QUIET/ERROR` output codes.

## Constraint check

- Preserves core purpose ✓ (still a digest of r/vibecoding signal)
- Preserves frontmatter format ✓ (name, description, var, tags)
- No new env vars required ✓ (no auth for Reddit JSON API)
- Follows Aeon conventions ✓ (reads MEMORY, logs to `memory/logs/${today}.md`, notifies via `./notify`)
- Never downgrades — improvement score 5 vs. baseline

---
Ported from aaronjmars/aeon-tmp#66.
