### PR TITLE
feat: SHOWCASE.md — active forks + ecosystem comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ The key difference: **other agents are interactive tools you use. Aeon is an aut
 
 This isn't better for everything — you still want Claude Code for writing code interactively. But for the 90% of recurring tasks that don't need you in the loop, the most autonomous agent is the one that never asks.
 
+For a comparison against the broader agent ecosystem (AutoGen, CrewAI, n8n, LangGraph) and a list of active forks running in production, see [`SHOWCASE.md`](SHOWCASE.md).
+
 ![Autonomy spectrum](./assets/autonomy.jpg)
 
 ---

--- a/SHOWCASE.md
+++ b/SHOWCASE.md
@@ -1,0 +1,72 @@
+<p align="center">
+  <img src="assets/aeon.jpg" alt="Aeon" width="80" />
+</p>
+
+<h1 align="center">Showcase</h1>
+
+<p align="center">
+  Active Aeon forks in the wild, and how Aeon compares to the agent frameworks you've already heard of.
+</p>
+
+---
+
+## Active forks
+
+A snapshot of the operators currently running their own Aeon instance. "Active" means the fork pushed within the last 30 days. Source: weekly `fork-contributor-leaderboard` and `skill-leaderboard` runs against the GitHub forks API.
+
+| Fork | Skills enabled | What it focuses on |
+|------|---------------:|--------------------|
+| [tomscaria/aeon](https://github.com/tomscaria/aeon) | 94 | The full catalog — nearly every shipped skill turned on. Single largest customizer in the fleet; accounts for the majority of all enabled skill slots across all active forks. |
+| [maacx2022/aeon](https://github.com/maacx2022/aeon) | 15 | A curated mid-size profile — picks a subset across research, code, and crypto rather than running everything. |
+| [DannyTsaii/aeon](https://github.com/DannyTsaii/aeon) | 3 | Content-leaning starter: `heartbeat` + `digest` + `idea-capture`. First fork to drive `digest` and `idea-capture` onto the leaderboard. |
+| [davenamovich/aeon](https://github.com/davenamovich/aeon) | 3 | A small, deliberate selection — uses Aeon as a low-touch personal automation. |
+| [0xfreddy/aeon](https://github.com/0xfreddy/aeon) | 2 | Ships a fork-only custom skill (`macos-apps`) alongside heartbeat — first fork to add a local-context skill that doesn't exist upstream. |
+| [pezetel/aeon](https://github.com/pezetel/aeon) | 2 | `heartbeat` + `github-trending` — a focused dev-pulse instance. The first fork to break `github-trending` out of the long tail. |
+
+The full ranking — including the per-week skill-divergence buckets and the contributor leaderboard — is regenerated every Sunday by the `fork-skill-digest` and `fork-contributor-leaderboard` skills, with the latest output published to [`articles/`](articles/).
+
+### What forks teach upstream
+
+The fleet is **infrastructure-first**: 18 of 24 active forks run only `heartbeat`. Of the rest, the most common second skills are `github-trending`, `morning-brief`, and the crypto cluster (`token-alert`, `token-movers`, `token-report`). When two or more forks independently flip the same default, the `fork-skill-digest` skill flags it as a `DEFAULT_FLIP` candidate and surfaces it for upstream consideration.
+
+If you're spinning up a new fork, the leaderboard is the cheapest map of what other operators have already validated.
+
+---
+
+## How Aeon compares
+
+Aeon is one of many ways to build agentic systems. Here's where it sits next to the other tools developers commonly evaluate.
+
+|  | **Aeon** | AutoGen | CrewAI | n8n | LangGraph |
+|--|----------|---------|--------|-----|-----------|
+| **Runtime** | GitHub Actions | Local / cloud | Local / cloud | Self-hosted or SaaS | Local / cloud |
+| **Scheduling** | Cron, native to runtime | Caller decides | Caller decides | Built-in cron triggers | Caller decides |
+| **Skill format** | Plain Markdown (`SKILL.md`) | Python classes & agents | Python crews & tasks | Visual JSON nodes | Python `StateGraph` |
+| **Persistent memory** | File-based, version-controlled | Per-session unless wired | Per-session unless wired | Per-workflow execution state | Graph state per run |
+| **Self-healing** | Yes — `heartbeat` + `skill-repair` auto-patch failing skills | No | No | No (workflow re-runs) | No |
+| **Quality scoring** | Every run scored 1–5 by Haiku | No | No | No | No |
+| **Reactive triggers** | Yes — `schedule: "reactive"` fires on conditions | Event hooks (manual) | No | Webhook nodes | No |
+| **Setup floor** | `git clone` + secrets | `pip install` + write code | `pip install` + write code | Docker or hosted account | `pip install` + write code |
+| **Hosting cost** | Free on public repos (Actions minutes) | Pay for compute | Pay for compute | Self-host or pay SaaS | Pay for compute |
+| **Operator role** | Configure once, walk away | Build & run orchestration | Build & run crews | Build & maintain workflows | Build & run graphs |
+| **External integration** | MCP server + A2A gateway | Function-calling agents | Tool-use API | 400+ pre-built integrations | Tool-use API |
+
+### One-line summary
+
+- **AutoGen** — Microsoft's multi-agent conversation framework. Best when you need multiple LLMs negotiating in a loop, in code you fully control.
+- **CrewAI** — Role-based crews with task hand-offs. Best when you're modelling a team (researcher + writer + critic) and want each role to be a discrete agent.
+- **n8n** — General-purpose visual workflow tool with a vast integration catalog. Best when the bottleneck is connecting SaaS APIs together, not the LLM step itself.
+- **LangGraph** — Stateful graph orchestration over LangChain. Best when your workflow has explicit state machines, branching, and replay needs.
+- **Aeon** — A configured-and-forgotten background agent on GitHub Actions. Best when the work is *recurring* (daily briefs, monitoring, PR reviews, research digests) and you want it to run without you, score itself, and patch itself when it breaks.
+
+The real distinction is *operator posture*. AutoGen, CrewAI, and LangGraph are libraries you build *with*. n8n is a workflow editor you build *in*. Aeon is a runtime you point at a goal and leave alone — the cron, the memory, the self-healing, and the public dashboard come included.
+
+If you need an agent you watch, pick one of the others. If you need an agent that watches itself, this is the lane.
+
+---
+
+## Add yourself
+
+Running an Aeon fork that should be on this page? Open a PR adding a row to the **Active forks** table. The weekly `fork-skill-digest` and `fork-contributor-leaderboard` skills automatically pick up active forks from the GitHub API; this page links the human-readable summary.
+
+For the comparison table, corrections from maintainers of the listed frameworks are welcome — open an issue or a PR.


### PR DESCRIPTION
## What

Adds `SHOWCASE.md` and a one-line pointer from `README.md`.

The new page has two sections:

1. **Active forks** — table of the 6 most-active forks (within the last 30 days), with skill counts and a one-line focus note for each. Sourced from the weekly `skill-leaderboard` skill output, so the data point of view matches the rest of the agent's reporting.
2. **How Aeon compares** — comparison table vs **AutoGen, CrewAI, n8n, LangGraph** plus a one-liner summary per framework. The existing in-README comparison (Aeon vs Claude Code / Hermes / OpenClaw) stays in place; this page covers the broader-ecosystem question that lands in inbound HN / MCP-registry traffic.

A small "Add yourself" note explains how forks can be listed.

## Why

From `articles/repo-actions-2026-04-26.md`, idea #2 (Repo Discovery Refresh, Growth, Small):

> Adding a SHOWCASE.md with the 5–6 most active forks and a comparison table (vs AutoGen/CrewAI/n8n/LangGraph) closes the "why Aeon vs X?" question for researchers landing from HN or MCP registries.

The repo is currently at 244 stars / 36 forks / 3 GitHub topics. Visitors landing from agent-framework comparisons have nothing to read that contextualizes Aeon against AutoGen / CrewAI / n8n / LangGraph specifically — the existing README comparison only spans the Claude-side tools (Claude Code / Hermes / OpenClaw). This page closes that gap. With the 300-star deadline approaching (May 25), discoverability is the cheapest lever.

## Changes

- `SHOWCASE.md` (new, 74 lines) — Active forks table + ecosystem comparison + one-liner summaries + Add-yourself note.
- `README.md` — single new line in the "Why most autonomous agent framework?" section pointing to `SHOWCASE.md` for the broader comparison.

## Topics (deferred — needs maintainer)

The repo-actions idea also called for expanding the GitHub topics from the current 3 (`aeon`, `ai-agents`, `claude-code`). The agent's token lacks admin scope on this repo, so the topic update needs to be applied by a maintainer:

\`\`\`bash
gh api repos/aaronjmars/aeon/topics -X PUT \\
  -f 'names[]=aeon' -f 'names[]=ai-agents' -f 'names[]=claude-code' \\
  -f 'names[]=autonomous-agents' -f 'names[]=github-actions' \\
  -f 'names[]=llm' -f 'names[]=claude' -f 'names[]=anthropic' \\
  -f 'names[]=automation' -f 'names[]=agent-framework'
\`\`\`

Zero-effort discoverability win — feels worth doing alongside this PR.

---
*Built autonomously by Aeon — triggered by `repo-actions-2026-04-26.md` idea #2*