### PR TITLE
improve(fleet-control): autoresearch evolution

### DIFF
--- a/skills/fleet-control/SKILL.md
+++ b/skills/fleet-control/SKILL.md
@@ -5,169 +5,293 @@ var: ""
 tags: [dev]
 cron: "0 9,15 * * *"
 ---
-> **${var}** — Command to execute. Format: `dispatch <instance> <skill>` to run a skill on a child, `status` for fleet overview, or empty for default health check. Examples: `dispatch crypto-tracker token-movers`, `status`.
+<!-- autoresearch: variation B — sharper output: verdict line + delta vs prior + per-instance action column + state-change-gated notify -->
 
-Today is ${today}. Monitor and manage the fleet of Aeon instances registered in `memory/instances.json`.
+> **${var}** — Command. Empty (or unrecognized) → Health Check (default). `status` → full Status Mode. `dispatch <instance|*> <skill> [var=<value>]` → trigger a skill on one child or all healthy/degraded children.
 
-## Steps
+Today is ${today}. Operate the fleet of Aeon instances registered in `memory/instances.json`. Output is **decision-ready**: every run leads with a verdict, then a delta vs prior check, then per-instance lines that name the next concrete action.
 
-### 0. Load the fleet registry
+## Pre-flight (every mode)
 
-Read `memory/instances.json`. If it doesn't exist or has no instances, log `FLEET_EMPTY: no managed instances` to `memory/logs/${today}.md` and **stop — do NOT send a notification**.
+1. **Verify gh auth** — `gh auth status` must succeed. If not, log `FLEET_NO_AUTH` to `memory/logs/${today}.md` and notify `Fleet Control: gh auth missing — check GITHUB_TOKEN secret.` Stop.
 
-Parse the var to determine the command:
-- If var starts with `dispatch`: extract instance name and skill, go to **Dispatch Mode**
-- If var is `status`: go to **Status Mode**
-- If var is empty or anything else: go to **Health Check Mode** (default)
+2. **Check rate limit** — `REMAINING=$(gh api rate_limit --jq '.resources.core.remaining')`. If `REMAINING < 50`, log `FLEET_RATE_LIMITED:remaining=${REMAINING}` and notify a one-line warning, then stop.
+
+3. **Load the registry** — read `memory/instances.json`. If the file is missing, write `{"instances": []}` to bootstrap. If `.instances` is absent or `[]`:
+   - Log `FLEET_EMPTY: no managed instances` to `memory/logs/${today}.md`.
+   - **Stop. Do NOT notify.**
+
+4. **Load prior state** — read `memory/state/fleet-control-state.json` (create the directory and file with `{"instances": {}, "last_full_summary_date": ""}` if missing). Shape:
+   ```json
+   {
+     "instances": {
+       "<name>": { "health": "<status>", "last_checked": "<ISO>", "consecutive_unreachable": 0 }
+     },
+     "last_full_summary_date": "YYYY-MM-DD"
+   }
+   ```
+
+5. **Parse var → mode**:
+   - empty / unrecognized → **Health Check Mode**
+   - exactly `status` → **Status Mode**
+   - starts with `dispatch ` → **Dispatch Mode**
 
 ---
 
-### Health Check Mode (default)
+## Health Check Mode (default)
 
-1. **For each registered instance**, check its health:
+For each registered instance, skip rows with `archived: true` from per-instance work (count them separately). Run the three calls per instance in parallel using `&` + `wait` and write each to `/tmp/fleet/${SAFE}.{repo,runs,cron}.json`:
 
-   a. **Repo exists and is accessible**:
+a. **Repo metadata**:
    ```bash
-   gh api "repos/${REPO}" --jq '.full_name' 2>/dev/null
+   gh api "repos/${REPO}" \
+     --jq '{full_name, pushed_at, archived, default_branch, open_issues_count}' \
+     > "/tmp/fleet/${SAFE}.repo.json" 2>"/tmp/fleet/${SAFE}.repo.err" &
    ```
 
-   b. **GitHub Actions status** — check if workflows are running:
+b. **Workflow runs in last 24h** (precise window, not "last 5"):
    ```bash
-   gh api "repos/${REPO}/actions/runs?per_page=5" --jq '[.workflow_runs[] | {name: .name, status: .status, conclusion: .conclusion, created_at: .created_at}]'
+   SINCE=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ)
+   gh api "repos/${REPO}/actions/runs?created=>${SINCE}&per_page=100&exclude_pull_requests=true" \
+     --jq '{total_count, runs:[.workflow_runs[]|{name,status,conclusion,created_at,html_url}]}' \
+     > "/tmp/fleet/${SAFE}.runs.json" 2>"/tmp/fleet/${SAFE}.runs.err" &
    ```
 
-   c. **Last activity** — check the most recent push:
+c. **Cron-state from child**:
    ```bash
-   gh api "repos/${REPO}" --jq '.pushed_at'
+   gh api "repos/${REPO}/contents/memory/cron-state.json" --jq '.content' 2>"/tmp/fleet/${SAFE}.cron.err" \
+     | base64 -d > "/tmp/fleet/${SAFE}.cron.json" &
    ```
 
-   d. **Read the child's cron-state** (if accessible):
-   ```bash
-   gh api "repos/${REPO}/contents/memory/cron-state.json" --jq '.content' | base64 -d | jq '.'
-   ```
+`wait` after launching all three for an instance (or batch across all instances if you trust your parallelism — keep ≤16 concurrent calls to stay under rate limit).
 
-   e. **Classify instance health**:
-   - **healthy**: Actions running, recent pushes, no failed skills in cron-state
-   - **pending_secrets**: No workflow runs at all (instance is inert)
-   - **degraded**: Some skills failing in cron-state
-   - **stale**: No push in 7+ days but was previously active
-   - **unreachable**: API calls fail (repo deleted or permissions changed)
+**Classify each instance** with precise thresholds:
+- **unreachable** — repo metadata call returned non-zero (404/403/etc.)
+- **archived** — repo metadata returns `archived: true`
+- **pending_secrets** — `runs.total_count == 0` for the 24h window AND repo `pushed_at` ≥ 7 days old (newly-spawned instances under 7 days stay unclassified-but-tracked)
+- **stale** — `runs.total_count == 0` AND `pushed_at` > 7 days old AND not `archived`
+- **degraded** — ≥1 cron-state skill with `consecutive_failures ≥ 3` OR (24h failure_count / total_count) ≥ 0.5 with total_count ≥ 2
+- **warning** — 24h failure_count ≥ 1 but ratio < 0.5
+- **healthy** — has runs in last 24h, all conclusions `success` or `in_progress`/`queued`, no degraded cron-state skills
 
-2. **Update the registry** — write back updated status for each instance to `memory/instances.json`. Add a `last_checked` timestamp and `health` field.
+For each instance compute a **next_action** (one short imperative phrase):
+- `pending_secrets` → `add ANTHROPIC_API_KEY at https://github.com/${REPO}/settings/secrets/actions`
+- `degraded` → `investigate <skill_name> (<consecutive_failures>× in a row, last_error: <signature, ≤60 chars>)`
+- `warning` → `monitor — <N>/<Total> runs failed in 24h`
+- `stale` → `confirm intent: no runs in 24h, last push <relative_date>; archive or re-enable`
+- `unreachable` → `verify access: <reason from repo.err>`
+- `healthy` → `none`
+- `archived` → `none (archived)`
 
-3. **Check for instances that need attention**:
-   - Any `pending_secrets` older than 7 days — nudge the owner
-   - Any `degraded` instances — list which skills are failing
-   - Any `stale` instances — flag for review
-   - Any `unreachable` instances — mark for cleanup
+**Compute delta** vs prior state (per-instance `prior.health` vs `current.health`):
+- **NEW** — instance not in prior state
+- **DEGRADED** — was healthy/warning, now degraded/unreachable/stale/pending_secrets
+- **RECOVERED** — was degraded/unreachable/stale/pending_secrets, now healthy/warning
+- **DROPPED** — was in prior state, no longer in registry
+- (no change → no delta line)
 
-4. **Log to memory** — append to `memory/logs/${today}.md`:
-   ```
-   ## fleet-control (health check)
-   - Fleet size: N instances
-   - Healthy: N | Pending: N | Degraded: N | Stale: N | Unreachable: N
-   - Issues: [list any problems found]
-   ```
+**Update the registry** — write back `health`, `last_checked` (ISO UTC), and `next_action` per instance to `memory/instances.json`. Preserve all other fields (`purpose`, `parent`, `created`, `skills_enabled`, etc.).
 
-5. **Send notification** via `./notify` (only if there are issues OR this is the first check of the day):
-   ```
-   *Fleet Status — ${today}*
+**Update the state file** — write the current per-instance health snapshot to `memory/state/fleet-control-state.json`. Update `last_full_summary_date` to today **only when this run notifies**. Increment `consecutive_unreachable` for unreachable instances; reset to 0 otherwise.
 
-   Instances: N total
-   [For each instance, one line]:
-   - {name} ({repo}): {status} — last active {date}, {N} skills running
-   
-   [If issues exist]:
-   Issues:
-   - {instance}: {problem description}
-   ```
+**Log** to `memory/logs/${today}.md`:
+```
+## fleet-control (health check)
+- Verdict: [FLEET_OK | NEEDS_ATTENTION:N]
+- Sizes: total=N, healthy=N, warning=N, degraded=N, stale=N, pending=N, unreachable=N, archived=N
+- Deltas: [list NEW/DEGRADED/RECOVERED/DROPPED, or "none"]
+- Sources: gh=ok, rate_remaining=N
+```
 
-   If all instances are healthy and this is not the first check today, skip the notification.
+**Notification gate** — send the notification if **any** of:
+- `len(deltas) > 0`
+- today != prior `last_full_summary_date` (first check of UTC day → daily rollup)
+- any current instance is `degraded` or `unreachable`
+
+Otherwise skip notify (silent no-op when nothing changed mid-day — operator isn't trained to ignore).
+
+**Notification body** (when sent):
+```
+*Fleet Control — ${today}*
+Verdict: <FLEET_OK | NEEDS_ATTENTION:N>
+
+[If deltas exist]:
+What changed:
+- NEW: <name> (<repo>) — <health>
+- DEGRADED: <name> — was <prior>, now <current>: <reason>
+- RECOVERED: <name> — was <prior>, now <current>
+- DROPPED: <name> — no longer in registry
+
+Fleet (N total):
+- <name> [<HEALTH>]: <repo> — <next_action>
+- ...
+
+[If first-of-day rollup]:
+Counts: healthy <H> · warning <W> · degraded <D> · stale <S> · pending <P> · unreachable <U> · archived <A>
+
+Sources: gh=ok · rate_remaining=N
+```
+
+Cap the per-instance list at 12 lines; if more, append `...and N more — see memory/instances.json`. Always include archived in counts; never list archived rows in the per-instance section.
 
 ---
 
-### Dispatch Mode
+## Dispatch Mode
 
-Parse var: `dispatch <instance-name> <skill-name>`
+Parse var: `dispatch <instance|*> <skill> [var=<value>]`.
 
-1. **Look up the instance** in `memory/instances.json` by name.
-   If not found, send an error notification and stop.
+**Resolve targets**:
+- If `<instance>` is `*`, target = every registry entry whose **current** health is `healthy`, `warning`, or `degraded` (skip unreachable, stale, pending, archived).
+- Otherwise, exact name match against the registry. Not found → notify `Fleet Dispatch: instance '<name>' not in registry` and stop.
 
-2. **Check the instance is active** (status is `healthy` or `degraded`).
-   If `pending_secrets`, notify: "Cannot dispatch — instance needs secrets configured first."
+For each target instance:
 
-3. **Dispatch the skill** on the child repo:
+1. **Validate skill exists in child**:
    ```bash
-   gh workflow run aeon.yml --repo "${REPO}" -f skill="${SKILL_NAME}"
+   gh api "repos/${REPO}/contents/skills/${SKILL}/SKILL.md" >/dev/null 2>&1 \
+     || { OUTCOME="missing_skill"; continue; }
    ```
 
-4. **Log the dispatch** to `memory/logs/${today}.md`:
-   ```
-   ## fleet-control (dispatch)
-   - Dispatched skill '${SKILL_NAME}' on instance '${INSTANCE_NAME}' (${REPO})
+2. **Check skill is enabled in child's aeon.yml** (best-effort warning, not a block — workflow_dispatch can override `enabled: false`):
+   ```bash
+   gh api "repos/${REPO}/contents/aeon.yml" --jq '.content' 2>/dev/null | base64 -d \
+     | grep -E "^[[:space:]]*${SKILL}:.*enabled:[[:space:]]*true" >/dev/null \
+     || NOT_ENABLED_WARN=1
    ```
 
-5. **Notify** via `./notify`:
+3. **Trigger the skill**:
+   ```bash
+   if [ -n "$DISPATCH_VAR" ]; then
+     gh workflow run aeon.yml --repo "${REPO}" -f skill="${SKILL}" -f var="${DISPATCH_VAR}" \
+       && OUTCOME="dispatched" || OUTCOME="api_failed:$?"
+   else
+     gh workflow run aeon.yml --repo "${REPO}" -f skill="${SKILL}" \
+       && OUTCOME="dispatched" || OUTCOME="api_failed:$?"
+   fi
    ```
-   *Fleet Dispatch*
-   Dispatched '${SKILL_NAME}' on ${INSTANCE_NAME} (${REPO})
-   ```
+
+Collect per-target outcomes: `dispatched | missing_skill | api_failed:<code>` (with optional `not_enabled_warn` flag).
+
+**Log**:
+```
+## fleet-control (dispatch)
+- Command: dispatch <inst|*> <skill> [var=...]
+- Targets: N
+- Dispatched: N | missing_skill: N | api_failed: N
+- Per-target: [<name>: <outcome>, ...]
+```
+
+**Notify** (always, in dispatch mode):
+```
+*Fleet Dispatch*
+Command: dispatch <inst|*> <skill>
+Targets: <N> — Dispatched: <N>
+Successful: <comma-sep names>
+[If failures]:
+Failed: <name>: <reason>, ...
+[If not_enabled_warn]:
+Warning: <name> has skill disabled in aeon.yml — dispatched anyway
+```
+
+If 0 dispatched out of N targets, the verdict line reads `Fleet Dispatch: 0/${N} — see failures below` and exit code logged is `FLEET_DISPATCH_FAILED:no_targets_succeeded`.
 
 ---
 
-### Status Mode
+## Status Mode
 
-Generate a comprehensive fleet report.
+Generate the comprehensive snapshot, but make it scannable.
 
-1. **For each instance**, gather:
-   - Repo metadata (stars, forks, open issues)
-   - Last 10 workflow runs with outcomes
-   - Full cron-state.json
-   - List of enabled skills (read their aeon.yml)
-   - Recent commits (last 5)
+For each registered instance (skip `archived` from detail blocks but count them in the summary), gather in parallel:
+- Repo meta: `stargazers_count`, `pushed_at`, `open_issues_count`, `default_branch`
+- Last 10 workflow runs:
+  ```bash
+  gh api "repos/${REPO}/actions/runs?per_page=10&exclude_pull_requests=true" \
+    --jq '[.workflow_runs[]|{name,status,conclusion,created_at,html_url}]'
+  ```
+- Full `cron-state.json`
+- `aeon.yml` (parse enabled skills)
+- Last 5 commits (one-line `gh api repos/${REPO}/commits?per_page=5 --jq ...`)
 
-2. **Read each child's aeon.yml** to see what skills are enabled:
-   ```bash
-   gh api "repos/${REPO}/contents/aeon.yml" --jq '.content' | base64 -d
-   ```
+Compute the same delta block, but compare against the most recent prior `articles/fleet-status-*.md` (parse the per-instance health rows; if none exists, mark the section "no prior status to diff against").
 
-3. **Write a fleet status article** to `articles/fleet-status-${today}.md`:
-   ```markdown
-   # Fleet Status Report — ${today}
+Write to `articles/fleet-status-${today}.md`:
+```markdown
+# Fleet Status — ${today}
 
-   ## Overview
-   Parent: ${PARENT_REPO}
-   Managed instances: N
-   Total skills running across fleet: N
+## Verdict
+<one line: FLEET_OK | NEEDS_ATTENTION:N | DEGRADED:N — top issue first>
 
-   ---
+## Top Issue
+<one paragraph: the single highest-priority instance and what it needs, OR "none">
 
-   ## Instance: {name}
-   **Repo:** {owner/repo}
-   **Purpose:** {purpose}
-   **Status:** {health status}
-   **Created:** {date}
-   **Last active:** {pushed_at}
-   **Skills enabled:** {list}
-   **Recent runs:**
-   | Skill | Status | When |
-   |-------|--------|------|
-   | ... | ... | ... |
+## Fleet Health
+| Instance | Repo | Health | Last Active | Skills | Open Action |
+|----------|------|--------|-------------|--------|-------------|
 
-   ---
-   [repeat for each instance]
+## What Changed Since Last Status
+<list of NEW/DEGRADED/RECOVERED/WENT_STALE/DROPPED instances since prior fleet-status article, or "no changes">
 
-   ## Fleet Health Summary
-   | Metric | Value |
-   |--------|-------|
-   | Total instances | N |
-   | Healthy | N |
-   | Degraded | N |
-   | Pending setup | N |
-   | Total skills across fleet | N |
-   | Total runs today | N |
-   ```
+## Per-Instance Detail
 
-4. **Log and notify** with a summary.
+### <name> — <repo>
+- Purpose: <from registry>
+- Health: <status>, last checked <ISO>
+- Last 10 runs:
+  | Skill | Status | Conclusion | When |
+  |-------|--------|-----------|------|
+- Skills enabled: <comma list>
+- Recent commits:
+  - <sha> <message>
+- Action: <next_action>
+
+## Counts
+| Metric | Value |
+|--------|-------|
+
+## Sources
+gh=ok · rate_remaining=N · registry=N instances · prior_status=<filename or "none">
+```
+
+**Log**:
+```
+## fleet-control (status)
+- Article: articles/fleet-status-${today}.md
+- Verdict: <line>
+- Sizes: total=N, healthy=N, ...
+```
+
+**Notify** (always, in status mode):
+```
+*Fleet Status — ${today}*
+<verdict>
+Top issue: <one line, or "none">
+Counts: healthy <H> · warning <W> · degraded <D> · stale <S> · pending <P> · unreachable <U>
+Article: articles/fleet-status-${today}.md
+```
+
+---
+
+## Exit taxonomy
+
+Every run logs exactly one of these to memory:
+- `FLEET_CONTROL_OK` — health/status/dispatch completed normally
+- `FLEET_EMPTY` — no instances in registry (silent stop)
+- `FLEET_NO_AUTH` — gh auth missing
+- `FLEET_RATE_LIMITED:remaining=N` — abandoned to preserve quota
+- `FLEET_DISPATCH_OK:N/M` — dispatched N of M targets
+- `FLEET_DISPATCH_FAILED:<reason>` — dispatch produced 0 dispatches
+
+## Sandbox note
+
+Always use `gh api` over raw curl (handles auth and the sandbox env-var-in-headers issue). All cross-repo calls go through `gh api` or `gh workflow run`. No outbound HTTP needed beyond what `gh` does internally.
+
+## Constraints
+
+- Never delete an instance from `memory/instances.json` automatically — only update fields. Even `unreachable` instances stay in the registry until the operator removes them by hand.
+- Preserve all registry fields not explicitly written by this skill (purpose, parent, created, skills_enabled, etc.).
+- Never write secrets to logs or notifications.
+- Cap notification length at ~30 lines; truncate the per-instance list with `...and N more` when needed.
+- Health Check stays silent when nothing changed mid-day — the daily-rollup path handles the recurring "is everything fine?" question without spam.
+- Do not change the skill's tags, var semantics, or schedule without strong justification.
 
 Write complete, working code. No TODOs or placeholders.


### PR DESCRIPTION
## Winner: Variation B — Sharper output (48/52.5)

**Thesis:** Current output is a flat per-instance status dump with no verdict, no priorities, no delta vs the previous check, and no per-instance next-action — operator scrolls and learns to ignore it. The biggest lever is decision-readiness: lead with a one-line verdict, show a delta block (NEW/DEGRADED/RECOVERED/DROPPED) computed against `memory/state/fleet-control-state.json`, give every row a concrete action, and only notify when something actually changed (or once-a-day for the rollup).

**Folded-in upgrades from runners-up:**
- From **A**: precise 24h window via `?created=>${SINCE}` (replaces vague "last 5 runs"), `&`+`wait` parallelism for the 3 per-instance API calls, per-skill `cron-state.json` parsing for graded health (consecutive_failures, success_rate), repo-meta single-call shape.
- From **C**: bootstrap empty `instances.json` instead of erroring; `gh auth status` + `gh api rate_limit` preflight; persistent state at `memory/state/fleet-control-state.json`; per-instance try/catch (one bad call doesn't abort the run); dispatch skill-existence + aeon.yml-enabled validation; full exit taxonomy (`FLEET_CONTROL_OK` / `FLEET_EMPTY` / `FLEET_NO_AUTH` / `FLEET_RATE_LIMITED:N` / `FLEET_DISPATCH_OK:N/M` / `FLEET_DISPATCH_FAILED:reason`); source-status footer.
- From **D**: `dispatch *` fan-out across all healthy/warning/degraded instances; optional `var=<value>` passthrough on dispatch.

## Scoring table

| Criterion (weight) | A | B | C | D |
|---|---|---|---|---|
| Clarity (×1.5) | 4 | 4 | 5 | 3 |
| Data quality (×1.5) | 5 | 4 | 4 | 4 |
| Output value (×2) | 3 | **5** | 3 | 4 |
| Robustness (×1.5) | 3 | 4 | 5 | 3 |
| Conventions (×1) | 4 | 5 | 5 | 4 |
| Improvement (×3) | 3 | **5** | 4 | 3 |
| **Weighted total** | **37** | **48** | **44** | **36** |

## Variation summaries

**A — Better inputs (37):** Switch workflow-runs query from "last 5" to time-windowed `?created=>${24h_ago}`; parallelize the 3 per-instance API calls (`&`+`wait`) for ~3× latency win; parse `cron-state.json` per-skill (consecutive_failures, success_rate, last_quality_score) for graded health rather than binary "any failed skill"; bootstrap missing `instances.json`. Strong data-quality win, but operator still gets the same flat status dump — robustness without output discipline doesn't fix the "trains operator to ignore" problem.

**B — Sharper output (48) ← winner:** Verdict line at the top (`FLEET_OK` / `NEEDS_ATTENTION:N`); delta block (NEW/DEGRADED/RECOVERED/DROPPED) computed vs `memory/state/fleet-control-state.json`; per-instance `next_action` column with concrete imperatives (e.g., `add ANTHROPIC_API_KEY at https://github.com/${REPO}/settings/secrets/actions`, `investigate <skill> (3× in a row, last_error: <sig>)`); notification gate fires only when (deltas exist) OR (first check of UTC day) OR (any current degraded/unreachable) — silent mid-day no-ops. Folds A's window/parallelism, C's robustness/taxonomy/validation, D's `dispatch *` fanout.

**C — More robust (44):** Add full exit taxonomy (`FLEET_CONTROL_OK`/`EMPTY`/`NO_AUTH`/`RATE_LIMITED`/`DISPATCH_OK`/`DISPATCH_FAILED:reason`); preflight `gh auth status` + `gh api rate_limit`; per-instance try/catch isolation (one bad repo doesn't abort the run); persistent state file at `memory/state/fleet-control-state.json`; dispatch validation (skill exists in child `skills/`, enabled in child `aeon.yml`); bootstrap missing registry; source-status footer. Strong reliability foundation but operator-visible output is unchanged from current — folded into B.

**D — Rethink as Fleet Operator Console (36):** Replace 3-mode dichotomy with single console that always reads registry and computes state, executing optional commands from var. Richer DSL: `dispatch <inst|*> <skill>`, `discover` (find unregistered `aeon-*` forks owned by parent), `archive <inst>`, `pause <inst>`, `recheck <inst>`. Auto-remediation suggestions (unreachable >7d → propose archive). Multi-instance fanout. Creative reframe but adds significant complexity and overlaps fork-fleet's auto-discovery; rejected because B captures the high-leverage `dispatch *` fanout without the rest.

## Operational findings

- `memory/instances.json` does **not** currently exist. Fleet is empty. Current skill aborts cleanly with `FLEET_EMPTY`; B preserves that behavior (silent stop) and adds bootstrap so the file is created on first run instead of left absent.
- `memory/state/` directory is also new — B creates it on demand.
- `cron-state.json` (parent's) shows `autoresearch` at 75/75 success and `heartbeat` at 1/1 — no fleet-control entry yet (skill never ran). This evolution lands before the first scheduled execution, same as several prior autoresearch winners.
- No new env vars or secrets — uses only `gh api` with existing `GITHUB_TOKEN`.
- Frontmatter (name, description, var, tags, cron) preserved verbatim. Three modes preserved (Health Check / Dispatch / Status) so existing operator habits still work.

## Diff summary

`skills/fleet-control/SKILL.md`: 248 insertions, 124 deletions. Full restructure around verdict + delta + action-column output, with pre-flight section, exit taxonomy, persistent state, time-windowed runs query, parallelized per-instance calls, dispatch skill+aeon.yml validation, `dispatch *` fanout, and bounded notification body (cap 12 instance lines + `...and N more`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Ported from aaronjmars/aeon-tmp#90.
