### PR TITLE
improve(star-milestone): autoresearch evolution

### DIFF
--- a/skills/star-milestone/SKILL.md
+++ b/skills/star-milestone/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: star-milestone
-description: Announces when a watched repo crosses a star-count milestone (100, 150, 200, 250, 500, 1000, ...) with a highlight reel of recent work
+description: Announces when a watched repo crosses a star-count milestone (100, 150, 200, 250, 500, 1000, ...) with a velocity-shaped narrative — time-to-milestone, growth shape, projection, and a tight highlight reel
 var: ""
 tags: [dev]
 ---
+<!-- autoresearch: variation B — sharper output via velocity shape, time-to-milestone framing, projected next milestone, stale-suppression, and fake-star defer -->
+
 > **${var}** — Repo (`owner/repo`) to check. If empty, checks all watched repos.
 
-Today is ${today}. Detect milestone star-count crossings on watched repos and celebrate them with a bonus notification. Milestones are a shareable social moment — an autonomous "we crossed 200 stars" post at exactly the right audience (operators already watching the repo) is a free word-of-mouth amplifier.
+Today is ${today}. Detect milestone star-count crossings on watched repos and celebrate them with a velocity-shaped narrative. A milestone notification is only valuable if the reader learns something they couldn't infer from the number alone — *how fast* it arrived, whether the trajectory is organic or a spike, and what's next. A bare "we crossed 200" without that context is just a vanity metric. This skill earns its slot by being the daily growth-pulse readout *gated* on a meaningful threshold crossing.
 
 ## Thresholds
-
-The skill watches these star-count milestones (in this order):
 
 ```
 25, 50, 100, 150, 175, 200, 250, 300, 400, 500, 750, 1000, 1500, 2000, 3000, 5000, 7500, 10000, 15000, 25000, 50000, 100000
@@ -18,69 +18,151 @@ The skill watches these star-count milestones (in this order):
 
 ## Steps
 
-1. **Load the repo list.** If `${var}` is set, use it as a single repo. Otherwise read `memory/watched-repos.md`. Skip any repo whose name ends with `-aeon` or contains `aeon-agent` (agent repos, not project repos).
+### 1. Load the repo list
 
-2. **Load milestone state.** Read `memory/topics/milestones.md` if present. If absent, treat state as empty. The file has a section per repo listing every milestone recorded so far, one per line:
+If `${var}` is set, treat it as the single repo. Otherwise read `memory/watched-repos.md`. Skip any repo whose name ends with `-aeon` or contains `aeon-agent` (agent repos, not project repos). If the list is empty, log `STAR_MILESTONE_NO_REPOS` and exit cleanly without notifying.
 
-   ```markdown
-   # Star Milestones
+### 2. Load milestone state
 
-   ## aaronjmars/aeon
-   - 150 stars — 2026-04-01 (bootstrap)
-   - 175 stars — 2026-04-15
-   - 200 stars — 2026-04-19
-   ```
+Read `memory/topics/milestones.md` if present. If absent, treat state as empty. The file has a section per repo, one milestone per line:
 
-3. **For each repo, fetch the current star count:**
-   ```bash
-   STARS=$(gh api repos/owner/repo --jq '.stargazers_count')
-   ```
+```markdown
+# Star Milestones
 
-4. **Find the highest threshold `M` where `M <= STARS`.** If no threshold is <= current count (e.g. fresh repo with 3 stars), log `STAR_MILESTONE_QUIET: below first threshold` and skip this repo.
+## aaronjmars/aeon
+- 150 stars — 2026-04-01 (bootstrap)
+- 175 stars — 2026-04-15
+- 200 stars — 2026-04-19
+```
 
-5. **Decide whether to announce:**
-   - If `memory/topics/milestones.md` already lists milestone `M` for this repo → no action.
-   - If the repo has **no prior entries** in `milestones.md` → this is the first run. **Bootstrap silently**: record `M` with the `(bootstrap)` suffix. Do NOT send a notification. This prevents retroactive spam on an established repo.
-   - Otherwise → a new milestone was crossed. Proceed to step 6.
+Suffix tokens you may write later: `(bootstrap)`, `(skipped)`, `(stale)`, `(deferred)`.
 
-6. **Build the highlight reel.** Read the last 14 days of `memory/logs/YYYY-MM-DD.md` (if fewer files exist, use what's available). Extract 3–5 concrete highlights from log sections such as `## Push Recap`, `## Feature Built`, `## Repo Article`, `## Repo Actions`, `## Hyperstitions Ideas`, and `## Changelog`. Prefer items that ship tangible value (merged PRs, new skills, articles) over ongoing monitoring runs. De-duplicate and keep the entries concise (one line each).
+### 3. Per repo — fetch count and stargazer timestamps
 
-   If there are no log entries in the window, use `gh api repos/owner/repo/commits?since=<14d-ago>` to pull recent commit subjects and pick 3 interesting ones.
+```bash
+STARS=$(gh api repos/$REPO --jq '.stargazers_count')
+```
 
-7. **Send the notification** via `./notify`. Required structure — do not compress this; the message goes to a Telegram group and should stand on its own:
+For velocity, fetch the most recent stargazer timestamps. The `star+json` accept header returns `starred_at`:
 
-   ```
-   *Milestone — ${M} stars*
-   ${owner/repo}
+```bash
+# Last page first (most recent stargazers). Page count = ceil(STARS/100).
+LAST_PAGE=$(( (STARS + 99) / 100 ))
+gh api -H "Accept: application/vnd.github.star+json" \
+  "repos/$REPO/stargazers?per_page=100&page=$LAST_PAGE" \
+  > .star-cache/$REPO.last.json 2>/dev/null
 
-   [owner/repo] just crossed ${M} stars on GitHub (now at ${STARS}).
-   [1–2 sentences framing why this matters — e.g. "This is the third milestone in 30 days, mirroring the post-launch growth curve since X."]
+# If STARS > 100, also fetch the page before for a 30d baseline.
+if [ "$LAST_PAGE" -gt 1 ]; then
+  gh api -H "Accept: application/vnd.github.star+json" \
+    "repos/$REPO/stargazers?per_page=100&page=$((LAST_PAGE - 1))" \
+    > .star-cache/$REPO.prev.json 2>/dev/null
+fi
+```
 
-   Highlights since the last milestone:
-   - [highlight 1]
-   - [highlight 2]
-   - [highlight 3]
-   - [highlight 4 — optional]
+Compute from these timestamps:
+- **`v7`** — stars added in the last 7 days (count `starred_at` within 7d of today)
+- **`v30`** — stars added in the last 30 days
+- **`baseline`** — median daily rate across the last 30 days (`v30 / 30`)
+- **`days_since_last_star`** — `today - max(starred_at)`
 
-   Repo: https://github.com/owner/repo
-   ```
+If `gh api` fails for the stargazer pages, set velocity fields to `null` and continue — the milestone check still runs without them, and the notification adapts (see step 7).
 
-8. **Update `memory/topics/milestones.md`.** Append the new entry under the repo's section. Create the file with a `# Star Milestones` header if it doesn't exist. Keep entries in ascending threshold order per repo.
+### 4. Find the highest threshold crossed
 
-9. **Log** to `memory/logs/${today}.md`:
-   ```
-   ## Star Milestone
-   - **owner/repo**: stargazers_count=N, milestone crossed: M
-   - **Highlights used:** [count]
-   - **Notification sent:** yes/no (reason if no)
-   ```
+Find the highest threshold `M` where `M <= STARS`. If none (e.g. 3 stars), log `STAR_MILESTONE_QUIET: below first threshold for $REPO` and skip this repo.
+
+### 5. Decide whether to announce
+
+Apply these gates in order:
+
+a. **Already recorded** — if `milestones.md` lists `M` for this repo → no action.
+b. **Bootstrap** — if the repo has *no* prior entries → record `M (bootstrap)` silently. No notification.
+c. **Stale-recovery** — if `M` is the lowest unrecorded threshold above the *previous* recorded one, but `days_since_last_star >= 7` (i.e. count crawled across the line and then stalled) → record `M (stale)` silently. No notification. The milestone is meaningless without momentum.
+d. **Suspected fake-star burst** — if `v7 >= 50` AND the most recent 30 stargazers show ≥40% accounts created within the last 30 days with 0 public events (sample via `gh api users/$LOGIN --jq '.created_at, .public_repos'`), record `M (deferred)` and log `SUSPECTED_FAKE_STARS for $REPO — manual review`. No notification. Skip the per-user lookup if `v7 < 50` (cheap-path: organic-rate milestones don't need this check).
+e. **Multiple thresholds crossed in one run** — record intermediate ones silently as `(skipped)`, announce only the highest.
+f. Otherwise → proceed to step 6.
+
+### 6. Determine the **shape**
+
+Pick one label from the time-to-milestone evidence. `Δprior` = days between this milestone and the previously-recorded non-bootstrap, non-stale milestone (use `Δprior = null` if there isn't one).
+
+| Shape | When |
+|-------|------|
+| **SPIKE** | `v7 >= 3 × baseline` and `v7 >= 20`, OR `Δprior` < 25% of the prior gap. Clearly above trend. |
+| **ORGANIC** | `v7` within 0.5×–2× baseline. Steady-state growth. |
+| **MIGRATED** | First non-bootstrap milestone with `STARS >= 2 × M_bootstrap`. The repo arrived loud (e.g. cross-post from elsewhere). |
+| **RECOVERY** | Prior `(stale)` entry within last 30 days, now `v7 >= 5`. Growth resumed. |
+| **TRICKLE** | `v7 < 0.5 × baseline` but milestone still crossed. Trajectory is decelerating; flag honestly. |
+
+If velocity data is unavailable (step 3 failed for this repo), use shape `UNKNOWN` and omit the velocity line in step 7.
+
+### 7. Send the notification
+
+Use this exact structure via `./notify` — do not compress; the message goes to a Telegram group and must stand on its own:
+
+```
+*Milestone — ${M} stars · ${SHAPE}*
+${owner/repo}
+
+[owner/repo] crossed ${M} stars (now ${STARS}).
+Time to ${M}: ${Δprior_days} days from ${prev_M} (${shape_one_liner}).
+Pace: ${v7}/wk · baseline ${baseline_per_day}/day · projected ${next_M} by ~${eta_date}.
+
+Highlights since ${prev_milestone_date}:
+- [verb + concrete noun + delta — e.g. "Shipped 4 autoresearch evolutions (PRs #12, #18, #25, #45)"]
+- [highlight 2]
+- [highlight 3]
+
+Repo: https://github.com/${owner/repo}
+${status_footer}
+```
+
+Field rules:
+- `${shape_one_liner}` — one short clause naming the trajectory in plain English. Examples by shape: *"3.2× the previous gap — clear acceleration"* (SPIKE) / *"on-trend with the last two milestones"* (ORGANIC) / *"first real milestone post-launch"* (MIGRATED) / *"resumed after 12 quiet days"* (RECOVERY) / *"crossed on residual momentum, current pace would take 60 days for the next"* (TRICKLE).
+- `${eta_date}` — `today + (next_M - STARS) / max(v7/7, 0.5)` rounded to a date. If TRICKLE or pace < 0.5/day, write *"no projection — pace too slow"* instead of an inflated date.
+- **Highlights**: cap at 3. Source from `memory/logs/YYYY-MM-DD.md` last 14 days, sections like `## Push Recap`, `## Feature Built`, `## Repo Article`, `## Repo Actions`, `## Changelog`. Each highlight must include a verb, a concrete noun, and a delta or specificity (count, PR/issue number, name). Reject vague items like "improved docs" — rewrite as "Added 3 sections to README (PR #N)" or drop. If logs are empty, fall back to `gh api repos/$REPO/commits?since=<14d-ago> --jq '.[].commit.message'` and pick 3 commit subjects that ship value (skip chore/typo).
+- If velocity is `UNKNOWN`, replace the `Time to` and `Pace` lines with a single line: *"Velocity data unavailable this run — milestone confirmed by repo count."*
+- **`${status_footer}`** — single line, only printed in the log entry (step 9), NOT in the user-facing notification body. Format: `_status: shape=$SHAPE, v7=$N, fake_check=$ok|skip|defer, log_window=$days_d_`
+
+### 8. Update `memory/topics/milestones.md`
+
+Append the new entry under the repo's section. Create the file with `# Star Milestones` header if absent. Keep entries in ascending threshold order per repo. Format:
+
+```
+- ${M} stars — ${today} (${shape_lowercase})
+```
+
+For silent records (bootstrap/stale/deferred/skipped), use the corresponding suffix instead of the shape.
+
+### 9. Log to `memory/logs/${today}.md`
+
+```
+## Star Milestone
+- **owner/repo**: stargazers_count=N, milestone=M, shape=$SHAPE
+- **Velocity**: v7=$N, v30=$N, baseline=$N/day, days_since_last_star=$N
+- **Δprior**: $N days from ${prev_M} (prior gap was $N days)
+- **Highlights used**: $N (source: logs|commits)
+- **Notification sent**: yes / no — ${reason}
+- **Status**: STAR_MILESTONE_OK | STAR_MILESTONE_QUIET | STAR_MILESTONE_DEFERRED | STAR_MILESTONE_DEGRADED
+```
+
+`STAR_MILESTONE_DEGRADED` means the repo count succeeded but velocity data didn't — distinguishes a partial run from a clean miss.
 
 ## Edge cases
 
-- **Multiple milestones crossed in one run** (e.g. skill was disabled for a long time and the repo jumped from 180 to 260). Announce only the **highest** crossed milestone. Record intermediate ones silently with the `(skipped)` suffix — they're historical anchors but don't deserve individual announcements.
-- **Unstars dropping count below a recorded milestone.** Do not "un-record" milestones. Once crossed, they stay in the file permanently.
-- **Repo deleted / 404 from `gh api`.** Log the error for that repo and continue with the rest of the list. Do not fail the whole run.
+- **Multiple milestones crossed in one run** — see step 5e. Highest only; intermediates `(skipped)`.
+- **Unstars dropping count below a recorded milestone** — never un-record. Once written, milestones stay forever.
+- **Repo deleted / 404** — log the error for that repo and continue with the rest of the list. Do not fail the whole run; emit `STAR_MILESTONE_DEGRADED` for that repo.
+- **Brand-new repo with `STARS == M_first` (e.g. 25)** — bootstrap rule (5b) handles it: silent record, no notification on first run.
+- **Empty highlight reel after both log and commit fallback** — drop the highlights block entirely. Send the notification without it rather than padding with filler.
 
 ## Sandbox note
 
-`gh api` handles auth via the workflow's `GITHUB_TOKEN` automatically, so no env-var curl workaround is needed. The skill writes notifications via `./notify`, which fans out to every configured channel.
+`gh api` handles auth via the workflow's `GITHUB_TOKEN`, so no env-var curl workaround is needed. The stargazer pagination call is the only network-heavy step; if it fails, fall through to `UNKNOWN` shape rather than aborting. `./notify` fans out to every configured channel.
+
+## Constraints
+
+- **Never spam.** A milestone announced without velocity context is worse than no announcement — it trains readers to mute the channel. Honor the stale-suppression and fake-star-defer gates strictly.
+- **Never inflate.** If `v7` is below baseline, label the shape **TRICKLE** honestly rather than wording around it. Credibility compounds.
+- **Preserve milestones.md format.** Other skills (e.g. weekly-review) may parse this file — append, don't restructure.


### PR DESCRIPTION
## Autoresearch — star-milestone

**Winner: Variation B** — sharper output via velocity shape, time-to-milestone framing, projected next milestone, stale-suppression, and fake-star defer.
**Score: 49.5 / 50** weighted.

### Thesis (B)

The star-milestone skill produces exactly one user-facing artifact: a Telegram message. The original emits a fixed-template blurb with `[1–2 sentences framing why this matters]` as the only place real content lives — and the skill is fired blind, with no growth-context to fill that placeholder usefully. A "we crossed 200 stars" with no time-to-milestone, no velocity, no shape, and no projection trains readers to mute the channel. The biggest single lever is reshaping the output around what the *number itself* doesn't tell you: how fast it arrived, whether the trajectory is organic or a spike, and what's next. Folds in A's stargazer-timestamp pagination as the data engine, A's fake-star sniff as a credibility gate, and C's source-status footer for the log.

### Scoring table

| Variation | Clarity (×1.5) | Data quality (×1.5) | Output value (×2) | Robustness (×1.5) | Conventions (×1) | Improvement (×3) | **Weighted total** |
|---|---|---|---|---|---|---|---|
| **A — Better inputs** | 4 | 5 | 3.5 | 3.5 | 4 | 4 | **41.75** |
| **B — Sharper output** ✅ | 4.5 | 4.5 | 5 | 4 | 5 | 5 | **49.5** |
| **C — More robust** | 4 | 3 | 3 | 5 | 4.5 | 3 | **37.5** |
| **D — Rethink (growth-inflection monitor)** | 3.5 | 4 | 4 | 3.5 | 4 | 4 | **40.5** |

### Variations considered

**A — Better inputs (41.75).** Pull paginated stargazer timestamps via the `Accept: application/vnd.github.star+json` header for `starred_at`; compute v7 / v30 / baseline / days-since-last-star. Add fake-star sniff sampling the last 30 stargazers' `created_at` and `public_repos`. Pull commits / releases / merged PRs via `gh api` for a richer highlight reel. Strong data engine but the output template stays flat — better data poured into the same vague "[1–2 sentences framing]" placeholder. Folded into B as the data layer.

**B — Sharper output (49.5).** Reshape the notification: lead with `${SHAPE}` label (SPIKE / ORGANIC / MIGRATED / RECOVERY / TRICKLE) computed from velocity vs prior-gap; add `Time to N→M: X days from prev_M`, `Pace: v7/wk · baseline/day · projected next_M by ETA`. Cap highlights at 3 with a hard `verb + concrete noun + delta` requirement; reject vague items rather than padding. Suppress stale-recovery milestones silently (count crawled across the line then stalled ≥7d). Defer suspected fake-star bursts (`v7 ≥ 50` AND >40% of last 30 stargazers <30d old with 0 public events). Status footer in the log distinguishes `OK / QUIET / DEFERRED / DEGRADED`. Folds in A's data and fake-star check, plus C's status footer.

**C — More robust (37.5).** Bootstrap on missing `watched-repos.md`; per-repo error catalog (404/rate-limit/transient) with continue-on-fail; idempotent `milestones.md` writes; `STAR_MILESTONE_*` status codes; persist last-checked count to detect zero growth between runs. Plumbing wins, but the underlying message is unchanged — a more reliable delivery of a low-value blurb. Status-footer idea folded into B's log entry.

**D — Rethink (40.5): growth-inflection monitor.** Reframe as daily growth-pulse emitting one of MILESTONE / ACCELERATION / STALL / RECOVERY / QUIET, not just threshold crossings. Good ideas (acceleration / stall as first-class events) but blurs the skill's core purpose — autoresearch's "evolution, not replacement" constraint penalizes scope creep. RECOVERY signal partially folded into B (post-stale shape label).

### Diff summary

- Replace static `[1–2 sentences framing]` template with structured velocity fields (`Time to N→M`, `Pace`, `projected next`).
- Add `${SHAPE}` taxonomy: SPIKE / ORGANIC / MIGRATED / RECOVERY / TRICKLE / UNKNOWN, computed from `v7` vs `baseline` and `Δprior` vs prior gap.
- Add stargazer-timestamp pagination (last page + previous, via `Accept: application/vnd.github.star+json`) for velocity.
- Add gates in step 5: bootstrap (silent), stale-recovery (silent `(stale)`), fake-star defer (`v7≥50` + >40% suspicious recent stargazers, silent `(deferred)`).
- Tighten highlights to 3 items with verb+noun+delta requirement; commit-log fallback explicitly skips chore/typo subjects.
- Add `STAR_MILESTONE_OK / QUIET / DEFERRED / DEGRADED` status codes for log.
- Add explicit `NO_REPOS` exit when watched-repos list is empty (no notification).
- Constraints section explicitly forbids inflating shape labels — TRICKLE must be labeled honestly.

### Why this is a real improvement, not just a rewrite

The skill's only output is a Telegram message. Variation B is the only variation that meaningfully changes what that message *contains*. A makes the same message better-informed, C makes it more reliably delivered, D adds new message types but at the cost of muddying the milestone semantics. B is the highest-leverage change *for this specific skill's product*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Ported from aaronjmars/aeon-tmp#68.
