### PR TITLE
improve(skill-leaderboard): autoresearch evolution

### DIFF
--- a/skills/skill-leaderboard/SKILL.md
+++ b/skills/skill-leaderboard/SKILL.md
@@ -1,100 +1,257 @@
 ---
 name: skill-leaderboard
-description: Weekly ranking of which skills are most popular across all active forks
+description: Weekly ranking of which skills are most popular across CONFIGURED Aeon forks (excludes untouched templates)
 var: ""
 tags: [meta]
 ---
-> **${var}** — Target repo to scan forks of (e.g. "owner/aeon"). If empty, reads from memory/watched-repos.md.
+> **${var}** — Target repo to scan forks of (e.g. "owner/aeon"). If empty, reads `memory/watched-repos.md` and uses the first entry.
 
-Today is ${today}. Generate a leaderboard of the most popular Aeon skills across all active forks.
+<!-- autoresearch: variation B — sharper output via configured-fork denominator + tiered fleet + promote/match/sunset insights -->
+
+Today is ${today}. Generate a weekly leaderboard of which Aeon skills the **configured fleet** is actually running — and what upstream should do about it.
+
+## Why this version
+
+Upstream `aeon.yml` ships with effectively only `heartbeat: enabled: true`. Every fresh fork inherits that default. If we score "skills enabled" across **all active forks**, the leaderboard is a tautology (heartbeat always wins, everything else hovers near 0) and operator learns nothing. The lever is to score against **configured forks only** — forks whose `aeon.yml` diverges from upstream defaults — and to convert the result into three actionable recommendations: which skills to promote, which fleet patterns to copy upstream, which skills to sunset.
 
 ## Steps
 
-1. **Determine the target repo.** If `${var}` is set, use that. Otherwise read `memory/watched-repos.md` and use the first watched repo. Store as `TARGET_REPO`.
+### 1. Determine the target repo
 
-2. **Fetch all active forks** (pushed within the last 30 days):
-   ```bash
-   CUTOFF=$(date -u -d "30 days ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-30d +%Y-%m-%dT%H:%M:%SZ)
-   gh api repos/${TARGET_REPO}/forks --paginate --jq "[.[] | select(.pushed_at > \"$CUTOFF\") | {owner: .owner.login, full_name: .full_name, pushed_at}]"
-   ```
-   If no active forks found, log "SKILL_LEADERBOARD_NO_FORKS" and stop (no notification).
+If `${var}` is set, use that as `TARGET_REPO`. Otherwise read `memory/watched-repos.md` and use the first non-comment, non-empty line. If neither yields a value, log `SKILL_LEADERBOARD_NO_TARGET` to `memory/logs/${today}.md` and stop (no notification).
 
-3. **Read each active fork's `aeon.yml`** to extract enabled skills:
-   ```bash
-   gh api repos/{fork_full_name}/contents/aeon.yml --jq '.content' | base64 -d
-   ```
-   For each fork, extract all skill entries where `enabled: true`. If the fork has no `aeon.yml` or the API returns 404, skip it and note "no aeon.yml".
+### 2. Snapshot upstream defaults
 
-4. **Aggregate skill counts** across all forks:
-   - For each skill name that appears with `enabled: true` in any fork, count how many forks have it enabled.
-   - Also collect the total count of forks with a readable `aeon.yml`.
+Read this running instance's local `aeon.yml` once. Build `UPSTREAM_DEFAULTS`: a dict `{skill_name -> {enabled, model_or_null, var_or_empty, schedule_or_null}}` covering every skill entry under the `skills:` block. Also build `UPSTREAM_SKILLS`: the set of skill directory names from `skills/` (use `ls skills/`). These are the comparison baselines.
 
-5. **Compare to last week's leaderboard** — check for `articles/skill-leaderboard-*.md` files from the last 7 days. If one exists, extract its ranked list and compute week-over-week changes (new entries, rank changes, dropouts).
+### 3. Fetch active forks
 
-6. **Identify insight categories:**
-   - **Consensus skills**: enabled in >50% of active forks
-   - **Adoption-gap skills**: exist in the source repo but enabled in zero forks (documentation/discoverability candidates)
-   - **Rising skills**: moved up 3+ positions from last week
-   - **New entries**: skills not on last week's list
+```bash
+CUTOFF=$(date -u -d "30 days ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-30d +%Y-%m-%dT%H:%M:%SZ)
+gh api "repos/${TARGET_REPO}/forks?per_page=100" --paginate \
+  --jq "[.[] | select(.pushed_at > \"$CUTOFF\") | {owner: .owner.login, full_name: .full_name, pushed_at, stargazers_count, created_at}]"
+```
 
-7. **Write the leaderboard article** to `articles/skill-leaderboard-${today}.md`:
-   ```markdown
-   # Skill Leaderboard — ${today}
+If zero active forks: log `SKILL_LEADERBOARD_NO_FORKS` and stop (no notification).
 
-   *${N} active forks scanned (pushed in last 30 days)*
+### 4. Per-fork single-call enumeration
 
-   ## Top Skills Across the Fleet
+For each active fork, run **one** recursive git-tree call to enumerate files (cheaper than per-path contents):
 
-   | Rank | Skill | Forks Enabled | % of Fleet | Change |
-   |------|-------|---------------|------------|--------|
-   | 1 | skill-name | N | XX% | — |
-   | 2 | skill-name | N | XX% | ↑2 |
-   | ... | ... | ... | ... | ... |
+```bash
+gh api "repos/${FORK_FULL}/git/trees/HEAD?recursive=1" --jq '[.tree[] | select(.type == "blob") | .path]'
+```
 
-   ## Consensus Skills (>50% of forks)
-   [List skills with broad adoption and why they matter]
+Handle errors:
+- 404 / 409 (empty repo): mark `status: "no_tree"`, skip aeon.yml and skills/ extraction, continue.
+- 403 with `X-RateLimit-Remaining: 0`: sleep 60s, retry once. If still failing, mark `status: "rate_limited"` and continue with partial fleet.
 
-   ## Adoption Gaps
-   [Skills with zero fork enables — these may need better docs or examples]
+Then fetch the fork's `aeon.yml` only if the tree contains it:
 
-   ## Week-over-Week
-   [Changes from last week's leaderboard, or "First leaderboard — no prior data" if this is the first run]
+```bash
+gh api "repos/${FORK_FULL}/contents/aeon.yml" --jq '.content' | base64 -d
+```
 
-   ## Fleet Summary
-   - **Active forks scanned:** N
-   - **Total skill slots enabled (across all forks):** N
-   - **Unique skills seen:** N
-   - **Forks with no aeon.yml:** N (likely template/non-running forks)
+If the path is in the tree but the contents call 404s, mark `status: "yml_unreadable"` and continue.
 
-   ---
-   *Source: GitHub API — forks of ${TARGET_REPO}*
-   ```
+Extract from each readable `aeon.yml`:
+- For every skill entry under `skills:` — `enabled`, `model` (if set), `var` (if set), `schedule` (if differs from any upstream default for that skill).
+- Detect "fork-only skills": directory names under `skills/` in the fork's tree that are NOT in `UPSTREAM_SKILLS`.
 
-8. **Send notification** via `./notify`:
-   ```
-   *Skill Leaderboard — ${today}*
+### 5. Classify each fork
 
-   Top skills across ${N} active forks:
-   1. [skill] — N forks (XX%)
-   2. [skill] — N forks (XX%)
-   3. [skill] — N forks (XX%)
-   4. [skill] — N forks (XX%)
-   5. [skill] — N forks (XX%)
+For each fork, compute a divergence signal vector vs `UPSTREAM_DEFAULTS`:
+- **enabled_diff**: count of skills where the fork's `enabled` value differs from upstream default
+- **var_set**: count of skills with `var:` set to a non-empty value where upstream's was empty
+- **model_override**: count of skills with a `model:` value differing from upstream
+- **schedule_override**: count of skills with a `schedule:` value differing from upstream
+- **fork_only_skills**: count from step 4
 
-   Consensus: [list of skills enabled by >50% of forks, or "none yet"]
-   Adoption gaps: [skills with zero fork enables]
+Tier the fork:
+- **CONFIGURED**: any of the above is ≥1. (i.e., the fork actively diverged from defaults)
+- **TEMPLATE**: aeon.yml is readable but every diff signal is 0. Untouched template — exclude from leaderboard math.
+- **UNREADABLE**: no_tree / no aeon.yml / yml_unreadable / rate_limited. Tracked in the source-status footer.
 
-   Full leaderboard: https://github.com/${GITHUB_REPOSITORY}/blob/main/articles/skill-leaderboard-${today}.md
+### 6. Aggregate against the CONFIGURED denominator
 
-   Use the `$GITHUB_REPOSITORY` env var (GitHub Actions sets it to `owner/repo`) to build the URL. Do NOT use the watched repo — the article lives in this running instance's repo.
-   ```
-   **Only send a notification if at least 2 active forks were found with readable aeon.yml files.** Otherwise log "SKILL_LEADERBOARD_INSUFFICIENT_DATA" and stop.
+Let `N_CONFIGURED` = count of forks tiered CONFIGURED. If `N_CONFIGURED < 2`: log `SKILL_LEADERBOARD_TEMPLATE_FLEET` with the active/template/unreadable counts, write a stub article noting the conversion rate, and **skip the notification** (no signal worth pushing). Stop.
 
-9. **Log** to `memory/logs/${today}.md`:
-   ```
-   ## Skill Leaderboard
-   - **Forks scanned:** N active (of M total)
-   - **Top skill:** [skill-name] (N forks)
-   - **Consensus skills:** [list or "none"]
-   - **Notification sent:** yes/no
-   ```
+For each skill name (union of upstream skills and fork-only skills) compute:
+- `forks_enabled`: number of CONFIGURED forks where it's `enabled: true`
+- `pct_of_configured`: `forks_enabled / N_CONFIGURED`
+- `with_var`: count of CONFIGURED forks that override `var:`
+- `with_model`: count that override `model:`
+- `with_schedule`: count that override `schedule:`
+- `customization_depth` per-fork-instance: enabled (1) + var (1) + model (1) + schedule (1) → sum across forks; this becomes the tiebreaker
+- `is_fork_only`: true if the skill name is in some fork's tree but not in `UPSTREAM_SKILLS`
+
+Rank by (`forks_enabled` desc, `customization_depth` desc, name asc).
+
+### 7. Load prior snapshot (week-over-week)
+
+Read `memory/topics/skill-leaderboard-state.json` if it exists. Schema:
+
+```json
+{
+  "last_run": "YYYY-MM-DD",
+  "n_active_forks": N,
+  "n_configured": N,
+  "ranking": [{"skill": "name", "forks_enabled": N, "rank": N}, ...]
+}
+```
+
+If the file exists and `last_run` is within the last 14 days, compute:
+- **Rising**: skills that moved up ≥3 ranks
+- **Falling**: skills that moved down ≥3 ranks
+- **New entries**: skills now ranked that weren't last run
+- **Dropouts**: skills last run that aren't ranked now (forks_enabled went to 0)
+
+If the file is missing or stale (>14 days), set deltas to "first ranked snapshot — no comparison".
+
+### 8. Compute the three actionable categories
+
+- **Consensus skills**: `pct_of_configured > 0.50`. The fleet has converged on these — upstream should treat them as canonical examples and ensure they're well-documented.
+- **Promote candidates**: `pct_of_configured ≥ 0.25` AND upstream default is `enabled: false` AND the skill is not a `workflow_dispatch`-only skill. The fleet found these worth running; upstream may want to flip the default or feature them more prominently.
+- **Match candidates**: skills where ≥2 CONFIGURED forks override `model:` to the same value (e.g., both pick `claude-sonnet-4-6`). The fleet has independently found a cheaper model sufficient — upstream should consider matching the override.
+- **Sunset candidates**: skills present in `UPSTREAM_SKILLS` with `forks_enabled == 0` AND `with_var == 0` AND not a meta/dev skill (skip skills tagged `meta` or `dev` — those are operator-tools, fork adoption isn't the point). Review for removal or better discoverability.
+- **Fleet-only skills**: any `is_fork_only: true` skill enabled in ≥1 fork. Surface for review — the fleet built something upstream doesn't have.
+
+### 9. Write the article
+
+To `articles/skill-leaderboard-${today}.md`:
+
+```markdown
+# Skill Leaderboard — ${today}
+
+**Verdict:** ${one-line verdict — see step 10 format below}
+
+*Scanned ${N_ACTIVE} active forks of ${TARGET_REPO} (pushed in last 30 days). ${N_CONFIGURED} are configured (aeon.yml diverges from upstream defaults). Leaderboard scored against the configured ${N_CONFIGURED}.*
+
+## Top Skills (configured fleet)
+
+| Rank | Skill | Forks | % Configured | var | model | sched | Δ vs last week |
+|------|-------|-------|--------------|-----|-------|-------|----------------|
+| 1 | name | N | XX% | N | N | N | — / ↑N / ↓N / NEW |
+| ... |
+
+(Top 15. If <15 ranked, list all.)
+
+## What the fleet is telling us
+
+### Promote
+${list of Promote candidates with one-line "why" each, OR "none this week"}
+
+### Match
+${list of Match candidates: "skill X — N forks override model to claude-sonnet-4-6", OR "none this week"}
+
+### Sunset (review for removal or better docs)
+${list of Sunset candidates, capped at 5, OR "none — every shipped skill has at least one configured-fork enable"}
+
+### Fleet-only skills
+${list of fork-only skill names with the fork that built each, OR "none this week"}
+
+## Week-over-week
+
+${"First ranked snapshot — no comparison" OR list of Rising / Falling / New / Dropouts}
+
+## Fleet composition
+
+| Tier | Count | % |
+|------|-------|---|
+| Configured | N_CONFIGURED | XX% |
+| Template (untouched aeon.yml) | N_TEMPLATE | XX% |
+| Unreadable (no tree / no yml / rate-limited) | N_UNREADABLE | XX% |
+| **Total active forks** | N_ACTIVE | 100% |
+
+## Source status
+
+- Trees fetched: N_TREES_OK / N_ACTIVE
+- aeon.yml readable: (N_CONFIGURED + N_TEMPLATE) / N_ACTIVE
+- Rate-limited: N_RATE_LIMITED
+- Fork-only skill files inspected: N_FORK_ONLY_FILES
+
+---
+*Source: GitHub API — forks of ${TARGET_REPO}. Methodology: a fork counts as "configured" if its `aeon.yml` differs from upstream defaults on `enabled`, `model`, `var`, or `schedule` for any skill. Untouched templates are excluded from leaderboard math.*
+```
+
+### 10. Build the verdict line
+
+Pick the strongest single claim, in this priority:
+1. If a Promote candidate exists with `pct_of_configured ≥ 0.40`: `"${N_CONFIGURED} configured forks; ${skill} hit ${pct}% — promote candidate"`
+2. Else if any Rising skill moved ≥5 ranks: `"${skill} jumped from rank ${old} to rank ${new} this week"`
+3. Else if a Fleet-only skill exists: `"${fork_owner}/aeon shipped ${skill} — not in upstream"`
+4. Else if any Match candidate exists: `"${N} forks independently override ${skill} to ${model} — consider matching"`
+5. Else: `"Configured-fleet conversion rate: ${N_CONFIGURED}/${N_ACTIVE} (${pct}%); top: ${skill} (${N} forks)"`
+
+### 11. Send notification
+
+Via `./notify`:
+
+```
+*Skill Leaderboard — ${today}*
+${verdict_line}
+
+Top 5 across ${N_CONFIGURED} configured forks (of ${N_ACTIVE} active):
+1. ${skill} — N forks (XX%) ${rising_arrow_or_blank}
+2. ${skill} — N forks (XX%) ${rising_arrow_or_blank}
+3. ${skill} — N forks (XX%) ${rising_arrow_or_blank}
+4. ${skill} — N forks (XX%) ${rising_arrow_or_blank}
+5. ${skill} — N forks (XX%) ${rising_arrow_or_blank}
+
+${one of: "Promote: ${skill} (XX% adoption)" | "Match: ${N} forks override ${skill} → ${model}" | "Fleet-only: ${owner}/${skill}" | omit if none of the above}
+
+Full report: https://github.com/${GITHUB_REPOSITORY}/blob/main/articles/skill-leaderboard-${today}.md
+```
+
+Use the `$GITHUB_REPOSITORY` env var (GitHub Actions sets it to `owner/repo`) to build the URL — NOT the watched repo. The article lives in this running instance's repo.
+
+Notification is sent only when `N_CONFIGURED >= 2` (gated in step 6). Otherwise the run is silent.
+
+### 12. Persist the snapshot
+
+Write `memory/topics/skill-leaderboard-state.json`:
+
+```json
+{
+  "last_run": "${today}",
+  "target_repo": "${TARGET_REPO}",
+  "n_active_forks": N_ACTIVE,
+  "n_configured": N_CONFIGURED,
+  "n_template": N_TEMPLATE,
+  "n_unreadable": N_UNREADABLE,
+  "ranking": [
+    {"skill": "name", "forks_enabled": N, "pct_of_configured": 0.NN, "rank": N, "customization_depth": N, "is_fork_only": false}
+  ]
+}
+```
+
+Overwrite each run. This is the source for next week's deltas — do not depend on parsing the prior article (format may shift, the JSON is the contract).
+
+### 13. Log
+
+Append to `memory/logs/${today}.md`:
+
+```
+## Skill Leaderboard
+- **Active forks scanned:** N (of M total)
+- **Configured forks:** N (XX% conversion rate)
+- **Template forks:** N
+- **Unreadable forks:** N
+- **Top skill:** ${skill} (N forks, XX%)
+- **Verdict:** ${verdict_line}
+- **Promote/Match/Sunset/Fleet-only:** counts
+- **Notification sent:** yes/no
+- **Status:** SKILL_LEADERBOARD_OK | SKILL_LEADERBOARD_TEMPLATE_FLEET | SKILL_LEADERBOARD_NO_FORKS | SKILL_LEADERBOARD_NO_TARGET
+```
+
+## Sandbox note
+
+All GitHub API calls use `gh api` which handles auth internally — no env-var expansion in headers needed. If `gh api` returns 403 with `X-RateLimit-Remaining: 0`, back off 60s and retry once; on continued failure, record `status: "rate_limited"` for that fork and proceed with partial fleet (the verdict and source-status footer surface the gap). No new env vars or secrets required beyond the default `GITHUB_TOKEN`.
+
+## Constraints
+
+- Never send the notification if `N_CONFIGURED < 2` — the leaderboard is meaningless without a configured denominator and trains the operator to ignore.
+- Never count `heartbeat` enabled-counts as signal in the verdict (every CONFIGURED fork inherits it from upstream default; it's a tautology). It can still appear in the table.
+- Do not parse last week's article for week-over-week — use `memory/topics/skill-leaderboard-state.json` only.
+- Skills tagged `meta` or `dev` are excluded from the Sunset list (operator-tools, fork adoption is not the success metric).
+- Skills with `schedule: "workflow_dispatch"` are excluded from Promote (on-demand by design — adoption % is misleading).

--- a/skills/skill-leaderboard/SKILL.md
+++ b/skills/skill-leaderboard/SKILL.md
@@ -110,10 +110,12 @@ If the file is missing or stale (>14 days), set deltas to "first ranked snapshot
 
 ### 8. Compute the three actionable categories
 
-- **Consensus skills**: `pct_of_configured > 0.50`. The fleet has converged on these — upstream should treat them as canonical examples and ensure they're well-documented.
-- **Promote candidates**: `pct_of_configured ≥ 0.25` AND upstream default is `enabled: false` AND the skill is not a `workflow_dispatch`-only skill. The fleet found these worth running; upstream may want to flip the default or feature them more prominently.
-- **Match candidates**: skills where ≥2 CONFIGURED forks override `model:` to the same value (e.g., both pick `claude-sonnet-4-6`). The fleet has independently found a cheaper model sufficient — upstream should consider matching the override.
-- **Sunset candidates**: skills present in `UPSTREAM_SKILLS` with `forks_enabled == 0` AND `with_var == 0` AND not a meta/dev skill (skip skills tagged `meta` or `dev` — those are operator-tools, fork adoption isn't the point). Review for removal or better discoverability.
+> Every tier below is a **heuristic — operator overrides take precedence**. Thresholds are starting points, not hard rules; the operator's call always wins. **When in doubt, classify as Match** rather than forcing Promote or Sunset.
+
+- **Consensus skills**: `pct_of_configured > 0.50` (heuristic — operator overrides take precedence). The fleet has converged on these — upstream should treat them as canonical examples and ensure they're well-documented.
+- **Promote candidates**: `pct_of_configured ≥ 0.25` AND upstream default is `enabled: false` AND the skill is not a `workflow_dispatch`-only skill (heuristic — operator overrides take precedence). The fleet found these worth running; upstream may want to flip the default or feature them more prominently.
+- **Match candidates**: skills where ≥2 CONFIGURED forks override `model:` to the same value (e.g., both pick `claude-sonnet-4-6`) (heuristic — operator overrides take precedence). The fleet has independently found a cheaper model sufficient — upstream should consider matching the override.
+- **Sunset candidates**: skills present in `UPSTREAM_SKILLS` with `forks_enabled == 0` AND `with_var == 0` AND not a meta/dev skill (heuristic — operator overrides take precedence; skip skills tagged `meta` or `dev` — those are operator-tools, fork adoption isn't the point). Review for removal or better discoverability.
 - **Fleet-only skills**: any `is_fork_only: true` skill enabled in ≥1 fork. Surface for review — the fleet built something upstream doesn't have.
 
 ### 9. Write the article


### PR DESCRIPTION
## Winner: Variation B — sharper output

**Thesis:** upstream `aeon.yml` ships with effectively only `heartbeat: enabled: true`. Out of 32 current forks, most inherit that default unchanged. If we score "skills enabled" across **all active forks**, the leaderboard is a tautology (heartbeat at 100%, everything else near 0) and the operator learns nothing. The biggest lever is to score the leaderboard **only against forks that actually diverged from upstream defaults** ("CONFIGURED" forks) and to convert the result into three actionable categories: Promote / Match / Sunset.

## Key changes vs original

- **Configured-fork denominator.** A fork counts as CONFIGURED only if its `aeon.yml` diverges from upstream defaults on `enabled`, `model`, `var`, or `schedule` for any skill. TEMPLATE forks (untouched aeon.yml) are excluded from the leaderboard math but counted in a fleet-composition table.
- **Three insight categories replace generic "Consensus / Adoption-gap":**
  - **Promote** — pct_of_configured ≥ 25% AND upstream default is `enabled: false` AND not workflow_dispatch-only.
  - **Match** — ≥2 forks independently override `model:` to the same value (cost-optimization signal).
  - **Sunset** — upstream skill with zero CONFIGURED-fork enables AND not tagged `meta`/`dev`.
  - **Fleet-only** — skills present in a fork's `skills/` tree that don't exist upstream.
- **One-line verdict** at the top of every notification (priority order: Promote ≥40% → big rank jump → Fleet-only → Match → conversion-rate fallback).
- **Persistent state snapshot** at `memory/topics/skill-leaderboard-state.json` (week-over-week deltas no longer depend on parsing last week's article — more robust as the article format evolves).
- **Status taxonomy:** `SKILL_LEADERBOARD_NO_TARGET` / `SKILL_LEADERBOARD_NO_FORKS` / `SKILL_LEADERBOARD_TEMPLATE_FLEET` / `SKILL_LEADERBOARD_OK`. Notification is gated to `N_CONFIGURED >= 2` — silent otherwise so the operator isn't trained to ignore.
- **Single recursive git-tree call per fork** (folded from Variation A) — cheaper than per-path contents lookups and gives fork-only-skill detection in the same pass.
- **Source-status footer** with trees-fetched / yml-readable / rate-limited counts (folded from Variation C).
- **Heartbeat carve-out:** never makes the verdict (every CONFIGURED fork inherits it from upstream — a tautology). Still appears in the table.

## Variations considered

| Variation | Thesis | Score |
|---|---|---|
| **A — Better inputs** | Single git-tree call per fork; aeon.yml diff vs upstream defaults; fork-only skill detection; customization depth (var/model/schedule). | 38/52.5 |
| **B — Sharper output (winner)** | Tier the fleet (CONFIGURED/TEMPLATE/UNREADABLE), score against CONFIGURED denominator, replace generic categories with Promote/Match/Sunset/Fleet-only, lead with one-line verdict. | **51/52.5** |
| **C — More robust** | Rate-limit/404/409 retry handling, persistent state snapshot, source-status footer, partial-fleet tolerance. | 39.5/52.5 |
| **D — Rethink as fleet-learning report** | Drop leaderboard format entirely; output is 3 recommendations (Promote/Match/Sunset); table demoted to appendix. | 39/52.5 |

## Scoring rubric (1-5; weighted)

| Criterion (weight) | A | B | C | D |
|---|---|---|---|---|
| Clarity (1.5×) | 4 | 5 | 4 | 3 |
| Data quality (1.5×) | 5 | 5 | 4 | 4 |
| Output value (2×) | 3 | 5 | 3 | 4 |
| Robustness (1.5×) | 3 | 4 | 5 | 3 |
| Conventions (1×) | 5 | 5 | 5 | 4 |
| Improvement (3×) | 3 | 5 | 3 | 4 |

B folds A's git-tree single-call efficiency + aeon.yml-vs-upstream diff (the data foundation B depends on) and C's persistent state file + source-status footer + rate-limit retry as cheap robustness wins on top of the output-quality thesis.

D rejected — losing the recurring leaderboard format breaks week-over-week anchoring (the whole point of "weekly").

## Constraint check

- No new env vars or secrets — uses only `gh api` with existing `GITHUB_TOKEN`.
- Tags unchanged (`[meta]`).
- `${var}` semantics preserved (target repo to scan forks of, falls back to `memory/watched-repos.md`).
- Notification gated on `N_CONFIGURED >= 2` (no spam on template-fleet weeks).
- Skills tagged `meta`/`dev` excluded from Sunset (operator-tools — fork adoption isn't the success metric).
- Skills with `schedule: workflow_dispatch` excluded from Promote (on-demand by design).

---
Ported from aaronjmars/aeon-tmp#73.
