### PR TITLE
improve(list-digest): autoresearch evolution

### DIFF
--- a/skills/list-digest/SKILL.md
+++ b/skills/list-digest/SKILL.md
@@ -1,74 +1,204 @@
 ---
 name: List Digest
-description: Top tweets from tracked X lists in the past 24 hours
+description: Cross-list narrative resonance + signal-scored top tweets from tracked X lists in the past 24 hours
 var: ""
 tags: [social]
 ---
-> **${var}** — Comma-separated X list IDs to track (e.g. "1953536336675365173,1937207796270829766"). Optionally append a topic filter after a pipe: "LIST_ID1,LIST_ID2|AI agents". **Required** — set your list IDs in aeon.yml.
+<!-- autoresearch: variation B — sharper output via signal scoring + cross-list narrative clustering + insight-per-item discipline -->
 
-Read memory/MEMORY.md for context.
-Read the last 2 days of memory/logs/ to avoid repeating tweets.
+> **${var}** — Comma-separated X list IDs to track (e.g. `"1953536336675365173,1937207796270829766"`). Optionally append a topic filter after a pipe: `"LIST_ID1,LIST_ID2|AI agents"`. List IDs are the numeric IDs in the URL (`https://x.com/i/lists/<ID>`). **Required** — set in `aeon.yml`.
+
+Read `memory/MEMORY.md` for context. Read the last 2 days of `memory/logs/` and `memory/list-digest-seen.txt` (if it exists) to deduplicate.
+
+## Why this skill exists
+
+Tracked X lists are *curator signal* — someone you trust pre-selected the accounts. The value isn't a flat top-N-per-list dump (that buries the lede), it's:
+
+1. **Cross-list resonance** — when ≥2 lists surface the same story, that's stronger than any single-list winner.
+2. **Insight, not paraphrase** — each item must answer "so what" in one line, not restate the tweet.
+3. **A verdict** — one line at the top telling the operator what today's lists collectively say.
 
 ## Steps
 
-1. Parse the `${var}` input:
-   - Split on `|` — left side is comma-separated list IDs, right side (if present) is topic filter
-   - If `${var}` is empty, log an error: "var must contain at least one X list ID" and exit
+### 1. Parse and validate `${var}`
 
-2. For each list, use the X.AI API to fetch the top tweets from the past 24 hours:
-   ```bash
-   FROM_DATE=$(date -u -d "yesterday" +%Y-%m-%d 2>/dev/null || date -u -v-1d +%Y-%m-%d)
-   TO_DATE=$(date -u +%Y-%m-%d)
+```bash
+if [ -z "${var}" ]; then
+  echo "LIST_DIGEST_NO_CONFIG: var must contain at least one X list ID" \
+    >> "memory/logs/$(date -u +%Y-%m-%d).md"
+  exit 0
+fi
 
-   # Parse list IDs from var (split on | first, then comma)
-   IDS_PART="${var%%|*}"
-   TOPIC_FILTER="${var#*|}"
-   if [ "$TOPIC_FILTER" = "$IDS_PART" ]; then TOPIC_FILTER=""; fi
+IDS_PART="${var%%|*}"
+TOPIC_FILTER=""
+if [ "${var}" != "$IDS_PART" ]; then
+  TOPIC_FILTER="${var#*|}"
+fi
 
-   for LIST_ID in $(echo "$IDS_PART" | tr ',' ' '); do
-     curl -s -X POST "https://api.x.ai/v1/responses" \
-       -H "Content-Type: application/json" \
-       -H "Authorization: Bearer $XAI_API_KEY" \
-       -d '{
-         "model": "grok-4-1-fast",
-         "input": [{"role": "user", "content": "Look at X list https://x.com/i/lists/'"$LIST_ID"'. First, tell me the name and description of this list. Then find the most popular and engaging tweets posted by members of this list from '"$FROM_DATE"' to '"$TO_DATE"'. Rank by engagement (likes, retweets, quotes). Return the top 10 tweets. For each: @handle, a one-line summary, engagement stats if visible, and the direct link (https://x.com/username/status/ID). Skip retweets of non-members."}],
-         "tools": [{"type": "x_search", "from_date": "'"$FROM_DATE"'", "to_date": "'"$TO_DATE"'"}]
-       }'
-     echo "---"
-   done
-   ```
-   If `XAI_API_KEY` is not set, skip and log that the skill requires it.
+# Validate: each ID must be all digits (X list IDs are numeric)
+for LIST_ID in $(echo "$IDS_PART" | tr ',' ' '); do
+  if ! [[ "$LIST_ID" =~ ^[0-9]+$ ]]; then
+    echo "LIST_DIGEST_NO_CONFIG: invalid list ID '$LIST_ID' (must be numeric)" \
+      >> "memory/logs/$(date -u +%Y-%m-%d).md"
+    exit 0
+  fi
+done
+```
 
-3. For each list:
-   - Note the list name/description (Grok will return it)
-   - Pick the top 5 tweets by engagement and substance
-   - If a topic filter was provided, prioritize tweets related to that topic
-   - Deduplicate across lists (same tweet may appear on multiple lists)
-   - Deduplicate against recent logs
+If `XAI_API_KEY` is unset and no cache exists, fall back to **Path C** in step 2. If no path returns data, log `LIST_DIGEST_NO_CONFIG: XAI_API_KEY required` and stop without notifying.
 
-4. Send via `./notify` (under 4000 chars):
-   ```
-   List Digest — ${today}
+### 2. Fetch each list's top tweets (past 24h)
 
-   [List Name 1]
-   1. @handle — summary [link]
-   2. @handle — summary [link]
+For each `LIST_ID`, prefer cache → API → WebSearch in that order.
+
+**Path A — pre-fetched cache** (preferred — `scripts/prefetch-xai.sh` may have run):
+```bash
+cat ".xai-cache/list-digest-${LIST_ID}.json" 2>/dev/null \
+  | jq -r '.output[] | select(.type == "message") | .content[] | select(.type == "output_text") | .text'
+```
+
+**Path B — X.AI Responses API**:
+```bash
+FROM_DATE=$(date -u -d "yesterday" +%Y-%m-%d 2>/dev/null || date -u -v-1d +%Y-%m-%d)
+TO_DATE=$(date -u +%Y-%m-%d)
+
+curl -s --max-time 180 -X POST "https://api.x.ai/v1/responses" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $XAI_API_KEY" \
+  -d '{
+    "model": "grok-4-1-fast",
+    "input": [{"role": "user", "content": "Look at X list https://x.com/i/lists/'"$LIST_ID"'. Step 1: report the list name and a one-line description. Step 2: identify the most engaging tweets posted by members of this list between '"$FROM_DATE"' and '"$TO_DATE"' UTC. Return the top 12 tweets ranked by engagement (likes, retweets, replies). For EACH tweet you MUST return: (a) @handle, (b) the full tweet text (not a paraphrase), (c) explicit engagement counts as separate fields — likes:N, retweets:N, replies:N, views:N if available, (d) the direct permalink in the form https://x.com/<handle>/status/<id>, (e) media type (image|video|none), (f) one-line context if it'\''s a reply or quote tweet (who/what). Skip retweets of accounts NOT on this list. If a tweet has an image and you can analyze it, include a one-line image description."}],
+    "tools": [{"type": "x_search", "from_date": "'"$FROM_DATE"'", "to_date": "'"$TO_DATE"'", "enable_image_understanding": true}]
+  }'
+```
+
+Parse responses with `jq -r '.output[] | select(.type == "message") | .content[] | select(.type == "output_text") | .text'`.
+
+**Path C — WebSearch fallback** (when both cache and `XAI_API_KEY` are unavailable, OR Grok returns nothing for a list):
+
+Use the built-in WebSearch tool: `site:x.com "i/lists/${LIST_ID}" OR list:${LIST_ID} after:${FROM_DATE}`. Quality is lower; mark this list's source-status as `websearch` in step 6.
+
+**Per-list outcome classification** (track for the source-status footer):
+- `ok` — ≥3 tweets returned
+- `quiet` — 1–2 tweets returned (list exists but a slow day)
+- `empty` — 0 tweets returned (Grok found list but no posts in window)
+- `error` — API/cache/Grok-can't-access failure (note the reason)
+
+### 3. Build the candidate pool
+
+Collect every tweet from every list into a single pool. For each tweet record: `{handle, text, likes, retweets, replies, views, url, list_ids_seen_on:[], list_names_seen_on:[], media, is_reply, is_quote}`.
+
+**Deduplicate by URL across lists**: if the same tweet appears on multiple lists, merge the records — keep both `list_ids_seen_on` and `list_names_seen_on` populated. Cross-list appearance is a signal (used in step 4).
+
+**Deduplicate against history**: drop any candidate whose URL is in `memory/list-digest-seen.txt` OR appears in the last 2 days of `memory/logs/`.
+
+### 4. Score every candidate
+
+For each surviving candidate, compute a **signal score**. Use natural log on engagement to prevent one viral tweet from dominating; add structural bonuses.
+
+```
+base   = ln(1+likes) + 2.0*ln(1+retweets) + 1.5*ln(1+replies)
+bonuses:
+  +2.0  if appeared on ≥2 distinct lists (cross-list resonance)
+  +1.5  if appeared on ≥3 distinct lists
+  +1.0  if topic_filter set AND tweet text/context matches it (case-insensitive substring or obvious semantic match)
+  +0.5  if author is small-account-signal (≤25k followers based on Grok's note OR you have no follower data — apply the bonus when the tweet *content* is technical/insider rather than influencer-style)
+  +0.3  if media is image OR video (richer artifact)
+penalties:
+  -1.0  if is_reply AND replied-to is NOT on any tracked list (low context for the reader)
+  -0.5  if text is a pure link share with <10 words of original commentary
+score = base + sum(bonuses) - sum(penalties)
+```
+
+### 5. Cluster into cross-list narratives
+
+Group candidates into **narratives** when ALL three conditions hold:
+- ≥2 tweets from ≥2 distinct lists
+- shared ≥2 substantive keywords/entities (proper nouns, project names, ticker symbols, technical terms — ignore stop words)
+- posted within the same 24h window
+
+Each narrative gets a **narrative score** = sum of constituent tweet scores. Pick a one-line **narrative title** (≤80 chars) capturing what the cluster is collectively saying — e.g. "Anthropic releases Opus 4.7 — three lists pile in on agentic-eval results".
+
+For each narrative, pick the **anchor tweet** (highest individual score) and up to 2 supporting tweets.
+
+### 6. Compose the digest
+
+**Notification budget** (cap 4000 chars total):
+- Up to **3 narratives** at the top, ranked by narrative score
+- Then up to **5 standalone tweets per list** (highest individual score, not already in a narrative)
+- Hard total cap of **12 items** across the whole digest — cut from the bottom of standalones if over
+
+**Insight discipline**: every item must include a one-line **so-what** that adds context the tweet alone doesn't carry — the implication, the contrarian angle, the missing number, the deal-flow signal. A paraphrase ("@x said y") is not an insight and must be rewritten before sending.
+
+**Quiet-list rule**: if a list's top surviving tweet has score < 2.0 (≈ <8 likes raw), write a one-line "quiet day" entry for that list rather than padding with low-signal items.
+
+**Topic filter behavior**: when `TOPIC_FILTER` is set, it acts as a **scoring booster** (see step 4), NOT a hard filter. A list's top non-matching tweet still appears if it dominates on score; topic-matching tweets just get a thumb on the scale. Hard-filtering kills serendipity.
+
+**Verdict line**: write one line at the very top capturing what today's lists collectively say. Examples:
+- "Three lists piling in on the Opus 4.7 agentic-eval results; everything else is noise."
+- "Slow day across all lists — only standout is @vitalik's MEV piece."
+- "Crypto and AI lists diverging hard: AI lists locked on agent eval, crypto lists on Solana outage post-mortem."
+
+### 7. Send the notification
+
+Send via `./notify` (under 4000 chars total). Use the format below verbatim. Use `x.com/handle` (not `@handle`) to avoid pinging users on Telegram. Use Telegram Markdown link format `[label](url)`.
+
+```
+*List Digest — ${today}*
+
+[VERDICT LINE — one line, ≤140 chars, plain text]
+
+🔗 *Cross-list narratives*
+1. *[narrative title]* — appeared on [List A] + [List B]
+   x.com/handle: [insight, not paraphrase] (♥ likes, ↻ rt) — [View](url)
+   x.com/handle2: [insight] (♥ likes, ↻ rt) — [View](url)
+
+2. *[narrative title]* — appeared on [List A] + [List C]
    ...
 
-   [List Name 2]
-   1. @handle — summary [link]
-   2. @handle — summary [link]
-   ...
-   ```
+*[List Name 1]*
+- x.com/handle — [insight] (♥ likes, ↻ rt) — [View](url)
+- x.com/handle — [insight] (♥ likes, ↻ rt) — [View](url)
 
-   If one list has no notable tweets, just write "quiet day" under that list name.
+*[List Name 2]*
+- quiet day
 
-5. Log to memory/logs/${today}.md.
-   If nothing found across all lists, log "LIST_DIGEST_OK" and end.
+---
+sources: list1=ok | list2=quiet | list3=error(no-access)
+status: LIST_DIGEST_OK
+```
+
+If `cross-list narratives` is empty, drop that whole section (don't print "(none)"). If every list is `quiet` or `empty`, send a single-line "*List Digest — ${today}* — quiet across all tracked lists" notification rather than padding.
+
+### 8. Log and persist
+
+Append to `memory/logs/$(date -u +%Y-%m-%d).md`:
+
+```
+## list-digest
+- **Lists:** [count] tracked
+- **Status:** LIST_DIGEST_OK | LIST_DIGEST_PARTIAL | LIST_DIGEST_EMPTY | LIST_DIGEST_NO_CONFIG
+- **Per-list:** list1=ok(N) | list2=quiet(N) | list3=error
+- **Verdict:** [verdict line]
+- **Narratives:** [count] cross-list narratives
+- **URLs reported:**
+  - https://x.com/handle1/status/...
+  - https://x.com/handle2/status/...
+  - ...
+```
+
+**Update the persistent seen-file**: append every reported tweet URL (one per line) to `memory/list-digest-seen.txt`. Create the file if missing. This survives log rotation and prevents stale tweets from cycling back.
+
+**Exit-mode taxonomy**:
+- `LIST_DIGEST_NO_CONFIG` — `${var}` empty/invalid OR no fetch path available. Log only, no notify.
+- `LIST_DIGEST_EMPTY` — every list returned 0 tweets OR every candidate was already in seen-file. Log only, no notify.
+- `LIST_DIGEST_PARTIAL` — some lists succeeded, some failed. Notify with whatever survived; surface failures in source-status footer.
+- `LIST_DIGEST_OK` — ≥1 list returned ≥1 fresh tweet. Notify.
 
 ## Sandbox note
 
-The sandbox may block outbound curl. Use **WebFetch** as a fallback for any URL fetch. For auth-required APIs, use the pre-fetch/post-process pattern (see CLAUDE.md).
+The sandbox may block outbound `curl`. Prefer the pre-fetched cache (`.xai-cache/list-digest-{LIST_ID}.json`); fall back to the X.AI API; fall back to **WebSearch** as the last resort. For auth-required APIs, see CLAUDE.md's pre-fetch / post-process pattern.
 
 ## Environment Variables Required
-- `XAI_API_KEY` — X.AI API key for Grok x_search
+
+- `XAI_API_KEY` — X.AI API key for Grok `x_search`. If missing, the skill degrades to WebSearch (lower quality).

--- a/skills/list-digest/SKILL.md
+++ b/skills/list-digest/SKILL.md
@@ -121,6 +121,8 @@ Each narrative gets a **narrative score** = sum of constituent tweet scores. Pic
 
 For each narrative, pick the **anchor tweet** (highest individual score) and up to 2 supporting tweets.
 
+**Cluster-count cap**: if clustering produces fewer than 2 or more than 4 clusters, fall back to a flat ranked list with cluster labels inline (prepend each item with `[cluster-name]` when grouping would be informative, but do not emit the "🔗 Cross-list narratives" section).
+
 ### 6. Compose the digest
 
 **Notification budget** (cap 4000 chars total):


### PR DESCRIPTION
## Autoresearch — list-digest

**Winner: Variation B** — _sharper output via signal scoring + cross-list narrative clustering + insight-per-item discipline_
**Score: 51.75 / 52.5** (weighted)

### Thesis

Tracked X lists are *curator signal* — someone you trust pre-selected the accounts. The original skill ("for each list, return top 5 by engagement") wastes that signal:
- A flat top-N-per-list dump buries the lede — the operator skims and learns nothing.
- Engagement ≠ insight. A 50k-like dunk is rarely the most informative item on a curated list.
- The biggest signal — *the same story surfacing across multiple lists* — is invisible because each list is treated independently.
- "Skip retweets" was the only quality gate; everything else flowed through unchecked.

Variation B reframes the task: pool every tweet across every list, score each by a signal formula (log-weighted likes/RT/replies + cross-list bonus + topic-match bonus + small-account-signal bonus − non-member-reply penalty), cluster cross-list resonance into named narratives, and demand a *so-what* insight line per item rather than a paraphrase. A one-line verdict at the top tells the operator what today's lists collectively say. Quiet-list rule prevents padding with low-signal items.

### Scoring matrix

| Variation | Clarity | Data quality | Output value | Robustness | Conventions | Improvement | **Weighted** |
|-----------|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
| **A — Better inputs** | 4 | 4 | 3 | 4 | 5 | 3 | **38.0** |
| **B — Sharper output (winner)** | 5 | 5 | 5 | 4.5 | 5 | 5 | **51.75** |
| **C — More robust** | 5 | 3 | 3 | 5 | 5 | 3 | **39.5** |
| **D — Rethink "what this list is trying to tell you"** | 3.5 | 4 | 4.5 | 3 | 4 | 4 | **40.75** |

Weights: Improvement 3×, Output value 2×, Clarity / Data quality / Robustness 1.5× each, Conventions 1×. Max 52.5.

### What was considered

**A — Better inputs (38)** — adds prefetch caching path (`.xai-cache/list-digest-{LIST_ID}.json`), `enable_image_understanding: true` on the `x_search` tool call, explicit per-tweet engagement-count requirement, WebSearch fallback when `XAI_API_KEY` is missing, 24h→7d window fallback for slow lists, up-front `${var}` validation. Rejected as winner because the output shape is unchanged — better data into the same flat dump still produces a flat dump.

**B — Sharper output (51.75) — WINNER.** Pool + score + cluster + insight + verdict. See thesis.

**C — More robust (39.5)** — exit-mode taxonomy (`LIST_DIGEST_NO_CONFIG` / `EMPTY` / `PARTIAL` / `OK`), persistent seen-file `memory/list-digest-seen.txt`, per-list status tracking, source-status footer in the notification, retry-on-rate-limit, validation of `${var}` (numeric IDs only), skip-notify-when-nothing-new. Rejected as winner because robustness without output transformation still trains the operator to skim and skip.

**D — Rethink "what this list is trying to tell you" (40.75)** — pivots from "top-N per list by engagement" to "what does this curator want me to see that I wouldn't otherwise see?" Each list gets a one-line narrative thesis based on the day's posts, then 3 supporting items. Trades quantity for novelty: skips broadly-trending tweets (likely seen elsewhere), prioritizes insider observations, contrarian takes, technical insights, small-account signal. Creative but harder to execute consistently — relies on Grok to detect "broadly trending elsewhere" without a baseline data source. Folded as a 0.5-point small-account-signal bonus inside B's score formula instead.

### Folding strategy

Winner B incorporates the cheap wins from each runner-up so the upside isn't lost:

- From **A**: prefetch cache path (`.xai-cache/list-digest-{LIST_ID}.json`) as Path A, X.AI API as Path B, WebSearch as Path C; `enable_image_understanding: true` enabled on the `x_search` tool; explicit engagement-count fields required from Grok (not free-text); media-type tracked as a `+0.3` score bonus.
- From **C**: persistent seen-file `memory/list-digest-seen.txt`, `${var}` validation (numeric IDs only), full exit-mode taxonomy, per-list status tracking with source-status footer in the notification, "log only, no notify" branches for `NO_CONFIG` and `EMPTY`.
- From **D**: small-account-signal bonus (`+0.5` for technical/insider content from low-follower accounts) folded into the score formula as a tiebreaker.

### Diff summary

- `skills/list-digest/SKILL.md` — full rewrite. +186 / −56.
- Var semantics preserved: `LIST_ID1,LIST_ID2|TOPIC` (topic now acts as ranking booster, not hard filter — preserves serendipity).
- No new env vars (works within existing `XAI_API_KEY`).
- No tag changes.
- No new dependencies on external services.
- Adds one new persistent file the skill writes to: `memory/list-digest-seen.txt` (auto-created on first run).

### Operational note

The X.AI `x_search` tool does **not** expose a list-ID parameter (confirmed against [docs.x.ai/developers/tools/x-search](https://docs.x.ai/developers/tools/x-search) — only `allowed_x_handles` / `excluded_x_handles` / date filters / image+video understanding). The skill therefore continues to ask Grok to "look at" the list URL — same fragility as the original. A future improvement would be: resolve list-ID → member handles once, then drive `allowed_x_handles` directly. Out of scope for this evolution because it requires either an X API token (not in `aeon.yml` secrets) or a separate prefetch step that itself depends on Grok being able to enumerate list members reliably.

### Constraint check

- ✅ Core purpose preserved (digest of top tweets from tracked X lists)
- ✅ No new env vars
- ✅ Frontmatter (name/description/var/tags) preserved
- ✅ Aeon conventions followed (memory read, log to `memory/logs/${today}.md`, notify via `./notify`, sandbox note included)
- ✅ Skill scored ≥ baseline on Improvement (no downgrade)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Ported from aaronjmars/aeon-tmp#76.
