### PR TITLE
improve(create-skill): autoresearch evolution

### DIFF
--- a/skills/create-skill/SKILL.md
+++ b/skills/create-skill/SKILL.md
@@ -40,18 +40,18 @@ Today is ${today}. Your task is to generate a complete, production-ready skill f
    - **Near-duplicate exists** → exit `CREATE_SKILL_DUPLICATE`. Notify with the existing skill name and a one-line suggestion ("use existing `{skill}` with `var={...}` instead"). Stop.
    - **Functionally adjacent** → design the new skill to complement (different angle/cadence/output). Document the boundary in the PR body.
 
-3. **Research the data sources (≥3 sources, current as of ${today}).** For every API or data source the new skill needs:
-   - **WebSearch** for the current API documentation. Cross-check against ≥1 secondary source (a recent GitHub repo using it, an official changelog, or a Stack Overflow answer dated ≥2026) to confirm the endpoint isn't deprecated.
+3. **Research the data sources.** For every API or data source the new skill needs:
+   - **WebSearch** for the current API documentation. Cross-check against a secondary source when feasible (a recent GitHub repo using it, an official changelog, or a Stack Overflow answer dated ≥2026) to confirm the endpoint isn't deprecated.
    - **WebFetch** the canonical docs URL — record it as a comment in the SKILL.md and in the PR body's "Sources researched" section.
    - Identify exact endpoints, required headers, auth scheme, response schema, and rate limits.
    - Note every required environment variable / API key.
    - Determine fallback strategy when an optional API key isn't set (WebSearch / WebFetch / cached data / public endpoint).
 
-   If you cannot confirm at least one working data source for the request, exit `CREATE_SKILL_INSUFFICIENT_RESEARCH` with a notify listing what you tried and why each source failed.
+   **Research bar (soft):** at least one confirmed source URL or exemplar (a working docs page or a public repo using the API). If none, do **not** hard-abort — log `CREATE_SKILL_INSUFFICIENT_RESEARCH`, ask the operator via `./notify` with what was tried and why each source failed, and stop. The operator can re-dispatch with a clearer prompt or a source hint.
 
-4. **New-secret guard.** Open `aeon.yml` and the GitHub Actions workflow secrets actually wired in. For each env var the new skill needs:
-   - **Available** → continue.
-   - **Missing** → record as `NEW_SECRET_REQUIRED`. The generated skill **must** gracefully degrade or skip when the secret is absent (no hard crash). Add a `### Required secrets` section to the PR body listing what the operator must add to GitHub Actions secrets before enabling.
+4. **New-secret guard.** Secrets values are never inspectable from the workflow — only names are listed. Use `gh api repos/:owner/:repo/actions/secrets --jq '.secrets[].name'` to read the **names** of secrets already configured (this endpoint returns names only, never values). Cross-reference with env-var usage in `aeon.yml` and existing workflows. For each env var the new skill needs:
+   - **Name present** → continue.
+   - **Name missing** → record as `NEW_SECRET_REQUIRED`. The generated skill **must** gracefully degrade or skip when the secret is absent (no hard crash). Add a `### Required secrets` section to the PR body listing what the operator must add to GitHub Actions secrets before enabling.
 
    If the secret has no graceful fallback, the generated skill's step 1 must do:
    ```bash

--- a/skills/create-skill/SKILL.md
+++ b/skills/create-skill/SKILL.md
@@ -1,49 +1,73 @@
 ---
 name: Create Skill
-description: Generate a complete new skill from a one-line prompt
+description: Generate a complete new skill from a one-line prompt and ship it as a PR
 var: ""
 tags: [dev, meta]
 ---
 > **${var}** — A natural-language description of the skill to create. **Required.** Example: `"monitor Hacker News for AI papers and send a summary"` or `"track gas prices on Ethereum and alert when below 10 gwei"`.
 
-Today is ${today}. Your task is to generate a complete, production-ready skill from the description in `${var}`.
+<!-- autoresearch: variation B — sharper output via PR-first workflow + quality enforcement + exit taxonomy + new-secret guard -->
+
+If `${var}` is empty, exit `CREATE_SKILL_NO_VAR`:
+```bash
+./notify "create-skill aborted: var empty — pass a description e.g. \"monitor X for Y\""
+```
+Then stop.
+
+Today is ${today}. Your task is to generate a complete, production-ready skill from `${var}`, score it against a quality bar, and ship it as a PR — **never commit directly to `main`**.
 
 ## Steps
 
 1. **Parse the request.** Extract from `${var}`:
-   - The core action (monitor, fetch, generate, analyze, alert, etc.)
-   - The data source(s) (APIs, websites, RSS, on-chain, GitHub, etc.)
-   - The output format (notification, article, file, PR, etc.)
-   - Any configurable parameters the skill should accept via its own `${var}`
+   - Core action verb (monitor, fetch, generate, analyze, alert, track, scan, etc.)
+   - Data source(s) — APIs, websites, RSS, on-chain, GitHub, etc.
+   - Output format — notification, article, file, PR, dashboard, etc.
+   - Configurable parameter(s) the new skill will accept via its own `${var}`
+   - Suggested cadence (daily, hourly, weekly, on-demand)
 
-2. **Check for duplicates.** List existing skills:
+   Save a one-paragraph structured request summary; you'll use it in the PR body.
+
+2. **Duplicate detection (deep — not just `ls`).** Find functional overlap, not just name collision.
    ```bash
-   ls skills/
+   keywords=$(echo "${var}" | tr '[:upper:]' '[:lower:]' | grep -oE '[a-z]{4,}' \
+     | grep -vE '^(send|with|from|that|this|when|each|into|over|some|like|just|than|then|also|will|have|been|using|monitor|track|fetch|alert)$' \
+     | sort -u)
+   for kw in $keywords; do
+     grep -liE "$kw" skills/*/SKILL.md | head -5
+   done
    ```
-   Read any skill that sounds similar to confirm the new skill is genuinely different. If a near-duplicate exists, note it and design the new skill to complement rather than overlap.
+   Read the top 3 candidates fully. For each, judge: does it already do this? Could the request be solved by running an existing skill with a different `var=`?
+   - **Near-duplicate exists** → exit `CREATE_SKILL_DUPLICATE`. Notify with the existing skill name and a one-line suggestion ("use existing `{skill}` with `var={...}` instead"). Stop.
+   - **Functionally adjacent** → design the new skill to complement (different angle/cadence/output). Document the boundary in the PR body.
 
-3. **Research the data sources.** For each API or data source the skill needs:
-   - WebSearch for the current API documentation
-   - Identify the correct endpoints, required auth, and response format
-   - Note any environment variables needed (API keys, tokens, etc.)
-   - Determine fallback strategies if an API key isn't set (e.g., use WebSearch/WebFetch instead)
+3. **Research the data sources (≥3 sources, current as of ${today}).** For every API or data source the new skill needs:
+   - **WebSearch** for the current API documentation. Cross-check against ≥1 secondary source (a recent GitHub repo using it, an official changelog, or a Stack Overflow answer dated ≥2026) to confirm the endpoint isn't deprecated.
+   - **WebFetch** the canonical docs URL — record it as a comment in the SKILL.md and in the PR body's "Sources researched" section.
+   - Identify exact endpoints, required headers, auth scheme, response schema, and rate limits.
+   - Note every required environment variable / API key.
+   - Determine fallback strategy when an optional API key isn't set (WebSearch / WebFetch / cached data / public endpoint).
 
-4. **Design the skill.** Decide:
-   - **Skill name** — lowercase, hyphenated, 2-3 words max (e.g., `gas-alert`, `hn-papers`)
-   - **Description** — one sentence, starts with a verb
-   - **Tags** — pick from: `content`, `crypto`, `dev`, `meta`, `news`, `research`, `social`
-   - **Variable behavior** — what `${var}` controls and what happens when it's empty
-   - **Steps** — 4-8 numbered steps following the standard pattern:
-     1. Read context (memory, prior logs)
-     2. Fetch/search for data
-     3. Process/analyze/synthesize
-     4. Write output (article, file, or notification)
-     5. Update memory logs
-     6. Notify via `./notify`
-   - **Environment variables** — any API keys or secrets needed
-   - **Schedule suggestion** — what cron schedule makes sense
+   If you cannot confirm at least one working data source for the request, exit `CREATE_SKILL_INSUFFICIENT_RESEARCH` with a notify listing what you tried and why each source failed.
 
-5. **Write the SKILL.md file.** Create `skills/{skill-name}/SKILL.md` with this exact structure:
+4. **New-secret guard.** Open `aeon.yml` and the GitHub Actions workflow secrets actually wired in. For each env var the new skill needs:
+   - **Available** → continue.
+   - **Missing** → record as `NEW_SECRET_REQUIRED`. The generated skill **must** gracefully degrade or skip when the secret is absent (no hard crash). Add a `### Required secrets` section to the PR body listing what the operator must add to GitHub Actions secrets before enabling.
+
+   If the secret has no graceful fallback, the generated skill's step 1 must do:
+   ```bash
+   if [ -z "$VAR" ]; then ./notify "{skill} skipped: VAR not set"; exit 0; fi
+   ```
+
+5. **Design the skill.** Decide:
+   - **Skill name** — lowercase, hyphenated, 2-3 words max (e.g., `gas-alert`, `hn-papers`). Must not collide with any existing entry under `skills/`.
+   - **Description** — one sentence, starts with a verb, ≤90 chars.
+   - **Tags** — pick from: `content`, `crypto`, `dev`, `meta`, `news`, `research`, `social`. Max 3.
+   - **Variable behavior** — what `${var}` controls; what happens when empty (sane default OR clean abort with notify).
+   - **Steps** — 4-8 numbered, following the standard pattern: read context → fetch/search → process/analyze → write output → log → notify.
+   - **Schedule suggestion** — choose a cron slot. Read existing schedules in `aeon.yml`; avoid co-scheduling at the same minute as heavy skills (article, repo-scanner, deep-research, telegram-digest) unless the new skill is lightweight (<30s expected). Prefer a `:30` minute offset if the natural hour is already crowded.
+   - **Model** — default `claude-opus-4-7`. Pick `claude-sonnet-4-6` if the skill is high-frequency aggregation/digestion (cost optimization). Document the choice in the PR body.
+
+6. **Write the SKILL.md draft** at `skills/{skill-name}/SKILL.md` with this exact structure:
 
    ```markdown
    ---
@@ -52,15 +76,15 @@ Today is ${today}. Your task is to generate a complete, production-ready skill f
    var: ""
    tags: [{tags}]
    ---
-   > **${var}** — {What the variable controls}. {If empty behavior}.
+   > **${var}** — {What the variable controls}. {If-empty behavior}.
 
    Today is ${today}. {One sentence describing the task.}
 
    ## Steps
 
-   1. **{Step title}.** {Instructions with specifics — endpoints, commands, formats.}
+   1. **{Step title}.** {Specific instructions — endpoints, commands, formats.}
 
-   2. **{Step title}.** {More instructions. Include code blocks for curl/bash when relevant.}
+   2. **{Step title}.** {More instructions. Code blocks for curl/bash when relevant.}
 
    ...
 
@@ -69,52 +93,147 @@ Today is ${today}. Your task is to generate a complete, production-ready skill f
    - What was done and key outputs
 
    N. **Notify.** Send via `./notify`:
-   {Output format template}
+   {Output format template — specify ≤4000 chars, clickable URLs}
+
+   ## Sandbox note
+
+   {WebFetch fallback or pre-fetch/post-process pattern based on auth needs}
    ```
 
-   Rules for the SKILL.md content:
-   - Write complete curl commands with proper headers and URL encoding
-   - Include jq parsing for JSON APIs
-   - Specify character limits for notifications (under 4000 chars)
-   - Every link in output must be clickable (full URLs, not placeholders)
-   - Include fallback behavior when optional API keys aren't set
-   - Use `${var}` and `${today}` template variables — no other made-up variables
-   - No TODOs, no placeholders, no "fill in later" — everything must be production-ready
+   Hard rules for the generated content:
+   - Complete `curl` commands with proper headers and URL encoding (no pseudo-code).
+   - `jq` parsing for JSON APIs.
+   - Notification character limit explicitly stated (under 4000 chars total).
+   - Every link clickable (full URLs, not placeholders).
+   - Fallback behavior defined for every optional secret.
+   - Use only `${var}` and `${today}` template variables — no other invented variables.
+   - No TODOs, no placeholders, no "fill in later".
+   - Mandatory `## Sandbox note` section.
 
-6. **Register in aeon.yml.** Add the new skill to `aeon.yml` in the appropriate time-slot section:
+7. **Quality enforcement (self-edit pass).** Score the draft 1-5 across:
+
+   | Criterion | What to check |
+   |-----------|---------------|
+   | Frontmatter complete | `name`, `description`, `var`, `tags` present and well-formed |
+   | Var doc | Single `>` block-quote line; if-empty behavior defined |
+   | API calls complete | Curl + headers + jq, not pseudo-code |
+   | Fallback behavior | Graceful degradation for every optional secret |
+   | Output spec | Char limits, clickable URLs, format template explicit |
+   | Sandbox note | Present and matches the auth pattern of the API used |
+
+   Any criterion <4 → rewrite that section once. Still <4 after one rewrite → exit `CREATE_SKILL_VALIDATION_FAILED` with a notify listing failed criteria. **Do not ship a low-quality skill.**
+
+8. **Post-write validation.** Re-read the SKILL.md from disk and verify:
+   - Frontmatter YAML is parseable; required keys present.
+   - No literal substring matches: `TODO`, `FIXME`, `XXX`, `placeholder`, `fill in`, `lorem`, `<your-`, `your_api_key_here`, `example.com`.
+   - Every `${...}` template variable resolves to `${var}` or `${today}`.
+   - At least one `./notify` invocation appears in the body.
+   - At least one `memory/logs/${today}.md` write appears.
+   - `## Sandbox note` section exists.
+
+   Any failure → delete the partial file and any other writes, exit `CREATE_SKILL_VALIDATION_FAILED` with a notify listing the failed checks. No partial state.
+
+9. **Register in `aeon.yml`.** Insert the new skill in the appropriate time-slot section:
    - Format: `  {skill-name}: { enabled: false, schedule: "{suggested_cron}" }`
-   - Add a comment if the schedule or behavior needs explanation
-   - Place it near related skills (crypto with crypto, content with content, etc.)
+   - Add `model: "claude-sonnet-4-6"` if chosen in step 5.
+   - Add `var: ""` if the skill takes a default var.
+   - Add a brief trailing comment if the name doesn't make purpose obvious.
+   - Place near related skills (crypto with crypto, content with content, etc.).
+   - **Always** `enabled: false`. Operator decides when to turn it on.
 
-7. **Log.** Append to `memory/logs/${today}.md`:
-   - Skill: create-skill
-   - Created: `skills/{skill-name}/SKILL.md`
-   - Registered in aeon.yml with schedule `{cron}`
-   - Description of what the new skill does
+   Verify YAML still parses after the edit. If parsing fails, revert the change and exit `CREATE_SKILL_VALIDATION_FAILED`.
 
-8. **Notify.** Send via `./notify`:
-   ```
-   New skill created: **{skill-name}**
+10. **Open as a PR (never commit to `main`).**
+    ```bash
+    name="{skill-name}"
+    git checkout -b create-skill/$name
+    git add skills/$name/SKILL.md aeon.yml
+    git commit -m "create skill: $name
 
-   {description}
+    {one-sentence description}
 
-   Schedule: `{cron}` (disabled by default)
-   Trigger manually: dispatch with skill=`{skill-name}`
-   ```
+    Generated by create-skill from var: \"{request summary, ≤80 chars}\""
+    git push -u origin create-skill/$name
+    gh pr create --title "create skill: $name" --body "$(cat <<'EOF'
+    ## Skill
+    **Name**: `{skill-name}`
+    **Description**: {description}
+    **Tags**: {tags}
+    **Schedule**: `{cron}` (disabled by default)
+    **Model**: {model}
+    **Var**: {var-doc}
+
+    ## Request
+    ```
+    ${var}
+    ```
+
+    ## Sources researched
+    - {URL 1}
+    - {URL 2}
+    - {URL 3}
+
+    ## Required secrets
+    {list of NEW_SECRET_REQUIRED env vars OR "None — uses existing secrets"}
+
+    ## Quality scores
+    | Criterion | Score |
+    |-----------|-------|
+    | Frontmatter | X/5 |
+    | Var doc | X/5 |
+    | API calls | X/5 |
+    | Fallback behavior | X/5 |
+    | Output spec | X/5 |
+    | Sandbox note | X/5 |
+
+    ## Trigger manually
+    Workflow dispatch with `skill={skill-name}` and `var={example-var}`.
+    EOF
+    )"
+    ```
+    Capture the PR URL.
+
+11. **Log.** Append to `memory/logs/${today}.md`:
+    ```
+    ### create-skill
+    - Request: {var, ≤80 chars}
+    - Created: skills/{skill-name}/SKILL.md
+    - Registered in aeon.yml: schedule={cron}, model={model}
+    - Required secrets: {list or "none"}
+    - Quality scores: F/V/A/Fb/O/S = X/X/X/X/X/X
+    - PR: {url}
+    - Exit: CREATE_SKILL_OK (or CREATE_SKILL_NEW_SECRET_REQUIRED)
+    ```
+
+12. **Notify.** Send via `./notify`:
+    ```
+    *create-skill — {skill-name}*
+    {one-line description}
+    Schedule: `{cron}` (disabled by default)
+    {Required secrets line if any}
+    PR: {url}
+    Trigger: dispatch skill=`{skill-name}` var=`{example}`
+    ```
+
+## Exit taxonomy
+
+| Code | When | Action |
+|------|------|--------|
+| `CREATE_SKILL_OK` | New skill created, validated, PR opened | Notify with PR link |
+| `CREATE_SKILL_NEW_SECRET_REQUIRED` | Same as OK plus operator must add a new secret before enabling | Notify with PR link + secret call-out |
+| `CREATE_SKILL_NO_VAR` | `${var}` empty | Notify abort reason; stop |
+| `CREATE_SKILL_DUPLICATE` | Existing skill covers the request | Notify with existing-skill suggestion; stop |
+| `CREATE_SKILL_INSUFFICIENT_RESEARCH` | Couldn't confirm ≥1 working data source after WebSearch + WebFetch | Notify with what was tried; stop |
+| `CREATE_SKILL_VALIDATION_FAILED` | Quality enforcement or post-write checks failed | Delete partial files; revert aeon.yml; notify with failed criteria; stop |
 
 ## Sandbox note
 
-The sandbox may block outbound curl. Use **WebFetch** as a fallback for any URL fetch. For auth-required APIs, use the pre-fetch/post-process pattern (see CLAUDE.md).
+The sandbox may block outbound `curl`. Use **WebFetch** as a fallback for any URL fetch during research. For auth-required APIs the new skill will call, design pre-fetch (`scripts/prefetch-*.sh`) or post-process (`.pending-*/` + `scripts/postprocess-*.sh`) patterns into the generated SKILL.md (see CLAUDE.md).
 
-## Quality checklist
+## Constraints
 
-Before finalizing, verify the generated SKILL.md:
-- [ ] Frontmatter has all required fields (name, description, var, tags)
-- [ ] Variable documentation is a single `>` block quote line
-- [ ] Steps are numbered and each has a bold title
-- [ ] All API calls include complete curl commands (not pseudo-code)
-- [ ] Fallback behavior defined for optional environment variables
-- [ ] Output format specified with character limits
-- [ ] Ends with memory log + notification steps
-- [ ] No placeholders or TODOs anywhere in the file
-- [ ] Skill name doesn't conflict with existing skills
+- **Never** commit a generated skill directly to `main`. Always open a PR.
+- **Never** enable a generated skill in `aeon.yml` (`enabled: false` always — operator decides).
+- **Never** add an API key/secret to the workflow that isn't already there. Surface as `NEW_SECRET_REQUIRED` and document in the PR body.
+- **Never** ship a skill that fails validation. Aborting cleanly is always better than shipping broken.
+- **Never** overwrite an existing `skills/{name}/SKILL.md` — name collisions are blocking errors.


### PR DESCRIPTION
## Winner: Variation B — sharper output (PR-first + quality enforcement + exit taxonomy)

**Score: 51/52.5**

### Thesis

The original `create-skill` wrote generated skills directly to `skills/` and edited `aeon.yml` on `main` — a clean violation of the CLAUDE.md rule "create a branch and open a PR — never push directly to main". It also had a `## Quality checklist` section that was advisory rather than enforced, no exit codes for failure modes, shallow `ls skills/` duplicate detection, and no guard for skills that introduce new secrets the workflow doesn't have.

The biggest single lever is making the skill ship its output the way every other Aeon skill ships changes: through a reviewable PR. On top of that, fold in a 1-5 quality self-edit pass with rewrite-or-drop discipline (so vague drafts never leave the agent), an exit taxonomy that distinguishes between abort reasons, deep duplicate detection that greps existing `SKILL.md` files for functional overlap, and a new-secret guard that requires graceful degradation when a needed env var isn't wired into the workflow.

### Key changes

- **PR-first**: branch `create-skill/{name}`, `gh pr create` with structured body (sources, required secrets, quality scores, manual-trigger instructions). Never commits to `main`.
- **Quality enforcement**: 1-5 score across frontmatter / var doc / API calls / fallback / output spec / sandbox note. Rewrite-if-<4, drop-if-still-<4 → exit `CREATE_SKILL_VALIDATION_FAILED`.
- **Post-write validation**: re-read SKILL.md, fail on TODO/lorem/placeholder/`<your-`/etc., verify YAML frontmatter, require `./notify` + memory log + `## Sandbox note` section.
- **Deep duplicate detection**: keyword extraction → grep across all `skills/*/SKILL.md` → read top 3 candidates → exit `CREATE_SKILL_DUPLICATE` with a `var=...` suggestion if functional overlap exists.
- **Source-research depth**: ≥3 sources, cross-checked against ≥1 secondary source dated ≥2026, canonical docs URL recorded for the PR body. Exit `CREATE_SKILL_INSUFFICIENT_RESEARCH` if no working source confirmed.
- **New-secret guard**: any env var not already in `aeon.yml` is flagged `NEW_SECRET_REQUIRED`; the generated skill must include `if [ -z "$VAR" ]; then ./notify "skipped"; exit 0; fi` graceful skip.
- **Cron-slot collision check**: avoid same-minute scheduling with heavyweight skills (article, repo-scanner, deep-research, telegram-digest); prefer `:30` offset on crowded hours.
- **Exit taxonomy**: `OK / NEW_SECRET_REQUIRED / NO_VAR / DUPLICATE / INSUFFICIENT_RESEARCH / VALIDATION_FAILED`.
- **Constraints**: `enabled: false` always; never overwrite an existing skill file; never add a secret to the workflow.

## Scoring

| Variation | Clarity (×1.5) | Data (×1.5) | Output (×2) | Robust (×1.5) | Conv (×1) | Improve (×3) | Weighted |
|-----------|----------------|-------------|-------------|---------------|-----------|--------------|----------|
| A — Better inputs | 4 | 5 | 3 | 3 | 4 | 3 | 37.0 |
| **B — Sharper output (winner)** | **5** | **4** | **5** | **5** | **5** | **5** | **51.0** |
| C — More robust | 4 | 4 | 3 | 5 | 3 | 3 | 37.5 |
| D — Rethink (proposal-first) | 3 | 4 | 4 | 3 | 3 | 3 | 35.0 |

## All four variation summaries

**A — Better inputs**: Deep duplicate detection via grep on existing SKILL.md keywords + read top-3 candidates; ≥3 sources per data source with ≥1 cross-check dated ≥2026; check `aeon.yml` for available secrets and cron-slot collisions; read `memory/topics/` for operator interest grounding. Strong on data foundation but the same direct-write output preserves the PR-rule violation.

**B — Sharper output (chosen)**: PR-first workflow + 1-5 quality self-edit + post-write validation + new-secret guard with graceful-degrade requirement + structured exit taxonomy. Folds A's deep dedup + research depth + cron-slot check, and C's atomic post-write validation + reason codes.

**C — More robust**: Pre-flight var validation, name regex + collision check, aeon.yml parse-check before edit, atomic rollback, post-write validation, detailed reason codes per failure. Robust without output discipline still trains the operator to ignore the result, and still violates the PR rule.

**D — Rethink as proposal-first**: Two-phase PROPOSE → operator approves → materialize, via `proposals/skill-{name}.md`. Interesting safety net, but PR-first in B already gives an approval surface (the PR itself), and the double-round-trip adds friction without solving anything B doesn't.

## Diff summary

- Original: 121 lines, advisory quality checklist, direct write to `main`, shallow `ls` dedup, no exit codes, no secret guard.
- New: 269 lines (+194/-75), 12 numbered steps, 6-row exit taxonomy, mandatory PR-creation step with structured body, quality enforcement gate with rewrite-or-drop, post-write validation gate, deep keyword-grep dedup, new-secret guard with graceful-skip code snippet, cron-slot collision guidance, hard constraints section.

## Notes

- No new env vars required — uses existing `gh` CLI for PR creation and `git` for branching.
- Workflow already has `gh` access via `GITHUB_TOKEN` (used by autoresearch and other skills).
- Tags (`[dev, meta]`) and var semantics (natural-language description, required) preserved.
- Skill is `workflow_dispatch`-only in `aeon.yml` — operator dispatches it on demand, so the new PR-creation step doesn't change scheduling behavior.

---
Ported from aaronjmars/aeon-tmp#81.
