### PR TITLE
fix(reply-maker): wire XAI prefetch case + cache-read path

### DIFF
--- a/scripts/prefetch-xai.sh
+++ b/scripts/prefetch-xai.sh
@@ -142,6 +142,27 @@ case "$SKILL" in
       "$THREE_DAYS_AGO"
     ;;
 
+  reply-maker)
+    if [ -z "$VAR" ]; then
+      echo "xai-prefetch: reply-maker has no var, skipping (skill falls back to memory logs + WebSearch)"
+      exit 0
+    fi
+    # Detect var shape: numeric → X list ID, @-prefixed → handle, anything else → topic
+    if echo "$VAR" | grep -Eq '^[0-9]+$'; then
+      xai_search "reply-maker.json" \
+        "Look at X list https://x.com/i/lists/${VAR}. Return the 12 most reply-worthy original posts (not retweets, not replies) by members of this list posted in the last 6 hours (between ${YESTERDAY} and ${TODAY}). Reply-worthy = has a take, claim, question, or framing worth engaging — NOT pure self-promo, breaking news without analysis, or threads already past 500 replies. For each: @handle, full tweet text, tweet URL, posted_at ISO timestamp, like/reply/retweet counts."
+    elif [ "${VAR#@}" != "$VAR" ]; then
+      ACCOUNT="${VAR#@}"
+      xai_search "reply-maker.json" \
+        "Search X for the 12 most reply-worthy original posts (not retweets, not replies) by @${ACCOUNT} between ${YESTERDAY} and ${TODAY}, prioritizing the last 6 hours. Reply-worthy = has a take, claim, question, or framing worth engaging — NOT pure self-promo, breaking news without analysis, or threads already past 500 replies. For each: @handle, full tweet text, tweet URL, posted_at ISO timestamp, like/reply/retweet counts." \
+        "$YESTERDAY" "$TODAY" \
+        "\"allowed_x_handles\": [\"${ACCOUNT}\"]"
+    else
+      xai_search "reply-maker.json" \
+        "Search X for 12 reply-worthy original posts on this topic: ${VAR}. Posted between ${YESTERDAY} and ${TODAY}, prioritizing the last 6 hours. Reply-worthy = has a take, claim, question, or framing worth engaging — NOT pure self-promo, breaking news without analysis, or threads already past 500 replies. Avoid threads already past 500 replies. For each: @handle, full tweet text, tweet URL, posted_at ISO timestamp, like/reply/retweet counts."
+    fi
+    ;;
+
   article)
     if [ -n "$VAR" ]; then
       xai_search "article-x.json" \

--- a/skills/reply-maker/SKILL.md
+++ b/skills/reply-maker/SKILL.md
@@ -29,6 +29,16 @@ Goal: assemble **10–15 candidates** posted in the **last 6 hours** (the high-l
 
 For every candidate, capture: `@handle`, full tweet text, tweet URL, `posted_at` (ISO), engagement counts (likes, replies, retweets if available), and a one-line **why-this-tweet** note.
 
+**Path A — pre-fetched cache (preferred).** The workflow pre-fetches Grok x_search results to `.xai-cache/reply-maker.json` (via `scripts/prefetch-xai.sh`, which has full env access and runs outside the Claude sandbox). Read it first:
+
+```bash
+jq -r '.output[] | select(.type == "message") | .content[] | select(.type == "output_text") | .text' .xai-cache/reply-maker.json
+```
+
+If parsing yields candidates, use them. The prefetch script already shapes the request based on `${var}` (numeric list ID, `@handle`, or topic) — see "Strategy depends on `${var}`" below for the contract it implements.
+
+**Path B — direct curl:** Skipped. The sandbox blocks env-var-authenticated curl; do not attempt at runtime.
+
 Strategy depends on `${var}`:
 
 **If `${var}` looks like an X list ID** (numeric):
@@ -52,7 +62,7 @@ curl -s -X POST "https://api.x.ai/v1/responses" \
 **If `${var}` is a topic** (or empty): same call with `${var}` (or top 2–3 topics from `memory/MEMORY.md`) as the search query. When empty, also pull tweet candidates surfaced in the last 2 days of `tweet-roundup` and `list-digest` logs as a backup pool.
 
 **Fallback chain** (use in order until you have ≥3 candidates):
-1. XAI x_search (above)
+1. Pre-fetched XAI cache at `.xai-cache/reply-maker.json` (Path A above)
 2. Recent `list-digest` + `tweet-roundup` outputs in `memory/logs/` — already have URLs and handles
 3. WebSearch for very recent posts on memory topics (filter: posted within last 6h, original post not reply)
 
@@ -154,7 +164,7 @@ Edit this list as tastes change — any draft reply containing one of these (ope
 
 ## Sandbox note
 
-The sandbox may block outbound curl. Use **WebFetch** as a fallback for any URL fetch. For auth-required APIs (XAI), use the pre-fetch pattern: write request JSON to `.xai-cache/reply-maker-${date}-${hour}.json` if you build a prefetch script later, or fall through to the memory/WebSearch fallback chain.
+The sandbox blocks outbound curl with `$XAI_API_KEY` in headers — always read the pre-fetched `.xai-cache/reply-maker.json` (populated by `scripts/prefetch-xai.sh`) or fall through to the memory/WebSearch fallback chain. Do not attempt direct curl to `api.x.ai` at runtime. Use **WebFetch** for any non-auth URL fetches.
 
 ## Environment Variables Required
 


### PR DESCRIPTION
## Summary

`scripts/prefetch-xai.sh` already has cases for `tweet-roundup` and `narrative-tracker`, both of which read their cached JSON in their respective SKILL.md files. `reply-maker` never got the same wiring, so under the sandbox-blocks-auth-curl pattern it has no usable XAI path at all — the SKILL.md fallback chain leads with a runtime curl that's documented to be blocked.

## Changes

- `scripts/prefetch-xai.sh` — add a `reply-maker)` case. It mirrors the var-shape contract in the SKILL.md:
  - numeric → treat as X list ID
  - `@`-prefixed → handle, with `allowed_x_handles` filter on the `x_search` tool
  - anything else → topic
  - empty → skip cleanly so the skill falls through to its memory-logs / WebSearch path
- `skills/reply-maker/SKILL.md` — add **Path A** (read `.xai-cache/reply-maker.json` first) and **Path B** (runtime curl is skipped under sandbox) at the top of step 1, matching the structure already used by `tweet-roundup` and `narrative-tracker`. Renumber the fallback chain to lead with the cache. Tighten the Sandbox note to point at the new prefetch artifact instead of the speculative `reply-maker-${date}-${hour}.json` filename it had before.

## Context

When running `reply-maker` on GitHub Actions, sandboxed curl with `$XAI_API_KEY` in headers fails (per CLAUDE.md "Sandbox Limitations"). Without a prefetch case, the skill drops straight to `memory/logs/` + WebSearch every run, which is exactly the structural throttle the prefetch pattern was designed to remove.

Pattern is already validated by `tweet-roundup` (`.xai-cache/roundup-var.json`) and `narrative-tracker` (`.xai-cache/narratives.json`).

---
Built by [Aeon](https://github.com/aaronjmars/aeon)