### PR TITLE
improve(skill-evals): autoresearch evolution

### DIFF
--- a/skills/skill-evals/SKILL.md
+++ b/skills/skill-evals/SKILL.md
@@ -1,96 +1,197 @@
 ---
 name: Skill Evals
-description: Evaluate skill output quality against assertion manifests — detects regressions before users notice
+description: Validate skill outputs against assertions, diff vs prior eval to flag regressions, file issues for new failures, and queue concrete fixes
 var: ""
 tags: [meta]
 ---
 
-> **${var}** — Skill name to evaluate. If empty, evaluates all skills in evals.json.
+<!-- autoresearch: variation B — verdict + action queue + diff vs prior + issue filing + notify gating -->
 
-Today is ${today}. Your task is to evaluate skill output quality by validating recent outputs against assertions defined in `skills/skill-evals/evals.json`.
+> **${var}** — Skill name to evaluate. If empty, evaluates all skills in `evals.json`.
+
+Today is ${today}. Read `memory/MEMORY.md` for context.
+
+This skill exists to catch quality regressions *between* runs — not just to re-state a snapshot of the latest output. The lede is **what changed since last eval** and **what to do about it**, not a flat pass/fail table.
 
 ## Steps
 
-1. **Read the assertion manifest** — read `skills/skill-evals/evals.json`.
+### 1. Load inputs
 
-2. **Read `aeon.yml`** to get the full registered skill list.
+- `skills/skill-evals/evals.json` — assertion manifest (read with `jq`; if parse fails, retry once after 5s, then exit `SKILL_EVALS_ERROR`).
+- `aeon.yml` — registered skills, enabled flags, cron schedules.
+- `memory/cron-state.json` — `total_runs`, `success_rate`, `last_quality_score`, `last_failed`, `last_success` per skill.
+- `memory/issues/INDEX.md` — currently open issues (used to dedupe issue filing in step 5b).
+- Most recent prior eval at `articles/skill-evals-*.md` (sorted descending, excluding today's). If none exist, mark prior_run as `BOOTSTRAP` — every result is `NEW_*`.
 
-3. **Read `memory/cron-state.json`** — contains `total_runs`, `success_rate`, `last_quality_score` per skill.
+If `evals.json` is missing or has zero `skills` keys, run `./scripts/eval-audit --stubs` to scaffold a starter spec and exit `SKILL_EVALS_BOOTSTRAP` with a notify telling the operator to commit the stub.
 
-4. **Determine which skills to evaluate**:
-   - If `${var}` is set, evaluate only that skill.
-   - Otherwise evaluate all skills listed in evals.json.
+### 2. Run coverage audit (delegated)
 
-5. **For each skill being evaluated**, run the following checks:
+Call `./scripts/eval-audit --json` and parse:
+- `summary.coverage_pct`, `summary.covered`, `summary.uncovered_enabled`, `summary.uncovered_disabled`
+- `uncovered_enabled[].skill` and `.inferred_pattern` — these are the spec-gap candidates surfaced in the Action Queue.
 
-   a. **Find the most recent output file** using the glob pattern from evals.json (`output_pattern`).
-      - Use Glob to find all matching files.
-      - Sort by filename descending to get the most recent.
-      - If no matching file exists → mark as **NO COVERAGE**.
+Do not re-implement coverage detection in prose. If the script fails, fall back to the in-memory check (compare `evals.json` keys to `aeon.yml` enabled skills) and mark `eval-audit=fail` in the source-status footer.
 
-   b. **Word count check**: count words in the file. Fail if below `min_words`.
+### 3. Determine eval scope
 
-   c. **Required pattern check**: for each pattern in `required_patterns`, search the file content.
-      - Patterns are pipe-separated alternatives (e.g. `"stars|forks"` — either must appear).
-      - Fail if any required pattern is not found.
+- If `${var}` is set → evaluate only that one skill (skip if not in `evals.json` and notify "skill-evals: ${var} has no spec — add an entry to evals.json").
+- Otherwise evaluate every skill in `evals.json`.
 
-   d. **Forbidden pattern check**: for each pattern in `forbidden_patterns`, search the file.
-      - Fail if any forbidden pattern IS found.
+### 4. For each skill in scope, run checks
 
-   e. **Numeric checks** (if `numeric_checks` is defined): for each entry:
-      - Extract the first number matching the regex `pattern` from the file.
-      - Fail if the extracted value is outside [`min`, `max`].
-      - If no match found and the field is expected (skip if not found is not specified), flag as WARN.
+  a. **Find latest output**: glob `output_pattern`, sort descending by filename. If empty → status `NO_OUTPUT`, root_cause `no_file_match`, skip remaining checks.
 
-   f. **Quality score cross-check**: read `memory/skill-health/{skill}.json` if it exists.
-      - If `avg_score` < 2.5 → flag as **QUALITY_DEGRADED** even if assertions pass.
-      - If `avg_score` >= 2.5 → note the score in the report.
+  b. **Empty/stale**: if file size is 0 bytes → `FAIL`, root_cause `empty_file`. If file mtime is older than `2× expected_cadence` (derived from the skill's cron in `aeon.yml`; fall back to 14 days if cron is `workflow_dispatch` or unparseable) → `STALE`, root_cause `stale_file`. Stale outputs still run their assertions but are reported as STALE so dashboard noise is correct.
 
-6. **Classify each skill**:
-   - **PASS** — all assertions pass, quality score >= 2.5 (or no health data yet)
-   - **FAIL** — one or more assertions failed (word count, required pattern, forbidden pattern, or numeric check)
-   - **QUALITY_DEGRADED** — assertions pass but avg quality score < 2.5
-   - **NO COVERAGE** — no output file found matching the pattern
+  c. **Word count**: count words; fail if `< min_words` → root_cause `word_count` (record actual vs threshold).
 
-7. **Detect coverage gaps** — skills that have cron-state entries with `total_runs > 0` but are NOT in evals.json.
-   These are skills running in production without any eval spec.
+  d. **Required patterns**: for each pattern (pipe-separated alternatives), grep with `-E`. Missing → root_cause `missing_pattern:<pattern>`.
 
-8. **Write the report** to `articles/skill-evals-${today}.md`:
+  e. **Forbidden patterns**: any match → root_cause `forbidden_pattern:<pattern>`.
 
-   ```markdown
-   # Skill Evals — ${today}
+  f. **Numeric checks**: for each entry, extract first regex match. Outside `[min, max]` → root_cause `numeric_oob:<label>`. If no match found and entry has `skip_if_not_found: true`, skip; otherwise `WARN` with root_cause `numeric_missing:<label>`.
 
-   ## Results
+  g. **Quality cross-check**: read `memory/skill-health/{skill}.json`. If `avg_score < 2.5` → status `QUALITY_DEGRADED`, root_cause `quality_score:<avg>`. If `2.5 ≤ avg_score < 3.5`, record as note (no status change). If file missing, record `quality=unknown`.
 
-   | Skill | Status | Details |
-   |-------|--------|---------|
-   | heartbeat | PASS | 52 words, all patterns matched |
-   | repo-pulse | FAIL | Missing pattern: "stars" |
-   | token-report | NO COVERAGE | No output file found |
+  Final status precedence: `NO_OUTPUT` > `FAIL` > `STALE` > `QUALITY_DEGRADED` > `WARN` > `PASS`.
 
-   ## Summary
-   - Evaluated: N skills (from evals.json)
-   - Passing: N
-   - Failing: N
-   - Quality degraded: N
-   - No coverage: N
+### 5. Diff vs prior eval (the lede)
 
-   ## Coverage Gaps (running in production but not in evals.json)
-   - skill-name: N runs (success_rate: X%)
+Parse the prior eval article's results table. For each skill produce one of:
 
-   ## Recommendations
-   [List specific fixes for failing skills and skills to add to evals.json]
-   ```
+- `NEW_FAIL` — was PASS/STALE/WARN, now FAIL/QUALITY_DEGRADED/NO_OUTPUT
+- `FIXED` — was failing, now PASS
+- `STILL_FAIL` — was failing, still failing (carry the issue ID forward)
+- `NEW_PASS` — wasn't in prior (newly added to evals.json)
+- `NEW_NO_COVERAGE` — covered prior, no eval entry now (rare; usually means evals.json edit)
+- `STABLE` — same status both runs
 
-9. **Send notification** via `./notify` if any skills are FAILING or QUALITY_DEGRADED. Include the full results table in the message.
-   If all skills pass or have no coverage issues, send a brief summary: "Skill Evals PASS — N/N skills healthy."
-
-10. **Log to `memory/logs/${today}.md`**:
+  a. **Issue filing.** For every `NEW_FAIL` and `NEW_QUALITY_DEGRADED`:
+  - Check `memory/issues/INDEX.md` — if an open issue already names this skill in the title, skip (avoid duplicates).
+  - Else write `memory/issues/ISS-{NNN}.md` with frontmatter:
+    ```yaml
+    ---
+    id: ISS-{NNN}
+    title: {skill}: {root_cause_short}
+    status: open
+    severity: {high if NEW_FAIL, medium if QUALITY_DEGRADED}
+    category: {map root_cause: missing_pattern→prompt-bug, forbidden_pattern→prompt-bug, numeric_oob→quality-regression, word_count→quality-regression, stale_file→missing-secret-or-cron, empty_file→quality-regression, quality_score→quality-regression, no_file_match→missing-secret-or-cron}
+    detected_by: skill-evals
+    detected_at: {ISO timestamp}
+    affected_skills: [{skill}]
+    root_cause: {full root_cause string}
+    ---
+    
+    {one-paragraph context with file path, expected vs actual, link to article}
     ```
-    ## Skill Evals — ${today}
-    - Evaluated N skills from evals.json
-    - PASS: X, FAIL: Y, NO_COVERAGE: Z
-    - Coverage gaps: [list skill names]
-    ```
+  - `{NNN}` = next free 3-digit ID (scan `memory/issues/ISS-*.md`, take max + 1, zero-pad).
+  - Append a row to `memory/issues/INDEX.md` Open table.
 
-Write complete output with no placeholders.
+  b. **Issue closing.** For every `FIXED`: scan `memory/issues/ISS-*.md` for an open issue whose `affected_skills` contains this skill and `detected_by: skill-evals`; flip `status: resolved`, set `resolved_at`, move row from Open → Resolved table in INDEX.md. (Don't touch issues filed by other detectors.)
+
+### 6. Compute verdict
+
+One-line verdict, picked by precedence:
+1. `SKILL_EVALS_REGRESSED` — any `NEW_FAIL` exists
+2. `SKILL_EVALS_QUALITY_DROP` — any `NEW_QUALITY_DEGRADED` (no NEW_FAIL)
+3. `SKILL_EVALS_RECOVERED` — `FIXED ≥ 1` and zero new failures
+4. `SKILL_EVALS_COVERAGE_CLIFF` — coverage_pct dropped ≥ 10 points vs last run, or absolute coverage_pct < 25 and last run was ≥ 25
+5. `SKILL_EVALS_OK` — all stable, all green
+
+### 7. Build the Action Queue
+
+A short, ordered, concrete checklist at the top of the article. Cap at 8 items. Each item is one line, naming a specific skill and a specific next step:
+
+- **Patch** (regex/threshold tweaks): `Patch evals.json:{skill} — {root_cause}`
+- **Investigate** (FAIL with no obvious fix): `Investigate {skill} — {root_cause} (ISS-{NNN})`
+- **Re-run** (NO_OUTPUT, no recent dispatch): `Dispatch {skill} — no output in {N} days`
+- **Add spec** (uncovered enabled): `Add evals.json entry for {skill} — pattern: {inferred_pattern}` (one line per uncovered enabled skill, max 5; if more, summarize "+N more — see Coverage Gaps")
+
+If the queue is empty, write `Action Queue: none — all green`.
+
+### 8. Write the article
+
+Path: `articles/skill-evals-${today}.md`. Skeleton:
+
+```markdown
+# Skill Evals — ${today}
+
+**Verdict:** {VERDICT}
+**Coverage:** {covered}/{enabled_total} ({coverage_pct}%) {↑↓ vs prior or "(first run)"}
+**Diff:** {N_NEW_FAIL} new fail · {N_FIXED} fixed · {N_STILL_FAIL} still failing · {N_STABLE} stable
+
+## Action Queue
+1. ...
+2. ...
+
+## Regressions (NEW_FAIL + NEW_QUALITY_DEGRADED)
+| Skill | Status | Root cause | Issue |
+|-------|--------|------------|-------|
+| ... | NEW_FAIL | missing_pattern:stars | ISS-014 |
+
+## Recovered (FIXED)
+| Skill | Was | Now |
+|-------|-----|-----|
+
+## Still Failing
+| Skill | Status | Root cause | Issue | Failing since |
+|-------|--------|------------|-------|---------------|
+
+## Full Results
+| Skill | Status | Diff | Root cause | Quality | Words | Last output |
+|-------|--------|------|------------|---------|-------|-------------|
+
+## Coverage Gaps (enabled in aeon.yml, missing from evals.json)
+- {skill} — inferred pattern: `{inferred_pattern}`
+
+## Sources
+- evals.json={ok|fail} · cron-state={ok|fail} · skill-health={ok|empty|fail} · eval-audit={ok|fail} · prior-article={ok|none}
+```
+
+Omit empty sections (no Recovered section if zero FIXED, etc.). Keep the Coverage Gaps section bounded to 10 lines max — overflow into a `+N more` summary.
+
+### 9. Notify (gated)
+
+Only call `./notify` when one of the following holds:
+- Verdict is `SKILL_EVALS_REGRESSED`, `SKILL_EVALS_QUALITY_DROP`, or `SKILL_EVALS_COVERAGE_CLIFF`
+- Verdict is `SKILL_EVALS_RECOVERED` (good news worth a ping)
+
+Stay silent on `SKILL_EVALS_OK` (still write the article + log entry; just don't ping). This trains the operator that a notification means action is needed.
+
+Notify body (concise, soul-voice):
+
+```
+*Skill Evals — {VERDICT}*
+{N_NEW_FAIL} new fail · {N_FIXED} fixed · coverage {coverage_pct}%
+Top action: {action_queue[0]}
+Article: articles/skill-evals-${today}.md
+```
+
+If `N_NEW_FAIL > 0`, append the first 3 regressions as `{skill}: {root_cause}` lines.
+
+### 10. Log
+
+Append to `memory/logs/${today}.md`:
+
+```
+### skill-evals
+- Verdict: {VERDICT}
+- Diff: {N_NEW_FAIL} new fail / {N_FIXED} fixed / {N_STILL_FAIL} still failing / {N_STABLE} stable
+- Coverage: {covered}/{enabled_total} ({coverage_pct}%)
+- Issues filed: [list ISS-IDs]
+- Issues closed: [list ISS-IDs]
+- Action queue head: {action_queue[0] or "none"}
+```
+
+## Sandbox note
+
+All inputs are local files (`evals.json`, `aeon.yml`, `memory/*`, `articles/*`, `scripts/eval-audit`). No outbound HTTP — no fallback needed. `./scripts/eval-audit` is a local bash script and uses `jq`; if jq is missing (rare on GH Actions ubuntu runners), the script will exit non-zero — mark `eval-audit=fail` in the source-status footer and continue with the in-memory coverage check.
+
+## Constraints
+
+- Never overwrite a prior issue file. Always allocate a fresh `ISS-{NNN}` number.
+- Never close an issue this skill didn't file (only `detected_by: skill-evals` issues are closeable here).
+- Don't notify when verdict is `SKILL_EVALS_OK` — silence is the correct signal on a green week.
+- Preserve the assertion schema (`output_pattern`, `min_words`, `required_patterns`, `forbidden_patterns`, `numeric_checks`) — additions allowed (`skip_if_not_found`, `expected_cadence`), removals are breaking.
+- Cap Coverage Gaps and Action Queue sections to keep the article scannable; the article is read by humans, not just machines.


### PR DESCRIPTION
## Winner — Variation B (49.5/52.5)

**Thesis:** the existing skill-evals re-states a flat snapshot every Sunday — operator scans the table, finds nothing changed, and learns to ignore it. The biggest lever is converting it into an actionable **regression-watch with machine-readable issue filing**: lead with what changed since the prior eval (NEW_FAIL / FIXED / STILL_FAIL / NEW_PASS / NEW_NO_COVERAGE / NEW_QUALITY_DEGRADED), file new failures to `memory/issues/ISS-{NNN}.md` per the CLAUDE.md tracker so `skill-repair` can pick them up, surface a concrete Action Queue at the top, and **silence notifications on green weeks** so a ping always means a real regression.

Folds in:
- Variation A's wins: `./scripts/eval-audit --json` for coverage (replacing in-prose detection at step 7), output freshness check vs 2× cron cadence, source-status footer, `skip_if_not_found` flag for numeric_checks.
- Variation C's wins: status taxonomy (`SKILL_EVALS_OK` / `REGRESSED` / `QUALITY_DROP` / `RECOVERED` / `COVERAGE_CLIFF` / `BOOTSTRAP` / `ERROR`), bootstrap mode via `eval-audit --stubs` when `evals.json` is missing, empty-file + stale-file detection, per-failure root_cause taxonomy.

## Scoring

| Criterion (weight) | A — Better inputs | B — Sharper output (winner) | C — More robust | D — Drift watch |
|---|---|---|---|---|
| Clarity (1.5x) | 4 → 6 | **4.5 → 6.75** | 4 → 6 | 3 → 4.5 |
| Data quality (1.5x) | 4 → 6 | **4.5 → 6.75** | 4 → 6 | 3.5 → 5.25 |
| Output value (2x) | 3 → 6 | **5 → 10** | 3.5 → 7 | 4 → 8 |
| Robustness (1.5x) | 3.5 → 5.25 | **4 → 6** | 5 → 7.5 | 3 → 4.5 |
| Conventions (1x) | 5 → 5 | **5 → 5** | 5 → 5 | 4 → 4 |
| Improvement (3x) | 3 → 9 | **5 → 15** | 3.5 → 10.5 | 3.5 → 10.5 |
| **Total / 52.5** | 37.25 | **49.5** | 42 | 36.75 |

## Variation summaries (what was considered)

- **A — Better inputs (37.25):** delegate coverage to `./scripts/eval-audit --json`; add output-freshness check (file mtime vs 2× cadence parsed from aeon.yml cron); pre-validate evals.json with jq + retry; `skip_if_not_found` flag; source-status footer. Solid data-quality wins but operator still gets the same wall-of-table report — doesn't fix the "nothing here trains me to act" problem.
- **B — Sharper output (49.5, winner):** verdict-driven lede; diff-vs-prior-article regression detection; issue filing to `memory/issues/ISS-{NNN}.md` with dedup via INDEX.md and severity/category mapping; auto-close matching skill-evals-filed issues on FIXED; per-failure root_cause column; Action Queue (Patch / Investigate / Re-run / Add spec) capped at 8; notify gated on regressions/recoveries/coverage-cliffs only.
- **C — More robust (42):** status taxonomy + bootstrap mode + empty/stale checks + retry-on-jq-fail + source-status footer. Strong on safety but report is still a flat snapshot — robustness without output discipline still trains scroll-past.
- **D — Rethink as drift watch (36.75):** week-over-week comparison along word_count_delta / numeric_value_deltas / section_structure_delta dimensions, classify each skill STABLE / GREW / SHRANK / RESHAPED / VANISHED, persistent baselines at `memory/skill-evals-baselines.json`. Rejected because the repo currently has only 2 articles total (`changelog-2026-03-19.md`, `workflow-security-audit-2026-04-11.md`) and the skill has never run before — drift baselines don't exist yet, so D would no-op for ~13 of 14 covered skills on the first several weeks. B captures D's "what changed is the lede" upside via the diff-vs-prior section without the baseline-bootstrap problem.

## Diff summary

The frontmatter, var semantics (empty = all skills, set = single skill), and core purpose (validate skill outputs against `evals.json` assertions) are preserved. The 10-step structure is rewritten:

- **New:** verdict line, Action Queue, diff-vs-prior section, issue filing/closing (steps 5a/5b), notify gating (step 9), bootstrap on missing evals.json, output-freshness/empty checks, root_cause taxonomy, delegated coverage call to `scripts/eval-audit --json`, source-status footer.
- **Removed:** in-prose coverage gap detection (step 7 in original), unconditional notify with full results table, single FAIL bucket (now decomposed by root_cause).
- **Preserved:** assertion schema in `evals.json`, all existing assertion types (word_count, required_patterns, forbidden_patterns, numeric_checks, quality cross-check), output path `articles/skill-evals-${today}.md`, log entry to `memory/logs/${today}.md`, soul-voice notification.

## Operational notes

- Repo currently has 96 skills in `skills/` and only 14 in `evals.json` (~14.6% coverage of all, smaller fraction of enabled). The Action Queue will surface this on the first run as a long "Add spec" list — capped at 5 lines + "+N more" overflow to keep the article scannable.
- `memory/issues/INDEX.md` exists and is empty (no open issues today); the first run that produces a NEW_FAIL will populate ISS-001 onward.
- No new env vars; uses existing `jq`, `gh`, and the local `./scripts/eval-audit` helper. No outbound HTTP — fully sandbox-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Ported from aaronjmars/aeon-tmp#87.
