### PR TITLE
improve(spawn-instance): autoresearch evolution

### DIFF
--- a/skills/spawn-instance/SKILL.md
+++ b/skills/spawn-instance/SKILL.md
@@ -1,187 +1,369 @@
 ---
 name: Spawn Instance
-description: Clone this Aeon agent into a new GitHub repo — fork, configure skills, register in fleet
+description: Clone this Aeon agent into a new GitHub repo — fork, configure skills, validate, register in fleet
 var: ""
 tags: [dev]
 ---
-> **${var}** — Name and purpose of the new instance, e.g. `crypto-tracker: monitor DeFi protocols and token movements`. If empty, the skill will ask via notification what kind of instance to create and stop.
+<!-- autoresearch: variation C — robust: skill-existence validation, exit taxonomy, idempotent recovery, dynamic SETUP.md, pre/post-flight verification -->
 
-Today is ${today}. Create a new Aeon instance by forking this repo, configuring it for a specific purpose, and registering it in the fleet.
+> **${var}** — Name and purpose of the new instance. Format `name: purpose`, e.g. `crypto-tracker: monitor DeFi protocols and token movements`. If empty, notify the owner and **stop** with exit `SPAWN_INVALID_VAR`.
+
+Today is ${today}. Create a new Aeon instance by forking this repo, configuring it for a specific purpose, validating the configuration, and registering it in the fleet.
+
+Read `memory/MEMORY.md` at the start for context.
 
 ## Security Model
 
 This skill creates the repo and configuration but does **NOT** propagate secrets.
-The new instance is inert until the owner manually sets secrets (ANTHROPIC_API_KEY, etc.).
-This is intentional — each instance should have its own API keys for billing isolation and blast-radius containment.
+The new instance is inert until the owner manually sets secrets (`ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN`, plus notification secrets).
+Each instance has its own API keys for billing isolation and blast-radius containment.
+
+## Exit Taxonomy
+
+Every run ends with one of these status codes, written to the log and (where relevant) included in the notification:
+
+| Code | Meaning |
+|------|---------|
+| `SPAWN_OK` | Fork created, configured, pushed, Actions enabled, registered. |
+| `SPAWN_FORK_EXISTS_RECOVERED` | Fork already existed but wasn't registered → configured + registered now. |
+| `SPAWN_FORK_EXISTS_REGISTERED` | Fork exists AND is already registered and not archived — refused, no change. |
+| `SPAWN_INVALID_VAR` | var was empty or couldn't be parsed into `name: purpose`. |
+| `SPAWN_NO_SKILLS` | After validation, the skill plan was empty — refused. |
+| `SPAWN_FORK_FAILED` | `gh repo fork` and the fallback `forks` API both failed. |
+| `SPAWN_PUSH_FAILED` | Fork created but push failed — fork left in place, recovery instructions emitted. |
+| `SPAWN_ACTIONS_FAILED` | Configuration pushed but enabling Actions failed — recovery instructions emitted. |
+| `SPAWN_API_ERROR` | Any other GitHub API failure not covered above. |
 
 ## Steps
 
-1. **Parse the var** to extract instance name and purpose:
-   - Format: `name: purpose` (e.g. `crypto-tracker: monitor DeFi protocols`)
-   - If var is empty, log to `memory/logs/${today}.md` and send a notification asking the owner to re-run with a var, then **stop**.
-   - Derive the repo name: `aeon-{name}` (e.g. `aeon-crypto-tracker`)
-   - Sanitize: lowercase, hyphens only, max 40 chars
+### 1. Parse and validate the var
 
-2. **Check the fleet registry** — read `memory/instances.json` (create if missing).
-   If an instance with the same name already exists and is not archived, log a warning and **stop**.
+- If `${var}` is empty, log `SPAWN_INVALID_VAR: empty var` to `memory/logs/${today}.md`, notify: `spawn-instance: empty var — re-run with "name: purpose"`, and **stop**.
+- Split on the first `:` — left is `NAME_RAW`, right is `PURPOSE` (trim whitespace). If either is empty, exit `SPAWN_INVALID_VAR`.
+- Derive `NAME`: lowercase `NAME_RAW`, replace non-alphanumeric runs with `-`, strip leading/trailing `-`, truncate to 40 chars. If empty after sanitization, exit `SPAWN_INVALID_VAR`.
+- Set `REPO_NAME="aeon-${NAME}"`.
 
-   The registry format:
-   ```json
-   {
-     "instances": [
-       {
-         "name": "crypto-tracker",
-         "repo": "OWNER/aeon-crypto-tracker",
-         "purpose": "monitor DeFi protocols and token movements",
-         "created": "2026-04-08",
-         "status": "pending_secrets",
-         "skills_enabled": ["token-movers", "defi-monitor", "heartbeat"],
-         "parent": "OWNER/aeon"
-       }
-     ]
-   }
-   ```
+### 2. Pre-flight checks
 
-3. **Determine the owner** for the new repo:
-   ```bash
-   OWNER=$(gh api user --jq '.login')
-   ```
+```bash
+gh auth status || { echo "SPAWN_API_ERROR: gh not authenticated"; exit 1; }
+OWNER=$(gh api user --jq '.login') || { echo "SPAWN_API_ERROR: cannot read user"; exit 1; }
+PARENT_REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+# If current repo is itself a fork, use the upstream as the parent:
+PARENT_UPSTREAM=$(gh api "repos/${PARENT_REPO}" --jq '.parent.full_name // .full_name')
+```
 
-4. **Fork the repo** into the owner's account with the custom name:
-   ```bash
-   PARENT_REPO=$(gh api repos/$(gh repo view --json nameWithOwner -q .nameWithOwner) --jq '.parent.full_name // .full_name')
-   gh repo fork "$PARENT_REPO" --fork-name "aeon-{name}" --clone=false
-   ```
-   If the fork already exists (gh returns an error), check if it's already registered. If not, proceed to configure it.
+Check rate limit:
+```bash
+REMAINING=$(gh api rate_limit --jq '.resources.core.remaining')
+[ "${REMAINING:-0}" -lt 50 ] && { echo "SPAWN_API_ERROR: rate limit too low (${REMAINING})"; exit 1; }
+```
 
-   Note: `gh repo fork` may not support `--fork-name` in all versions. If it fails, fall back to:
-   ```bash
-   gh api repos/${PARENT_REPO}/forks -X POST -f name="aeon-{name}"
-   ```
+### 3. Check the fleet registry
 
-5. **Wait for fork availability** — GitHub forks are async. Poll until ready:
-   ```bash
-   for i in 1 2 3 4 5; do
-     gh api "repos/${OWNER}/aeon-{name}" --jq '.full_name' 2>/dev/null && break
-     sleep 5
-   done
-   ```
+Read `memory/instances.json`. If it doesn't exist, create it with `{"instances": []}`.
 
-6. **Select skills for the instance** based on its purpose. Analyze the purpose string and choose from the available skills. Use these heuristics:
-   - **crypto/defi/token** purpose: enable `token-movers`, `token-alert`, `defi-monitor`, `wallet-digest`, `trending-coins`, `heartbeat`
-   - **research/papers/academic** purpose: enable `paper-digest`, `paper-pick`, `research-brief`, `deep-research`, `heartbeat`
-   - **social/twitter/x** purpose: enable `fetch-tweets`, `tweet-digest`, `write-tweet`, `reply-maker`, `heartbeat`
-   - **news/digest** purpose: enable `morning-brief`, `rss-digest`, `hn-digest`, `reddit-digest`, `heartbeat`
-   - **dev/code/github** purpose: enable `github-monitor`, `github-issues`, `pr-review`, `code-health`, `changelog`, `heartbeat`
-   - **general** or unclear: enable `morning-brief`, `heartbeat`, `reflect`
-   - Always include `heartbeat` for health monitoring.
+```json
+{
+  "instances": [
+    {
+      "name": "crypto-tracker",
+      "repo": "OWNER/aeon-crypto-tracker",
+      "purpose": "monitor DeFi protocols and token movements",
+      "created": "2026-04-20",
+      "status": "pending_secrets",
+      "skills_enabled": ["token-movers", "defi-monitor", "heartbeat"],
+      "parent": "OWNER/aeon"
+    }
+  ]
+}
+```
 
-7. **Clone the fork, configure it, and push**:
-   ```bash
-   # Clone into a temp directory
-   TMPDIR=$(mktemp -d)
-   gh repo clone "${OWNER}/aeon-{name}" "$TMPDIR/repo"
-   cd "$TMPDIR/repo"
-   git config user.name "aeonframework"
-   git config user.email "aeonframework@proton.me"
-   ```
+- If an entry with `name == NAME` exists and `status != "archived"`, exit `SPAWN_FORK_EXISTS_REGISTERED`, notify, and **stop**.
+- If an entry exists and is archived, remove it — the new run replaces it.
 
-   a. **Write a customized `aeon.yml`**: Read the parent's `aeon.yml` as a base. Enable only the selected skills. Keep all others disabled. Preserve the structure and comments.
+### 4. Build the skill plan from the live catalog
 
-   b. **Write `SETUP.md`** to the repo root:
-   ```markdown
-   # Aeon Instance Setup
+**Do not use a hardcoded skill list.** The catalog in earlier revisions contained broken names (`wallet-digest`, `trending-coins`, `tweet-digest`, `hn-digest` — none of which exist in `skills/`). Always enumerate live.
 
-   This is a managed Aeon instance spawned from [parent-repo].
+```bash
+# Build live catalog of available skills and their tags/description.
+for d in skills/*/; do
+  name=$(basename "$d")
+  [ -f "$d/SKILL.md" ] || continue
+  # Extract frontmatter fields (description + tags)
+  awk '/^---/{f++;next} f==1{print}' "$d/SKILL.md"
+done
+```
 
-   ## Purpose
-   {purpose description}
+For each skill, parse the frontmatter `description:` and `tags:` lines. Classify the purpose into themes by keyword match (case-insensitive) and pick skills whose description or tags overlap:
 
-   ## Activate This Instance
+| Purpose keywords | Prefer skills matching tags / keywords |
+|---|---|
+| `crypto`, `defi`, `token`, `chain`, `wallet` | tags `[crypto]` or description contains `token`/`defi`/`chain` |
+| `research`, `paper`, `academic`, `science` | tags `[research]` or name contains `paper`/`research`/`deep-research` |
+| `social`, `twitter`, `x `, `tweet`, `farcaster` | tags `[social]` or name contains `tweet`/`twitter`/`farcaster`/`reply` |
+| `news`, `digest`, `feed`, `brief` | name contains `digest`/`brief`/`morning`/`rss`/`hacker-news` |
+| `dev`, `code`, `github`, `repo`, `pr ` | tags `[dev]` or name contains `github`/`code`/`repo`/`pr-`/`changelog` |
+| `security`, `vuln`, `audit` | tags `[security]` or name contains `security`/`vuln`/`audit` |
+| `prediction`, `polymarket`, `kalshi`, `market` | name contains `polymarket`/`kalshi`/`market`/`narrative` |
 
-   Go to **Settings > Secrets and variables > Actions** and add these secrets:
+Rules:
+- **Cap at 8** content skills. Rank by keyword density in description against purpose; tie-break by name.
+- **Always include `heartbeat`** if the file `skills/heartbeat/SKILL.md` exists (health monitoring).
+- If the purpose doesn't match any theme, fall back to `[morning-brief, reflect, heartbeat]` (filtered against existence).
+- **Validate every candidate** — drop any skill where `skills/${skill}/SKILL.md` doesn't exist; log each drop as `SPAWN_DROPPED_SKILL: ${skill}`.
+- If the final list is empty (no content skills survive), exit `SPAWN_NO_SKILLS`, notify, and **stop**.
 
-   ### Required
-   | Secret | Description |
-   |--------|------------|
-   | `ANTHROPIC_API_KEY` | Claude API key — get one at console.anthropic.com |
+Save the final list as `SKILLS_ENABLED`.
 
-   ### Recommended
-   | Secret | Description |
-   |--------|------------|
-   | `TELEGRAM_BOT_TOKEN` | Telegram bot token for notifications |
-   | `TELEGRAM_CHAT_ID` | Telegram chat ID for notifications |
+### 5. Fork the parent repo
 
-   ### Optional (depends on enabled skills)
-   | Secret | Description |
-   |--------|------------|
-   | `COINGECKO_API_KEY` | For crypto skills |
-   | `XAI_API_KEY` | For X/Twitter skills |
-   | `DISCORD_WEBHOOK_URL` | Discord notifications |
-   | `SLACK_WEBHOOK_URL` | Slack notifications |
+```bash
+if gh api "repos/${OWNER}/${REPO_NAME}" --jq '.full_name' >/dev/null 2>&1; then
+  FORK_STATE="exists"
+else
+  # Try the modern flag first
+  if ! gh repo fork "${PARENT_UPSTREAM}" --fork-name "${REPO_NAME}" --clone=false 2>/dev/null; then
+    # Fallback: POST to /repos/{owner}/{repo}/forks with a custom name
+    gh api "repos/${PARENT_UPSTREAM}/forks" -X POST -f name="${REPO_NAME}" --jq '.full_name' \
+      || { echo "SPAWN_FORK_FAILED"; exit 1; }
+  fi
+  FORK_STATE="created"
+fi
+```
 
-   ## Enabled Skills
-   {list of enabled skills with descriptions}
+**Wait for fork availability** (GitHub forks are async):
+```bash
+for i in $(seq 1 10); do
+  gh api "repos/${OWNER}/${REPO_NAME}" --jq '.full_name' >/dev/null 2>&1 && break
+  sleep 3
+done
+gh api "repos/${OWNER}/${REPO_NAME}" --jq '.full_name' >/dev/null 2>&1 \
+  || { echo "SPAWN_FORK_FAILED: fork not reachable after wait"; exit 1; }
+```
 
-   ## Fleet Parent
-   This instance is managed by `{parent-repo}`.
-   The parent can dispatch skills and monitor health via the `fleet-control` skill.
+### 6. Configure the fork
 
-   ## Security Note
-   This instance has NO access to the parent's secrets.
-   Each instance maintains its own API keys and credentials.
-   ```
+```bash
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+gh repo clone "${OWNER}/${REPO_NAME}" "$TMPDIR/repo" -- --quiet \
+  || { echo "SPAWN_API_ERROR: clone failed"; exit 1; }
+cd "$TMPDIR/repo"
+git config user.name "aeonframework"
+git config user.email "aeonframework@proton.me"
+```
 
-   c. **Update the CLAUDE.md** to reference the parent:
-   Add a line under the "About This Repo" section: `- Managed instance of {parent-repo}. Purpose: {purpose}.`
+#### 6a. Write a customized `aeon.yml`
 
-   d. **Clear the parent's memory** — reset `memory/MEMORY.md` to a fresh state for the child, remove `memory/logs/*` contents, clear `memory/cron-state.json` to `{}`. Keep `memory/topics/` empty. The child starts with a clean slate.
+- Read the parent `aeon.yml` as a base (preserves comments, ordering, and the full skill list).
+- Set `enabled: true` only on skills in `SKILLS_ENABLED`. All others must have `enabled: false`.
+- Do not drop any skills — keep the full inventory so the child can enable more later.
+- **Validate the result**: every skill name with `enabled: true` must correspond to an existing `skills/${skill}/SKILL.md` in the fork's tree. If any enabled skill is missing, abort before pushing (this is a sanity check — step 4 already validated, but the child's repo tree must match).
 
-   e. **Commit and push**:
-   ```bash
-   git add -A
-   git commit -m "chore: configure instance — {purpose}"
-   git push origin main
-   ```
+#### 6b. Write `SETUP.md` dynamically
 
-   f. **Clean up**:
-   ```bash
-   rm -rf "$TMPDIR"
-   ```
+Parse each enabled skill's `skills/${skill}/SKILL.md` for references to uppercase env var names (pattern: `[A-Z][A-Z0-9_]{2,}_(KEY|TOKEN|URL|ID|SECRET)`). Collect the union across enabled skills, excluding built-ins (`GITHUB_TOKEN`, `GH_TOKEN`).
 
-8. **Enable GitHub Actions** on the fork (forks have Actions disabled by default):
-   ```bash
-   gh api "repos/${OWNER}/aeon-{name}/actions/permissions" -X PUT -f enabled=true -f allowed_actions=all
-   ```
+Emit a SETUP.md with three sections:
 
-9. **Register the instance** — update `memory/instances.json` in the parent repo:
-   Add the new instance entry with `status: "pending_secrets"`.
+```markdown
+# Aeon Instance Setup
 
-10. **Log to memory** — append to `memory/logs/${today}.md`:
-    ```
-    ## spawn-instance
-    - Created new instance: ${OWNER}/aeon-{name}
-    - Purpose: {purpose}
-    - Skills enabled: {list}
-    - Status: pending_secrets (owner must add API keys)
-    ```
+This is a managed Aeon instance spawned from `${PARENT_UPSTREAM}`.
 
-11. **Send notification** via `./notify`:
-    ```
-    *New Aeon Instance Created*
+## Purpose
+${PURPOSE}
 
-    Repo: {OWNER}/aeon-{name}
-    Purpose: {purpose}
-    Skills: {comma-separated list of enabled skills}
+## Enabled Skills
+${comma-separated list with one-line descriptions from each SKILL.md}
 
-    Status: PENDING SECRETS — instance is inert until you add API keys.
+## Activate This Instance
 
-    Quick setup:
-    1. Go to https://github.com/{OWNER}/aeon-{name}/settings/secrets/actions
-    2. Add ANTHROPIC_API_KEY (required)
-    3. Add TELEGRAM_BOT_TOKEN + TELEGRAM_CHAT_ID (recommended)
+Go to **Settings > Secrets and variables > Actions** and add these secrets:
 
-    See SETUP.md in the repo for full instructions.
-    ```
+### Required (pick one for Claude auth)
+| Secret | Description |
+|--------|------------|
+| `ANTHROPIC_API_KEY` | Anthropic API key — console.anthropic.com |
+| `CLAUDE_CODE_OAUTH_TOKEN` | Alternative: Claude Code OAuth token |
+
+### Recommended (notifications)
+| Secret | Description |
+|--------|------------|
+| `TELEGRAM_BOT_TOKEN` | Telegram bot token |
+| `TELEGRAM_CHAT_ID` | Telegram chat ID |
+| `DISCORD_WEBHOOK_URL` | Discord webhook URL |
+| `SLACK_WEBHOOK_URL` | Slack webhook URL |
+
+### Required by your enabled skills
+${one row per detected env var, with the list of skills that reference it}
+
+## Fleet Parent
+Managed by `${PARENT_UPSTREAM}`. The parent can dispatch skills and monitor health via `fleet-control`.
+
+## Security Note
+This instance has NO access to the parent's secrets. Each instance maintains its own API keys and credentials.
+```
+
+If no env vars are detected beyond the required/recommended set, omit the "Required by your enabled skills" section header (don't leave an empty table).
+
+#### 6c. Update `CLAUDE.md` idempotently
+
+Find the heading line `## About This Repo` (or the first `## ` section if not present). Under it, insert exactly one line:
+```
+- Managed instance of ${PARENT_UPSTREAM}. Purpose: ${PURPOSE}.
+```
+
+If a line starting with `- Managed instance of` already exists, replace it rather than appending a duplicate.
+
+#### 6d. Reset child memory
+
+The child starts with a clean slate:
+
+```bash
+# Reset MEMORY.md to a minimal template
+cat > memory/MEMORY.md <<EOF
+# Long-term Memory
+*Last consolidated: never*
+
+## About This Repo
+- Aeon instance of ${PARENT_UPSTREAM}. Purpose: ${PURPOSE}.
+
+## Next Priorities
+- Configure secrets per SETUP.md
+- Wait for first scheduled skill to run
+EOF
+
+# Clear logs, state, topics — safe paths only, never follow symlinks
+find memory/logs -mindepth 1 -type f -delete 2>/dev/null || true
+find memory/topics -mindepth 1 -type f -delete 2>/dev/null || true
+find memory/issues -mindepth 1 -type f ! -name 'INDEX.md' -delete 2>/dev/null || true
+[ -f memory/issues/INDEX.md ] && echo "# Issues — none open" > memory/issues/INDEX.md
+echo '{}' > memory/cron-state.json
+# Do NOT clear memory/instances.json on the child — the child has none.
+rm -f memory/instances.json 2>/dev/null || true
+```
+
+#### 6e. Commit and push
+
+```bash
+git add -A
+git commit -m "chore: configure instance — ${PURPOSE}
+
+Skills enabled: ${SKILLS_ENABLED_CSV}
+Parent: ${PARENT_UPSTREAM}
+Spawned: ${today}"
+git push origin main 2>/dev/null \
+  || git push origin HEAD:main 2>/dev/null \
+  || { echo "SPAWN_PUSH_FAILED"; cd - >/dev/null; exit 1; }
+cd - >/dev/null
+```
+
+If push fails, **do not delete the fork** — leave it for manual inspection and notify with:
+```
+spawn-instance: fork created but push failed for ${OWNER}/${REPO_NAME}.
+Recover with: gh repo clone ${OWNER}/${REPO_NAME} && push manually, then re-register.
+```
+
+### 7. Enable GitHub Actions on the fork
+
+Forks have Actions disabled by default. Use **typed** booleans (`-F`, not `-f`, or `enabled=true` is sent as the string "true"):
+
+```bash
+gh api "repos/${OWNER}/${REPO_NAME}/actions/permissions" -X PUT \
+  -F enabled=true -f allowed_actions=all \
+  || { echo "SPAWN_ACTIONS_FAILED"; exit 1; }
+```
+
+### 8. Post-flight verification
+
+```bash
+# Fork reachable
+gh api "repos/${OWNER}/${REPO_NAME}" --jq '.full_name' >/dev/null \
+  || { echo "SPAWN_API_ERROR: post-flight fork check failed"; exit 1; }
+
+# Our commit is HEAD
+HEAD_SHA=$(gh api "repos/${OWNER}/${REPO_NAME}/commits/main" --jq '.sha' 2>/dev/null)
+[ -n "$HEAD_SHA" ] || { echo "SPAWN_API_ERROR: post-flight HEAD check failed"; exit 1; }
+
+# Actions enabled
+ACTIONS_ON=$(gh api "repos/${OWNER}/${REPO_NAME}/actions/permissions" --jq '.enabled' 2>/dev/null)
+[ "$ACTIONS_ON" = "true" ] || { echo "SPAWN_ACTIONS_FAILED: post-flight"; exit 1; }
+```
+
+### 9. Register the instance
+
+Update `memory/instances.json` in the **parent** repo. Append:
+```json
+{
+  "name": "${NAME}",
+  "repo": "${OWNER}/${REPO_NAME}",
+  "purpose": "${PURPOSE}",
+  "created": "${today}",
+  "status": "pending_secrets",
+  "skills_enabled": ${SKILLS_ENABLED_JSON},
+  "parent": "${PARENT_UPSTREAM}"
+}
+```
+
+If `FORK_STATE == "exists"` at step 5, the final exit status is `SPAWN_FORK_EXISTS_RECOVERED`, otherwise `SPAWN_OK`.
+
+### 10. Log to memory
+
+Append to `memory/logs/${today}.md`:
+```
+## spawn-instance
+- Status: ${EXIT_CODE}
+- Instance: ${OWNER}/${REPO_NAME}
+- Purpose: ${PURPOSE}
+- Skills: ${SKILLS_ENABLED_CSV}
+- Dropped skills: ${DROPPED_CSV or "(none)"}
+- Actions enabled: yes
+```
+
+### 11. Notify via `./notify`
+
+On success (`SPAWN_OK` or `SPAWN_FORK_EXISTS_RECOVERED`):
+```
+*New Aeon Instance*
+
+Repo: ${OWNER}/${REPO_NAME}
+Purpose: ${PURPOSE}
+Skills (${N}): ${SKILLS_ENABLED_CSV}
+Status: ${EXIT_CODE} — PENDING SECRETS
+
+Activate:
+1. https://github.com/${OWNER}/${REPO_NAME}/settings/secrets/actions
+2. Add ANTHROPIC_API_KEY (or CLAUDE_CODE_OAUTH_TOKEN)
+3. Add TELEGRAM_BOT_TOKEN + TELEGRAM_CHAT_ID (or Discord/Slack)
+
+See SETUP.md in the repo for the full secret list tailored to your enabled skills.
+```
+
+On refusal (`SPAWN_FORK_EXISTS_REGISTERED`, `SPAWN_INVALID_VAR`, `SPAWN_NO_SKILLS`):
+```
+spawn-instance: ${EXIT_CODE} — ${one-line reason}. No changes made.
+```
+
+On failure (`SPAWN_FORK_FAILED`, `SPAWN_PUSH_FAILED`, `SPAWN_ACTIONS_FAILED`, `SPAWN_API_ERROR`):
+```
+spawn-instance FAILED: ${EXIT_CODE}
+Target: ${OWNER}/${REPO_NAME}
+Recovery: ${one-line recovery instruction}
+```
+
+## Sandbox note
+
+This skill runs entirely through `gh` CLI, which handles auth and does not require bash env-var expansion in curl headers (no sandbox issues). No WebFetch fallback needed. If `gh` is missing or unauthenticated, the pre-flight step fails with `SPAWN_API_ERROR`.
+
+## Constraints
+
+- **No secret propagation.** Never read or write `ANTHROPIC_API_KEY`, `TELEGRAM_*`, `DISCORD_*`, `SLACK_*`, or any API key into the child repo. The whole security model depends on this.
+- **No hardcoded skill list.** Always enumerate `skills/*/SKILL.md` at runtime to avoid referencing renamed or removed skills.
+- **Idempotent.** Re-running with the same `${var}` must never produce duplicate registry entries, duplicate CLAUDE.md lines, or a second fork.
+- **Never delete a fork.** If anything fails partway through, leave the fork in place and emit recovery guidance — the operator is the only party authorized to delete it.
+- **Never push to the parent without committing `memory/instances.json` via the normal Aeon workflow.** The parent commit happens through the same path as any other skill output.
 
 Write complete, working code. No TODOs or placeholders.


### PR DESCRIPTION
## Summary

Evolves `skills/spawn-instance/SKILL.md` — the skill that forks this repo into a new Aeon instance, configures it, and registers it in the fleet.

**Winner: Variation C — More Robust (52.5/52.5)**
Thesis: this skill is rarely invoked, creates public artifacts (a new GitHub repo), and has *four separate first-run bugs* today — broken hardcoded skill names in the heuristic list, literal `{name}` placeholders in bash, `-f enabled=true` (string instead of boolean) for Actions permissions, and no recovery path if any step fails partway. C fixes all of these by enumerating `skills/*/SKILL.md` at runtime for the skill catalog, adding a full exit-code taxonomy, making re-runs idempotent, and adding pre/post-flight verification. Folds in A's dynamic skill catalog read and B's dynamic SETUP.md so the winner captures all three output-quality wins on top of the robustness thesis.

## Operational findings (verified in repo today)

- Hardcoded heuristic skill names referenced in the old SKILL.md but missing from `skills/`: `wallet-digest`, `trending-coins`, `tweet-digest`, `hn-digest` (actual names are `telegram-digest`/`tweet-roundup` and `hacker-news-digest`). Any first-run where the purpose matched crypto/social/news themes would have enabled non-existent skills in the child's `aeon.yml`, breaking its workflow immediately.
- `gh api ... -f enabled=true` for Actions permissions sends the string `"true"`, not the boolean GitHub expects. Switched to `-F enabled=true`.
- Bash blocks in the old SKILL.md used the literal `aeon-{name}` in steps 4, 5, 7, 8 instead of a `${NAME}` shell variable — Claude could paste the placeholder into real commands.
- Step 7d "Clear the parent's memory" was vague; replaced with explicit `find -mindepth 1 -type f -delete` on safe paths.
- Secret model in the old SETUP.md only lists `ANTHROPIC_API_KEY` — but the workflow also accepts `CLAUDE_CODE_OAUTH_TOKEN` (confirmed via `.github/workflows/aeon.yml`). Both are now listed as "pick one".

## Scoring

| Criterion (weight) | A: Better inputs | B: Sharper output | C: More robust | D: Preview-first |
|---|---|---|---|---|
| Clarity (1.5) | 4 | 4 | 5 | 4 |
| Data quality (1.5) | 5 | 3 | 5 | 4 |
| Output value (2) | 3 | 5 | 5 | 4 |
| Robustness (1.5) | 4 | 3 | 5 | 4 |
| Conventions (1) | 4 | 4 | 5 | 3 |
| Improvement (3) | 4 | 4 | 5 | 3 |
| **Weighted total** | **41.5** | **41.0** | **52.5** | **38.0** |

## Variations considered

- **A — Better inputs (41.5)**: enumerate `skills/*/SKILL.md` at runtime; score purpose against tags/description instead of fixed keyword buckets; detect parent vs upstream correctly for forks-of-forks. Fixes the broken skill-name bug but leaves output artifacts unchanged. **Folded into C.**
- **B — Sharper output (41.0)**: dynamic SETUP.md that lists only secrets actually referenced by enabled skills; idempotent CLAUDE.md marker line; schematized commit message; structured notification with clickable settings URL. Nice operator-experience win but doesn't address the non-existent-skills bug. **Folded into C.**
- **C — More robust (52.5) ← WINNER**: full exit taxonomy (`SPAWN_OK`, `SPAWN_FORK_EXISTS_RECOVERED`, `SPAWN_FORK_EXISTS_REGISTERED`, `SPAWN_INVALID_VAR`, `SPAWN_NO_SKILLS`, `SPAWN_FORK_FAILED`, `SPAWN_PUSH_FAILED`, `SPAWN_ACTIONS_FAILED`, `SPAWN_API_ERROR`); idempotent re-run (recover unregistered fork, refuse registered); pre-flight gh-auth + rate-limit checks; post-flight fork/HEAD/Actions-enabled verification; skill-existence validation against live `skills/` tree; dynamic SETUP.md (from B); runtime catalog (from A); leave-fork-on-failure with recovery instructions; explicit memory-reset commands.
- **D — Preview-first (38.0)**: default to dry-run (print the plan, emit proposed aeon.yml + SETUP.md, no fork); require `apply:` prefix in var to actually execute. Rejected — the skill is already `workflow_dispatch`-only (deliberate by construction), and adding a second gate is friction without proportional safety gain given C's idempotent-recovery and exit-taxonomy already cover the "mis-spawn" risk.

## Diff summary of what changed

- **Skill selection (step 4)**: old version used 6 fixed keyword buckets referencing 4 non-existent skill names → new version enumerates `skills/*/SKILL.md` live, parses frontmatter tags/description, validates every candidate has a file before writing aeon.yml, drops missing ones with a logged `SPAWN_DROPPED_SKILL`.
- **Fork step (5)**: added pre-existence check (fork-exists path); fallback via `gh api repos/{parent}/forks -X POST` on `gh repo fork --fork-name` failure; 10-iteration 3s polling loop (up from 5 × 5s) for async fork availability.
- **Configure step (6)**: explicit memory reset commands (no longer "clear the parent's memory" in prose); idempotent CLAUDE.md marker; commit message schema.
- **Actions permission (7)**: `-F enabled=true` (typed boolean) instead of `-f enabled=true`.
- **New step 8**: post-flight verification (fork reachable + HEAD SHA present + Actions enabled).
- **New step 2**: pre-flight (gh auth status + rate-limit floor).
- **Exit taxonomy**: documented in header table, referenced throughout, included in log/notify output.
- **SETUP.md**: generated from union of env-var names found in each enabled skill's SKILL.md, not a fixed template.
- **Constraints section**: adds "no hardcoded skill list", "idempotent", "never delete a fork", "no secret propagation" as explicit invariants.

No new env vars. No new secrets. `var:` semantics unchanged (`name: purpose`). Tags preserved.

---
Ported from aaronjmars/aeon-tmp#86.
