### PR TITLE
improve(action-converter): autoresearch evolution

### DIFF
--- a/skills/action-converter/SKILL.md
+++ b/skills/action-converter/SKILL.md
@@ -17,6 +17,8 @@ Read `articles/` (last 7 days, filenames only — peek at the 2 most recent for 
 If `soul/SOUL.md` exists, read it for identity, voice, focus areas.
 Run `gh pr list --state open --limit 20 --json number,title,createdAt,isDraft,reviewDecision,headRefName 2>/dev/null` to get open PRs (used to anchor "ship" / "review" / "merge" loops).
 
+**Graceful bootstrap** — each of the reads above may be missing on cold starts. For every source, if the file/directory is missing or empty (including `memory/topics/*.md`, `memory/cron-state.json`, and `gh pr list` returning empty or erroring), skip it and record `BOOTSTRAP: <resource> not yet populated` in the run's working notes. Continue with whatever signals are available — the skill must degrade gracefully, never fail. If every single source is empty, fall through to the `ACTION_CONVERTER_NO_CONTEXT` mode below.
+
 ## Steps
 
 ### 1. Detect mode

--- a/skills/action-converter/SKILL.md
+++ b/skills/action-converter/SKILL.md
@@ -1,67 +1,148 @@
 ---
 name: Action Converter
-description: 5 concrete real-life actions for today based on recent signals and memory
+description: 5 concrete real-life actions for today, leverage-scored against open loops with specificity and anti-fluff gates
 var: ""
 tags: [meta]
 ---
-> **${var}** — Focus area (e.g. "health", "networking", "learning", "shipping"). If empty, covers all areas.
+<!-- autoresearch: variation B — sharper output via specificity gates, leverage scoring, banned-phrase lint, open-loop anchoring, empty-state taxonomy -->
 
-Read memory/MEMORY.md for current goals, priorities, and tracked items.
-Read the last 7 days of memory/logs/ for recent activity, patterns, and what's been happening.
-If soul files exist (`soul/SOUL.md`), read them for context on identity and focus areas.
+> **${var}** — Optional focus area (e.g. `health`, `networking`, `learning`, `shipping`, `crypto`, `repo`). If empty, covers all areas. Treated as a tiebreaker, not a hard filter.
+
+Read `memory/MEMORY.md` for stated goals, "Next Priorities", tracked items, and current topics.
+Read the last 7 days of `memory/logs/` for recent activity, patterns, and what's already been suggested or done.
+Read `memory/topics/` (every file) for active threads.
+Read `memory/cron-state.json` for failing or stuck skills.
+Read `memory/watched-repos.md` for repos under attention.
+Read `articles/` (last 7 days, filenames only — peek at the 2 most recent for theme).
+If `soul/SOUL.md` exists, read it for identity, voice, focus areas.
+Run `gh pr list --state open --limit 20 --json number,title,createdAt,isDraft,reviewDecision,headRefName 2>/dev/null` to get open PRs (used to anchor "ship" / "review" / "merge" loops).
 
 ## Steps
 
-1. Build context on the current state:
-   - What has been worked on this week? (from logs)
-   - What are the stated priorities? (from MEMORY.md)
-   - What topics and projects are being tracked?
-   - If `${var}` is set, weight actions toward that area
+### 1. Detect mode
 
-2. Generate **5 specific, actionable things** to do TODAY. Not vague advice — real actions with clear outcomes. Each action should:
-   - Be completable in a single day (most in under 2 hours)
-   - Have a concrete deliverable or outcome
-   - Connect to something already being worked on or tracked
-   - Be the kind of thing that compounds over time
+Decide which exit mode this run will produce based on context volume:
 
-3. Pick 5 actions from the pool below. Do NOT use all categories every time — pick whichever 5 are most relevant to what's actually happening this week. Some days might be 3 Build actions and 2 Learn. Some days might have zero Health actions. Let the context drive it, not a checklist.
+- **ACTION_CONVERTER_NO_CONTEXT** — if BOTH `memory/logs/` has 0 entries AND `memory/MEMORY.md` is the unmodified template (matches "*Last consolidated: never*" AND "Configure notification channels"). Notify the operator and stop — do not invent actions out of thin air.
+- **ACTION_CONVERTER_BOOTSTRAP** — if `memory/logs/` has <3 distinct dates in the last 14 days OR `memory/MEMORY.md` "Next Priorities" still contains template entries ("Configure notification channels", "Run first digest"). Switch the action pool to setup-completion actions: enable specific skills in `aeon.yml`, configure missing notification secrets, run the first digest, populate `memory/topics/` for the first tracked thread, etc. These are still real, named, completable actions — not generic onboarding advice.
+- **ACTION_CONVERTER_OK** — otherwise. Use the full leverage-scored loop pipeline below.
 
-   Possible categories (use any mix):
-   - **Build** — ship, write, create, deploy, fix, prototype
-   - **Connect** — reach out, reply, collaborate, attend, post publicly
-   - **Learn** — read, study, explore, reverse-engineer, experiment
-   - **Health/Energy** — physical, mental, sleep, nutrition, environment
-   - **Money** — revenue, fundraising, deals, financial moves
-   - **Position** — content, reputation, visibility, thought leadership
-   - **Explore** — something lateral, unexpected, or outside the usual lanes
+### 2. Extract open loops
 
-   IMPORTANT: Avoid repeating generic actions across runs. Check the last 7 days of logs — if "go for a walk" or "DM 3 people" appeared recently, do NOT suggest them again. Every action should feel specific to TODAY's context, not a template.
+Build a single deduped list of named open loops from every source above. A loop is a specific in-flight thing, not an area. Each loop captures at minimum: `id` (short slug), `text` (one phrase), `source` (where it came from), `age_days`, `urgency_signal` (deadline / blocker / stalled / fresh).
 
-4. For each action, include:
-   - The action itself (one sentence, imperative, specific enough that you'd know when it's done)
-   - Why now (one sentence — what makes this relevant today, not generically good advice)
-   - Expected outcome (one sentence — what's different after you do this)
+Sources to mine:
+- **Open PRs** — every entry from `gh pr list`. Loop text: `PR #N: <title>` with urgency = `stalled` if >3 days old or review_decision is REQUEST_CHANGES.
+- **MEMORY.md "Next Priorities"** — each bullet becomes a loop. Skip template lines.
+- **`memory/topics/*.md`** — for each topic file, scan for headings or bullets that look like ongoing work (TODO, WIP, "In progress", "Tracking", trailing question marks, dated items in the last 30 days).
+- **`memory/cron-state.json`** — every skill with `consecutive_failures > 0` OR `last_status != success` becomes a loop: `fix <skill>`. Urgency = `blocker` if consecutive_failures ≥ 3.
+- **Recent logs (last 7 days)** — any line ending in `?`, containing "blocked", "next:", "todo", "follow-up", "unfinished", or naming a deferred decision.
+- **Recent articles (last 7 days)** — each new article opens a distribution/syndication loop ("syndicate <slug>") if `syndicate-article` is enabled, and a feedback loop ("respond to comments on <slug>") if traffic is plausible.
+- **${var}** — if set, add a synthetic loop "advance ${var}" so at least one action ties to the requested focus area.
 
-5. Send via `./notify`:
-   ```
-   *5 Actions — ${today}*
+Deduplicate by similarity in `text`. Cap the loop list at 25.
 
-   1. [action]
-   why: [context]
-   outcome: [result]
+### 3. Score loops
 
-   2. [action]
-   why: [context]
-   outcome: [result]
+Score every loop on three 1–5 axes. Total = leverage × urgency × concreteness.
 
-   ... (5 total)
-   ```
-   IMPORTANT: Do NOT indent the why/outcome lines — no leading spaces. Every line starts at column 0 (except the number prefix).
+| Axis | 1 | 3 | 5 |
+|---|---|---|---|
+| **leverage** | personal hygiene | useful but local | unblocks others, shippable artifact, or compounds |
+| **urgency** | nice-to-have | this week | today (deadline / blocker / >5 day stall on hot loop) |
+| **concreteness** | "think about X" | known shape, no draft | next step is one named action |
 
-6. Log to memory/logs/${today}.md:
-   ```
-   ## Action Converter
-   - **Actions generated:** 5
-   - **Focus:** [area or "general"]
-   - **Notification sent:** yes
-   ```
+Drop any loop scoring <8 from the candidate pool. If `${var}` is set, give a +0.5 leverage bump to loops touching that area.
+
+### 4. Convert loops to actions
+
+Convert the top loops into actions until you have 5 distinct ones. Constraints on every action:
+
+1. **Specificity gate** — must name at least one of: a file path, a PR number, a person/handle, a project/repo, a tool/CLI command, a URL, a tracked entity from MEMORY.md. Generic "reach out to people" / "review your goals" / "explore opportunities" fails this gate.
+2. **Banned-phrase lint** — reject any action whose `action` text contains: `go for a walk`, `drink water`, `take a break`, `reflect`, `journal`, `meditate`, `brainstorm`, `review your`, `think about`, `consider`, `look into`, `explore opportunities`, `reach out to people`, `network with`, `clean up your inbox`, `organize your`, `plan tomorrow`, `do some reading`, `check social media`. These are filler, not actions.
+3. **Time estimate** — must fit in ≤2 hours; bias toward 30–60 min slots.
+4. **Definition of done** — one observable check. "PR opened" / "commit pushed" / "message sent to <handle>" / "doc has section X with ≥3 items". Not "feel better" or "have more clarity".
+5. **Anti-template (14-day novelty check)** — for each candidate action, extract the verb + main noun. Reject if the same verb+noun appears in any `memory/logs/*.md` from the last 14 days. (Different verb+same noun is fine — only the bigram blocks.)
+6. **Score ≥4 on the 1–5 quality scale** below. Anything <4 is dropped and replaced from the next loop in the queue.
+
+Quality 1–5: 1 = filler, 2 = vague, 3 = specific but low-leverage, 4 = specific + tied to a real loop, 5 = specific + high-leverage + would visibly move the project today.
+
+If after exhausting the loop list you have <5 surviving actions, fill the rest from the **category pool below** but only with category-specific candidates that pass all gates above. Categories exist as a fallback, not a checklist:
+- **Build** — ship, write, create, deploy, fix, prototype, refactor against a named file/PR
+- **Connect** — DM/reply/quote a *named* handle about a *named* topic; comment on a *named* PR/issue
+- **Learn** — read a *named* paper/doc/repo and write a 5-bullet takeaway to `memory/topics/`
+- **Health/Energy** — only if tied to a named, novel, non-banned action (rare; usually skipped)
+- **Money** — concrete revenue/funding/deal step naming a counterparty
+- **Position** — write a *named* tweet/cast/post on a *named* claim
+- **Explore** — lateral move tied to a named external signal from this week's logs
+
+If even with the category pool you can't reach 5, output fewer (3 or 4) and flag `ACTION_CONVERTER_THIN` in the notify — don't pad.
+
+### 5. Compose the output
+
+Build one **today's shape** line: ≤14 words capturing the dominant theme of the 5 actions ("Ship 2 PRs, unblock failing skill, syndicate yesterday's article" — not "be productive today"). This becomes the lede.
+
+Order the 5 actions by descending quality score, then by descending urgency.
+
+### 6. Send via `./notify`
+
+Use this exact format. Telegram-MD friendly. **No leading spaces on any line** (Telegram renders indents as code blocks).
+
+```
+*5 Actions — ${today}*
+Shape: <today's shape line>
+
+1. <action — one imperative sentence, names a specific entity>
+why: <≤18 words, what makes this leverage today, names a specific signal>
+done: <one observable check>
+loop: <loop id or "category:<name>" if filled from pool>
+
+2. <action>
+why: <…>
+done: <…>
+loop: <…>
+
+3. <action>
+why: <…>
+done: <…>
+loop: <…>
+
+4. <action>
+why: <…>
+done: <…>
+loop: <…>
+
+5. <action>
+why: <…>
+done: <…>
+loop: <…>
+
+sources: memory=<lines> logs=<days> topics=<files> prs=<open> cron_failing=<n> mode=<OK|BOOTSTRAP|THIN>
+```
+
+Notification rules:
+- Drop any action whose `done:` line couldn't be written without hand-waving.
+- If mode is `ACTION_CONVERTER_NO_CONTEXT`, skip the action list entirely and notify: `*Action Converter — no context yet*` plus a one-line pointer ("Populate memory/MEMORY.md or run a skill to seed memory/logs/").
+- If mode is `ACTION_CONVERTER_BOOTSTRAP`, prefix the shape line with `Bootstrap mode: ` and pull all actions from the setup-completion pool.
+
+### 7. Log to `memory/logs/${today}.md`
+
+Append:
+```
+## Action Converter
+- **Mode:** OK | BOOTSTRAP | THIN | NO_CONTEXT
+- **Focus:** <var or "general">
+- **Shape:** <today's shape line>
+- **Actions:** N (quality avg <x.x>/5)
+- **Loops anchored:** <list of loop ids surfaced>
+- **Loops carried over:** <list of high-score loops not chosen, for tomorrow>
+- **Notification sent:** yes
+```
+
+Carrying loops forward in the log is what powers the 14-day novelty check and lets the next run see what's been deferred.
+
+## Sandbox note
+
+`gh pr list` works in the GitHub Actions sandbox via the `gh` CLI (handles auth internally). If `gh` is unavailable or returns empty, treat the open-PR loop source as `prs=0` and continue — do not block the whole run.
+
+No outbound HTTP is required. All inputs are local files and `gh`. No new env vars.


### PR DESCRIPTION
## Autoresearch — action-converter

**Winner:** Variation B (46/52.5) — sharper output via specificity gates, leverage scoring, banned-phrase lint, open-loop anchoring, exit-mode taxonomy.

### Thesis

The original picks 5 actions across 7 categories with a soft "avoid generic" hint and no quality gates. The dominant failure mode is filler ("go for a walk", "reach out to people", "review your goals") — the kind of thing that trains the operator to stop reading. The biggest single lever is post-write quality enforcement: every action must name a specific entity (file/PR/handle/topic), pass a banned-phrase lint, fit a 14-day verb+noun novelty check, carry a definition-of-done line, and score ≥4 on a 1–5 quality scale (drop-and-replace otherwise). Each action ties to an extracted "open loop" from the actual repo state (open PRs, MEMORY.md priorities, failing skills in cron-state, recent articles, topics/, watched-repos), so actions reflect what's actually unfinished today rather than category templates.

### Scoring table

| Criterion (weight) | A | B | C | D |
|---|---:|---:|---:|---:|
| Clarity (×1.5) | 4.0 | 4.5 | 4.5 | 3.5 |
| Data quality (×1.5) | 4.5 | 3.5 | 3.5 | 4.0 |
| Output value (×2) | 3.5 | **5.0** | 4.0 | 4.5 |
| Robustness (×1.5) | 3.5 | 4.0 | **5.0** | 3.5 |
| Conventions (×1) | 4.5 | 4.5 | 4.5 | 4.0 |
| Improvement (×3) | 3.5 | **4.5** | 3.5 | 4.0 |
| **Weighted total / 52.5** | 40.0 | **46.0** | 42.5 | 41.5 |

### Variations considered

- **A — Better inputs (40/52.5)**: mine open PRs (`gh pr list`), `cron-state.json`, `MEMORY.md` "Next Priorities", `memory/topics/`, `watched-repos.md`, recent `articles/`. Strong on data quality but doesn't fix the filler-output failure mode.
- **B — Sharper output (46/52.5) — winner**: specificity gates, leverage×urgency×concreteness scoring, banned-phrase lint, time estimate, definition-of-done, anti-template 14-day novelty check, today's-shape verdict line.
- **C — More robust (42.5/52.5)**: empty-state detection (`ACTION_CONVERTER_BOOTSTRAP` when memory is thin), exit-mode taxonomy, source-status footer, fail-loud rather than slop. Right impulse but doesn't sharpen the OK-mode output.
- **D — Rethink as open-loops queue (41.5/52.5)**: two-pass — extract open loops, score by leverage×urgency×concreteness, top loops become today's actions with `loop:` field. Best framing but loses the categorical-fallback safety net for low-loop days.

### How B folds in the runners-up

- **From A**: full input pipeline — `gh pr list`, `cron-state.json` for failing skills, `MEMORY.md` "Next Priorities" parsed explicitly (skipping template lines), `memory/topics/`, `watched-repos.md`, recent `articles/`. These feed the leverage scoring instead of being a separate flat aggregation.
- **From C**: `ACTION_CONVERTER_NO_CONTEXT` (empty memory, stop), `ACTION_CONVERTER_BOOTSTRAP` (thin memory or template "Next Priorities", switch to setup-completion pool), `ACTION_CONVERTER_OK`, `ACTION_CONVERTER_THIN` (output 3–4 instead of padding to 5); source-status footer (`memory=N logs=N topics=N prs=N cron_failing=N mode=…`).
- **From D**: open-loop extraction is the primary action source; each action carries a `loop:` field tying it back to a named loop; quality-scored loops not chosen this run are logged as "carried over" so tomorrow's run sees the deferred queue.

### Diff summary

- Added explicit input pipeline (gh PRs, cron-state.json, topics/, watched-repos.md, articles/, soul/) — was previously only MEMORY.md + logs.
- Added 3-mode exit taxonomy with bootstrap path for thin-memory state (current repo state).
- Added per-action gates: specificity (must name entity), banned-phrase lint (16 filler phrases blocked), time estimate ≤2h, definition-of-done, 14-day verb+noun novelty check, quality score ≥4 with drop-and-replace.
- Added today's-shape lede line (≤14 words) capturing dominant theme.
- Added `loop:` field on every action; categories demoted to fallback pool when loops can't fill 5 slots.
- Notify format: removed indentation footgun (was already a "do not indent" warning — now structurally enforced); added source-status footer.
- Log format: now records mode, quality avg, anchored loops, and carried-over loops to power the novelty check on subsequent runs.

### Constraints honored

- No new env vars (uses existing `gh` CLI).
- No new outbound HTTP (all local files + `gh`).
- Core purpose preserved: 5 concrete daily actions via `./notify`.
- Tags + var semantics preserved (`${var}` still optional focus area, now an additive bias rather than a hard filter).

---
Ported from aaronjmars/aeon-tmp#72.
