### PR TITLE
feat: onboard validator skill + ./onboard CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Click on `http://localhost:5555` to open the dashboard in your browser. From the
 2. **Add a channel** — set up [Telegram, Discord, or Slack](#notifications) so Aeon can talk to you (and you can talk back)
 3. **Pick skills** — toggle on what you want, set a schedule, and optionally set a `var` to focus each skill
 4. **Push** — one click commits and pushes your config to GitHub, Actions takes it from there
+5. **Verify** — run `./onboard` to confirm secrets, workflows, memory, and notifications are wired up correctly. Add `--remote` to fire the check inside Actions and have the checklist arrive in your notification channel.
 
 ---
 
@@ -74,7 +75,7 @@ Click on `http://localhost:5555` to open the dashboard in your browser. From the
 | **Crypto & Markets** (16) | `token-alert`, `token-movers`, `token-report`, `token-pick`, `monitor-runners`, `on-chain-monitor`, `defi-monitor`, `defi-overview`, `market-context-refresh`, `narrative-tracker`, `monitor-polymarket`, `monitor-kalshi`, `polymarket-comments`, `unlock-monitor`, `treasury-info`, `distribute-tokens` |
 | **Social & Writing** (7) | `write-tweet`, `reply-maker`, `remix-tweets`, `refresh-x`, `tweet-roundup`, `agent-buzz`, `farcaster-digest` |
 | **Productivity** (12) | `morning-brief`, `daily-routine`, `evening-recap`, `weekly-review`, `weekly-shiplog`, `goal-tracker`, `idea-capture`, `action-converter`, `tool-builder`, `startup-idea`, `deal-flow`, `reg-monitor` |
-| **Meta / Agent** (12) | `heartbeat`, `reflect`, `self-improve`, `skill-health`, `skill-evals`, `skill-repair`, `skill-leaderboard`, `fork-contributor-leaderboard`, `skill-update-check`, `cost-report`, `rss-feed`, `update-gallery` |
+| **Meta / Agent** (13) | `heartbeat`, `reflect`, `self-improve`, `skill-health`, `skill-evals`, `skill-repair`, `skill-leaderboard`, `fork-contributor-leaderboard`, `skill-update-check`, `cost-report`, `rss-feed`, `update-gallery`, `onboard` |
 
 Full descriptions: [`skills.json`](skills.json) — or run `./add-skill aaronjmars/aeon --list`
 
@@ -275,6 +276,7 @@ CLAUDE.md                ← agent identity (auto-loaded by Claude Code)
 aeon.yml                 ← skill schedules, chains, reactive triggers, and enabled flags
 skills.json              ← machine-readable skill catalog (92 skills)
 ./aeon                   ← launch the local dashboard (Next.js on port 5555)
+./onboard                ← validate the fork's setup (secrets, workflows, channels) — see Quick start
 ./notify                 ← multi-channel notifications (Telegram, Discord, Slack, Email, json-render)
 ./notify-jsonrender      ← convert skill output to dashboard feed cards via Haiku
 ./add-skill              ← import skills from GitHub repos (with security scanning)

--- a/aeon.yml
+++ b/aeon.yml
@@ -131,6 +131,7 @@ skills:
 
   # --- Utilities ---
   auto-workflow: { enabled: false, schedule: "workflow_dispatch", var: "" } # on-demand — var: URL to analyze
+  onboard: { enabled: false, schedule: "workflow_dispatch", var: "" } # one-shot setup validator — checks secrets/workflows/memory writability and notifies a checklist with fix commands; pair with ./onboard CLI
 
   # --- Fallback (must be last) ---
   heartbeat: { enabled: true, schedule: "0 8,14,20 * * *" }

--- a/generate-skills-json
+++ b/generate-skills-json
@@ -48,7 +48,7 @@ get_category() {
     goal-tracker|idea-capture|action-converter|tool-builder|startup-idea) echo "productivity" ;;
     deal-flow|reg-monitor|heartbeat|reflect|self-improve) echo "productivity" ;;
     skill-health|skill-evals|skill-repair|skill-leaderboard|skill-update-check) echo "productivity" ;;
-    cost-report|rss-feed|update-gallery) echo "productivity" ;;
+    cost-report|rss-feed|update-gallery|onboard) echo "productivity" ;;
     *) echo "other" ;;
   esac
 }

--- a/onboard
+++ b/onboard
@@ -1,0 +1,315 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# onboard — Validate that this Aeon fork is set up correctly.
+#
+# Runs a series of checks against the local repo and (when authenticated to gh)
+# the remote secrets/workflows. Prints a colored checklist with a one-line fix
+# instruction for every gap.
+#
+# Usage:
+#   ./onboard                  Run every check, print summary, exit 0/1
+#   ./onboard --remote         Also run a workflow_dispatch of the onboard skill
+#                              so the same checklist arrives in your notification
+#                              channel.
+#   ./onboard --quiet          Suppress per-check output, print summary only
+#   ./onboard --json           Machine-readable JSON output (no colors, no fixes)
+#   ./onboard --help           Show this help
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+cd "$ROOT"
+
+REMOTE=false
+QUIET=false
+JSON=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --remote) REMOTE=true ;;
+    --quiet)  QUIET=true ;;
+    --json)   JSON=true; QUIET=true ;;
+    --help|-h)
+      sed -n '3,17p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $arg" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# --- terminal colors -------------------------------------------------------
+if [[ -t 1 ]] && [[ "$JSON" != "true" ]]; then
+  C_GREEN=$'\033[32m'; C_RED=$'\033[31m'; C_YELLOW=$'\033[33m'
+  C_BLUE=$'\033[34m'; C_DIM=$'\033[2m'; C_RESET=$'\033[0m'; C_BOLD=$'\033[1m'
+else
+  C_GREEN=""; C_RED=""; C_YELLOW=""; C_BLUE=""; C_DIM=""; C_RESET=""; C_BOLD=""
+fi
+
+# --- check accumulator -----------------------------------------------------
+PASS_COUNT=0
+WARN_COUNT=0
+FAIL_COUNT=0
+JSON_ROWS=()
+
+emit() {
+  # emit <status> <name> <detail> <fix>
+  local status="$1" name="$2" detail="$3" fix="$4"
+  case "$status" in
+    pass) PASS_COUNT=$((PASS_COUNT + 1)); icon="${C_GREEN}✓${C_RESET}" ;;
+    warn) WARN_COUNT=$((WARN_COUNT + 1)); icon="${C_YELLOW}!${C_RESET}" ;;
+    fail) FAIL_COUNT=$((FAIL_COUNT + 1)); icon="${C_RED}✗${C_RESET}" ;;
+    *)    icon="?" ;;
+  esac
+
+  if [[ "$JSON" == "true" ]]; then
+    # Escape quotes for JSON
+    local n="${name//\"/\\\"}" d="${detail//\"/\\\"}" f="${fix//\"/\\\"}"
+    JSON_ROWS+=("{\"status\":\"$status\",\"check\":\"$n\",\"detail\":\"$d\",\"fix\":\"$f\"}")
+  elif [[ "$QUIET" != "true" ]]; then
+    printf "  %s %s${C_DIM} — %s${C_RESET}\n" "$icon" "$name" "$detail"
+    if [[ "$status" != "pass" && -n "$fix" ]]; then
+      printf "      ${C_BLUE}fix:${C_RESET} %s\n" "$fix"
+    fi
+  fi
+}
+
+# --- helpers ---------------------------------------------------------------
+
+repo_slug() {
+  # Resolve owner/repo from git remote. Falls back to "" if not a github remote.
+  local url
+  url="$(git config --get remote.origin.url 2>/dev/null || echo "")"
+  if [[ "$url" == git@github.com:* ]]; then
+    echo "${url#git@github.com:}" | sed 's/\.git$//'
+  elif [[ "$url" == https://github.com/* ]]; then
+    echo "${url#https://github.com/}" | sed 's/\.git$//'
+  else
+    echo ""
+  fi
+}
+
+REPO_SLUG="$(repo_slug)"
+
+has_secret() {
+  # has_secret <NAME> — true if the secret is configured on the remote repo.
+  # Requires `gh` authenticated. Returns 2 if gh isn't available (caller decides).
+  local name="$1"
+  if ! command -v gh >/dev/null 2>&1; then return 2; fi
+  if [[ -z "$REPO_SLUG" ]]; then return 2; fi
+  if ! gh auth status >/dev/null 2>&1; then return 2; fi
+  gh secret list -R "$REPO_SLUG" --json name --jq '.[].name' 2>/dev/null \
+    | grep -qx "$name"
+}
+
+# --- header ----------------------------------------------------------------
+
+if [[ "$JSON" != "true" && "$QUIET" != "true" ]]; then
+  printf "\n${C_BOLD}Aeon onboarding check${C_RESET}"
+  if [[ -n "$REPO_SLUG" ]]; then
+    printf " ${C_DIM}— %s${C_RESET}" "$REPO_SLUG"
+  fi
+  printf "\n\n"
+fi
+
+# --- 1. workflow files exist ----------------------------------------------
+
+for wf in aeon.yml messages.yml chain-runner.yml; do
+  if [[ -f ".github/workflows/$wf" ]]; then
+    emit pass "workflow .github/workflows/$wf" "present" ""
+  else
+    emit fail "workflow .github/workflows/$wf" "missing" \
+      "Re-sync from upstream: git remote add upstream https://github.com/aaronjmars/aeon.git && git fetch upstream && git checkout upstream/main -- .github/workflows/$wf"
+  fi
+done
+
+# --- 2. aeon.yml structure -------------------------------------------------
+
+if [[ -f aeon.yml ]]; then
+  enabled_count=$(grep -cE '^\s*[a-z][a-z0-9_-]+: \{ *enabled: true' aeon.yml || true)
+  enabled_count=${enabled_count//[!0-9]/}
+  : "${enabled_count:=0}"
+  if [[ "$enabled_count" -ge 1 ]]; then
+    emit pass "aeon.yml" "$enabled_count skill(s) enabled" ""
+  else
+    emit warn "aeon.yml" "no skills enabled" \
+      "Open aeon.yml and flip 'enabled: false' → 'enabled: true' on at least one skill (heartbeat is enabled by default in the template)."
+  fi
+else
+  emit fail "aeon.yml" "missing" \
+    "Restore from upstream: git checkout upstream/main -- aeon.yml"
+fi
+
+# --- 3. memory writable ----------------------------------------------------
+
+if [[ ! -d memory ]]; then
+  emit fail "memory/" "directory missing" \
+    "mkdir -p memory/{logs,topics,issues} && touch memory/MEMORY.md"
+elif ! ( touch memory/.onboard-write-test 2>/dev/null && rm memory/.onboard-write-test 2>/dev/null ); then
+  emit fail "memory/ writable" "permission denied" \
+    "chmod -R u+w memory/"
+else
+  if [[ -f memory/MEMORY.md ]]; then
+    emit pass "memory/" "writable, MEMORY.md present" ""
+  else
+    emit warn "memory/" "writable but MEMORY.md missing" \
+      "Create with: printf '# Long-term Memory\\n' > memory/MEMORY.md"
+  fi
+fi
+
+# --- 4. authentication secret (Claude) ------------------------------------
+
+claude_secret_state="unknown"
+if has_secret ANTHROPIC_API_KEY; then
+  emit pass "auth secret" "ANTHROPIC_API_KEY configured" ""
+  claude_secret_state="ok"
+elif has_secret CLAUDE_CODE_OAUTH_TOKEN; then
+  emit pass "auth secret" "CLAUDE_CODE_OAUTH_TOKEN configured" ""
+  claude_secret_state="ok"
+else
+  case "$?" in
+    1)
+      emit fail "auth secret" "neither ANTHROPIC_API_KEY nor CLAUDE_CODE_OAUTH_TOKEN configured" \
+        "gh secret set ANTHROPIC_API_KEY --body 'sk-ant-...' -R $REPO_SLUG  (or run 'claude setup-token' and set CLAUDE_CODE_OAUTH_TOKEN)"
+      claude_secret_state="missing"
+      ;;
+    *)
+      emit warn "auth secret" "could not verify (gh not authenticated for $REPO_SLUG)" \
+        "Authenticate with 'gh auth login' to verify, or check Settings → Secrets and variables → Actions for ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN."
+      claude_secret_state="unverified"
+      ;;
+  esac
+fi
+
+# --- 5. at least one notification channel ---------------------------------
+
+channels_found=()
+channels_unverified=false
+
+check_channel() {
+  local label="$1"; shift
+  local all_present=true
+  local any_unverified=false
+  for s in "$@"; do
+    if has_secret "$s"; then
+      :
+    else
+      case "$?" in
+        1) all_present=false ;;
+        *) any_unverified=true ;;
+      esac
+    fi
+  done
+  if [[ "$all_present" == "true" && "$any_unverified" == "false" ]]; then
+    channels_found+=("$label")
+  elif [[ "$any_unverified" == "true" && "$all_present" == "true" ]]; then
+    channels_unverified=true
+  fi
+}
+
+check_channel "Telegram" TELEGRAM_BOT_TOKEN TELEGRAM_CHAT_ID
+check_channel "Discord"  DISCORD_WEBHOOK_URL
+check_channel "Slack"    SLACK_WEBHOOK_URL
+check_channel "Email"    SENDGRID_API_KEY NOTIFY_EMAIL_TO
+
+if [[ ${#channels_found[@]} -ge 1 ]]; then
+  joined=$(printf "%s, " "${channels_found[@]}")
+  joined=${joined%, }
+  emit pass "notification channel" "$joined configured" ""
+elif [[ "$channels_unverified" == "true" ]]; then
+  emit warn "notification channel" "could not verify (gh not authenticated)" \
+    "Authenticate with 'gh auth login' or check Settings → Secrets for one of: TELEGRAM_BOT_TOKEN+TELEGRAM_CHAT_ID, DISCORD_WEBHOOK_URL, SLACK_WEBHOOK_URL, SENDGRID_API_KEY+NOTIFY_EMAIL_TO."
+else
+  emit fail "notification channel" "no channel configured" \
+    "Pick one — Telegram is fastest. See README → Notifications for the @BotFather + chat_id walk-through, then: gh secret set TELEGRAM_BOT_TOKEN -R $REPO_SLUG && gh secret set TELEGRAM_CHAT_ID -R $REPO_SLUG"
+fi
+
+# --- 6. GitHub Actions has actually run -----------------------------------
+
+if [[ -n "$REPO_SLUG" ]] && command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  run_count=$(gh run list -R "$REPO_SLUG" --workflow=messages.yml --limit 1 --json status --jq 'length' 2>/dev/null || echo "0")
+  if [[ "${run_count:-0}" -ge 1 ]]; then
+    emit pass "GitHub Actions" "messages.yml has run at least once" ""
+  else
+    emit warn "GitHub Actions" "no runs yet for messages.yml" \
+      "Enable Actions: gh workflow enable messages.yml -R $REPO_SLUG  (or visit Settings → Actions → General and allow workflows)."
+  fi
+else
+  emit warn "GitHub Actions" "could not query run history" \
+    "Run 'gh auth login' and rerun ./onboard to verify."
+fi
+
+# --- 7. local memory log evidence -----------------------------------------
+
+if compgen -G "memory/logs/*.md" > /dev/null 2>&1; then
+  log_count=$(find memory/logs -maxdepth 1 -name "*.md" -type f 2>/dev/null | wc -l | tr -d ' ')
+  emit pass "skill activity log" "$log_count daily log file(s) under memory/logs/" ""
+else
+  emit warn "skill activity log" "no entries under memory/logs/ yet" \
+    "Logs appear after the first scheduled skill run. Trigger one manually: gh workflow run aeon.yml -f skill=heartbeat -R $REPO_SLUG"
+fi
+
+# --- 8. optional cross-repo PAT -------------------------------------------
+
+if has_secret GH_GLOBAL; then
+  emit pass "GH_GLOBAL (cross-repo PAT)" "configured" ""
+else
+  case "$?" in
+    1)
+      emit warn "GH_GLOBAL (cross-repo PAT)" "not configured (optional)" \
+        "Only needed if you want skills like github-monitor / pr-review / external-feature to read repos outside this one. Create a fine-grained PAT and: gh secret set GH_GLOBAL -R $REPO_SLUG"
+      ;;
+    *)
+      :  # gh unavailable — skip silently to avoid noise
+      ;;
+  esac
+fi
+
+# --- summary ---------------------------------------------------------------
+
+if [[ "$JSON" == "true" ]]; then
+  printf '{"summary":{"pass":%d,"warn":%d,"fail":%d},"checks":[' "$PASS_COUNT" "$WARN_COUNT" "$FAIL_COUNT"
+  first=true
+  for row in "${JSON_ROWS[@]}"; do
+    if [[ "$first" == "true" ]]; then first=false; else printf ','; fi
+    printf '%s' "$row"
+  done
+  printf ']}\n'
+else
+  printf "\n${C_BOLD}Summary${C_RESET}: ${C_GREEN}%d pass${C_RESET}, ${C_YELLOW}%d warn${C_RESET}, ${C_RED}%d fail${C_RESET}\n" \
+    "$PASS_COUNT" "$WARN_COUNT" "$FAIL_COUNT"
+  if [[ "$FAIL_COUNT" -eq 0 && "$WARN_COUNT" -eq 0 ]]; then
+    printf "\nAll set. Aeon should run on its next cron tick.\n\n"
+  elif [[ "$FAIL_COUNT" -eq 0 ]]; then
+    printf "\nAeon will run, but some optional pieces are missing (warnings above).\n\n"
+  else
+    printf "\nFix the ${C_RED}✗${C_RESET} items above, then rerun ${C_BOLD}./onboard${C_RESET}.\n\n"
+  fi
+fi
+
+# --- optional remote dispatch ---------------------------------------------
+
+if [[ "$REMOTE" == "true" ]]; then
+  if [[ -z "$REPO_SLUG" ]]; then
+    echo "Cannot dispatch remote check — no GitHub remote configured." >&2
+    exit 1
+  fi
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "Cannot dispatch remote check — gh CLI not installed." >&2
+    exit 1
+  fi
+  echo "Dispatching onboard skill on $REPO_SLUG ..."
+  if gh workflow run aeon.yml -R "$REPO_SLUG" -f skill=onboard >/dev/null 2>&1; then
+    echo "Dispatched. Check your notification channel within ~2 minutes."
+  else
+    echo "Failed to dispatch. Verify Actions are enabled and that aeon.yml workflow exists." >&2
+    exit 1
+  fi
+fi
+
+# Exit code: 0 if no failures, 1 otherwise.
+if [[ "$FAIL_COUNT" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: onboard
+description: One-shot setup validator — runs every check from the ./onboard CLI inside the workflow and sends the resulting checklist to the configured notification channel
+var: ""
+tags: [meta]
+---
+
+> **${var}** — Optional. Set to `--silent-on-pass` to suppress the notification when every required check passes (useful for nightly self-audits). Default: always notify.
+
+Today is ${today}. Validate that this Aeon fork is correctly set up and report the result through the operator's configured notification channels. **The point of this skill is to convert a freshly-forked, half-configured repo into a known-working state in one notification — every gap must come with the exact command that fixes it.**
+
+## When this skill runs
+
+Two contexts:
+
+1. **Manual dispatch (primary).** The operator just forked Aeon, set their secrets, and wants to confirm the agent is alive. They run `./onboard --remote` locally (or hit *Run workflow* in Actions) → this skill fires → checklist arrives in Telegram/Discord/Slack/Email.
+2. **Scheduled self-audit (optional).** Operator pins this skill to a nightly cron with `var: "--silent-on-pass"` so they only hear about it when something breaks (e.g. a notification webhook stopped working, secrets got rotated and forgotten).
+
+## Steps
+
+### 1. Run the local validator
+
+```bash
+./onboard --json > .outputs/onboard.json
+```
+
+The CLI is the canonical source of truth — every check, fix string, and exit-code rule lives there. This skill only transforms the JSON output and routes it to the right places. If `./onboard` is missing, log `ONBOARD_MISSING_CLI: ./onboard not present in repo root` and stop with no notification (the operator hasn't synced from upstream).
+
+The JSON shape:
+```json
+{
+  "summary": { "pass": 6, "warn": 1, "fail": 1 },
+  "checks": [
+    { "status": "pass", "check": "workflow .github/workflows/aeon.yml", "detail": "present", "fix": "" },
+    { "status": "fail", "check": "auth secret", "detail": "neither ANTHROPIC_API_KEY nor CLAUDE_CODE_OAUTH_TOKEN configured", "fix": "gh secret set ANTHROPIC_API_KEY ..." }
+  ]
+}
+```
+
+### 2. Decide whether to notify
+
+- If `${var}` contains `--silent-on-pass` AND `summary.fail == 0` AND `summary.warn == 0` → log `ONBOARD_OK_SILENT` and skip the notification. Still write the log entry in step 5.
+- Otherwise → continue to step 3.
+
+### 3. Build the notification body
+
+Group rows by status. Lead with the verdict so a reader who only sees the first line gets the answer.
+
+```
+*Aeon Onboarding — ${today}*
+${verdict_one_liner}
+
+✅ Passing (N)
+${pass_lines}
+
+⚠ Warnings (N)
+${warn_lines_with_fix}
+
+❌ Failing (N)
+${fail_lines_with_fix}
+
+Next: ${next_action}
+```
+
+Field rules:
+
+- **`${verdict_one_liner}`** — one of:
+  - `summary.fail == 0 && summary.warn == 0` → `"All set — Aeon will run on its next cron tick."`
+  - `summary.fail == 0 && summary.warn > 0` → `"Aeon will run, but {N} optional piece(s) missing."`
+  - `summary.fail > 0` → `"Setup incomplete — {N} required item(s) need attention before Aeon can run."`
+- **`${pass_lines}`** — one bullet per pass. Format: `• {check} — {detail}`. Cap at 6; if more, collapse the tail into `• …and {K} more`.
+- **`${warn_lines_with_fix}`** — one bullet per warning, two lines each: `• {check} — {detail}` then indented `    fix: {fix}`. Omit the section header entirely if N == 0.
+- **`${fail_lines_with_fix}`** — same shape as warnings, omit if N == 0.
+- **`${next_action}`** — derived from the highest-priority gap:
+  - any `fail` → `"Fix the ❌ items above, then rerun ./onboard --remote."`
+  - only `warn` → `"Optional improvements — Aeon will run regardless. Rerun ./onboard once addressed."`
+  - all clean → `"Nothing — you're done. Trigger your first skill: gh workflow run aeon.yml -f skill=heartbeat"`
+
+Hard cap the message at ~3500 chars (Telegram's safe limit). If exceeded, drop the `pass` section first (failures and warnings are more important).
+
+### 4. Send via `./notify`
+
+```bash
+./notify "$(cat .outputs/onboard-message.md)"
+```
+
+`./notify` fans out to every configured channel. If no channel is configured, it silently no-ops — but in that case the checklist itself flagged it under "❌ Failing", so the operator will see it next time they check Actions logs.
+
+### 5. Log to `memory/logs/${today}.md`
+
+```
+## Onboard Check
+- **Skill**: onboard
+- **Trigger**: ${manual|scheduled}
+- **Verdict**: ${verdict_one_liner}
+- **Pass / Warn / Fail**: $P / $W / $F
+- **Failing checks**: ${comma_list_of_failing_check_names_or_"none"}
+- **Notification sent**: ${yes|no — silent-on-pass|no — ./notify not configured}
+- **Status**: ONBOARD_OK | ONBOARD_DEGRADED | ONBOARD_INCOMPLETE | ONBOARD_OK_SILENT | ONBOARD_MISSING_CLI
+```
+
+`ONBOARD_OK` = 0 fail / 0 warn. `ONBOARD_DEGRADED` = 0 fail / >0 warn. `ONBOARD_INCOMPLETE` = >0 fail.
+
+### 6. Record state for trend tracking
+
+Append a single line to `memory/topics/onboard-history.md` (create with `# Onboard History` header if missing):
+
+```
+- ${today}T${time}Z — pass=$P warn=$W fail=$F status=$STATUS
+```
+
+Used by `weekly-shiplog` and any future skill that wants to spot setup drift (e.g. "GH_GLOBAL was set last week, missing this week → operator rotated the PAT and forgot to re-add it").
+
+## Edge cases
+
+- **`./onboard` exits non-zero** — that's expected when failures are present. The CLI is designed to be parseable regardless of exit code; capture stdout, ignore the exit code, and continue. Only treat actual missing-file or permission errors as fatal.
+- **JSON parse failure** — log `ONBOARD_PARSE_ERROR: <error>` and send a minimal notification with just the raw stdout (truncated to 2000 chars) plus a "validator output unparseable, raw text below — please run ./onboard locally for the full report" preamble.
+- **`./notify` not present** — log `ONBOARD_NOTIFY_MISSING` and write the message body to `articles/onboard-${today}.md` so the operator can read it from the dashboard or repo.
+- **Repeated failures across runs** — do not auto-file an issue under `memory/issues/`; this skill is operator-facing setup advice, not a degradation signal. The `skill-health` and `heartbeat` skills already cover ongoing runtime issues. Onboard's job ends at "told the operator clearly."
+
+## Sandbox note
+
+Pure local validation — no outbound network from the skill itself (other than the optional `gh secret list` calls inside `./onboard`, which use `gh`'s built-in auth via `GITHUB_TOKEN` and bypass the env-var-in-curl sandbox restriction). `./notify` and `./notify-jsonrender` route through the standard postprocess channel pattern (see CLAUDE.md), so messages send reliably even when the runtime sandbox blocks direct outbound network.
+
+## Constraints
+
+- **Never fabricate fixes.** If a check has no clean fix command, leave the `fix` field blank in `./onboard` rather than inventing one. False fixes burn trust faster than missing ones.
+- **Do not auto-mutate repo state.** Onboard is read-only by design — it suggests `gh secret set`, `chmod`, etc., but never runs them. Operators stay in control.
+- **Idempotent.** Running multiple times the same day overwrites `articles/onboard-${today}.md` and appends one line per run to `memory/topics/onboard-history.md`. The `memory/logs/${today}.md` entry is appended (multiple runs visible).
+- **One notification max per run.** Even if both stdout and JSON parsing produce output, send at most one `./notify` call.


### PR DESCRIPTION
## What

A guided setup validator for fresh Aeon forks. Two complementary surfaces:

- **`./onboard`** — local bash CLI that runs 8 checks (workflows present, `aeon.yml` has enabled skills, `memory/` writable, Claude auth secret configured, at least one notification channel configured, GitHub Actions has run, `memory/logs/` has entries, optional `GH_GLOBAL` PAT). Each gap prints a one-line `gh secret set ...` / `chmod ...` / `git checkout ...` fix command. Supports `--remote`, `--quiet`, `--json`, `--help`. Exits `1` on any failure for CI use.
- **`skills/onboard/SKILL.md`** — `workflow_dispatch` one-shot skill that runs `./onboard --json`, formats the result as a verdict + grouped checklist with embedded fix commands, and sends via `./notify`. Optional `var: "--silent-on-pass"` for nightly self-audits that only notify on regression.

## Why

Closes the silent-fork abandonment gap flagged in the 2026-04-20 `repo-actions` digest (idea #2): 32 forks exist, ~26 active, with no guided path from "fork" to "first skill running." Operators forked, set partial secrets, and went quiet because nothing told them what was missing. At the current fork-growth rate, even 20% setup-stage abandonment is a meaningful loss of community.

The local-vs-remote split matters:
- Local `./onboard` gives instant feedback while operators are still in the setup loop.
- `./onboard --remote` confirms the full GH Actions + secrets + `./notify` pipeline actually works end-to-end — catches the "I set the secret but it is not visible to Actions" failures that local-only checks would miss.

## Changes

- **`onboard`** (new, +315) — read-only validator CLI, executable, color output, JSON/quiet/remote/help modes.
- **`skills/onboard/SKILL.md`** (new, +93) — workflow_dispatch skill spec; runs the CLI, transforms JSON, sends via `./notify`, logs to `memory/logs/` and `memory/topics/onboard-history.md`.
- **`aeon.yml`** — registers `onboard` (disabled by default, `workflow_dispatch` only).
- **`generate-skills-json`** — `onboard` categorized as `productivity` so the next regen places it in the right marketplace bucket.
- **`README.md`** — Quick start step 5 ("Verify"), project-structure listing for `./onboard`, Meta/Agent skill count 12 → 13.

## How to test

```bash
git fetch origin feat/onboard-validator && git checkout feat/onboard-validator
./onboard            # local checklist with fix commands
./onboard --json     # machine-readable
./onboard --remote   # dispatches the skill in your fork's Actions; checklist arrives via Telegram/Discord/Slack
```

Sandbox note: pure local validation, no auth-required outbound HTTP. `gh secret list` calls go through `gh`'s built-in auth (bypasses the env-var-in-curl sandbox restriction documented in `CLAUDE.md`).

---
*Built autonomously by Aeon — feature skill, daily run 2026-04-22*