### PR TITLE
feat: integration examples for A2A gateway and MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,21 @@ Aeon skills work outside GitHub Actions too — use them from Claude or any AI a
 
 Skills run locally via `claude -p -`, identical to Actions. API keys read from your environment or a `.env` file in the repo root.
 
+### Integration examples
+
+Working client scripts for every supported stack live in [`examples/`](examples/) — each one is &lt;100 lines, talks to a running A2A gateway or MCP server, and calls a real Aeon skill end-to-end:
+
+| Stack | File | Skill called |
+|-------|------|--------------|
+| LangChain | [`examples/a2a/langchain_client.py`](examples/a2a/langchain_client.py) | `aeon-fetch-tweets` |
+| AutoGen | [`examples/a2a/autogen_workflow.py`](examples/a2a/autogen_workflow.py) | `aeon-deep-research` |
+| CrewAI | [`examples/a2a/crewai_task.py`](examples/a2a/crewai_task.py) | `aeon-pr-review` |
+| OpenAI Agents SDK | [`examples/a2a/openai_agents_client.py`](examples/a2a/openai_agents_client.py) | `aeon-token-report` |
+| MCP (stdio) | [`examples/mcp/test_connection.py`](examples/mcp/test_connection.py) | `aeon-cost-report` |
+| Claude Desktop | [`examples/mcp/claude_desktop_config.json`](examples/mcp/claude_desktop_config.json) | — |
+
+Start with [`examples/README.md`](examples/README.md) for the full setup walk-through.
+
 ---
 
 ## Two-repo strategy

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,55 @@
+# Aeon integration examples
+
+Aeon ships an [A2A gateway](../a2a-server/) and an [MCP server](../mcp-server/) so any agent stack can call its 90+ skills. The scripts here are the shortest possible "first call works" demos — point them at a running gateway, run `python <file>`, get a real Aeon output back.
+
+| File | Stack | Skill called | What it shows |
+|------|-------|--------------|---------------|
+| [`a2a/langchain_client.py`](a2a/langchain_client.py) | LangChain | `aeon-fetch-tweets` | Wrap a skill as a `langchain.tools.Tool` |
+| [`a2a/autogen_workflow.py`](a2a/autogen_workflow.py) | AutoGen | `aeon-deep-research` | Function tool inside a multi-agent chat |
+| [`a2a/crewai_task.py`](a2a/crewai_task.py) | CrewAI | `aeon-pr-review` | Subclass `BaseTool`, hand to a Crew agent |
+| [`a2a/openai_agents_client.py`](a2a/openai_agents_client.py) | OpenAI Agents SDK | `aeon-token-report` | `@function_tool` decorator pattern |
+| [`mcp/test_connection.py`](mcp/test_connection.py) | MCP (stdio) | `aeon-cost-report` (default) | List + invoke any `aeon-*` tool |
+| [`mcp/claude_desktop_config.json`](mcp/claude_desktop_config.json) | Claude Desktop | — | Drop-in config snippet |
+
+Every A2A script is &lt;100 lines, depends only on `requests` plus the framework SDK, and reads its endpoint from `A2A_GATEWAY_URL` (defaults to `http://localhost:41241`).
+
+## A2A — start the gateway, then run any client
+
+```bash
+# Terminal 1 — start the gateway from your aeon repo
+./add-a2a                      # listens on http://localhost:41241
+
+# Terminal 2 — point a client at it
+export A2A_GATEWAY_URL=http://localhost:41241
+pip install langchain requests
+python examples/a2a/langchain_client.py "AI agents"
+```
+
+Swap the script for `autogen_workflow.py`, `crewai_task.py`, or `openai_agents_client.py` to drive the gateway from a different framework. The four files share the same submit/poll pattern so you can crib whichever one matches your stack.
+
+To call a different skill, change the `skillId` (and the `var` if the skill needs one). The agent card at `http://localhost:41241/.well-known/agent.json` lists every tool, its description, and an example invocation.
+
+## MCP — verify the round-trip
+
+```bash
+./add-mcp --build-only          # produce mcp-server/dist/index.js
+pip install mcp                 # official Anthropic MCP client
+python examples/mcp/test_connection.py
+```
+
+You should see the full list of `aeon-*` tools followed by a real `aeon-cost-report` output. Once that works, hand `mcp-server/dist/index.js` to Claude Code with `./add-mcp` (already done if you ran `./add-mcp` without `--build-only`) or to Claude Desktop using [`mcp/claude_desktop_config.json`](mcp/claude_desktop_config.json) — replace `/ABSOLUTE/PATH/TO/aeon` with your actual repo path.
+
+## Picking a different skill
+
+`skills.json` at the repo root is the source of truth — every entry is callable as `aeon-<slug>` from MCP and as `skillId: "aeon-<slug>"` from A2A. Some good first calls:
+
+- `aeon-cost-report` — fast, no external API needed, safe to run anywhere
+- `aeon-token-report` (`var=AEON`) — public DexScreener data, no secrets required
+- `aeon-deep-research` (`var="your topic"`) — long-running; expect 5–10 min
+- `aeon-fetch-tweets` (`var="your topic"`) — needs `XAI_API_KEY` in the Aeon repo's environment
+
+Skills that hit external APIs need the same secrets the Aeon GitHub Actions runner uses. Drop them into a `.env` file at the Aeon repo root before you start the gateway or MCP server.
+
+## What the gateway is doing under the hood
+
+Every Aeon skill is a markdown prompt at `skills/<slug>/SKILL.md`. The A2A and MCP servers both spawn `claude -p -` with the same prompt the GitHub Actions runner uses — so a skill behaves identically whether it fires on a cron, from your terminal, or from a remote agent on the other side of the protocol. No re-implementation, no drift.

--- a/examples/a2a/autogen_workflow.py
+++ b/examples/a2a/autogen_workflow.py
@@ -1,0 +1,96 @@
+"""
+AutoGen ↔ Aeon A2A example.
+
+Registers `aeon-deep-research` as a function tool that an AutoGen
+AssistantAgent can call inside a multi-agent conversation. The user agent
+asks the assistant to research a topic; the assistant calls Aeon and
+returns the report.
+
+Setup:
+    export A2A_GATEWAY_URL=http://localhost:41241
+    export OPENAI_API_KEY=sk-...                # AutoGen needs an LLM
+    pip install pyautogen requests
+    python examples/a2a/autogen_workflow.py "self-hosted LLM gateways 2026"
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+import uuid
+
+import requests
+from autogen import AssistantAgent, UserProxyAgent
+
+GATEWAY = os.environ.get("A2A_GATEWAY_URL", "http://localhost:41241")
+
+
+def call_aeon_skill(skill_id: str, var: str = "") -> str:
+    """Submit an Aeon task and poll until done. Returns the artifact text."""
+    task_id = str(uuid.uuid4())
+    requests.post(
+        GATEWAY,
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tasks/send",
+            "params": {
+                "id": task_id,
+                "skillId": skill_id,
+                "var": var,
+                "message": {
+                    "role": "user",
+                    "parts": [{"type": "text", "text": f"Run {skill_id} var={var}"}],
+                },
+            },
+        },
+        timeout=30,
+    ).raise_for_status()
+
+    for _ in range(120):
+        time.sleep(5)
+        status = requests.post(
+            GATEWAY,
+            json={"jsonrpc": "2.0", "id": 2, "method": "tasks/get", "params": {"id": task_id}},
+            timeout=30,
+        ).json()["result"]
+        if status["status"]["state"] == "completed":
+            return status["artifacts"][0]["parts"][0]["text"]
+        if status["status"]["state"] in ("failed", "canceled"):
+            raise RuntimeError(f"Aeon skill {skill_id} failed: {status['status']}")
+    raise TimeoutError(f"Aeon skill {skill_id} timed out")
+
+
+def aeon_deep_research(topic: str) -> str:
+    """Exhaustive multi-source research via Aeon (30–50 sources)."""
+    return call_aeon_skill("aeon-deep-research", topic)
+
+
+config_list = [{"model": "gpt-4o-mini", "api_key": os.environ["OPENAI_API_KEY"]}]
+
+assistant = AssistantAgent(
+    name="researcher",
+    llm_config={"config_list": config_list, "temperature": 0},
+    system_message=(
+        "You are a research assistant. When asked to research a topic, call the "
+        "`aeon_deep_research` tool with the topic and return the result verbatim. "
+        "End your message with TERMINATE when done."
+    ),
+)
+assistant.register_for_llm(name="aeon_deep_research", description="Deep multi-source research via Aeon")(
+    aeon_deep_research
+)
+
+user = UserProxyAgent(
+    name="user",
+    human_input_mode="NEVER",
+    max_consecutive_auto_reply=2,
+    code_execution_config=False,
+    is_termination_msg=lambda m: "TERMINATE" in (m.get("content") or ""),
+)
+user.register_for_execution(name="aeon_deep_research")(aeon_deep_research)
+
+
+if __name__ == "__main__":
+    topic = " ".join(sys.argv[1:]) or "self-hosted LLM gateways 2026"
+    user.initiate_chat(assistant, message=f"Research this topic deeply: {topic}")

--- a/examples/a2a/crewai_task.py
+++ b/examples/a2a/crewai_task.py
@@ -1,0 +1,88 @@
+"""
+CrewAI ↔ Aeon A2A example.
+
+Wraps `aeon-pr-review` as a CrewAI BaseTool so a Crew agent can review
+pull requests on any GitHub repo as part of a larger workflow.
+
+Setup:
+    export A2A_GATEWAY_URL=http://localhost:41241
+    export OPENAI_API_KEY=sk-...               # CrewAI default LLM
+    pip install crewai crewai-tools requests
+    python examples/a2a/crewai_task.py owner/repo
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+import uuid
+
+import requests
+from crewai import Agent, Crew, Task
+from crewai.tools import BaseTool
+from pydantic import Field
+
+GATEWAY = os.environ.get("A2A_GATEWAY_URL", "http://localhost:41241")
+
+
+def _call_aeon(skill_id: str, var: str) -> str:
+    task_id = str(uuid.uuid4())
+    requests.post(
+        GATEWAY,
+        json={
+            "jsonrpc": "2.0", "id": 1, "method": "tasks/send",
+            "params": {
+                "id": task_id, "skillId": skill_id, "var": var,
+                "message": {"role": "user", "parts": [{"type": "text",
+                            "text": f"Run {skill_id} var={var}"}]},
+            },
+        },
+        timeout=30,
+    ).raise_for_status()
+    for _ in range(120):
+        time.sleep(5)
+        status = requests.post(
+            GATEWAY,
+            json={"jsonrpc": "2.0", "id": 2, "method": "tasks/get",
+                  "params": {"id": task_id}},
+            timeout=30,
+        ).json()["result"]
+        if status["status"]["state"] == "completed":
+            return status["artifacts"][0]["parts"][0]["text"]
+        if status["status"]["state"] in ("failed", "canceled"):
+            raise RuntimeError(f"Aeon {skill_id} failed: {status['status']}")
+    raise TimeoutError(f"Aeon {skill_id} timed out")
+
+
+class AeonPRReviewTool(BaseTool):
+    name: str = "aeon_pr_review"
+    description: str = (
+        "Review all open pull requests on a GitHub repo via Aeon. "
+        "Input: a repo in owner/repo format. Returns: a markdown summary "
+        "with risk flags, suggested merges, and blocking issues."
+    )
+    gateway_url: str = Field(default=GATEWAY)
+
+    def _run(self, repo: str) -> str:
+        return _call_aeon("aeon-pr-review", repo)
+
+
+reviewer = Agent(
+    role="Senior PR reviewer",
+    goal="Triage open PRs on the target repo and recommend which to merge first.",
+    backstory="A senior engineer who delegates the heavy reading to Aeon, then "
+              "writes the prioritised summary for the team standup.",
+    tools=[AeonPRReviewTool()],
+    verbose=True,
+    allow_delegation=False,
+)
+
+if __name__ == "__main__":
+    repo = sys.argv[1] if len(sys.argv) > 1 else "aaronjmars/aeon"
+    review_task = Task(
+        description=f"Use the aeon_pr_review tool on {repo}, then write a 5-bullet "
+                    f"prioritised standup summary.",
+        expected_output="Markdown bullet list, ranked by merge priority.",
+        agent=reviewer,
+    )
+    print(Crew(agents=[reviewer], tasks=[review_task], verbose=True).kickoff())

--- a/examples/a2a/langchain_client.py
+++ b/examples/a2a/langchain_client.py
@@ -1,0 +1,85 @@
+"""
+LangChain ↔ Aeon A2A example.
+
+Wraps an Aeon skill as a LangChain Tool so any LangChain agent can call it.
+This example calls `aeon-fetch-tweets` to grab the latest mentions of a topic.
+
+Setup:
+    export A2A_GATEWAY_URL=http://localhost:41241   # ./add-a2a in your aeon repo
+    pip install langchain requests
+    python examples/a2a/langchain_client.py "AI agents"
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+import uuid
+
+import requests
+from langchain.tools import Tool
+
+GATEWAY = os.environ.get("A2A_GATEWAY_URL", "http://localhost:41241")
+POLL_SECONDS = 5
+MAX_POLLS = 120  # 10 min — matches Aeon's GitHub Actions timeout
+
+
+def call_aeon(skill_id: str, var: str = "") -> str:
+    """Submit an Aeon skill task via JSON-RPC and poll until it completes."""
+    task_id = str(uuid.uuid4())
+    submit = requests.post(
+        GATEWAY,
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tasks/send",
+            "params": {
+                "id": task_id,
+                "skillId": skill_id,
+                "var": var,
+                "message": {
+                    "role": "user",
+                    "parts": [{"type": "text", "text": f"Run {skill_id} var={var}"}],
+                },
+            },
+        },
+        timeout=30,
+    ).json()
+    if "error" in submit:
+        raise RuntimeError(f"Aeon rejected task: {submit['error']}")
+
+    for _ in range(MAX_POLLS):
+        time.sleep(POLL_SECONDS)
+        status = requests.post(
+            GATEWAY,
+            json={
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tasks/get",
+                "params": {"id": task_id},
+            },
+            timeout=30,
+        ).json()
+        state = status["result"]["status"]["state"]
+        if state == "completed":
+            return status["result"]["artifacts"][0]["parts"][0]["text"]
+        if state in ("failed", "canceled"):
+            raise RuntimeError(f"Skill {skill_id} {state}: {status['result']['status']}")
+    raise TimeoutError(f"Skill {skill_id} timed out after {POLL_SECONDS * MAX_POLLS}s")
+
+
+aeon_fetch_tweets = Tool(
+    name="aeon_fetch_tweets",
+    func=lambda topic: call_aeon("aeon-fetch-tweets", topic),
+    description=(
+        "Fetch the latest tweets matching a topic, handle, or keyword via Aeon. "
+        "Input: a search query (e.g. 'AI agents', '$AEON', '@aeonframework'). "
+        "Returns: a markdown digest of recent tweets ranked by engagement."
+    ),
+)
+
+
+if __name__ == "__main__":
+    topic = " ".join(sys.argv[1:]) or "AI agents"
+    print(f"[langchain_client] Calling aeon-fetch-tweets via {GATEWAY} for: {topic}")
+    print(aeon_fetch_tweets.run(topic))

--- a/examples/a2a/openai_agents_client.py
+++ b/examples/a2a/openai_agents_client.py
@@ -1,0 +1,87 @@
+"""
+OpenAI Agents SDK ↔ Aeon A2A example.
+
+Registers `aeon-token-report` as a function tool the Agent can call when
+the user asks about a crypto token. The Agent decides when to call it,
+extracts the symbol/address from the prompt, and returns the report.
+
+Setup:
+    export A2A_GATEWAY_URL=http://localhost:41241
+    export OPENAI_API_KEY=sk-...
+    pip install openai-agents requests
+    python examples/a2a/openai_agents_client.py "what's the price of $AEON?"
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+import uuid
+
+import requests
+from agents import Agent, Runner, function_tool
+
+GATEWAY = os.environ.get("A2A_GATEWAY_URL", "http://localhost:41241")
+
+
+def _call_aeon(skill_id: str, var: str) -> str:
+    task_id = str(uuid.uuid4())
+    requests.post(
+        GATEWAY,
+        json={
+            "jsonrpc": "2.0", "id": 1, "method": "tasks/send",
+            "params": {
+                "id": task_id, "skillId": skill_id, "var": var,
+                "message": {"role": "user", "parts": [{"type": "text",
+                            "text": f"Run {skill_id} var={var}"}]},
+            },
+        },
+        timeout=30,
+    ).raise_for_status()
+    for _ in range(120):
+        time.sleep(5)
+        result = requests.post(
+            GATEWAY,
+            json={"jsonrpc": "2.0", "id": 2, "method": "tasks/get",
+                  "params": {"id": task_id}},
+            timeout=30,
+        ).json()["result"]
+        state = result["status"]["state"]
+        if state == "completed":
+            return result["artifacts"][0]["parts"][0]["text"]
+        if state in ("failed", "canceled"):
+            raise RuntimeError(f"Aeon {skill_id} {state}: {result['status']}")
+    raise TimeoutError(f"Aeon {skill_id} timed out")
+
+
+@function_tool
+def aeon_token_report(token: str) -> str:
+    """Get a full Aeon token report for a crypto token.
+
+    Args:
+        token: A token symbol (e.g. 'AEON', 'BTC') or a contract address.
+               Pass the bare symbol without the leading '$'.
+
+    Returns:
+        Markdown report with price, 24h change, liquidity, volume, FDV,
+        and recent buy/sell stats.
+    """
+    return _call_aeon("aeon-token-report", token)
+
+
+crypto_analyst = Agent(
+    name="crypto-analyst",
+    instructions=(
+        "You are a crypto analyst. When the user asks about a token's price, "
+        "stats, or fundamentals, call `aeon_token_report` with the token "
+        "symbol or address, then summarise the key numbers in two sentences "
+        "and append the full report below."
+    ),
+    tools=[aeon_token_report],
+)
+
+
+if __name__ == "__main__":
+    prompt = " ".join(sys.argv[1:]) or "what's the price of $AEON?"
+    result = Runner.run_sync(crypto_analyst, prompt)
+    print(result.final_output)

--- a/examples/mcp/claude_desktop_config.json
+++ b/examples/mcp/claude_desktop_config.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "aeon": {
+      "command": "node",
+      "args": ["/ABSOLUTE/PATH/TO/aeon/mcp-server/dist/index.js"]
+    }
+  }
+}

--- a/examples/mcp/test_connection.py
+++ b/examples/mcp/test_connection.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""
+Sanity-check the Aeon MCP server end-to-end.
+
+What it does:
+  1. Spawns `node mcp-server/dist/index.js` as a stdio MCP server.
+  2. Sends `tools/list` and prints every aeon-* tool that is registered.
+  3. Calls one tool (default: `aeon-cost-report`, fast and offline-safe)
+     so you can confirm the full request/response cycle works.
+
+Why a separate Python script: the MCP SDK ships the JSON-RPC framing,
+but a hand-rolled client is the smallest possible reproduction. If this
+script works, your Claude Desktop / Claude Code wiring will too.
+
+Setup:
+    cd /path/to/aeon
+    ./add-mcp --build-only          # produce mcp-server/dist/index.js
+    pip install mcp                 # official anthropic MCP client
+    python examples/mcp/test_connection.py            # lists + calls default tool
+    python examples/mcp/test_connection.py aeon-token-report AEON
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+
+def repo_root() -> Path:
+    """Walk up from this file until we find the Aeon repo root."""
+    here = Path(__file__).resolve()
+    for candidate in (here, *here.parents):
+        if (candidate / "skills.json").exists() and (candidate / "mcp-server").is_dir():
+            return candidate
+    raise SystemExit(
+        "Could not locate Aeon repo root (no skills.json + mcp-server/ above this file)."
+    )
+
+
+async def main(tool_name: str, var_value: str) -> int:
+    root = repo_root()
+    server_js = root / "mcp-server" / "dist" / "index.js"
+    if not server_js.exists():
+        print(f"✗ MCP server build missing at {server_js}")
+        print("  Run `./add-mcp --build-only` from the repo root first.")
+        return 1
+
+    params = StdioServerParameters(
+        command="node",
+        args=[str(server_js)],
+        env=os.environ.copy(),
+    )
+
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+
+            tools = (await session.list_tools()).tools
+            print(f"✓ MCP server connected. {len(tools)} tools advertised.\n")
+            for t in tools[:10]:
+                print(f"  • {t.name}")
+            if len(tools) > 10:
+                print(f"  … and {len(tools) - 10} more")
+
+            print(f"\n→ Calling {tool_name}" + (f" (var={var_value!r})" if var_value else ""))
+            result = await session.call_tool(
+                tool_name,
+                arguments={"var": var_value} if var_value else {},
+            )
+            for block in result.content:
+                text = getattr(block, "text", None) or str(block)
+                print(text[:2000])
+                if len(text) > 2000:
+                    print(f"\n… ({len(text) - 2000} more chars truncated)")
+            print("\n✓ Round-trip succeeded.")
+    return 0
+
+
+if __name__ == "__main__":
+    tool = sys.argv[1] if len(sys.argv) > 1 else "aeon-cost-report"
+    var = sys.argv[2] if len(sys.argv) > 2 else ""
+    sys.exit(asyncio.run(main(tool, var)))


### PR DESCRIPTION
## What

Adds an `examples/` directory with copy-paste client scripts for every supported integration stack, plus links to it from the main README. Each script is a single self-contained file that talks to a running A2A gateway (`./add-a2a`) or MCP server (`./add-mcp`) and gets back a real Aeon skill output.

| File | Stack | Skill called |
|------|-------|--------------|
| `examples/a2a/langchain_client.py` | LangChain | `aeon-fetch-tweets` |
| `examples/a2a/autogen_workflow.py` | AutoGen | `aeon-deep-research` |
| `examples/a2a/crewai_task.py` | CrewAI | `aeon-pr-review` |
| `examples/a2a/openai_agents_client.py` | OpenAI Agents SDK | `aeon-token-report` |
| `examples/mcp/test_connection.py` | MCP (stdio) | `aeon-cost-report` |
| `examples/mcp/claude_desktop_config.json` | Claude Desktop | drop-in snippet |
| `examples/README.md` | — | walk-through linking everything |

## Why

The A2A gateway and MCP adaptor have been live for weeks with no observed external integrations (yesterday's `repo-actions` flagged this as the highest-impact gap). The barrier isn't protocol complexity — it's that operators face a blank page after `./add-a2a`. A working `examples/` directory collapses adoption time from "read the spec" to "change the URL." It pairs naturally with the recent `fork-contributor-leaderboard` (rewards contributors) by removing the friction for *integrators*.

## Changes

- `examples/a2a/`: four ~80-line client scripts, one per major agent framework. All four share the same submit/poll pattern over JSON-RPC so users can crib whichever matches their stack. Each reads its endpoint from `A2A_GATEWAY_URL` (defaults to `http://localhost:41241`), depends only on `requests` plus the framework SDK, and prints real Aeon output to stdout.
- `examples/mcp/test_connection.py`: minimal Anthropic MCP-client smoke test that auto-locates the repo root, spawns `node mcp-server/dist/index.js`, lists every `aeon-*` tool, and invokes one (default `aeon-cost-report` because it's offline-safe). If this script works, Claude Desktop wiring will too.
- `examples/mcp/claude_desktop_config.json`: drop-in `mcpServers` snippet — replace the `/ABSOLUTE/PATH/TO/aeon` placeholder with the local repo path.
- `examples/README.md`: full walk-through with start commands, picking-a-different-skill notes, and a "what the gateway is doing under the hood" section.
- `README.md`: new "Integration examples" subsection inside the existing "Integrations (MCP & A2A)" block, with the table above and a link to `examples/README.md`.

No changes to the gateway, MCP server, or any skill — pure additive integration surface.

---
*Built autonomously by Aeon*