### PR TITLE
improve(deploy-prototype): autoresearch evolution

### DIFF
--- a/skills/deploy-prototype/SKILL.md
+++ b/skills/deploy-prototype/SKILL.md
@@ -4,56 +4,83 @@ description: Generate a small app or tool and deploy it live to Vercel via API
 var: ""
 tags: [dev, build]
 ---
-> **${var}** — What to build and deploy. If empty, picks from recent signals (articles, skill outputs, ideas in memory).
+<!-- autoresearch: variation B — sharper output via prototype quality bar + self-check + signal-anchored record -->
 
-If `${var}` is set, build that specific prototype instead of auto-selecting.
+> **${var}** — What to build and deploy.
+> - Empty → auto-select from recent signals (articles, logs, memory topics).
+> - Plain text (e.g. `market heatmap`) → interpret as a build brief.
+> - Typed form `type:slug description` (e.g. `tool:market-heatmap volume heatmap of top-20 tokens`, `viz:tx-graph`, `api:summarize`, `landing:startup-idea`) → use `type` to bias shape and `slug` as the deployment name.
 
-Today is ${today}. Your task is to build a small, self-contained prototype and prepare it for deployment to Vercel.
+Today is ${today}. Your task is to ship a small, self-contained prototype that someone could actually use in the browser today.
 
 ## Steps
 
-1. **Read context.** Read `memory/MEMORY.md` and recent logs in `memory/logs/` for ideas.
-   If running as part of a chain, check the chain context for upstream skill outputs to build from.
+1. **Read context.** Read `memory/MEMORY.md` and the most recent entries in `memory/logs/` for active topics.
+   If running as part of a chain, scan injected upstream outputs for a concrete artifact worth making interactive.
 
-2. **Decide what to build.** Pick something small and shippable:
-   - A single-page interactive tool or visualization
-   - A tiny API endpoint that does something useful
-   - A landing page or dashboard for a concept from recent research
-   - A prototype of a startup idea or technical concept
+2. **Pick what to build (if `${var}` is empty or vague).**
 
-   Keep scope tight — it must be deployable as static files or a single serverless function.
+   Scan these sources, in order, for prototype-worthy signals:
+   - `articles/` — last 7 entries by mtime: any claim, finding, or dataset that would be more useful as an interactive page?
+   - `memory/topics/*.md` — running narratives; pick one with a live data source (prices, feeds, markets)
+   - `memory/logs/${today}.md` and the two prior days — skill outputs flagged as interesting
+   - `memory/MEMORY.md` → "Next Priorities" and "Recent Articles"
 
-3. **Build it.** Write the files to `.pending-deploy/files/`:
+   Score each candidate 1-5 on:
+   - **Leverage** — does an interactive version beat the static write-up?
+   - **Concreteness** — is the spec obvious in one sentence? (if no, reject)
+   - **Novelty** — haven't shipped this in the last 14 days (check `articles/prototype-*.md` by mtime and any `memory/topics/prototypes.md`)
+
+   Pick the highest-total candidate. If no candidate reaches 9/15, skip building and exit as `DEPLOY_PROTOTYPE_EMPTY` (step 9).
+
+   Record the chosen signal — its source file(s) and one-line rationale — you'll use it in steps 6 and 7.
+
+3. **Commit to a shape before writing code.** Before touching `.pending-deploy/`, write out (in your reasoning, not a file):
+   - **Slug**: `aeon-prototype-<descriptor>`, all lowercase, `[a-z0-9-]`, 3–50 chars after prefix (e.g. `aeon-prototype-market-heatmap`). If `${var}` supplied a typed slug, use it; otherwise derive one.
+   - **Tagline** (≤90 chars) — the one-liner that appears in the page title and OG tags.
+   - **Primary action** — what is the one thing a visitor does in the first 10 seconds? (read a number, click a filter, submit an input, compare two things). If you can't name it, go back to step 2.
+   - **Shape**: static HTML+JS / static + `api/` function / Next.js. Default to static single-file HTML unless the idea genuinely needs a serverless function.
+
+4. **Write the files.**
    ```bash
+   rm -rf .pending-deploy        # clear stale state from prior runs
    mkdir -p .pending-deploy/files
    ```
-   Write all prototype source files into `.pending-deploy/files/`. This directory is the
-   complete project root — everything here gets pushed to a new GitHub repo and deployed to Vercel.
+   Write all project files into `.pending-deploy/files/`. This directory is the repo root — everything here is pushed to GitHub and deployed to Vercel.
 
-   Write complete, working code. No placeholders. No TODO comments.
+   **Quality bar — every prototype must meet these:**
+   - **Self-contained** — no external build step where avoidable. Prefer one `index.html` with inline `<style>` and `<script>`; fall back to a `main.css` / `main.js` only when size justifies it.
+   - **Loads in <1s on a cold visit.** No jQuery, no CDN UI libraries for a single-page tool. Vanilla JS or a ~10KB util max. No `<link rel="stylesheet">` to a CDN font unless it's one font.
+   - **Mobile-first, works on a phone.** Viewport meta set, tap targets ≥40px, no horizontal scroll at 360px wide.
+   - **Share-friendly.** Include `<title>`, `<meta name="description">`, `<meta property="og:title">`, `<meta property="og:description">`, `<meta property="og:type" content="website">`. Skip OG image unless you generate one.
+   - **Real content, not lorem.** If the prototype shows data, fetch it from a public no-auth endpoint at load time (CoinGecko, GitHub public API, public RSS, public JSON feeds) — or hardcode a recent, realistic snapshot with the timestamp visible. Never ship placeholder `[example data]`.
+   - **One visible CTA or primary surface.** Clear hierarchy: what does the visitor look at first?
+   - **Works with JS disabled to at least show the tagline** (progressive enhancement — not required for interactive tools, but the title and description must render server-free).
+   - **Light + dark via `prefers-color-scheme`** — 4 CSS vars is enough.
+   - **No secrets.** No API keys, tokens, or env vars embedded anywhere. If the idea requires auth, redesign around a public endpoint or drop the idea.
+   - **Include a `README.md`** in `.pending-deploy/files/` with: what it is (1 line), how to run locally (1 line), signal source (1 line link to the article/log/topic from step 2).
 
-   For **static sites**: write HTML/CSS/JS files directly.
-   For **API endpoints**: write files in `api/` directory (e.g. `api/index.js` exporting a handler).
-   For **Next.js**: keep it minimal — `package.json`, `pages/index.js`, or `app/page.tsx`.
+   For **API endpoints**: place handlers in `api/` (e.g. `api/index.js` exporting `export default function handler(req, res) { ... }`).
+   For **Next.js**: keep it one page — `package.json` + `pages/index.js`. Only if the idea genuinely needs SSR.
 
-   Prefer static HTML + vanilla JS when possible — fewer build steps, faster deploys, less to break.
-
-4. **Write deploy metadata.** Create `.pending-deploy/meta.json`:
+5. **Write deploy metadata.** Create `.pending-deploy/meta.json`:
    ```json
    {
-     "name": "aeon-prototype-DESCRIPTIVE_SLUG",
-     "description": "One-sentence description of what this does",
-     "framework": null
+     "name": "aeon-prototype-<slug-from-step-3>",
+     "description": "One-sentence description, matches the OG description on the page",
+     "framework": null,
+     "tagline": "≤90 chars — matches <title> on the page",
+     "signal_source": "path or URL of the article/log/topic that triggered this prototype",
+     "primary_action": "what the visitor does in the first 10 seconds"
    }
    ```
-   - `name` becomes both the GitHub repo name and Vercel project name.
-   - `framework`: set to `null` for static, or `"nextjs"`, `"svelte"`, etc. if using one.
-   - Use descriptive slugs: `aeon-prototype-market-heatmap`, not `aeon-prototype-1`.
+   - `framework`: `null` for static; `"nextjs"`, `"svelte"`, etc. when used.
+   - The extra fields (`tagline`, `signal_source`, `primary_action`) are for the prototype record and downstream dashboards; the postprocess script may ignore them.
 
-5. **Prepare Vercel deploy payload.** Build `.pending-deploy/payload.json` with all files inlined:
+6. **Build the Vercel deploy payload.** Write `.pending-deploy/payload.json`:
    ```json
    {
-     "name": "aeon-prototype-DESCRIPTIVE_SLUG",
+     "name": "aeon-prototype-<slug>",
      "files": [
        { "file": "index.html", "data": "<!DOCTYPE html>...", "encoding": "utf-8" }
      ],
@@ -65,50 +92,85 @@ Today is ${today}. Your task is to build a small, self-contained prototype and p
      "target": "production"
    }
    ```
+   Use `"encoding": "base64"` for any binary file.
 
-   For binary files use `"encoding": "base64"`.
-   If using a framework, set `projectSettings.framework` and include `package.json`.
+   **Pre-flight checks** (run before writing the notify):
+   - File count ≤ 20. Reject if above.
+   - Total payload JSON ≤ 4MB. Reject if above (Vercel inline deploy practical limit).
+   - Slug matches `^aeon-prototype-[a-z0-9][a-z0-9-]{2,49}$`.
+   - Grep every file for: `VERCEL_TOKEN`, `GH_GLOBAL`, `ANTHROPIC_API_KEY`, `sk-ant-`, `sk-`, `ghp_`, `xoxb-`, `xai-`. Any hit → abort and rewrite the offending file without the value.
+   - Grep every file for literal `TODO`, `FIXME`, `lorem ipsum`, `placeholder`. Any hit → fix in place before proceeding.
+   - If `scripts/postprocess-deploy.sh` does not exist, continue but flag `DEPLOY_PROTOTYPE_NO_POSTPROCESS` in the notify (operator needs to know deploys won't happen automatically).
 
-6. **Save the prototype record.** Write to `articles/prototype-${today}.md`:
+7. **Save the prototype record.** Write to `articles/prototype-${today}.md`. If a file with that name already exists (second run in the same day), append `-02`, `-03`, etc.
    ```markdown
-   # Prototype: [Name]
+   # Prototype: <Name>
 
    **Built:** ${today}
-   **What:** One-sentence description
+   **Tagline:** <tagline from meta.json>
    **Status:** Pending deploy
+   **Live URL:** _(filled by postprocess-deploy.sh on successful deploy)_
 
-   ## Why
-   What signal or idea triggered this.
+   ## Signal
+   What triggered this: one paragraph. Link the source article/log/topic (`signal_source` from meta.json).
 
-   ## How
-   Brief technical notes — stack, approach, interesting bits.
+   ## What it does
+   One paragraph, plain language. Include the primary action a visitor takes.
+
+   ## How it works
+   Brief technical notes — stack, data source, anything non-obvious. No code dumps.
 
    ## Files
-   - file list with brief descriptions
+   - `index.html` — brief description
+   - …
 
-   ## Next
-   What would make this a real product.
+   ## Extend
+   Three bullets on what would make this a real product (not placeholder — concrete next steps).
    ```
 
-7. **Notify.** Send via `./notify`:
+   Append a one-line row to `memory/topics/prototypes.md` (create the file with a header row if missing):
    ```
-   built: [name] — [one-line description]. deploying to vercel...
+   | date | slug | tagline | signal_source | live_url |
+   |------|------|---------|---------------|----------|
+   | 2026-04-20 | aeon-prototype-foo | ... | articles/... | _pending_ |
    ```
 
-8. **Log.** Append what you did to `memory/logs/${today}.md`.
+8. **Notify.** Send via `./notify` (one of these, depending on outcome):
+   - Built + will deploy: `built: <slug> — <tagline>. deploying to vercel…`
+   - Built but postprocess missing: `built: <slug> — <tagline>. ⚠ scripts/postprocess-deploy.sh not found — deploy will not run automatically`
+   - No signal worth shipping: handled in step 9.
+
+9. **Exit modes.** End the run with one of these, logged in `memory/logs/${today}.md` under `### deploy-prototype`:
+   - `DEPLOY_PROTOTYPE_OK` — prototype built, payload valid, postprocess script present.
+   - `DEPLOY_PROTOTYPE_NO_POSTPROCESS` — prototype built and valid, but `scripts/postprocess-deploy.sh` missing; operator action needed.
+   - `DEPLOY_PROTOTYPE_EMPTY` — no candidate cleared the quality threshold in step 2. Log the top candidate and its score so the next run can reconsider. `./notify "deploy-prototype: no candidate cleared threshold today — top was <slug> (<score>/15)"`.
+   - `DEPLOY_PROTOTYPE_VALIDATION_FAILED` — a pre-flight check in step 6 failed and couldn't be fixed automatically. Leave `.pending-deploy/` in place, log the failure reason, notify the operator.
+
+10. **Log.** Append to `memory/logs/${today}.md`:
+    ```
+    ### deploy-prototype
+    - Exit: DEPLOY_PROTOTYPE_<MODE>
+    - Slug: aeon-prototype-<slug> (or — if empty)
+    - Signal: <signal_source>
+    - Notes: <anything the next run should know>
+    ```
 
 ## Environment Variables
 
-- `VERCEL_TOKEN` — Required. Vercel API bearer token.
-- `GH_GLOBAL` — Required. GitHub PAT with repo creation permission (used by post-run step).
+- `VERCEL_TOKEN` — Required for the deploy (used by `scripts/postprocess-deploy.sh`, not by Claude).
+- `GH_GLOBAL` — Required for GitHub repo creation in the postprocess step.
+
+Neither is needed during Claude's in-sandbox run. Do not read them, do not embed them in any file.
 
 ## Guidelines
 
-- Keep prototypes small. A single HTML file is ideal. Max ~5 files.
-- Name deployments descriptively.
-- Prefer zero-build static deploys over framework-heavy setups.
-- Clean, minimal code. No npm install steps unless absolutely required.
-- Do not hardcode any secrets into deployed files.
-- Always include a README.md in `.pending-deploy/files/` with a brief description.
-- The actual GitHub repo creation, push, and Vercel deploy happen in a post-run workflow step
-  outside the sandbox. Your job is to write the files and metadata correctly.
+- A prototype is not a PoC. It's a page someone with zero context can load, understand in 10 seconds, and get value from. Hold that bar.
+- Single `index.html` is almost always the right answer. Resist the urge to add tooling.
+- Max ~5 files (enforced at 20 in pre-flight).
+- Descriptive slugs. `aeon-prototype-market-heatmap`, not `aeon-prototype-1`.
+- Never hardcode secrets. If a public-auth endpoint isn't enough for the idea, drop the idea.
+- The actual GitHub repo creation, push, and Vercel deploy happen in `scripts/postprocess-deploy.sh` outside the sandbox. Your job: write files and metadata correctly so that script can run unattended.
+
+## Sandbox note
+
+All the skill's work happens inside the sandbox — file writes and notify only. No outbound network required during Claude's run. The deploy step runs post-sandbox from `scripts/postprocess-deploy.sh`, which reads `.pending-deploy/` and uses `VERCEL_TOKEN` + `GH_GLOBAL` directly. If that script is missing, flag it in the notify (exit mode `DEPLOY_PROTOTYPE_NO_POSTPROCESS`) — the skill still succeeds at its file-writing job, but the operator needs to add the postprocess script for deploys to actually happen.


### PR DESCRIPTION
## Winner — Variation B (sharper output)
**Score: 46.75 / 52.5**

**Thesis:** the original skill's biggest gap is that it has no standard for what a *shippable* prototype actually looks like — the "quality bar" is one line ("prefer static HTML"). Without a concrete bar, an autonomous agent defaults to throwaway pages with lorem-ish copy, no mobile consideration, no OG tags, and vague "what is this" framing. Fixing the selection (A), robustness (C), or reframing the flow (D) only matters if the artifact itself is good. B sets that bar explicitly and folds in the highest-value pieces of A/C/D on top.

### Key changes
- **Prototype quality bar** — single-file HTML preferred, <1s load, mobile-first (360px, 40px targets), `prefers-color-scheme` light/dark, real content not lorem, one clear primary action, OG/description meta tags, no secrets ever.
- **Signal-anchored record** — every prototype captures the source article/log/topic in `signal_source` (borrowed from D) via `meta.json` and `articles/prototype-${today}.md`; appends a running ledger row to `memory/topics/prototypes.md`.
- **Pre-flight self-check** (borrowed from C) — file count ≤20, payload ≤4MB, slug regex, grep for `VERCEL_TOKEN`/`sk-ant-`/`ghp_`/`xai-`/etc. and for `TODO`/`lorem ipsum`/`placeholder`. Rewrites-on-hit, aborts if unrecoverable.
- **Exit-mode taxonomy**: `DEPLOY_PROTOTYPE_OK` / `_EMPTY` (no candidate cleared score threshold) / `_NO_POSTPROCESS` (flags missing `scripts/postprocess-deploy.sh` — **currently missing in repo**, which means today's deploys aren't running end-to-end) / `_VALIDATION_FAILED`.
- **Richer `var` syntax** (from A) — accepts `type:slug description` (`tool:market-heatmap …`, `viz:…`, `api:…`, `landing:…`) in addition to plain prose or empty.
- **Step 3 "commit to a shape" gate** — forces the agent to name slug, tagline (≤90 chars), primary action, and shape *before* writing files. If the primary action can't be named in one sentence, return to selection.
- **Duplicate-date article handling** — `prototype-${today}-02.md` etc. on re-runs.
- **Clean `.pending-deploy/` at start** — removes stale state from prior runs.
- **Explicit note that `VERCEL_TOKEN` / `GH_GLOBAL` are postprocess-only** — Claude's in-sandbox run must not read them.

## Scoring table (weighted, 1–5 × listed weight)

| Criterion (weight) | A: Better inputs | **B: Sharper output** | C: More robust | D: Rethink (signal-first) |
|---|---|---|---|---|
| Clarity (×1.5) | 4 | **4.5** | 4 | 3.5 |
| Data quality (×1.5) | 4 | **4** | 3.5 | 4.5 |
| Output value (×2) | 3.5 | **5** | 3.5 | 4.5 |
| Robustness (×1.5) | 3 | **4** | 5 | 3.5 |
| Conventions (×1) | 4 | **4.5** | 4.5 | 4 |
| Improvement (×3) | 3.5 | **4.5** | 3.5 | 4 |
| **Total / 52.5** | 38 | **46.75** | 40.75 | 42.25 |

## Variation summaries

- **A — Better inputs (38)**: richer `var` syntax (`type:slug`), structured idea-sourcing (articles → topics → logs → MEMORY.md), 7/14-day dedup against past prototypes. Improves selection but doesn't fix the core problem that the built artifact has no standards.
- **B — Sharper output (46.75) — WINNER**: prototype quality bar + pre-flight self-check + signal-anchored record + exit taxonomy. Folds in A (var syntax, memory scoring), C (validation, exit modes, missing-postprocess flag), and D (signal_source field, running ledger).
- **C — More robust (40.75)**: clean `.pending-deploy/`, payload validation (count/size/slug/secrets), missing-postprocess detection, duplicate-date handling, exit-mode taxonomy. Strong robustness but doesn't raise the artifact quality on its own.
- **D — Rethink signal-first (42.25)**: two-phase flow — Phase 1 picks a concrete signal via leverage×concreteness×novelty scoring (skip if nothing clears threshold), Phase 2 builds directly against that signal with `signal_source` tie-through. Compelling reframe, but without the quality bar of B, a well-chosen signal still ships as a rough page.

## Operational note
While reviewing, I noticed `scripts/postprocess-deploy.sh` does not exist in the repo — the workflow runs `scripts/postprocess-*.sh` with `VERCEL_TOKEN` in env, but there is no handler for `.pending-deploy/`. The winning variation surfaces this as a first-class exit mode (`DEPLOY_PROTOTYPE_NO_POSTPROCESS`) in the notify so the operator sees it immediately. Creating that script is out of scope for autoresearch (skill-file evolution only), but is the single most impactful follow-up.

---
Ported from aaronjmars/aeon-tmp#69.
