### PR TITLE
improve(fork-fleet): autoresearch evolution

### DIFF
--- a/skills/fork-fleet/SKILL.md
+++ b/skills/fork-fleet/SKILL.md
@@ -5,128 +5,284 @@ var: ""
 tags: [dev]
 cron: "0 10 * * 1"
 ---
-> **${var}** — Optional owner/repo to analyze a single fork. If empty, scans all active forks.
+<!-- autoresearch: variation B — sharper output: verdict + PROMOTE/REVIEW/NOTE tiers + week-over-week delta + notify gate -->
+> **${var}** — Optional `owner/repo` to analyze a single fork. If empty, scans all active forks.
 
-Today is ${today}. Track Aeon's fork fleet: discover active forks, analyze divergence, surface the most innovative work for potential upstream contribution.
+Today is ${today}. Track Aeon's fork fleet: discover active forks, surface the fork work that actually matters, and gate notifications on real change.
+
+## Operating principles
+- **Verdict first, catalog second.** Operator reads one line and knows if action is needed.
+- **Silent when nothing changed.** Weekly cadence + dormant fleet = a read-once habit to kill.
+- **Per-fork compare is one call, not three.** `/compare/{owner}:main...{fork_owner}:main` returns ahead/behind/unique commits/files in a single round-trip.
+- **Substance ≠ noise.** A new `skills/*/SKILL.md` is worth 100 cron-time edits in `aeon.yml`. Score accordingly.
 
 ## Steps
 
-0. **Load managed instance registry** — read `memory/instances.json` (if it exists).
-   Build a set of repo full_names that are managed instances (e.g. `owner/aeon-crypto-tracker`).
-   These will be tagged differently from organic community forks in the report.
+### 0. Bootstrap + load state
 
-1. **Fetch all forks** of this repo (determine the repo from `git remote get-url origin`):
-   ```bash
-   PARENT_REPO=$(gh api repos/$(gh repo view --json nameWithOwner -q .nameWithOwner) --jq '.parent.full_name // .full_name')
-   gh api repos/${PARENT_REPO}/forks --paginate --jq '[.[] | {owner: .owner.login, full_name: .full_name, pushed_at, stargazers_count, open_issues_count, forks_count, description}]'
-   ```
+```bash
+mkdir -p memory/topics
+[ -f memory/instances.json ] || echo '{}' > memory/instances.json
+[ -f memory/topics/fork-fleet-state.json ] || echo '{"forks":{},"last_run":null}' > memory/topics/fork-fleet-state.json
+```
 
-2. **Filter for active forks** — keep only forks with a `pushed_at` within the last 30 days. If no active forks exist, log `FORK_FLEET_QUIET: no active forks` to `memory/logs/${today}.md` and **stop — do NOT send any notification**.
+Read `memory/instances.json` → set of repo `full_name`s that are managed instances (tagged separately from organic community forks in the report).
+Read `memory/topics/fork-fleet-state.json` → prior run's per-fork `{pushed_at, ahead_by, default_branch, new_skill_count}` keyed by `full_name`. Used for the what-changed delta.
 
-3. **For each active fork**, analyze divergence by comparing commits against upstream:
-   ```bash
-   # Get fork's commits not in upstream (diverged work)
-   gh api repos/FORK_OWNER/aeon/commits --paginate --jq '[.[] | {sha: .sha[0:7], message: .commit.message, author: .commit.author.name, date: .commit.author.date}]' -X GET -f since="$(date -u -d '90 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-90d +%Y-%m-%dT%H:%M:%SZ)"
-   ```
-   Then check which of those SHAs exist in upstream:
-   ```bash
-   gh api repos/${PARENT_REPO}/commits --paginate --jq '[.[].sha]' -X GET -f since="$(date -u -d '90 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-90d +%Y-%m-%dT%H:%M:%SZ)"
-   ```
-   Commits in the fork but NOT in upstream are **unique fork commits**.
+### 1. Resolve parent + list forks
 
-4. **Classify divergence** for each fork using the unique commits. Check which areas were modified by fetching the file tree comparison:
-   ```bash
-   gh api repos/FORK_OWNER/aeon/compare/${PARENT_REPO##*/}:main...FORK_OWNER:main --jq '{ahead_by: .ahead_by, behind_by: .behind_by, files: [.files[] | {filename, status, additions, deletions}]}'
-   ```
-   Classify each fork into divergence signals:
-   - **New skills**: files added under `skills/` not present in upstream
-   - **Custom schedule**: modifications to `aeon.yml` (different cron times, new skill entries)
-   - **Modified dashboard**: changes to `dashboard/` directory
-   - **Custom notify**: changes to `notify` or `notify-jsonrender` scripts
-   - **New articles/content**: files added to `articles/` or `memory/`
-   - **Config changes**: changes to `CLAUDE.md`, `.github/`, or root scripts
+```bash
+PARENT_REPO=$(gh api repos/$(gh repo view --json nameWithOwner -q .nameWithOwner) --jq '.parent.full_name // .full_name')
+PARENT_NAME="${PARENT_REPO##*/}"
+PARENT_OWNER="${PARENT_REPO%%/*}"
+```
 
-5. **Score each fork** by divergence:
-   - +3 points per new skill file
-   - +2 points per unique commit (up to 10)
-   - +1 point per modified core file (aeon.yml, dashboard, notify)
-   - +1 point per star
-   Rank forks by score descending. Flag forks with 5+ unique commits as "high-divergence — potential upstream contribution".
+Single paginated listing — includes `default_branch`, `archived`, `disabled`, `pushed_at`:
 
-6. **Deep-read top 3 forks**: for each of the top 3 by score, read the actual content of their unique skill files:
-   ```bash
-   gh api repos/FORK_OWNER/aeon/contents/skills/SKILL_NAME/SKILL.md --jq '.content' | base64 -d
-   ```
-   Summarize what each unique skill does in 1-2 sentences.
+```bash
+gh api "repos/${PARENT_REPO}/forks" --paginate \
+  --jq '[.[] | {full_name, owner: .owner.login, default_branch, pushed_at, pushed_at_epoch: (.pushed_at | fromdateiso8601), stargazers_count, open_issues_count, archived, disabled, description}]'
+```
 
-7. **Write the article** to `articles/fork-fleet-${today}.md`:
-   ```markdown
-   # Fork Fleet Report — ${today}
+Skip `archived=true` or `disabled=true`. Retain the rest as the total fork population (`N_TOTAL`).
 
-   ## Overview
-   Aeon has N total forks. X are active (pushed within 30 days). Summary of divergence landscape.
+**If `${var}` is set** to `owner/repo`, filter to that single fork and skip step 2 (treat as "active").
 
-   ---
+### 2. Classify by activity window
 
-   ## Active Forks — Ranked by Divergence
+- **Active** = `pushed_at` within last 30 days.
+- **Stale** = 30–365 days.
+- **Dormant** = >365 days or never pushed after creation.
 
-   ### 1. owner/aeon — Score: N [MANAGED INSTANCE | COMMUNITY FORK]
-   **Type:** Managed instance (spawned {date}, purpose: {purpose}) | Community fork
-   **Activity:** Last pushed YYYY-MM-DD | Stars: N | Unique commits: N
-   **Divergence signals:** [list of signals: "3 new skills", "custom schedule", "modified dashboard"]
-   **Unique skills:** [list skill names and 1-sentence descriptions if found]
-   **Upstream potential:** [Yes — N new skills worth reviewing / No — schedule changes only]
+If zero active forks AND no state change (no new forks, no forks that flipped active→stale or stale→active vs prior state):
+- Write status=`FORK_FLEET_QUIET` to `memory/logs/${today}.md`.
+- Update state file.
+- **Do NOT send any notification.**
+- Stop.
 
-   ### 2. owner/aeon — Score: N [MANAGED INSTANCE | COMMUNITY FORK]
-   ...
+### 3. Per-fork compare (one call each)
 
-   ---
+For each active fork, call cross-repo compare using the fork's own `default_branch` and `full_name` (fixes any repo-rename drift):
 
-   ## Top Upstream Contribution Candidate
-   **Fork:** owner/aeon
-   **Why:** [What makes this fork's work most valuable to merge upstream]
-   **Suggested action:** [Open a PR from fork's branch, or reach out to fork owner]
+```bash
+gh api "repos/${PARENT_REPO}/compare/${PARENT_OWNER}:${PARENT_DEFAULT_BRANCH}...${FORK_OWNER}:${FORK_DEFAULT_BRANCH}" \
+  --jq '{ahead_by, behind_by, status, files: [.files[]? | {filename, status, additions, deletions}], commits: [.commits[]? | {sha: .sha[0:7], msg: .commit.message | split("\n")[0], author: .commit.author.name, date: .commit.author.date}]}'
+```
 
-   ---
+On `404` (branch missing / fork emptied): mark fork `UNREADABLE` and continue.
+On `429`: sleep 60s, retry once. On `5xx`: sleep 10s, retry once. On persistent fail: mark `API_FAIL` for that fork.
 
-   ## Fleet vs Community
-   | Category | Count |
-   |----------|-------|
-   | Managed instances | N |
-   | Community forks | N |
-   | Inactive (30+ days) | N |
+Cross-repo compare returns unique fork commits (`commits`) and changed files (up to 300) in one shot. No separate `/commits` calls needed.
 
-   ## Coverage Gaps
-   Forks not analyzed (inactive for 30+ days): [list]
-   ```
+### 4. Classify divergence signals per fork
 
-8. **Save to memory** — append to `memory/logs/${today}.md`:
-   ```
-   ## fork-fleet
-   - Analyzed N active forks out of M total
-   - Top fork: owner/aeon (score: N, N unique commits, N new skills)
-   - Article: articles/fork-fleet-${today}.md
-   ```
+From the `files` array, tag each fork with signals:
+- **New skills**: files with `status=added` under `skills/*/SKILL.md`
+- **Modified skills**: `status=modified` under `skills/*/SKILL.md`
+- **Custom schedule**: any change to `aeon.yml`
+- **Modified dashboard**: any change under `dashboard/`
+- **Custom notify**: change to `notify` or `notify-jsonrender`
+- **New content**: additions under `articles/` or `memory/topics/`
+- **Config changes**: changes to `CLAUDE.md`, `.github/`, or root `scripts/`
+- **Workflow changes**: changes under `.github/workflows/`
 
-9. **Send a detailed notification** via `./notify`:
-   ```
-   *Fork Fleet Report — ${today}*
+### 5. Score each fork (substance-weighted)
 
-   Aeon has [N] active forks (out of [M] total). [1-2 sentence overview of what the fleet looks like — are they mostly dormant clones, or are people actually building?]
+```
+score =  10 × (new skill files)
+       +  4 × (modified skill files)
+       +  2 × min(unique_commits, 15)
+       +  3 × (new content files, capped at 5)
+       +  2 × (workflow/config files, capped at 3)
+       +  1 × (custom-schedule flag)
+       +  1 × stargazers
+```
 
-   Top fork: [owner/aeon]
-   [2-3 sentences: what makes this fork stand out. How many unique commits? What did they build? Any new skills not in upstream?]
+Sort active forks by score descending. Flag any fork with ≥1 new skill file as a **PROMOTE** candidate; ≥3 unique commits OR ≥1 modified skill as **REVIEW**; otherwise **NOTE**.
 
-   Divergence signals across fleet:
-   - [N] forks with new skills not in upstream
-   - [N] forks with custom schedules
-   - [N] forks with modified dashboards
-   - [N] high-divergence forks (5+ unique commits)
+### 6. Deep-read top upstream candidates
 
-   Upstream contribution candidate: [owner/aeon]
-   [1-2 sentences on what this fork built that could be merged back and why it's valuable]
+For every PROMOTE fork (capped at 5), fetch each unique skill's SKILL.md from the fork's default branch:
 
-   Full report: articles/fork-fleet-${today}.md
-   ```
+```bash
+gh api "repos/${FORK_FULL_NAME}/contents/${SKILL_PATH}?ref=${FORK_DEFAULT_BRANCH}" --jq '.content' | base64 -d
+```
 
-Write the full article. No TODOs or placeholders.
+On failure fall back to the file tree listing and note "could not read content". Synthesize each unique skill into a 1-2 sentence description of what it does. Do NOT deep-read REVIEW or NOTE forks (output stays actionable).
+
+### 7. Compute week-over-week delta
+
+Compare current active-fork set to prior state file:
+- **NEW_FORK**: full_name absent from prior state
+- **NEW_ACTIVE**: was stale/dormant, now active
+- **WENT_STALE**: was active, now stale/dormant
+- **NEW_SKILLS**: active in both snapshots, `new_skill_count` increased
+- **GONE**: archived / deleted since prior run
+
+### 8. Pick the verdict
+
+One line at the top. Priority order:
+1. `NEW UPSTREAM CANDIDATE: {fork}` — if ≥1 PROMOTE fork has ≥1 new skill not present in prior state
+2. `ACTIVE FLEET: {N} forks building` — if ≥3 PROMOTE+REVIEW combined
+3. `FLEET STIRRING: {N} new active` — if ≥2 NEW_FORK or NEW_ACTIVE
+4. `HOLDING PATTERN: {N} active, no new work` — active forks present but nothing crossed REVIEW
+5. `DORMANT: no active forks` — shouldn't reach notify (step 2 would have gated), included for log-only path
+
+### 9. Write the article
+
+To `articles/fork-fleet-${today}.md`:
+
+```markdown
+# Fork Fleet Report — ${today}
+
+**Verdict:** {one-line verdict}
+
+Fleet: N_TOTAL total forks · N_ACTIVE active · N_MANAGED managed instances · N_COMMUNITY community.
+
+---
+
+## What changed this week
+- **New forks**: [list or "none"]
+- **Went active**: [list or "none"]
+- **New skills landed**: [fork → skill names, or "none"]
+- **Went stale**: [list or "none"]
+- **Archived/deleted**: [list or "none"]
+(Omit the entire section if every bucket is empty.)
+
+---
+
+## PROMOTE — upstream contribution candidates
+
+### {fork_full_name} — score N [MANAGED | COMMUNITY]
+**Activity:** last pushed YYYY-MM-DD · stars N · +N/-M commits vs upstream
+**Unique skills:**
+- `skills/foo/SKILL.md` — {one-line synthesis of what it does, from deep-read}
+- `skills/bar/SKILL.md` — {synthesis}
+
+**Why promote:** {1-2 sentence take — what this skill does that upstream lacks, and whether it's generalizable}
+**Suggested action:** Open a PR cherry-picking `skills/foo/` (or reach out to {owner} to upstream themselves).
+
+(Repeat for each PROMOTE fork, capped at 5.)
+
+If PROMOTE is empty: write "No upstream candidates this week."
+
+---
+
+## REVIEW — worth a look
+
+| Fork | Score | Ahead | New/Modified | Notable |
+|------|-------|-------|--------------|---------|
+| owner/repo | N | +N/-M | 0/2 | dashboard rewrite, custom notify |
+
+(Omit if empty.)
+
+---
+
+## NOTE — low divergence
+
+Terse one-liner per fork: `owner/repo (+N/-M, schedule tweak only)`. Collapse if >5 entries into a count. Omit if empty.
+
+---
+
+## Fleet vs community
+
+| Category | Count |
+|----------|-------|
+| Managed instances | N |
+| Community forks | N |
+| Stale (30-365d) | N |
+| Dormant (>365d) | N |
+
+## Source status
+`forks_list=ok|fail · compare_ok=N/M · deep_read=N/M · rate_limit_retries=N · unreadable=N`
+```
+
+Cap total article length at ~500 lines. If PROMOTE has >5 forks, keep only the top 5 by score; list the rest in REVIEW.
+
+### 10. Update state
+
+Write `memory/topics/fork-fleet-state.json`:
+
+```json
+{
+  "last_run": "${today}",
+  "last_status": "FORK_FLEET_OK",
+  "parent_repo": "owner/repo",
+  "forks": {
+    "owner/repo": {
+      "pushed_at": "YYYY-MM-DD...",
+      "default_branch": "main",
+      "ahead_by": N,
+      "behind_by": N,
+      "new_skill_count": N,
+      "score": N,
+      "tier": "PROMOTE|REVIEW|NOTE|UNREADABLE|API_FAIL",
+      "unique_skills": ["skills/foo/SKILL.md", "..."]
+    }
+  }
+}
+```
+
+### 11. Log
+
+Append to `memory/logs/${today}.md`:
+
+```
+## fork-fleet
+- Status: FORK_FLEET_OK (or NO_CHANGE / QUIET / API_FAIL)
+- Verdict: {one-line verdict}
+- Fleet: N_ACTIVE active / N_TOTAL total (N_MANAGED managed, N_COMMUNITY community)
+- PROMOTE: N forks (list), REVIEW: N, NOTE: N
+- Delta: {new_forks:N, new_active:N, new_skills:N, went_stale:N}
+- Article: articles/fork-fleet-${today}.md
+- Source status: forks_list=ok|fail · compare_ok=N/M · deep_read=N/M · unreadable=N
+```
+
+### 12. Notify — gated
+
+**Skip notify entirely** when:
+- Status is `FORK_FLEET_QUIET` (no active forks, no state change), OR
+- Status is `FORK_FLEET_NO_CHANGE` (no PROMOTE, no REVIEW, and every `what-changed` bucket empty)
+
+Otherwise send via `./notify`:
+
+```
+*Fork Fleet — ${today}*
+{verdict line}
+
+Fleet: N_ACTIVE active / N_TOTAL total. {1 sentence describing shape — "mostly managed instances", "community picking up", "dormant templates", etc.}
+
+{If PROMOTE non-empty:}
+Upstream candidate: {top PROMOTE fork}
+{2 sentences: what they built, why it's worth merging back}
+
+{If delta has any NEW_SKILLS:}
+New skills landed this week:
+- {fork} → `skills/foo/SKILL.md` — {synthesis}
+
+{If delta has any NEW_FORK or NEW_ACTIVE:}
+New activity: {fork names}
+
+Full report: articles/fork-fleet-${today}.md
+```
+
+Keep under ~800 chars total so it renders cleanly across Telegram/Discord/Slack.
+
+## Exit taxonomy
+
+| Status | Meaning | Notify? |
+|--------|---------|---------|
+| `FORK_FLEET_OK` | Active forks present AND (PROMOTE/REVIEW non-empty OR delta non-empty) | Yes |
+| `FORK_FLEET_NO_CHANGE` | Active forks exist but nothing crossed REVIEW and delta is empty | No (log only) |
+| `FORK_FLEET_QUIET` | Zero active forks and no state change | No (log only) |
+| `FORK_FLEET_API_FAIL` | Fork listing failed or >50% of compares failed | Yes (error notify) |
+
+## Constraints
+- Cross-repo compare accepts up to 300 files per response; if any fork exceeds this, note `files_truncated=true` for that fork and proceed.
+- Cap active-fork deep processing at 50 per run — if more, rank by `pushed_at_epoch` desc and trim (log `truncated_at=50`).
+- Never deep-read content from a fork with `archived=true` or if the SKILL.md path is absent from the compare `files` list (cheapest sanity check).
+- Never invent PROMOTE candidates — a fork with zero new skill files is at most REVIEW.
+
+## Sandbox note
+
+Uses `gh api` throughout — authenticates via `GITHUB_TOKEN` automatically and works from the sandbox. No `curl` needed. If `gh api` fails due to rate limits, honor the retry policy in step 3; if the initial `/forks` listing fails after retry, status=`FORK_FLEET_API_FAIL` with source-status `forks_list=fail`.


### PR DESCRIPTION
## Autoresearch evolution — fork-fleet

**Winner:** Variation B — sharper output: verdict + PROMOTE/REVIEW/NOTE tiers + week-over-week delta + notify gate
**Score:** 48/52.5

### Thesis

Original is a flat catalog (Active Forks ranked by score + per-fork detail blocks + divergence signal counts) with no verdict, no week-over-week delta, and no notify gate. Weekly cadence + mostly-dormant fleet = a report the operator learns to ignore. Biggest lever is decision-readiness: one-line verdict chosen from a priority ladder; three tiers (PROMOTE = fork with new skill files worth merging upstream, REVIEW = non-trivial divergence worth a skim, NOTE = terse one-liners); "What changed this week" section diffed against a persistent state file; notify gated on FORK_FLEET_OK (silent when status is NO_CHANGE or QUIET). Also folds in A's single `/compare/{owner}:main...{fork_owner}:main` cross-repo call per fork (replaces the original's 3-call pattern per fork: separate /commits on fork, /commits on upstream, then /compare — all now handled by one compare call which returns ahead/behind/commits/files in one round-trip); C's bootstrap for missing `memory/instances.json` + exit taxonomy + rate-limit retry (60s on 429, 10s on 5xx) + source-status footer; D's "upstream contribution candidates" framing as the PROMOTE tier (not the whole report — catalog preserved so downstream skills can still read fleet state).

### Scoring

| Variation | Clarity ×1.5 | Data ×1.5 | Output ×2 | Robustness ×1.5 | Conventions ×1 | Improvement ×3 | Total |
|-----------|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
| A — Better inputs (single /compare + default_branch from list + paginate) | 4 | 5 | 3 | 4 | 4 | 3 | 38.5 |
| **B — Sharper output (verdict + tiers + delta + notify gate)** | **4** | **4** | **5** | **4** | **5** | **5** | **48** |
| C — More robust (rate-limit retry + persistent state + taxonomy) | 4 | 4 | 3 | 5 | 4 | 3 | 38.5 |
| D — Rethink as upstream contribution pipeline | 4 | 4 | 4 | 3 | 4 | 4 | 40.5 |

### Variations considered

- **A — Better inputs:** Single `/compare/{owner}:{branch}...{fork_owner}:{branch}` cross-repo call per fork (replaces 3 calls), `default_branch` pulled from the initial `/forks` listing, full pagination, GraphQL batching option. Fixes the hardcoded `/aeon/` path bug. Unchanged output shape — operator still sees the same wall.
- **B — Sharper output (winner):** Verdict-first article with priority-ladder verdict picker (NEW_UPSTREAM_CANDIDATE > ACTIVE_FLEET > FLEET_STIRRING > HOLDING_PATTERN > DORMANT). Three-tier classification: PROMOTE (≥1 new skill file), REVIEW (≥3 unique commits OR ≥1 modified skill), NOTE (everything else). Deep-read capped at PROMOTE only (not top 3 by score — avoids reading fluff). Substance-weighted score: 10× new skill files, 4× modified skills, 2× min(commits,15), 3× new content (cap 5), 2× config/workflow (cap 3), 1× schedule flag, 1× stars. Persistent state at `memory/topics/fork-fleet-state.json` drives the "What changed this week" section. Notify gated on FORK_FLEET_OK — silent on NO_CHANGE/QUIET.
- **C — More robust:** Rate-limit retry (60s on 429, 10s on 5xx), bootstrap missing `memory/instances.json`, per-fork default_branch detection, exit taxonomy, source-status footer, cap at 50 active forks with truncation flag, archived/disabled fork handling. Fixes the hardcoded `/aeon/` path bug. Doesn't change the output format — same wall, cleaner data.
- **D — Rethink as upstream contribution pipeline:** Drop ranking entirely; reframe around "what work should we pull upstream this week?" Pipeline: extract unique files → filter to skills/scripts/docs → read content → score candidacy → produce 0-3 concrete upstream PR candidates. Only notify when ≥1 candidate emerges. Rejected because it loses the catalog that downstream skills (e.g., skill-leaderboard, fork-contributor-leaderboard) may cross-reference, and candidacy scoring by reading SKILL.md content is hard to do well without drifting into code-review quality judgments.

### Diff summary

- Fixed hardcoded `/aeon/` path bug — old skill had `gh api repos/FORK_OWNER/aeon/...` on three lines; new skill uses `${FORK_FULL_NAME}` from the initial listing + `${PARENT_REPO}`/`${PARENT_NAME}` variables parsed from `gh repo view`.
- Single `/compare/{owner}:{branch}...{fork_owner}:{branch}` call per fork returns ahead/behind/unique commits/changed files in one round-trip (was 3 calls).
- Added per-fork `default_branch` detection from the initial `/forks` listing — original assumed `main` everywhere.
- Substance-weighted scoring: 10× new skill files (was 3×), cron-time edits demoted, unique commits cap raised to 15.
- Three-tier classification (PROMOTE/REVIEW/NOTE) with deep-read limited to PROMOTE (≤5 forks).
- Persistent state file `memory/topics/fork-fleet-state.json` with keys `{pushed_at, default_branch, ahead_by, behind_by, new_skill_count, score, tier, unique_skills}` per fork.
- New "What changed this week" article section: NEW_FORK / NEW_ACTIVE / WENT_STALE / NEW_SKILLS / GONE.
- Exit taxonomy: FORK_FLEET_OK | NO_CHANGE | QUIET | API_FAIL with notify gating.
- Rate-limit retry (60s on 429, 10s on 5xx).
- Bootstrap for missing `memory/instances.json` and `memory/topics/fork-fleet-state.json`.
- Cap at 50 active forks processed per run (truncation flag logged).
- Source-status footer: `forks_list=ok|fail · compare_ok=N/M · deep_read=N/M · rate_limit_retries=N · unreadable=N`.
- Notification capped at ~800 chars for clean rendering across Telegram/Discord/Slack.

### Constraints checked

- No new env vars — still uses `gh api` with existing `GITHUB_TOKEN`.
- No new secrets in `aeon.yml`.
- Frontmatter preserved (name, description, var, tags, cron).
- `${var}` semantics preserved (empty = scan all forks; set = single fork).
- Core purpose preserved (inventory active forks, detect diverged work, surface upstream contribution candidates).
- Downstream catalog preserved — other skills can still read fleet shape from the article and state file.

### Operational finding

This skill has never run in aeon-tmp (no prior `articles/fork-fleet-*.md`, no memory log entries). First execution will bootstrap `memory/topics/fork-fleet-state.json` + `memory/instances.json` if absent, so no manual setup required. Today's repo (`aaronjmars/aeon-tmp`) has 0 forks — first run will land as `FORK_FLEET_QUIET` (silent, log-only). The skill is designed for the real parent repo `aaronjmars/aeon` which has a substantial fork network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Ported from aaronjmars/aeon-tmp#82.
