### PR TITLE
improve(weekly-shiplog): autoresearch evolution

### DIFF
--- a/skills/weekly-shiplog/SKILL.md
+++ b/skills/weekly-shiplog/SKILL.md
@@ -4,99 +4,233 @@ description: Weekly narrative of everything shipped — features, fixes, and mom
 var: ""
 tags: [content]
 ---
-> **${var}** — Focus area or theme override. If empty, covers everything shipped this week.
+> **${var}** — Optional theme filter (e.g. `dashboard`, `security`, `ai`). If set, narrows analysis to commits/PRs/issues whose messages or changed-file paths match the theme (case-insensitive). If empty, covers everything shipped this week.
 
-Read memory/MEMORY.md and the last 7 days of memory/logs/ for context.
-Read memory/watched-repos.md for repos to cover.
+<!-- autoresearch: variation B — sharper output via thesis-first writing, theme-cap, status taxonomy, theme filter that actually uses ${var}, and HTTPS URL fix -->
+
+Read `memory/MEMORY.md` and the last 7 days of `memory/logs/` for context.
+Read `memory/watched-repos.md` for repos to cover. If empty or missing, exit with `SHIPLOG_NO_REPOS` (notify + log, no article).
+
+## Idempotency
+
+If `articles/weekly-shiplog-${today}.md` already exists, exit with `SHIPLOG_ALREADY_RAN_TODAY` — no commit, no notify, no overwrite. One shiplog per day.
 
 ## Steps
 
-1. **Gather the full week of activity** for each watched repo (read repo list from `memory/watched-repos.md`):
-   ```bash
-   # For each REPO in watched-repos.md:
+### 1. Compute the 7-day window
 
-   # Commits from the last 7 days
-   gh api repos/${REPO}/commits -X GET -f since="$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-7d +%Y-%m-%dT%H:%M:%SZ)" --jq '.[] | {sha: .sha[0:7], full_sha: .sha, message: .commit.message | split("\n")[0], author: .commit.author.name, date: .commit.author.date}' --paginate
+```bash
+SINCE=$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-7d +%Y-%m-%dT%H:%M:%SZ)
+TODAY=$(date -u +%Y-%m-%d)
+```
 
-   # PRs merged this week
-   gh api repos/${REPO}/pulls -X GET -f state=closed -f sort=updated -f direction=desc --jq '[.[] | select(.merged_at != null) | select(.merged_at > (now - 604800 | strftime("%Y-%m-%dT%H:%M:%SZ"))) | {number, title, user: .user.login, merged_at, labels: [.labels[].name]}]'
+Use `$SINCE` for ALL time filtering — never substitute "since midnight Monday" or similar drift-prone shortcuts.
 
-   # Releases this week
-   gh api repos/${REPO}/releases --jq '[.[] | select(.published_at > (now - 604800 | strftime("%Y-%m-%dT%H:%M:%SZ"))) | {tag_name, name, published_at, body}]'
-   ```
+### 2. Gather raw shipping data per repo
 
-2. **Read this week's push-recap articles** from `articles/push-recap-*.md` (last 7 days) to get detailed diff context without re-fetching everything.
+For each `REPO` in `memory/watched-repos.md`, collect from these endpoints. Track success/failure of each in a `sources` map (`commits`, `prs`, `releases`, `issues`, `open_prs`) — on a single endpoint failure log `fail` and continue, do NOT abort the whole skill.
 
-3. **Read diffs for the most significant commits** (top 10 by lines changed) to understand substance:
-   ```bash
-   gh api repos/${REPO}/commits/FULL_SHA --jq '{files: [.files[] | {filename, status, additions, deletions}], stats: .stats}'
-   ```
+```bash
+# Commits — last 7 days, first-line of message + author + date
+gh api "repos/${REPO}/commits" -X GET -f since="$SINCE" \
+  --jq '.[] | {sha: .sha[0:7], full_sha: .sha, message: (.commit.message | split("\n")[0]), author: .commit.author.name, date: .commit.author.date}' \
+  --paginate
 
-4. **Synthesize into a narrative shiplog.** This is NOT a changelog or diff dump. Write it as a story of the week:
-   - What was the main thrust? What moved the project forward?
-   - What new capabilities exist now that didn't a week ago?
-   - What problems got solved?
-   - What's the pace/momentum like compared to recent weeks?
+# Merged PRs this week (with body excerpt for substance)
+gh api "repos/${REPO}/pulls" -X GET -f state=closed -f sort=updated -f direction=desc \
+  --jq "[.[] | select(.merged_at != null) | select(.merged_at > \"$SINCE\") | {number, title, user: .user.login, merged_at, labels: [.labels[].name], body: (.body // \"\" | .[0:400])}]"
 
-5. **Search the web** briefly for any external mentions, reactions, or related ecosystem developments that give context to the shipping.
+# Releases this week
+gh api "repos/${REPO}/releases" \
+  --jq "[.[] | select(.published_at != null and .published_at > \"$SINCE\") | {tag_name, name, published_at, body: (.body // \"\" | .[0:400])}]"
 
-6. **Write a 800-1200 word article** to `articles/weekly-shiplog-${today}.md`:
-   ```markdown
-   # Week in Review: [Compelling title capturing the week's theme]
+# Issues closed this week — excludes PRs (which appear in /issues by default)
+gh api "repos/${REPO}/issues" -X GET -f state=closed -f sort=updated -f direction=desc -f since="$SINCE" \
+  --jq "[.[] | select(.pull_request == null) | select(.closed_at > \"$SINCE\") | {number, title, user: .user.login, labels: [.labels[].name]}]"
 
-   *${today} — Weekly shipping update*
+# Open PRs (top 10 by updated) — feeds the "What's Nearly Here" section
+gh api "repos/${REPO}/pulls" -X GET -f state=open -f sort=updated -f direction=desc \
+  --jq '[.[0:10] | .[] | {number, title, user: .user.login, draft, updated_at}]'
+```
 
-   ## The Big Picture
-   [3-4 sentences: what was the week about? What's the one-line summary someone would share?]
+Also read this week's `articles/push-recap-*.md` (if any exist) — they already contain digested diff context and save you re-fetching everything.
 
-   ## What Shipped
+### 3. Classify the week's signal
 
-   ### [Feature/Theme 1]
-   [What it is, why it matters, how it works in plain language. Not commit messages — explain it like you're telling a colleague over coffee.]
+Compute:
+- `total_commits` = all commits in window
+- `substantive_commits` = commits whose first-line message does NOT start with `chore:`, `docs:`, `style:`, `ci:`, `build:`, `test:`, `refactor:`, `Merge`, or `Revert`
+- `total_prs_merged`, `total_releases`, `total_issues_closed`
 
-   ### [Feature/Theme 2]
-   [Same treatment]
+Branch on signal:
 
-   ### [Feature/Theme 3 if applicable]
-   [Same treatment]
+| Condition | Status | Action |
+|-----------|--------|--------|
+| `total_commits == 0` AND `total_prs_merged == 0` AND `total_releases == 0` | `SHIPLOG_QUIET_WEEK` | Notify only — no article. Skip to step 7. |
+| `substantive_commits < 3` AND `total_releases == 0` | `SHIPLOG_LIGHT_WEEK` | Short-form 300–500 word article (template below). |
+| Otherwise | `SHIPLOG_OK` | Full 800–1200 word article. |
 
-   ## Fixes & Improvements
-   [Bullet list of notable fixes, refactors, DX improvements — brief but specific]
+If `${var}` is set: filter `substantive_commits` and merged PRs by theme — keep items whose message OR changed-file paths contain `${var}` (case-insensitive). If the filtered set is empty, status becomes `SHIPLOG_NO_THEME_MATCH` — notify and exit, no article.
 
-   ## By the Numbers
-   - **Commits:** N across M repos
-   - **PRs merged:** N
-   - **Files changed:** N
-   - **Lines:** +X / -Y
-   - **Contributors:** [list]
+### 4. Score and pick themes (cap = 3)
 
-   ## Momentum Check
-   [How does this week compare to recent weeks? Accelerating? Steady? What's the trajectory?]
+For each substantive commit/PR, compute a signal score:
+- Lines changed (capped at 500): +0.5 per 100 lines
+- File diversity: +1 if files span ≥3 directories
+- Reviewer/comment diversity on PRs: +1 if ≥2 distinct non-author commenters
+- Release association: +2 if commit appears in a release this week
+- Label boost: +1 if labeled `feature`, `enhancement`, `breaking`, or `security`
 
-   ## What's Next
-   [Based on open PRs, branches, TODO patterns, and recent direction — what's likely coming next week?]
+Cluster top-scored items into themes by file-path overlap and shared keywords (extract dominant nouns from commit messages and PR titles). **Cap at 3 themes.** Each theme MUST:
+- Name a concrete user-facing capability change (not "refactored X internals")
+- Reference ≥1 specific commit `(sha)` or PR `(#N)`
+- Be describable in one short paragraph (2–4 sentences)
 
-   ---
-   *Sources: [repo links, any external references]*
-   ```
+**Drop themes that fail these gates rather than padding to 3.** Two strong themes beats three weak ones.
 
-7. **Send notification** via `./notify`:
-   ```
-   *Weekly Shiplog — ${today}*
+### 5. Pull diff stats for the top items
 
-   [The one-line summary of the week]
+For the top 5 commits by signal score:
 
-   Shipped:
-   - [Feature/theme 1 — one sentence]
-   - [Feature/theme 2 — one sentence]
-   - [Feature/theme 3 if applicable]
+```bash
+gh api "repos/${REPO}/commits/${FULL_SHA}" \
+  --jq '{files: [.files[] | {filename, status, additions, deletions}], stats: .stats}'
+```
 
-   Stats: N commits, M PRs merged, +X/-Y lines
-   Full update: [link to articles/weekly-shiplog-${today}.md — use `git remote get-url origin` for THIS repo]
-   ```
+Use `additions + deletions` and the changed-file list to write substance into theme paragraphs — quote real file names where relevant ("the change touches `dashboard/lib/runs.ts` and the workflow runner").
 
-8. **Log** to `memory/logs/${today}.md`.
+### 6. Write the article
+
+Write to `articles/weekly-shiplog-${TODAY}.md`. Use the template matching the status from step 3.
+
+**`SHIPLOG_OK` (full):**
+
+```markdown
+# Week in Review: [4–8 word title that names the thesis]
+
+*${TODAY} — Weekly shipping update*
+
+> [ONE sentence — the thesis. Must name a concrete capability/direction change in the project this week. Not "we shipped a lot." Not "exciting progress."]
+
+## What Shipped
+
+### [Theme 1 — verb-led title naming the capability change]
+[2–4 sentences. Lead with the user-facing change, then how it works, then why it matters. Reference (sha) or (#PR). Plain language — translate commit-speak into "what a colleague would understand over coffee."]
+
+### [Theme 2]
+[Same treatment]
+
+### [Theme 3 — only if it earns its place per the gates in step 4]
+
+## Fixes & Polish
+- [Bullet — only the user-noticeable ones, max 6 bullets, each one specific with a (sha) or (#PR)]
+
+## What's Nearly Here
+[1–3 sentences pulled from open PRs that look close to merging — name them by title and #N. Skip the entire section if no open PR is close.]
+
+---
+
+**Stats:** N commits · M PRs merged · K issues closed · +X / −Y lines · contributors: [names]
+**Sources:** [repo URL] · commits=[ok|fail] · prs=[ok|fail] · releases=[ok|fail] · issues=[ok|fail] · open_prs=[ok|fail]
+```
+
+**`SHIPLOG_LIGHT_WEEK` (short, 300–500 words):**
+
+```markdown
+# Week in Review: A Quieter Week
+
+*${TODAY}*
+
+> [ONE sentence — what little did happen, framed honestly. Don't pretend this was a big week.]
+
+## What Shipped
+- [3–6 specific bullets, each with (sha) or (#PR). No padding, no recycled commit messages.]
+
+---
+**Stats:** N commits · M PRs · +X / −Y
+```
+
+**Hard rules for both forms:**
+- Only include a "Momentum Check" section if a prior `articles/weekly-shiplog-*.md` exists from 7–14 days ago to compare against. If none exists, omit the section — do not invent a baseline.
+- Cite every concrete claim with `(sha)` or `(#PR)`. Anything uncitable goes.
+- If you would write "the team continued working on X," delete that sentence.
+- **Banned phrases:** "exciting", "robust", "leveraging", "unlocks", "in this fast-moving space", "we're thrilled", "stay tuned".
+
+### 7. Notify
+
+Build the article URL from `gh` (do NOT use `git remote get-url origin` — it returns SSH form on some setups):
+
+```bash
+REPO_URL=$(gh repo view --json url -q .url)
+ARTICLE_URL="${REPO_URL}/blob/main/articles/weekly-shiplog-${TODAY}.md"
+```
+
+Send via `./notify` based on status:
+
+**`SHIPLOG_OK` / `SHIPLOG_LIGHT_WEEK`:**
+
+```
+*Weekly Shiplog — ${TODAY}*
+
+[Thesis sentence from the article — verbatim]
+
+Themes:
+- [Theme 1 title — ≤12 words]
+- [Theme 2 title — ≤12 words]
+- [Theme 3 title — only if exists]
+
+N commits · M PRs · +X / −Y
+${ARTICLE_URL}
+```
+
+**`SHIPLOG_QUIET_WEEK`:**
+
+```
+*Weekly Shiplog — ${TODAY}*
+SHIPLOG_QUIET_WEEK — 0 commits, 0 PRs merged, 0 releases in the last 7 days. No article written.
+```
+
+**`SHIPLOG_NO_THEME_MATCH`:**
+
+```
+*Weekly Shiplog — ${TODAY}*
+SHIPLOG_NO_THEME_MATCH — no shipping matched theme "${var}" this week. No article written.
+```
+
+**`SHIPLOG_NO_REPOS`:**
+
+```
+*Weekly Shiplog — ${TODAY}*
+SHIPLOG_NO_REPOS — memory/watched-repos.md is empty or missing. Add a repo to enable this skill.
+```
+
+**`SHIPLOG_ALREADY_RAN_TODAY`:** silent — no notify, no commit. Just log and exit.
+
+### 8. Log
+
+Append to `memory/logs/${TODAY}.md`:
+
+```
+### weekly-shiplog
+- Status: SHIPLOG_OK | SHIPLOG_LIGHT_WEEK | SHIPLOG_QUIET_WEEK | SHIPLOG_NO_THEME_MATCH | SHIPLOG_NO_REPOS | SHIPLOG_ALREADY_RAN_TODAY
+- Theme filter: ${var:-none}
+- Repos covered: [list]
+- Commits / PRs merged / Issues closed: N / M / K
+- Themes: [theme 1 title; theme 2 title; theme 3 title]
+- Sources: commits=ok|fail, prs=ok|fail, releases=ok|fail, issues=ok|fail, open_prs=ok|fail
+- Article: articles/weekly-shiplog-${TODAY}.md (if written)
+- Notify URL: ${ARTICLE_URL} (if applicable)
+```
 
 ## Sandbox note
 
-The sandbox may block outbound curl. Use **WebFetch** as a fallback for any URL fetch. For auth-required APIs, use the pre-fetch/post-process pattern (see CLAUDE.md).
+The sandbox may block outbound `curl`. `gh` CLI handles auth internally and is the preferred path here — every API call above uses `gh api`. If a `gh api` call fails for transient reasons, retry once with a smaller `--paginate` page size. For non-API web fetches (e.g. external mention search), use **WebFetch** as the fallback per `CLAUDE.md`.
+
+## Constraints
+
+- One shiplog per day — always check for an existing `articles/weekly-shiplog-${today}.md` first.
+- Themes name capability changes, not refactors. Drop weak themes rather than pad to 3.
+- The thesis sentence is mandatory; it must come from the actual data, not boilerplate.
+- Never invent activity that isn't in the raw data — every claim needs a `(sha)` or `(#PR)`.
+- The notify URL must be the GitHub web URL via `gh repo view --json url`, not the SSH remote.
+- Banned phrases (see step 6) are non-negotiable — they signal stock-newsletter output.


### PR DESCRIPTION
## Winner: Variation B — Sharper output (46.75 / 52.5)

**Thesis:** the original is template-driven — fixed sections (Big Picture / What Shipped / Fixes / By the Numbers / Momentum Check / What's Next) force the writer to fill every slot regardless of whether there's substance, the declared `${var}` ("Focus area or theme override") is never actually used in the body, and the notify URL builder relies on `git remote get-url origin` which returns SSH form on some setups. Biggest lever is editorial discipline: mandatory thesis sentence at the top, cap themes at 3 with hard gates ("must name a capability change, not a refactor"), drop sections rather than pad, and a status taxonomy that handles quiet weeks honestly instead of pretending they were big ones.

### Key changes

- **Mandatory thesis sentence** — one line at top of article naming the week's actual capability/direction change. No more "we shipped a lot" openers.
- **Theme cap = 3 with capability-change gates** — themes must name a user-facing change, cite ≥1 (sha) or (#PR), and pass a 2–4 sentence describability test. Drop weak themes rather than pad.
- **Status taxonomy** — `SHIPLOG_OK` / `SHIPLOG_LIGHT_WEEK` (300–500 words) / `SHIPLOG_QUIET_WEEK` (notify only, no article) / `SHIPLOG_NO_THEME_MATCH` / `SHIPLOG_NO_REPOS` / `SHIPLOG_ALREADY_RAN_TODAY` — each branches notify content and skips article generation when warranted.
- **`${var}` actually wired in** — previously declared as "theme override" but never referenced. Now filters substantive_commits + merged PRs by case-insensitive match on message and changed-file paths; empty result → `SHIPLOG_NO_THEME_MATCH`.
- **HTTPS URL fix** — uses `gh repo view --json url -q .url` instead of `git remote get-url origin` (which returns `git@github.com:owner/repo.git` on SSH-configured machines and breaks the article link).
- **Idempotency check** — exits if `articles/weekly-shiplog-${today}.md` already exists; one shiplog per day.
- **Issues-closed + open-PRs added as inputs** — issues feed signal classification, open PRs power "What's Nearly Here" (replaces vague "What's Next" which had no data source defined).
- **Sources footer** — `commits=ok|fail · prs=ok|fail · releases=ok|fail · issues=ok|fail · open_prs=ok|fail` so endpoint failures are visible without aborting the run.
- **Banned-phrase list** — "exciting", "robust", "leveraging", "unlocks", "in this fast-moving space", "we're thrilled", "stay tuned" — non-negotiable, removes stock-newsletter tone.
- **"Momentum Check" only if real baseline** — original section depended on comparing to "recent weeks" with no defined baseline source. Now: only emit the section if a prior `articles/weekly-shiplog-*.md` exists from 7–14 days ago. No phantom comparisons.
- **Drop-rather-than-pad principle** — applied throughout. Two strong themes beats three weak ones.

### Scoring (1–5 per criterion; weights: Improvement 3×, Output 2×, Clarity/Data/Robust 1.5× each, Conventions 1×)

| Variation | Clarity | Data | Output | Robust | Conv | Improve | Weighted |
|-----------|---------|------|--------|--------|------|---------|----------|
| **A — Better inputs** (issues + discussions + traffic + external mentions) | 4 | 4.5 | 3.5 | 3.5 | 4 | 3.5 | **39.5** |
| **B — Sharper output** ⭐ winner | 4.5 | 4 | 5 | 4 | 4.5 | 4.5 | **46.75** |
| **C — More robust** (per-source try/catch + idempotency + URL fix + ${var} validation) | 4 | 4 | 3.5 | 5 | 4 | 3.5 | **41** |
| **D — Rethink momentum-first** (cluster commits → capability-delta paragraphs, baseline from prior shiplogs, skip-if-low-signal) | 3.5 | 4 | 4.5 | 3.5 | 4 | 4 | **41.5** |

### Variation summaries (for reviewer context)

- **A — Better inputs:** add issues opened/closed, discussions, traffic stats, and external-mention web search. Same template, broader data. Rejected because the original's biggest weakness is template-driven fluff, not data scarcity — adding more inputs to a template that pads regardless wouldn't move the output quality bar.
- **B — Sharper output (winner):** mandatory thesis, theme cap, status taxonomy, capability-change gates, banned phrases, theme filter wired up, HTTPS URL fix. Folds in C's idempotency + sources footer + URL fix and A's issues + open-PRs as inputs.
- **C — More robust:** per-source try/catch, source-status footer, idempotency check, HTTPS URL via `gh repo view`, ${var} validation against unintended values, date-portable fallback chain. Rejected solo because it leaves the output template untouched — a quiet week still produces the same padded "Momentum Check" filler.
- **D — Rethink momentum-first:** cluster commits into 2–4 work-streams via path-overlap + keyword extraction, write each as a "capability delta" paragraph (not a commit list), use prior shiplogs as trajectory baseline, skip output entirely if signal too low. Strong reframe but riskier — clustering can produce weird groupings on small commit counts (current watched repo has only one entry, so most weeks will be < 20 commits where clustering is fragile). B captures most of D's framing intent through the theme-cap + capability-change gates without depending on clustering quality.

### Notes

- B folds C's idempotency check, sources footer, and HTTPS URL fix as cheap robustness wins.
- B folds A's issues-closed and open-PRs endpoints — the latter feeds "What's Nearly Here" with concrete data instead of speculation.
- B preserves D's "drop-rather-than-pad" instinct via the theme cap + capability gates.
- No new env vars or secrets required; uses `gh` CLI exclusively (already available in workflow).
- `${var}` semantic preserved verbatim ("Focus area or theme override") — original declared it but never implemented it; this is a fix, not a change.
- Tags unchanged (`[content]`).

### Diff summary

- 199 insertions, 65 deletions in `skills/weekly-shiplog/SKILL.md`
- New sections: Idempotency, Classify the week's signal (status taxonomy), Score and pick themes (signal scoring + 3-theme cap), Notify (per-status branches), Constraints
- Existing template restructured: thesis sentence required, "Momentum Check" gated on baseline existence, "What's Next" replaced by data-backed "What's Nearly Here", "By the Numbers" demoted from section to footer line

---
Ported from aaronjmars/aeon-tmp#77.
