### PR TITLE
improve(fork-contributor-leaderboard): autoresearch evolution

### DIFF
--- a/skills/fork-contributor-leaderboard/SKILL.md
+++ b/skills/fork-contributor-leaderboard/SKILL.md
@@ -4,9 +4,11 @@ description: Weekly ranking of developers contributing to the fork fleet and bac
 var: ""
 tags: [meta, community]
 ---
+<!-- autoresearch: variation A — better inputs (compare API + PR reviews + first-timer signal), folds in B's "Movement This Week" lede -->
+
 > **${var}** — Target repo to scan contributors of (e.g. "owner/aeon"). If empty, reads from memory/watched-repos.md.
 
-Today is ${today}. Rank the humans behind the fork fleet — who's pushing commits into their forks, who's sending work back upstream, and who's building new skills that upstream hasn't seen yet.
+Today is ${today}. Rank the humans behind the fork fleet — who's pushing commits into their forks, who's sending work back upstream, who's reviewing other people's code, and who's building new skills that upstream hasn't seen yet.
 
 This complements `skill-leaderboard` (what is popular) and `fork-fleet` (which forks diverge). This skill asks: **who are the people?**
 
@@ -16,144 +18,157 @@ The `tweet-allocator` skill rewards social mentions with $AEON. Code contributor
 
 ## Steps
 
-1. **Determine the target repo.** If `${var}` is set, use that. Otherwise read `memory/watched-repos.md` and use the first entry. Store as `TARGET_REPO`.
+1. **Determine the target repo.** If `${var}` is set, use that. Otherwise read `memory/watched-repos.md` and use the first entry. Store as `TARGET_REPO`. Resolve the upstream default branch once: `UPSTREAM_BRANCH=$(gh api repos/${TARGET_REPO} --jq .default_branch)`.
 
 2. **Fetch all active forks** (pushed within the last 30 days):
    ```bash
    CUTOFF=$(date -u -d "30 days ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-30d +%Y-%m-%dT%H:%M:%SZ)
    gh api repos/${TARGET_REPO}/forks --paginate \
-     --jq "[.[] | select(.pushed_at > \"$CUTOFF\") | {owner: .owner.login, full_name: .full_name, pushed_at, stargazers_count, created_at}]"
+     --jq "[.[] | select(.pushed_at > \"$CUTOFF\") | {owner: .owner.login, full_name: .full_name, default_branch, pushed_at, stargazers_count, created_at}]"
    ```
    If no active forks found, log `FORK_CONTRIBUTOR_LEADERBOARD_NO_FORKS` to `memory/logs/${today}.md` and stop (no notification).
 
-3. **Fetch all upstream PRs** in one paginated call (cheaper than per-fork lookups):
+3. **Fetch all upstream PRs** in one paginated call. Keep `author_association` so we can flag first-time contributors without an extra call:
    ```bash
    gh api "repos/${TARGET_REPO}/pulls?state=all&per_page=100" --paginate \
-     --jq '[.[] | {number, state, merged_at, user: .user.login, title, created_at}]'
+     --jq '[.[] | {number, state, merged_at, user: .user.login, title, created_at, author_association}]'
    ```
-   Build a map `{login -> {opened: N, merged: N, pr_numbers: [...]}}` keyed on `.user.login`.
-   Skip bots: any login ending in `[bot]`, plus `aaronjmars`, `aeonframework`, `github-actions` (these are the core team and core automation — they are not the audience this skill celebrates).
+   Build a map `{login -> {opened: N, merged: N, first_time: bool, pr_titles: [...]}}` keyed on `.user.login`. Set `first_time: true` if any of their PRs has `author_association == "FIRST_TIME_CONTRIBUTOR"`.
+   Skip bots: any login ending in `[bot]`, plus `aaronjmars`, `aeonframework`, `github-actions`.
 
-4. **For each active fork, pull the fork owner's own commit count** since the fork was created:
+4. **Fetch all upstream PR review comments** in one paginated call (this is the missing reviewer signal):
    ```bash
-   gh api "repos/${FORK_FULL_NAME}/commits?author=${FORK_OWNER}&since=${FORK_CREATED_AT}&per_page=100" \
-     --paginate --jq '. | length'
+   SINCE=$CUTOFF
+   gh api "repos/${TARGET_REPO}/pulls/comments?since=${SINCE}&per_page=100" --paginate \
+     --jq '[.[] | {user: .user.login, pr_url: .pull_request_url, created_at}]'
    ```
-   Cap the counted commits at 100 per fork (the scoring formula caps anyway, and some forks have thousands of inherited commits — we only want authored work). If the API returns 409 (empty repo) or 404, record `commits: 0` and move on.
+   Build `{login -> review_comments: N}`. Apply the same bot filter. Cap at 20 review comments per contributor (someone who left 200 nit comments on one PR shouldn't dominate).
 
-5. **Detect new skills** added by each fork owner. For each active fork, list the contents of `skills/`:
+5. **For each active fork, get authored commit count via the compare endpoint** (one call per fork, returns `ahead_by` plus a commits array with author metadata — replaces the prior per-fork pagination loop):
    ```bash
-   gh api "repos/${FORK_FULL_NAME}/contents/skills" --jq '[.[] | .name]'
+   gh api "repos/${TARGET_REPO}/compare/${UPSTREAM_BRANCH}...${FORK_OWNER}:${FORK_DEFAULT_BRANCH}" \
+     --jq "{ahead_by: .ahead_by, owner_commits: ([.commits[] | select(.author.login == \"${FORK_OWNER}\")] | length)}"
    ```
-   Compare against upstream's skill directory names (already known — scan this repo's `skills/` locally). Any skill names in the fork but not upstream count as **new skills**. Cap at 5 per fork to prevent mass-rename gaming.
+   Record `owner_commits` (capped at 30 by the scoring formula) and `ahead_by` (used in the article narrative, not scored). The compare endpoint returns up to 250 commits — more than enough; if `ahead_by > 250`, treat owner_commits as a lower bound and note it. If the call returns 404 (deleted fork), 422 (no common ancestor), or 409 (empty repo): record `owner_commits: 0, ahead_by: 0` and continue.
 
-6. **Score each contributor** using this formula:
+6. **Detect new skills** added by each fork owner. For each active fork, list the contents of `skills/` against their default branch:
+   ```bash
+   gh api "repos/${FORK_FULL_NAME}/contents/skills?ref=${FORK_DEFAULT_BRANCH}" --jq '[.[] | .name]'
+   ```
+   Compare against upstream's skill directory names (scan this repo's `skills/` locally). Any skill names in the fork but not upstream count as **new skills**. Cap at 5 per fork to prevent mass-rename gaming. If the fork has no `skills/` dir (404), record `new_skills: []`.
+
+7. **Score each contributor** using this formula:
    - `+10` per merged upstream PR (authored by the contributor)
-   - `+3` per opened-but-not-merged upstream PR (still a contribution signal)
+   - `+5` first-time-contributor bonus (one-time, applies if any of their PRs is `FIRST_TIME_CONTRIBUTOR` — first PRs are the highest-leverage signal)
+   - `+3` per opened-but-not-merged upstream PR
+   - `+2` per upstream PR review comment they left (capped at 20)
    - `+1` per authored commit to their own fork (capped at 30)
    - `+5` per new skill file detected in their fork (capped at 5)
-   - `+2` per star on their fork (encourages visible forks over private ones)
+   - `+1` per star on their fork (was +2 — halved to reduce star-farm gaming; cap at 20 stars)
 
-   Rank all contributors by score descending. A contributor is anyone who either owns an active fork OR has authored an upstream PR in the past 30 days (union of both sets).
+   Rank all contributors by score descending. A contributor is anyone who either owns an active fork OR has authored an upstream PR in the past 30 days OR has left ≥1 upstream review comment in the past 30 days (union of all three sets).
 
-7. **Compare to last week's leaderboard** — check for `articles/fork-contributor-leaderboard-*.md` files from the last 14 days. If one exists:
-   - Parse its ranked list (names + scores).
-   - Compute week-over-week rank changes (new entries, rank shifts, dropouts).
-   - Flag **rising contributors** (moved up 3+ positions) and **new entrants**.
+8. **Compare to last week's leaderboard.** Glob `articles/fork-contributor-leaderboard-*.md` from the last 14 days, pick the most recent, and parse its ranked list (logins + scores) using a tolerant regex on the table rows (`^\| \d+ \| @(\S+) \| (\d+) \|`). If parsing yields zero rows, skip the comparison silently (don't crash). Compute week-over-week rank changes (new entries, rank shifts ≥3, dropouts).
 
-8. **Write the article** to `articles/fork-contributor-leaderboard-${today}.md`:
+9. **Write the article** to `articles/fork-contributor-leaderboard-${today}.md`. Lead with the narrative — the table is the proof, not the headline:
+
    ```markdown
    # Fork Contributor Leaderboard — ${today}
 
-   *Ranking the humans moving ${TARGET_REPO} forward. ${N_CONTRIBUTORS} contributors across ${N_FORKS} active forks and ${N_UPSTREAM_PRS} upstream PRs in the last 30 days.*
+   *${N_CONTRIBUTORS} contributors moved ${TARGET_REPO} this week across ${N_FORKS} active forks, ${N_UPSTREAM_PRS} upstream PRs, and ${N_REVIEW_COMMENTS} review comments.*
+
+   ## Movement This Week
+
+   *3–5 short paragraphs telling the story of the week. Each paragraph names one contributor and what they shipped. Pull from real PR titles, real new skill names, real review counts. Prioritize, in order: (a) first-time contributors who landed a merged PR, (b) contributors who jumped 3+ ranks, (c) the top reviewer if they're not also #1 by score, (d) the contributor who shipped the most new skills. If none of these apply, write "Quiet week — baseline maintained" and skip to the table.*
 
    ## Top Contributors
 
-   | Rank | Contributor | Score | Merged PRs | Open PRs | Fork Commits | New Skills | Change |
-   |------|-------------|-------|------------|----------|--------------|------------|--------|
-   | 1 | @login | N | N | N | N | N | — |
-   | 2 | @login | N | N | N | N | N | ↑3 |
-   | ... | ... | ... | ... | ... | ... | ... | ... |
+   | Rank | Contributor | Score | Merged PRs | Open PRs | Reviews | Fork Commits | New Skills | First PR? | Change |
+   |------|-------------|-------|------------|----------|---------|--------------|------------|-----------|--------|
+   | 1 | @login | N | N | N | N | N | N | — | — |
+   | 2 | @login | N | N | N | N | N | N | ✨ | ↑3 |
+   | ... | ... | ... | ... | ... | ... | ... | ... | ... | ... |
 
-   *(include up to the top 20; if fewer than 20 qualify, list all)*
+   *(top 20; if fewer than 20 qualify, list all. ✨ in First PR? column means at least one of their upstream PRs was their first-ever contribution to ${TARGET_REPO}.)*
 
-   ## Notable Contributions
+   ## Outreach Candidates
 
-   ### @top_contributor
-   [2-3 sentences on what they shipped: PR titles if merged, new skills they built, notable divergence. Pull real PR titles from the upstream PR list.]
-
-   ### @second_contributor
-   [same format]
-
-   ### @third_contributor
-   [same format]
-
-   ## Rising This Week
-   [Contributors who moved up 3+ positions or are new to the leaderboard, with 1 sentence each on what drove the rise. If first run or no data, write "First leaderboard — baseline established."]
+   *Active forks whose owner has never opened an upstream PR — the highest-conversion outreach pool. List up to 10, sorted by fork commit count descending. Format: "@login — N fork commits, N stars, N new skills". If none, write "All active fork owners have opened ≥1 upstream PR. No outreach gap."*
 
    ## Upstream Contribution Signal
 
    - **Contributors with merged upstream PRs:** N
-   - **Contributors with at least one upstream PR (any status):** N
-   - **Active forks whose owner has NEVER opened an upstream PR:** N — outreach candidates
+   - **First-time contributors this period:** N (with names)
+   - **Top reviewer:** @login with N review comments
    - **Most-merged contributor:** @login with N merged PRs
+   - **Active forks whose owner has never opened an upstream PR:** N
 
    ## Fork Fleet Summary
+
    - **Active forks scanned (pushed last 30d):** N
    - **Total upstream PRs tracked (last 30d):** N
+   - **Total review comments tracked (last 30d):** N
    - **Unique contributors:** N
    - **Contributors filtered as bots/core:** N
 
    ---
-   *Source: GitHub API — forks and pulls of ${TARGET_REPO}. Scoring: merged PR +10, open PR +3, fork commit +1 (cap 30), new skill +5 (cap 5), fork star +2.*
+   *Source: GitHub API — forks, pulls, pull review comments, and compare endpoints of ${TARGET_REPO}. Scoring: merged PR +10, first-PR bonus +5, open PR +3, review comment +2 (cap 20), fork commit +1 (cap 30), new skill +5 (cap 5), fork star +1 (cap 20).*
    ```
 
-9. **Send notification** via `./notify`:
-   ```
-   *Fork Contributor Leaderboard — ${today}*
+10. **Send notification** via `./notify`. Lead with the headline story, not a generic top-5:
+    ```
+    *Fork Contributor Leaderboard — ${today}*
 
-   ${N_CONTRIBUTORS} developers are moving ${TARGET_REPO} forward. Here's this week's top 5:
+    ${HEADLINE_LINE}
 
-   1. @login — score N (N merged PRs, N new skills)
-   2. @login — score N (N merged PRs, N fork commits)
-   3. @login — score N (...)
-   4. @login — score N (...)
-   5. @login — score N (...)
+    Top 5:
+    1. @login — score N (N merged PRs, N reviews)
+    2. @login — score N (...)
+    3. @login — score N (...)
+    4. @login — score N (...)
+    5. @login — score N (...)
 
-   Rising: @login (↑N), @login (new entry)
-   Most-merged: @login with N upstream PRs
+    First PRs this week: @login, @login (or "none")
+    Top reviewer: @login (N comments)
 
-   Full leaderboard: https://github.com/${GITHUB_REPOSITORY}/blob/main/articles/fork-contributor-leaderboard-${today}.md
+    Full leaderboard: https://github.com/${GITHUB_REPOSITORY}/blob/main/articles/fork-contributor-leaderboard-${today}.md
+    ```
 
-   Use the `$GITHUB_REPOSITORY` env var (GitHub Actions sets it to `owner/repo`) to build the URL. Do NOT use the watched repo — the article lives in this running instance's repo.
-   ```
+    `${HEADLINE_LINE}` is one sentence drawn from the Movement This Week lede — e.g. "@alice landed her first upstream PR (renames the fetch-tweets timeout to be configurable) and jumped to #4." If nothing notable, fall back to "${N_CONTRIBUTORS} developers are moving ${TARGET_REPO} forward this week."
 
-   **Only send a notification if at least 2 contributors qualify** (otherwise the signal is not meaningful). If fewer than 2 qualify, log `FORK_CONTRIBUTOR_LEADERBOARD_INSUFFICIENT_DATA` and stop.
+    Use the `$GITHUB_REPOSITORY` env var (GitHub Actions sets it to `owner/repo`) to build the URL. Do NOT use the watched repo — the article lives in this running instance's repo.
 
-10. **Log** to `memory/logs/${today}.md`:
+    **Only send a notification if at least 2 contributors qualify.** If fewer than 2 qualify, log `FORK_CONTRIBUTOR_LEADERBOARD_INSUFFICIENT_DATA` and stop.
+
+11. **Log** to `memory/logs/${today}.md`:
     ```
     ## Fork Contributor Leaderboard
     - **Contributors ranked:** N
     - **Active forks scanned:** N
     - **Upstream PRs tracked (last 30d):** N
+    - **Review comments tracked (last 30d):** N
     - **Top contributor:** @login (score: N)
     - **Most-merged:** @login (N merged PRs)
+    - **Top reviewer:** @login (N review comments)
+    - **First-time contributors:** [list or "none"]
     - **New entries:** [list or "none"]
     - **Rising:** [list or "none"]
+    - **Forks failing compare API:** [list or "none"]
     - **Notification sent:** yes/no
     ```
 
 ## Sandbox note
 
-All GitHub API calls use `gh api` which handles auth internally — no env var expansion needed. No external webhook writes, no secrets required beyond the default `GITHUB_TOKEN`. If `gh api` returns rate-limit errors (403 with `X-RateLimit-Remaining: 0`), back off and retry once after 60 seconds; if it still fails, log the error and continue with partial data rather than crashing.
+All GitHub API calls use `gh api` which handles auth internally — no env var expansion needed. No external webhook writes, no secrets required beyond the default `GITHUB_TOKEN`. If `gh api` returns rate-limit errors (403 with `X-RateLimit-Remaining: 0`), back off and retry once after 60 seconds; if it still fails, log the error and continue with partial data rather than crashing. The compare endpoint (step 5) has a per-fork failure mode — capture failures into a list and continue; do not let one bad fork abort the whole run.
 
 ## Privacy & safety
 
-- Only **public** GitHub data is read (public forks, public PRs, public commits). No private email addresses are extracted.
+- Only **public** GitHub data is read (public forks, public PRs, public review comments, public commits). No private email addresses are extracted.
 - Contributor logins are used verbatim — no scraping of profile bios, emails, or follower counts.
 - If a contributor has configured their GitHub account to hide email addresses, nothing changes — this skill never touches `.email` fields.
 - Bot accounts (`*[bot]`, `github-actions`) and the core team (`aaronjmars`, `aeonframework`) are filtered out so the leaderboard surfaces **community** contributors only.
 - The notification mentions @handles; if you don't want to be on the leaderboard, open an issue on the watched repo and the skill will add you to a local opt-out list in `memory/topics/leaderboard-optout.md`. If that file exists, filter matching logins out before ranking.
+- Review comments are public artifacts on public PRs — counting them is not surveillance; ignoring them undercounts a major form of contribution.
 
 ## What's next
 


### PR DESCRIPTION
## Autoresearch — fork-contributor-leaderboard

**Winner: Variation A — Better inputs (43.5/50 weighted)**

The original ranks contributors but leaves three large signals on the table: PR reviewers (currently invisible), first-time contributors (highest-leverage signal in OSS), and divergence size per fork (only authored commit counts are tracked). It also has an N+1 problem on per-fork commit pagination that risks rate limits as the fork fleet grows.

### Variations considered

| ID | Thesis | Weighted score |
|----|--------|----------------|
| **A** | **Better inputs** — compare API replaces per-fork commit pagination; PR review comments add a +2 signal; `author_association` flags first-time contributors with +5 bonus; star weight halved to reduce gaming | **43.5** |
| B | Sharper output — lead with "Movement This Week" narrative; demote table; per-contributor blurbs cite real PR titles; outreach-candidates section; headline-driven notification | 41 |
| C | More robust — rate-limit pre-check, exponential backoff, per-fork failure capture into degraded[], named-capture regex with empty fallback, checkpoint state cache | 38 |
| D | Rethink — drop ranking; produce 3–5 "contributor stories of the week" + community pulse paragraph; no score column. Reduces gaming, increases readability | 39.5 |

### Scoring (1–5 per criterion, weighted)

| Criterion | Weight | A | B | C | D |
|---|---|---|---|---|---|
| Clarity | 1.5x | 4 | 4 | 4 | 3 |
| Data quality | 1.5x | 5 | 3 | 3 | 3 |
| Output value | 2x | 4 | 5 | 3 | 5 |
| Robustness | 1.5x | 4 | 3 | 5 | 3 |
| Conventions | 1x | 4 | 4 | 5 | 4 |
| Improvement | 3x | 4 | 4 | 3 | 4 |
| **Total** | | **43.5** | **41** | **38** | **39.5** |

### Why A won

Better data unlocks better output downstream — and A fixes a real performance/rate-limit risk while adding two structurally new signals (reviews + first-time contributors) that the original couldn't see at all. The compare endpoint returns `ahead_by` plus a 250-commit author-filterable array in one call, replacing what was previously a paginated per-fork commit walk. `author_association == "FIRST_TIME_CONTRIBUTOR"` is on every PR payload — getting first-PR detection costs zero extra API calls.

The runner-up's "Movement This Week" lede + "Outreach Candidates" section + headline-driven notification are folded into the winner, capturing most of B's output gain on top of A's data improvements.

### Diff summary

- **Step 3:** Keep `author_association` field in the PR fetch (was discarded)
- **Step 4 (new):** Fetch upstream PR review comments — single paginated call against `repos/{repo}/pulls/comments?since=$CUTOFF`
- **Step 5:** Replace per-fork `commits?author=` pagination with single `compare/{base}...{owner}:{branch}` call (returns `ahead_by` + commits with author info)
- **Step 6:** Resolve fork default branch via `?ref=` (was implicit, broke for forks with non-`main` default)
- **Step 7:** Two new score components (review comments +2 cap 20, first-time contributor bonus +5); fork-star weight halved (+2 → +1) and capped at 20 to reduce star-farm gaming
- **Step 8:** Tolerant regex parser for last-week's leaderboard, silent skip on zero rows
- **Step 9:** Article reorganized — "Movement This Week" narrative lede leads, table demoted to second section, "Outreach Candidates" section added, "First PR?" column added to table
- **Step 10:** Notification leads with a headline story (one sentence drawn from the lede), not the generic top-5
- **Step 11:** Log entry expanded — review comments, first-time contributors, top reviewer, failed-compare forks
- **Privacy & safety:** Added clarifying note that review comments are public artifacts; explicit per-fork failure capture in the sandbox note

### Constraint check

- ✅ Original frontmatter preserved (name, description, var, tags)
- ✅ No new env vars (all `gh api`, default `GITHUB_TOKEN`)
- ✅ Core purpose preserved — still ranks contributors, still weekly, still surfaces upstream PRs
- ✅ Aeon conventions: reads memory, logs to memory/logs/${today}.md, notifies via `./notify`

---
Ported from aaronjmars/aeon-tmp#67.
