### PR TITLE
improve(distribute-tokens): autoresearch evolution

### DIFF
--- a/skills/distribute-tokens/SKILL.md
+++ b/skills/distribute-tokens/SKILL.md
@@ -1,149 +1,214 @@
 ---
 name: Distribute Tokens
-description: Send tokens to a list of contributors via Bankr Agent API (supports Twitter handles and EVM addresses)
+description: Send tokens to a list of contributors via Bankr Wallet API with per-recipient idempotency, two-phase resolve→execute, dry-run, and recovery from partial runs
 var: ""
 tags: [crypto]
 ---
-> **${var}** — Distribution list label to use. If empty, uses the default list. Pass a label to target a specific group (e.g. "contributors", "team").
+<!-- autoresearch: variation C — robustness via per-recipient idempotency state, two-phase resolve→execute, dry-run, retries, 403/429 handling, recovery -->
+
+> **${var}** — Distribution list label. If empty, uses the first list in `memory/distributions.yml`. Pass `dry-run:LABEL` to preview without sending. Pass `LABEL` alone to execute.
+
+## Why this design
+
+This skill moves real money. The biggest failure mode is double-sending (re-runs, retries after partial failures, day-rollover bypass of "skip if today" logic) or sending into a black hole (no preflight balance, deprecated API path, missing handle resolution). The skill therefore:
+
+1. **Persists per-recipient idempotency state** in `memory/state/distributions.json` keyed on `(list, recipient, date_utc)` with the txHash. A successful transfer is *never* re-sent within the same UTC day, even across re-runs or workflow restarts.
+2. **Two-phase execution**: RESOLVE (validate config, key, balance, resolve all handles → addresses, build plan) → EXECUTE (send each transfer, persist state after each one). RESOLVE failures abort before any send.
+3. **Dry-run mode** outputs the full plan with no transfers.
+4. **Wallet API only** for actual transfers — Bankr's docs deprecate the Agent API for transfers. Agent API is used only for handle→address resolution.
 
 ## Config
 
-This skill reads distribution lists from `memory/distributions.yml`. If the file doesn't exist, log a warning and exit.
+Reads `memory/distributions.yml`. If missing, bootstrap with a commented template (see Bootstrap step) and exit cleanly with `DISTRIBUTE_TOKENS_OK — bootstrapped distributions.yml; edit and re-run`.
 
 ```yaml
 # memory/distributions.yml
 defaults:
-  token: USDC
-  amount: "5"          # per recipient
+  token: USDC          # USDC | ETH (Base only)
+  amount: "5"
   chain: base
 
 lists:
   contributors:
     description: "Weekly contributor rewards"
-    token: USDC        # override default
-    amount: "10"       # override default
+    token: USDC
+    amount: "10"
     recipients:
-      - handle: "@alice_dev"      # Twitter/X handle — resolved via Bankr
-        amount: "15"              # per-recipient override (optional)
+      - handle: "@alice_dev"      # Twitter/X — resolved via Bankr Agent API
+        amount: "15"
       - handle: "@bob_builder"
-      - address: "0x742d...5678"  # direct EVM address
+      - address: "0x742d...5678"  # direct EVM address — preferred path
         label: "Charlie"
         amount: "20"
-
-  team:
-    description: "Monthly team distribution"
-    token: ETH
-    amount: "0.01"
-    recipients:
-      - handle: "@core_dev1"
-      - handle: "@core_dev2"
 ```
 
 ### Required secrets
 
 | Secret | Purpose |
 |--------|---------|
-| `BANKR_API_KEY` | Bankr API key (prefixed `bk_`). Must have **read-write** access and **Agent API** enabled. |
+| `BANKR_API_KEY` | Bankr API key (`bk_...`). Must be **read-write** with **Wallet API** enabled. Read-only keys → 403. |
 
-Get a key at [bankr.bot/api](https://bankr.bot/api). Enable read-write mode and Agent API access in key settings.
+### Token addresses on Base
 
-### How it works
-
-- **Twitter handles** (`@username`): Sent via the Bankr Agent API using natural language. Bankr resolves the handle to the recipient's linked wallet. The recipient must have a Bankr account — if they don't, that transfer fails and is logged.
-- **EVM addresses** (`0x...`): Sent via the direct Wallet Transfer API (`POST /wallet/transfer`). Base chain only.
+- USDC: `0x833589fcd6edb6e08f4c7c32d4f71b54bda02913`
+- ETH (native): `tokenAddress: "0x0000000000000000000000000000000000000000"`, `isNativeToken: true`
 
 ---
 
-Read memory/MEMORY.md and memory/distributions.yml.
-Read the last 2 days of memory/logs/ to check for recent distributions (avoid double-sending).
+Read `memory/MEMORY.md` and `memory/distributions.yml`.
+Read `memory/state/distributions.json` (if present) for idempotency state.
 
-Steps:
+## Steps
 
-1. **Validate config** — parse `memory/distributions.yml`. If `${var}` is set, find the matching list by label. If not set, use the first list. Abort if no lists found or file missing.
+### 1. Parse var and load config
 
-2. **Check for duplicates** — scan recent logs for distributions to the same list in the last 24 hours. If found, log "DISTRIBUTE_TOKENS_SKIPPED — already distributed to '${list}' today" and exit. This prevents accidental double-sends from re-runs.
+- If `${var}` starts with `dry-run:`, set `MODE=dry-run` and `LABEL=${var#dry-run:}`. Otherwise `MODE=execute` and `LABEL=${var}`.
+- If `memory/distributions.yml` missing → **Bootstrap**: write the example config (commented out so it's inert), notify `DISTRIBUTE_TOKENS_OK — bootstrapped distributions.yml; edit and re-run`, log, exit.
+- Parse YAML. If `LABEL` empty, use the first list. Else find the matching list. If not found → notify `DISTRIBUTE_TOKENS_ERROR — list '${LABEL}' not found`, log, exit.
+- Resolve `today_utc=$(date -u +%F)`.
 
-3. **Check BANKR_API_KEY** — if not set, log "DISTRIBUTE_TOKENS_ERROR — BANKR_API_KEY not configured" and exit.
+### 2. Pre-flight: key, write access, balance
 
-4. **Process each recipient** — for each entry in the list:
+If `BANKR_API_KEY` not set → `DISTRIBUTE_TOKENS_ERROR — BANKR_API_KEY not configured`, log, exit.
 
-   Determine the amount: use recipient-level `amount` if set, otherwise list-level `amount`, otherwise `defaults.amount`.
-   Determine the token: use list-level `token`, otherwise `defaults.token`.
+```bash
+ME=$(curl -fsS "https://api.bankr.bot/wallet/me" -H "X-API-Key: ${BANKR_API_KEY}")
+```
 
-   **Path A — Twitter handle** (starts with `@`):
+- HTTP 403 → `DISTRIBUTE_TOKENS_ERROR — API key is read-only; needs wallet write scope`, exit.
+- HTTP 429 → `DISTRIBUTE_TOKENS_ERROR — rate-limited at /wallet/me; aborting`, exit.
+- Network failure → use **WebFetch** fallback. If still failing → `DISTRIBUTE_TOKENS_ERROR — Bankr /wallet/me unreachable`, exit.
 
-   Use the Bankr Agent API with a natural language transfer command:
-   ```bash
-   JOB_ID=$(curl -s -X POST "https://api.bankr.bot/agent/prompt" \
-     -H "X-API-Key: ${BANKR_API_KEY}" \
-     -H "Content-Type: application/json" \
-     -d '{"prompt":"send '"${amount}"' '"${token}"' to '"${handle}"' on base"}' \
-     | jq -r '.jobId')
-   ```
+```bash
+PORTFOLIO=$(curl -fsS "https://api.bankr.bot/wallet/portfolio?chain=base" -H "X-API-Key: ${BANKR_API_KEY}")
+```
 
-   Poll for completion (max 60s, 5s intervals):
-   ```bash
-   for i in $(seq 1 12); do
-     RESULT=$(curl -s "https://api.bankr.bot/agent/job/${JOB_ID}" \
-       -H "X-API-Key: ${BANKR_API_KEY}")
-     STATUS=$(echo "$RESULT" | jq -r '.status')
-     if [ "$STATUS" = "completed" ] || [ "$STATUS" = "failed" ]; then break; fi
-     sleep 5
-   done
-   ```
+Extract sender's balance for the target token. Compute `total_required` from the recipient list (sum of per-recipient amounts, applying overrides). If `balance < total_required * 1.05` (5% headroom for any failed retries) → `DISTRIBUTE_TOKENS_ERROR — insufficient balance: have X, need Y ${TOKEN}`, exit. Do not start a partial run.
 
-   Record result: if `completed`, extract tx hash from response. If `failed`, log the error (likely "no linked wallet for this handle").
+### 3. RESOLVE phase — build the plan
 
-   **Path B — EVM address** (starts with `0x`):
+For each recipient, build a row: `{key, type, amount, token, target_address, label, status}` where `key = sha256("${LABEL}|${recipient_id}|${today_utc}")` and `recipient_id` is the handle (lowercase) or address (lowercase).
 
-   For USDC on Base, the token address is `0x833589fcd6edb6e08f4c7c32d4f71b54bda02913`.
-   For native ETH, set `isNativeToken: true`.
+**Idempotency check** (before resolving): if `memory/state/distributions.json` contains `key` with `status=completed` → mark row `SKIPPED_DEDUP`, carry forward the prior `txHash`.
 
-   Use the Wallet Transfer API:
-   ```bash
-   RESULT=$(curl -s -X POST "https://api.bankr.bot/wallet/transfer" \
-     -H "X-API-Key: ${BANKR_API_KEY}" \
-     -H "Content-Type: application/json" \
-     -d '{
-       "recipientAddress": "'"${address}"'",
-       "tokenAddress": "'"${token_address}"'",
-       "amount": "'"${amount}"'",
-       "isNativeToken": '"${is_native}"'
-     }')
-   ```
+**Handle resolution** (`@username`): use Bankr Agent API to look up the linked wallet:
+```bash
+JOB=$(curl -fsS -X POST "https://api.bankr.bot/agent/prompt" \
+  -H "X-API-Key: ${BANKR_API_KEY}" -H "Content-Type: application/json" \
+  -d "{\"prompt\":\"What is the EVM address linked to ${HANDLE} on Base? Respond with only the address.\"}" | jq -r '.jobId')
+# Poll every 2s, max 30s
+for i in $(seq 1 15); do
+  R=$(curl -fsS "https://api.bankr.bot/agent/job/${JOB}" -H "X-API-Key: ${BANKR_API_KEY}")
+  S=$(echo "$R" | jq -r '.status')
+  [ "$S" = "completed" ] || [ "$S" = "failed" ] && break
+  sleep 2
+done
+```
+Extract the address from the response (regex `0x[a-fA-F0-9]{40}`). If extraction fails → mark row `RESOLVE_FAILED` with reason `NO_LINKED_WALLET`. Do **not** abort the whole plan; let the executor skip this row.
 
-   Check `success` field. Extract `txHash` on success.
+**Address resolution** (`0x...`): validate format `^0x[a-fA-F0-9]{40}$`. If invalid → `RESOLVE_FAILED` reason `BAD_ADDRESS`.
 
-   Common token addresses on Base:
-   - USDC: `0x833589fcd6edb6e08f4c7c32d4f71b54bda02913`
-   - BNKR: look up via Bankr Agent API if needed
-   - ETH (native): use `isNativeToken: true`, any `tokenAddress`
+After RESOLVE, print the plan to the console (and to the dry-run notification if `MODE=dry-run`):
 
-5. **Build summary** — compile results:
-   ```
-   *Token Distribution — ${today}*
+```
+Plan for list '${LABEL}' (${today_utc}):
+  ✓ @alice_dev → 0x1234... — 15 USDC          [READY]
+  ✓ Charlie    → 0x742d... — 20 USDC          [READY]
+  ↻ @bob_builder → 0xabcd... — 10 USDC        [SKIPPED_DEDUP] (tx 0xprev...)
+  ✗ @inactive → ?                             [RESOLVE_FAILED: NO_LINKED_WALLET]
 
-   List: ${list_label} (${description})
-   Token: ${token} on Base
-   Total sent: ${total_amount} ${token}
+Summary: 2 to send (35 USDC), 1 deduped, 1 unresolvable. Sender balance: 100 USDC.
+```
 
-   ✓ @alice_dev — 15 USDC (tx: 0xabc...)
-   ✓ @bob_builder — 10 USDC (tx: 0xdef...)
-   ✓ Charlie (0x742d...) — 20 USDC (tx: 0x123...)
-   ✗ @inactive_user — failed: no linked Bankr wallet
+If `MODE=dry-run`: notify the plan, log, exit `DISTRIBUTE_TOKENS_DRY_RUN`. Do not proceed.
 
-   Success: N/M recipients
-   ```
+If 0 rows are `READY` (everything deduped/failed) → notify the plan, log, exit `DISTRIBUTE_TOKENS_OK — nothing to send`.
 
-6. **Send** via `./notify`.
+### 4. EXECUTE phase
 
-7. **Log** results to `memory/logs/${today}.md`:
-   - List label, token, chain
-   - Each recipient with status (success/fail), amount, tx hash
-   - Total distributed vs total attempted
+For each `READY` row, send via `/wallet/transfer` (the only sanctioned transfer endpoint per Bankr docs):
+
+```bash
+RESP=$(curl -fsS -X POST "https://api.bankr.bot/wallet/transfer" \
+  -H "X-API-Key: ${BANKR_API_KEY}" -H "Content-Type: application/json" \
+  -d "{\"recipientAddress\":\"${ADDR}\",\"tokenAddress\":\"${TOKEN_ADDR}\",\"amount\":\"${AMT}\",\"isNativeToken\":${IS_NATIVE}}")
+```
+
+Outcome handling:
+- HTTP 200 + `success: true` → status `COMPLETED`, store `txHash`. **Persist the state file immediately** (write after every recipient, not at the end — survives mid-run crashes).
+- HTTP 200 + `success: false` → status `FAILED`, store `error` field as reason.
+- HTTP 403 → status `FAILED` reason `READ_ONLY_KEY`. Abort remaining rows (key won't suddenly gain write access). Persist state.
+- HTTP 429 → status `FAILED` reason `RATE_LIMIT`. Sleep 60s, retry once. If still 429, abort remaining (rolling-window quota exhausted). Persist state.
+- HTTP 5xx or network error → retry once after 10s. If still failing, status `FAILED` reason `API_ERROR`.
+- Any other → status `FAILED` reason `HTTP_${code}`.
+
+State file shape (`memory/state/distributions.json`, append/upsert):
+```json
+{
+  "contributors|@alice_dev|2026-04-20": {
+    "list": "contributors",
+    "recipient": "@alice_dev",
+    "address": "0x1234...",
+    "amount": "15",
+    "token": "USDC",
+    "status": "completed",
+    "txHash": "0xabc...",
+    "timestamp": "2026-04-20T12:34:56Z"
+  }
+}
+```
+
+### 5. Build summary notification
+
+Top line is a verdict: `COMPLETE` (all READY succeeded) / `PARTIAL` (some failed) / `FAILED` (none succeeded) / `DRY_RUN` / `NOTHING_TO_SEND`.
+
+```
+*Token Distribution — ${today_utc}* — VERDICT
+
+List: ${LABEL} (${description})
+Token: ${TOKEN} on Base
+Sent: ${total_sent} ${TOKEN} to ${n_success}/${n_attempted} recipients
+Skipped (already sent today): ${n_dedup}
+Unresolvable: ${n_unresolved}
+
+✓ @alice_dev — 15 USDC ([tx](https://basescan.org/tx/0xabc...))
+✓ Charlie (0x742d...) — 20 USDC ([tx](https://basescan.org/tx/0x123...))
+↻ @bob_builder — 10 USDC (already sent: [tx](https://basescan.org/tx/0xprev...))
+✗ @inactive_user — RESOLVE_FAILED: NO_LINKED_WALLET
+
+Sender balance after: ${remaining} ${TOKEN}
+```
+
+Suppress empty sections (no `Skipped:` line if `n_dedup=0`, etc.). Send via `./notify`.
+
+### 6. Log
+
+Append to `memory/logs/${today_utc}.md`:
+
+```
+### distribute-tokens
+- List: ${LABEL} | Token: ${TOKEN} | Mode: ${MODE}
+- Verdict: ${VERDICT}
+- Sent: ${total_sent} ${TOKEN} to ${n_success}/${n_attempted}; deduped: ${n_dedup}; unresolved: ${n_unresolved}
+- Failures (if any): @x — REASON, @y — REASON
+- State file: memory/state/distributions.json (${total_keys} entries)
+```
+
+Exit codes (for downstream automation):
+- `DISTRIBUTE_TOKENS_OK` — nothing to send (everything deduped or list empty), or bootstrap
+- `DISTRIBUTE_TOKENS_COMPLETE` — all READY rows succeeded
+- `DISTRIBUTE_TOKENS_PARTIAL` — some succeeded, some failed
+- `DISTRIBUTE_TOKENS_DRY_RUN` — dry-run completed, no sends
+- `DISTRIBUTE_TOKENS_ERROR` — preflight or config failure, no sends attempted
 
 ## Sandbox note
 
-The sandbox may block outbound curl. Use **WebFetch** as a fallback for any URL fetch. For auth-required APIs, use the pre-fetch/post-process pattern (see CLAUDE.md).
+Outbound curl may fail in the GH Actions sandbox. For each curl call, on failure try **WebFetch** (no body for GET; for POST use the pre-fetch / post-process pattern in CLAUDE.md). For `/wallet/transfer` specifically — because it's a write endpoint with auth headers — if curl fails, queue the request as a JSON file under `.pending-bankr/` and rely on a `scripts/postprocess-bankr.sh` runner if available; otherwise mark the row `FAILED` reason `SANDBOX_BLOCKED` and continue. Never silently drop a transfer.
 
-If `memory/distributions.yml` doesn't exist, send nothing. Log "DISTRIBUTE_TOKENS_OK — no distribution lists configured" and end.
+## Constraints
+
+- **Idempotency is non-negotiable.** Always read state file before sending; always persist after every transfer. Never batch state writes to end-of-run.
+- Treat the 24h Bankr rate limit (100/day standard) as a hard cap. Lists >50 recipients should be split.
+- Never send if preflight balance is < `total_required * 1.05`.
+- Never use the Agent API for transfers (deprecated). Agent API only for handle→address resolution.
+- Never abort the RESOLVE phase on a single bad recipient — collect all errors, present them, then let executor skip.


### PR DESCRIPTION
## Autoresearch — distribute-tokens

Improve a money-moving skill by adding per-recipient idempotency, two-phase resolve→execute with dry-run, and switching off Bankr's deprecated Agent API path for transfers.

## Scoring (weighted, max 52.5)

| | Clarity ×1.5 | Data ×1.5 | Output ×2 | Robust ×1.5 | Conv ×1 | Improve ×3 | **Total** |
|---|---|---|---|---|---|---|---|
| **A** Better inputs | 4 | 5 | 3 | 3 | 5 | 4 | 41.0 |
| **B** Sharper output | 4 | 3 | 5 | 3 | 5 | 4 | 42.0 |
| **C** More robust ✅ | 4 | 4 | 4 | 5 | 5 | 5 | **47.5** |
| **D** Rethink (single batch tx) | 3 | 4 | 3 | 3 | 4 | 3 | 34.0 |

## Variation summaries

**A — Better inputs (41.0)**: Fix the deprecated Agent-API-for-transfers path (Bankr docs moved transfers to `/wallet/transfer`), add `/wallet/me` write-scope preflight + `/wallet/portfolio` balance preflight, resolve all Twitter handles upfront via Agent API, drop polling interval from 5s to docs-recommended 2s. Strong on inputs but does nothing about idempotency, dry-run, or output.

**B — Sharper output (42.0)**: Top-line verdict (COMPLETE / PARTIAL / FAILED), USD totals (CoinGecko), Basescan link per tx, per-failure reason codes (NO_LINKED_WALLET / INSUFFICIENT_BAL / RATE_LIMIT), suppress empty sections, snapshot to memory/topics/distributions.md. Big output win but leaves the core robustness gaps in place.

**C — More robust (47.5) ✅ winner**: Persistent per-recipient idempotency state in `memory/state/distributions.json` keyed on `(list, recipient, date_utc)` with txHash — never re-sends within a UTC day even across re-runs or crashes. Two-phase RESOLVE→EXECUTE with dry-run mode (`var=dry-run:LABEL`). Pre-flight key + balance checks abort before any send. Per-recipient retry with backoff. Structured exit codes (OK / COMPLETE / PARTIAL / DRY_RUN / ERROR). State written after every transfer, not at end. Bootstrap on missing config. Folds in A's deprecated-Agent-API fix + 2s polling + /wallet/me + /wallet/portfolio preflight, plus B's verdict line + Basescan links + reason codes as cheap wins.

**D — Rethink: single batch tx (34.0)**: Use `/wallet/sign` + `/wallet/submit` to call the Disperse contract on Base (`0xD152f549545093347A162Dce210e7293f1452150`) once for all EVM-address recipients — atomic, gas-efficient. Rejected: calldata construction risk on a financial skill is high without a test environment, atomic-or-nothing semantics destroy per-recipient failure granularity (one bad address aborts the whole batch), and the gas savings don't justify the blast radius for typical 5-20 recipient lists.

## Why C wins

This skill moves real money. The original's only safeguard is a "scan logs for 24h to skip duplicates" heuristic — fragile (UTC day rollover, log-format drift), bypassed by re-runs across days, and provides no recovery if the run dies mid-list. Per-recipient persistent idempotency state is the highest-leverage single change. Pre-flight balance + key checks turn silent partial failures into clean aborts. Two-phase execution + dry-run lets the operator preview before committing. The Bankr-docs-deprecated Agent-API-for-transfers path was a latent bug — handle resolution stays on Agent API (its actual job), transfers move to the sanctioned `/wallet/transfer`.

## Diff summary

- New: per-recipient idempotency state file `memory/state/distributions.json` (sha256-keyed by list+recipient+date)
- New: two-phase RESOLVE → EXECUTE with `dry-run:LABEL` mode
- New: pre-flight via `/wallet/me` (write-scope check) + `/wallet/portfolio` (balance vs total_required × 1.05)
- New: bootstrap missing `distributions.yml` with commented template, exit clean
- New: structured exit codes — OK / COMPLETE / PARTIAL / DRY_RUN / ERROR
- New: 403 (read-only key) / 429 (rate limit, 60s backoff + retry once) / 5xx (10s backoff + retry once) handling
- New: state persisted after *every* transfer (survives mid-run crashes)
- New: verdict line + Basescan tx links + per-failure reason codes (NO_LINKED_WALLET, BAD_ADDRESS, INSUFFICIENT_BAL, RATE_LIMIT, READ_ONLY_KEY, API_ERROR, SANDBOX_BLOCKED)
- Changed: handle resolution moved upfront in RESOLVE phase (collect all errors before any send)
- Changed: polling 5s → 2s (matches Bankr docs)
- Changed: `/wallet/transfer` only for transfers; Agent API only for handle resolution (per Bankr docs deprecation)
- Constraint: lists >50 recipients should be split (100/day standard rate limit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Ported from aaronjmars/aeon-tmp#70.
