### PR TITLE
fix(dashboard): pass -R repo to gh commands so multi-remote setups work

### DIFF
--- a/dashboard/app/api/auth/route.ts
+++ b/dashboard/app/api/auth/route.ts
@@ -10,13 +10,25 @@ function ghAvailable(): boolean {
   }
 }
 
+function ghRepoFlag(): string {
+  try {
+    const repo = execSync('gh repo set-default --view', { stdio: 'pipe' }).toString().trim()
+    if (repo && repo !== 'no default repository has been set') return ` -R ${repo}`
+  } catch {}
+  try {
+    const repo = execSync('gh repo view --json nameWithOwner -q .nameWithOwner', { stdio: 'pipe' }).toString().trim()
+    if (repo) return ` -R ${repo}`
+  } catch {}
+  return ''
+}
+
 export async function GET() {
   // Check if ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is set
   try {
     if (!ghAvailable()) {
       return NextResponse.json({ authenticated: false, error: 'gh CLI not authenticated' })
     }
-    const out = execSync('gh secret list --json name -q ".[].name"', {
+    const out = execSync(`gh secret list${ghRepoFlag()} --json name -q ".[].name"`, {
       stdio: 'pipe',
     }).toString().trim()
     const secrets = out ? out.split('\n').filter(Boolean) : []
@@ -43,7 +55,7 @@ export async function POST(request: Request) {
       // API keys (sk-ant-api) → ANTHROPIC_API_KEY
       const isOauth = key.startsWith('sk-ant-oat')
       const secretName = isOauth ? 'CLAUDE_CODE_OAUTH_TOKEN' : 'ANTHROPIC_API_KEY'
-      execSync(`gh secret set ${secretName}`, {
+      execSync(`gh secret set${ghRepoFlag()} ${secretName}`, {
         input: key,
         stdio: ['pipe', 'pipe', 'pipe'],
       })
@@ -81,7 +93,7 @@ export async function POST(request: Request) {
     }
     const token = tokenChars.join('')
 
-    execSync('gh secret set CLAUDE_CODE_OAUTH_TOKEN', {
+    execSync(`gh secret set${ghRepoFlag()} CLAUDE_CODE_OAUTH_TOKEN`, {
       input: token,
       stdio: ['pipe', 'pipe', 'pipe'],
     })

--- a/dashboard/app/api/auth/route.ts
+++ b/dashboard/app/api/auth/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server'
-import { execSync } from 'child_process'
+import { execFileSync, execSync } from 'child_process'
 
 function ghAvailable(): boolean {
   try {
@@ -10,16 +10,21 @@ function ghAvailable(): boolean {
   }
 }
 
-function ghRepoFlag(): string {
+function ghRepo(): string | null {
   try {
     const repo = execSync('gh repo set-default --view', { stdio: 'pipe' }).toString().trim()
-    if (repo && repo !== 'no default repository has been set') return ` -R ${repo}`
+    if (repo && !repo.startsWith('no default')) return repo
   } catch {}
   try {
     const repo = execSync('gh repo view --json nameWithOwner -q .nameWithOwner', { stdio: 'pipe' }).toString().trim()
-    if (repo) return ` -R ${repo}`
+    if (repo) return repo
   } catch {}
-  return ''
+  return null
+}
+
+function ghArgsRepo(): string[] {
+  const repo = ghRepo()
+  return repo ? ['-R', repo] : []
 }
 
 export async function GET() {
@@ -28,7 +33,7 @@ export async function GET() {
     if (!ghAvailable()) {
       return NextResponse.json({ authenticated: false, error: 'gh CLI not authenticated' })
     }
-    const out = execSync(`gh secret list${ghRepoFlag()} --json name -q ".[].name"`, {
+    const out = execFileSync('gh', ['secret', 'list', ...ghArgsRepo(), '--json', 'name', '-q', '.[].name'], {
       stdio: 'pipe',
     }).toString().trim()
     const secrets = out ? out.split('\n').filter(Boolean) : []
@@ -55,7 +60,7 @@ export async function POST(request: Request) {
       // API keys (sk-ant-api) → ANTHROPIC_API_KEY
       const isOauth = key.startsWith('sk-ant-oat')
       const secretName = isOauth ? 'CLAUDE_CODE_OAUTH_TOKEN' : 'ANTHROPIC_API_KEY'
-      execSync(`gh secret set${ghRepoFlag()} ${secretName}`, {
+      execFileSync('gh', ['secret', 'set', secretName, ...ghArgsRepo()], {
         input: key,
         stdio: ['pipe', 'pipe', 'pipe'],
       })
@@ -93,7 +98,7 @@ export async function POST(request: Request) {
     }
     const token = tokenChars.join('')
 
-    execSync(`gh secret set${ghRepoFlag()} CLAUDE_CODE_OAUTH_TOKEN`, {
+    execFileSync('gh', ['secret', 'set', 'CLAUDE_CODE_OAUTH_TOKEN', ...ghArgsRepo()], {
       input: token,
       stdio: ['pipe', 'pipe', 'pipe'],
     })

--- a/dashboard/app/api/secrets/route.ts
+++ b/dashboard/app/api/secrets/route.ts
@@ -57,11 +57,7 @@ function ghArgsRepo(): string[] {
 
 function listSecrets(): string[] {
   try {
-    const repo = ghRepo()
-    const cmd = repo
-      ? `gh secret list -R ${repo} --json name -q ".[].name"`
-      : 'gh secret list --json name -q ".[].name"'
-    const out = execSync(cmd, {
+    const out = execFileSync('gh', ['secret', 'list', ...ghArgsRepo(), '--json', 'name', '-q', '.[].name'], {
       stdio: 'pipe',
       cwd: process.cwd(),
     }).toString().trim()

--- a/dashboard/app/api/secrets/route.ts
+++ b/dashboard/app/api/secrets/route.ts
@@ -38,9 +38,30 @@ function ghAvailable(): boolean {
   }
 }
 
+function ghRepo(): string | null {
+  try {
+    const repo = execSync('gh repo set-default --view', { stdio: 'pipe' }).toString().trim()
+    if (repo && !repo.startsWith('no default')) return repo
+  } catch {}
+  try {
+    const repo = execSync('gh repo view --json nameWithOwner -q .nameWithOwner', { stdio: 'pipe' }).toString().trim()
+    if (repo) return repo
+  } catch {}
+  return null
+}
+
+function ghArgsRepo(): string[] {
+  const repo = ghRepo()
+  return repo ? ['-R', repo] : []
+}
+
 function listSecrets(): string[] {
   try {
-    const out = execSync('gh secret list --json name -q ".[].name"', {
+    const repo = ghRepo()
+    const cmd = repo
+      ? `gh secret list -R ${repo} --json name -q ".[].name"`
+      : 'gh secret list --json name -q ".[].name"'
+    const out = execSync(cmd, {
       stdio: 'pipe',
       cwd: process.cwd(),
     }).toString().trim()
@@ -93,7 +114,7 @@ export async function POST(request: Request) {
   }
 
   try {
-    execFileSync('gh', ['secret', 'set', name, '-b', value], {
+    execFileSync('gh', ['secret', 'set', name, ...ghArgsRepo(), '-b', value], {
       stdio: 'pipe',
       cwd: process.cwd(),
     })
@@ -116,7 +137,7 @@ export async function DELETE(request: Request) {
   }
 
   try {
-    execFileSync('gh', ['secret', 'delete', name], { stdio: 'pipe', cwd: process.cwd() })
+    execFileSync('gh', ['secret', 'delete', name, ...ghArgsRepo()], { stdio: 'pipe', cwd: process.cwd() })
     return NextResponse.json({ ok: true })
   } catch (error: unknown) {
     const msg = error instanceof Error ? error.message : 'Failed to delete secret'


### PR DESCRIPTION
Split of #167 — dashboard fix only. Sync-upstream workflow lives in a separate PR.

## Summary

The README recommends a two-repo strategy: run production from a private fork and add the public upstream as a second remote. As soon as `upstream` is added, the dashboard's auth and secrets API routes break:

```
multiple remotes detected. please specify which repo to use by providing the -R, --repo argument
```

`gh secret list/set/delete` errors out because it can't pick a default repo. Auth modal and any change in the Secrets panel return HTTP 500.

## Fix

Both routes resolve the active repo once via `gh repo set-default --view` (with `gh repo view --json nameWithOwner` as fallback) and pass it to every `gh` invocation via `-R`. When only a single remote is present, the helper falls back to no flag so single-remote forks are unchanged.

Files touched:
- `dashboard/app/api/auth/route.ts` — GET (list) + POST (set) paths
- `dashboard/app/api/secrets/route.ts` — GET (list) + POST (set) + DELETE paths

## Test plan

- [x] On a fork with `origin` + `upstream` remotes, paste a token into the Auth modal → 200, secret lands.
- [x] On a fork with `origin` + `upstream` remotes, set/delete custom secrets in the Secrets panel → 200, secret lands.
- [x] On a fork with only `origin`, both flows still work unchanged.

Credit: @traewang (original PR #167)