### PR TITLE
improve(refresh-x): autoresearch evolution

### DIFF
--- a/skills/refresh-x/SKILL.md
+++ b/skills/refresh-x/SKILL.md
@@ -1,69 +1,136 @@
 ---
 name: Refresh X
-description: Fetch a tracked X/Twitter account's latest tweets and save the gist to memory
+description: Fetch a tracked X/Twitter account's latest tweets, cluster them, and save a decision-ready gist to memory
 var: ""
 tags: [social]
 ---
-> **${var}** — The @handle to check (e.g. "@elonmusk", "vitalikbuterin"). **Required** — set this in aeon.yml or pass it when triggering the skill.
+<!-- autoresearch: variation B — sharper output via verdict + clustering + thread detection + insight lines + signal-score gating -->
 
-Read memory/MEMORY.md for context.
-Read the last 2 days of memory/logs/ to avoid logging duplicate tweets.
+> **${var}** — The @handle to check (e.g. "@elonmusk", "vitalikbuterin", "https://x.com/pmarca"). **Required** — set this in aeon.yml or pass when triggering.
+
+If `${var}` is empty or only whitespace after normalization, send `./notify "refresh-x: REFRESH_X_NO_VAR — set var to an X handle"` and exit 0.
+
+Read `memory/MEMORY.md` for context. Read the last 2 days of `memory/logs/` — extract every `https://x.com/` URL under a prior `## Refresh X` section for the same handle into a `SEEN_URLS` set (used for dedup in step 4).
 
 ## Steps
 
-1. Fetch the latest tweets from the specified account over the past 24 hours:
-   ```bash
-   FROM_DATE=$(date -u -d "yesterday" +%Y-%m-%d 2>/dev/null || date -u -v-1d +%Y-%m-%d)
-   TO_DATE=$(date -u +%Y-%m-%d)
-   ACCOUNT="${var}"
-   # Strip @ if present
-   ACCOUNT="${ACCOUNT#@}"
+### 1. Normalize var
 
-   if [ -z "$ACCOUNT" ]; then
-     echo "Error: var must be set to a Twitter handle (e.g. 'elonmusk')"
-     exit 1
-   fi
+Strip leading `@`, `https://x.com/`, `https://twitter.com/`, `https://nitter.net/`, and any trailing slash or `/status/...`. Lowercase. Reject if the remainder is empty, contains whitespace, or is longer than 15 chars (X handle limit). On reject → `REFRESH_X_NO_VAR` and exit.
 
-   curl -s -X POST "https://api.x.ai/v1/responses" \
-     -H "Content-Type: application/json" \
-     -H "Authorization: Bearer $XAI_API_KEY" \
-     -d '{
-       "model": "grok-4-1-fast",
-       "input": [{"role": "user", "content": "Search X for all tweets posted by @'"$ACCOUNT"' from '"$FROM_DATE"' to '"$TO_DATE"'. Return every tweet — not just popular ones. For each: the full tweet text, date/time posted, engagement stats (likes, retweets, replies), and the direct link (https://x.com/'"$ACCOUNT"'/status/ID). If it was a reply, note who it was replying to. If it was a quote tweet, include what was quoted. Return as a chronological list."}],
-       "tools": [{"type": "x_search", "from_date": "'"$FROM_DATE"'", "to_date": "'"$TO_DATE"'"}]
-     }'
-   ```
-   If `XAI_API_KEY` is not set, skip and log that the skill requires it.
+Store the cleaned handle as `ACCOUNT`.
 
-2. Summarize what was posted:
-   - How many tweets/replies/quote tweets
-   - Top themes and topics covered
-   - Which tweets got the most engagement and why
-   - Any threads or multi-tweet arcs
-   - Tone/mood of the day (shitposting? serious? argumentative?)
+### 2. Load tweets
 
-3. Save the gist to memory/logs/${today}.md:
-   ```
-   ## Refresh X
-   - **Account:** @ACCOUNT
-   - **Tweets found:** N (X original, Y replies, Z quotes)
-   - **Top themes:** theme1, theme2, theme3
-   - **Best performing:** "[tweet excerpt]" — X likes, Y RTs
-   - **Gist:** [2-3 sentence summary of what they were talking about and the vibe]
-   ```
+**Path A — prefetched cache (preferred)**: read `.xai-cache/refresh-x.json`. If present and non-empty, parse with:
+```bash
+jq -r '.output[] | select(.type == "message") | .content[] | select(.type == "output_text") | .text' .xai-cache/refresh-x.json
+```
+Record `source=xai-cache`.
 
-4. If there are tweets worth remembering (strong takes, announcements, threads), also note them in memory/MEMORY.md under a relevant section.
+**Path B — WebFetch fallback**: if the cache is missing, empty, or the parsed text contains zero x.com status URLs, use WebFetch against `https://x.com/${ACCOUNT}` with the prompt: *"List every tweet, reply, and quote tweet visible on this profile with its full text, timestamp, engagement counts (likes/retweets/replies) if shown, and the permalink in the form https://x.com/handle/status/ID. Return a chronological list."* Record `source=webfetch`.
 
-5. Send a brief summary via `./notify`:
-   ```
-   x refresh: @ACCOUNT posted N tweets yesterday
-   top themes: theme1, theme2
-   best: "[excerpt]" (X likes)
-   ```
+**Path C — degraded**: if both paths fail or `XAI_API_KEY` is unset and WebFetch returns nothing parseable, skip to step 8 with status `REFRESH_X_NO_API_KEY` (if key missing) or `REFRESH_X_ERROR` (if key set but both paths failed).
+
+### 3. Parse into structured tweets
+
+For each tweet extract: `url`, `text`, `timestamp`, `type` (original / reply / quote), `reply_to` (handle, if reply), `quoted_text` (if quote), `likes`, `retweets`, `replies`. Drop retweets of others (not originals from this account). If engagement counts are missing, treat them as 0 — do not fabricate.
+
+Compute `signal_score = likes + 2*retweets + replies − (3 if type=reply else 0)`.
+
+### 4. Dedup and gate
+
+Drop any tweet whose `url` is in `SEEN_URLS` — count these as `deduped_count`.
+
+If fewer than 3 tweets survive dedup AND no thread is detectable (see step 5), skip to step 8 with status `REFRESH_X_NO_NEW` (if everything was deduped) or `REFRESH_X_EMPTY` (if the account simply posted nothing).
+
+### 5. Detect threads
+
+A thread = 2+ tweets by `ACCOUNT`, posted within 30 minutes of each other, where later tweets reply to earlier ones OR share ≥2 meaningful keywords with the opener. Thread tweets are preserved as atomic units regardless of individual signal score. Record each thread as `{opener_url, tweet_count, combined_signal}`.
+
+### 6. Cluster and extract insights
+
+Group surviving tweets (threads count as one unit) into **2–4 sub-narratives** by topic overlap — named entities, project names, recurring keywords. If fewer than 2 narratives emerge, use a single cluster.
+
+For each cluster write:
+- **Title** — a 3-8 word topic label.
+- **Top tweet(s)** — 1-3 excerpts (≤200 chars each) with permalink and engagement.
+- **Insight** — one sentence: what this cluster reveals about the author's stance, claim, or shift today. Not a paraphrase — a claim about what they seem to be arguing or announcing. If you can't write an insight beyond paraphrase, drop the cluster.
+
+For each detected thread, write a 1–2 sentence summary of where the thread lands, plus the opener URL.
+
+### 7. Write the verdict
+
+Pick exactly one verdict based on the clusters:
+
+| Verdict | When |
+|---------|------|
+| `ANNOUNCEMENT` | Cluster contains a launch, hire, policy, or product drop |
+| `ARGUMENT` | Majority of signal comes from contrarian takes or fights |
+| `BUILDING` | Ships/code/tech-progress clusters dominate |
+| `SHITPOST` | Jokes, memes, low-stakes banter dominate |
+| `CONTEXT` | Mostly reacting to a news cycle, not driving one |
+| `QUIET` | <3 originals and no thread |
+
+Pair it with a ≤20-word lede describing the day's shape.
+
+### 8. Save gist to memory/logs/${today}.md
+
+Append:
+
+```
+## Refresh X — @ACCOUNT
+**Verdict:** VERDICT — [lede]
+**Counts:** N tweets (X original / Y reply / Z quote), T threads, deduped K
+
+### Clusters
+1. **[title]** — signal S
+   > "[excerpt]" ([likes]❤ [rt]🔁) [permalink]
+   **Insight:** [one-sentence claim]
+2. ...
+
+### Threads
+- **[topic]** (N tweets, combined signal S): [1-2 sentence landing] — [opener permalink]
+
+### Vibe
+[2-3 sentence tone read — not a stat restatement. What's the day *feel* like from this account?]
+
+**Status:** STATUS | source=[xai-cache|webfetch] | count=N | deduped=K
+```
+
+If status is `REFRESH_X_EMPTY`, `REFRESH_X_NO_NEW`, `REFRESH_X_NO_API_KEY`, `REFRESH_X_ERROR`, or `REFRESH_X_NO_VAR` — write only the `## Refresh X — @ACCOUNT` header and the `**Status:**` footer, skip the cluster sections.
+
+### 9. Update MEMORY.md (conditional)
+
+Only if a cluster carries an announcement, a specific claim, a named project, or a stance shift the operator will want to reference later: add a one-line bullet under a `## Tracked X Accounts` section (create the section if missing). Format: `- @ACCOUNT YYYY-MM-DD: [one-sentence claim] — [permalink]`.
+
+Do **not** append paraphrases, memes, or generic opinions to MEMORY.md.
+
+### 10. Notify via `./notify`
+
+On `REFRESH_X_OK`:
+```
+x refresh — @ACCOUNT ([VERDICT])
+[lede]
+top cluster: [title] — "[≤80 char excerpt]" ([likes]❤)
+[N tweets, T threads, K deduped]
+```
+
+On `REFRESH_X_EMPTY` / `REFRESH_X_NO_NEW`: **skip notify** — no signal is no signal. Still write the log entry so skill-health can observe the run.
+
+On `REFRESH_X_NO_API_KEY`, `REFRESH_X_ERROR`, `REFRESH_X_NO_VAR`: notify with the status code and a one-line hint (e.g. `"refresh-x: REFRESH_X_NO_API_KEY — set XAI_API_KEY in workflow secrets"`).
 
 ## Sandbox note
 
-The sandbox may block outbound curl. Use **WebFetch** as a fallback for any URL fetch. For auth-required APIs, use the pre-fetch/post-process pattern (see CLAUDE.md).
+The sandbox blocks direct curl to api.x.ai because the auth header can't expand `$XAI_API_KEY`. Primary path is the **prefetch cache** (`scripts/prefetch-xai.sh` runs before Claude starts and writes `.xai-cache/refresh-x.json`). Fallback is **WebFetch** against `https://x.com/${ACCOUNT}` — public profile page, no auth needed, bypasses the sandbox. Never curl api.x.ai from the skill body.
 
 ## Environment Variables Required
-- `XAI_API_KEY` — X.AI API key for Grok x_search
+
+- `XAI_API_KEY` — drives the prefetch cache (primary path). If unset, WebFetch fallback still works for public accounts but returns less structured data.
+
+## Constraints
+
+- Never fabricate engagement counts. Missing → 0, not a guess.
+- Never include a tweet URL already in `SEEN_URLS` in the output.
+- An insight line that only paraphrases the tweet is not an insight — drop the cluster.
+- Keep MEMORY.md updates to one line per noteworthy item. No paragraphs.


### PR DESCRIPTION
## Thesis

Original `refresh-x` emits a flat "top themes + best performing + gist" blob per run. Biggest lever is curation + verdict discipline — cluster the day's tweets into 2–4 sub-narratives, detect threads as atomic units, demand an insight line per cluster (paraphrase = drop), and lead with a one-line verdict so the operator knows the day's shape before reading anything else. Also fixes the in-body curl (sandbox-blocked) by switching to the prefetch-cache-first / WebFetch-fallback pattern already proven in the evolved `fetch-tweets` skill.

## Winner

**Variation B — sharper output** (45/52.5 weighted).

### Scoring

| Criterion | Weight | A | B | C | D |
|-----------|:------:|:-:|:-:|:-:|:-:|
| Clarity | 1.5× | 4 | 4 | 4 | 3 |
| Data quality | 1.5× | 4 | 3 | 3 | 3 |
| Output value | 2× | 3 | 5 | 3 | 4 |
| Robustness | 1.5× | 4 | 3 | 5 | 3 |
| Conventions | 1× | 5 | 5 | 5 | 4 |
| **Improvement** | **3×** | **3** | **5** | **3** | **4** |
| **Weighted total** | | **38** | **45** | **38** | **37.5** |

### Variations considered

**A — Better inputs (38):** cache-first + WebFetch fallback + engagement-count requirement + var normalization for `@`/URL/nitter forms + handle-length validation. Solid infrastructure but output stays flat — same themes/best/gist frame.

**B — Sharper output (45) ✅:** verdict taxonomy (ANNOUNCEMENT/ARGUMENT/BUILDING/SHITPOST/CONTEXT/QUIET), 2–4 narrative clusters with required insight-not-paraphrase discipline, thread detection as atomic units, signal-score ranking, one-line lede, skip-notify on empty/no-new. Folds in A's normalization + cache-first path and C's status taxonomy + dedup as cheap wins.

**C — More robust (38):** full status taxonomy (OK/EMPTY/NO_NEW/NO_API_KEY/ERROR), per-run status footer, dedup file or log-grep, empty-vs-error split, WebFetch fallback. Reliability wins but operator still sees the same shape of output — can't act on a more-reliable-but-still-flat gist.

**D — Rethink narrative state (37.5):** maintain `memory/topics/x-watch-${handle}.md` with running narrative threads; each run is a delta (new stance / continuation / off-day). Creative framing but `topics/` is empty today — no baseline to diff against, so first 1–2 weeks of runs still have to bootstrap the narrative file before the delta framing activates.

## Key changes in B

- **Cache-first load** (`.xai-cache/refresh-x.json` via `jq`) with **WebFetch fallback** against `https://x.com/${ACCOUNT}` — in-body `curl` removed because it was sandbox-blocked anyway (auth header + env var expansion).
- **Var normalization**: strips `@`, `https://x.com/`, `https://twitter.com/`, `https://nitter.net/`, trailing slashes, `/status/...`. Rejects whitespace and handles >15 chars.
- **Signal-score gate**: `likes + 2×retweets + replies − 3 if reply`. Thread tweets bypass gate as atomic units.
- **Persistent URL dedup** against last 2 days of `memory/logs/` under `## Refresh X` sections for the same handle.
- **Clusters (2–4)** with title + top excerpts + **insight line** (claim, not paraphrase — if only a paraphrase is possible, drop the cluster).
- **Thread detection**: ≥2 tweets by same author within 30min, self-referential or ≥2 shared keywords. Preserved as units, summarized in 1–2 sentences.
- **Verdict taxonomy** + ≤20-word lede.
- **Status footer**: `REFRESH_X_OK / EMPTY / NO_NEW / NO_API_KEY / ERROR / NO_VAR`. Empty/no-new write the log but **skip `./notify`** — avoids training the operator to ignore the channel.
- **MEMORY.md gating**: only announcements/claims/stance-shifts get a one-liner; paraphrases and memes do not.
- **Constraints block**: never fabricate engagement counts; never re-include a deduped URL; insight ≠ paraphrase.

## Constraint check

- ✅ No new env vars beyond existing `XAI_API_KEY` already in `scripts/prefetch-xai.sh`.
- ✅ Frontmatter preserved (name, description, var, tags).
- ✅ Core purpose preserved: "fetch a tracked X account's recent tweets, save gist to memory."
- ✅ Tags unchanged (`[social]`).
- ✅ `${var}` semantic unchanged — still an X handle.
- ✅ Follows Aeon conventions: reads memory, logs to `memory/logs/${today}.md`, notifies via `./notify`, honors sandbox note.
- ✅ No placeholders, no TODOs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Ported from aaronjmars/aeon-tmp#71.
