### PR TITLE
fix(dashboard/skills/run): use execFileSync to harden against shell injection

### DIFF
--- a/dashboard/app/api/skills/[name]/run/route.ts
+++ b/dashboard/app/api/skills/[name]/run/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server'
-import { execSync } from 'child_process'
+import { execFileSync } from 'child_process'
 import { resolve } from 'path'
 
 const REPO_ROOT = resolve(process.cwd(), '..')
@@ -29,11 +29,11 @@ export async function POST(
       }
     } catch { /* no body is fine */ }
 
-    let cmd = `gh workflow run aeon.yml -f skill=${name}`
-    if (skillVar) cmd += ` -f var=${JSON.stringify(skillVar)}`
-    if (model) cmd += ` -f model=${JSON.stringify(model)}`
+    const args = ['workflow', 'run', 'aeon.yml', '-f', `skill=${name}`]
+    if (skillVar) args.push('-f', `var=${skillVar}`)
+    if (model) args.push('-f', `model=${model}`)
 
-    execSync(cmd, { stdio: 'pipe', cwd: REPO_ROOT })
+    execFileSync('gh', args, { stdio: 'pipe', cwd: REPO_ROOT })
 
     return NextResponse.json({ ok: true })
   } catch (error: unknown) {


### PR DESCRIPTION
## Summary

Mirror of #150's hardening on the dashboard's `gh secret set/delete` endpoints — applies the same `execFileSync` swap to the workflow_dispatch trigger at `dashboard/app/api/skills/[name]/run/route.ts`, the only remaining `execSync` path that interpolates user-supplied input (`var`, `model`).

## Changes

- `dashboard/app/api/skills/[name]/run/route.ts` — replace `execSync` (string command) with `execFileSync` (file + args array). Drop the `JSON.stringify` shell-quoting on `var`/`model` — those quotes only existed to survive the bash round-trip, and gh receives `-f key=value` directly.

## Context

The character whitelist on `var` (line 25) and `model` (line 28) already strips shell metacharacters, so this is defense-in-depth rather than fixing a live exploit. But it makes the dashboard's three `gh`-shelling endpoints (`secrets`, `auth`, and now `skills/run`) consistent with the pattern #150 set, and removes the only place where dashboard input still touches a shell.

I checked the other dashboard `execSync` call sites (`auth`, `analytics`, `runs`, `runs/[id]/logs`, `outputs`, `sync`, `skills` GET); all use hardcoded commands or pre-validated digit-only IDs. Nothing else to change.

---
Built by [Aeon](https://github.com/aaronjmars/aeon-aaron)
