### PR TITLE
fix(dashboard): wire gateway prop through TopBar + SkillDetail

### DIFF
--- a/dashboard/app/page.tsx
+++ b/dashboard/app/page.tsx
@@ -112,7 +112,7 @@ export default function Dashboard() {
           )}
           {skill && (
             <SkillDetail
-              skill={skill} runs={runs} model={model} busy={busy}
+              skill={skill} runs={runs} model={model} gateway={gateway} busy={busy}
               onToggle={toggleSkill} onRun={runSkill} onDelete={deleteSkill}
               onUpdateSchedule={updateSchedule} onUpdateVar={updateVar} onUpdateModel={updateSkillModel}
               onViewRun={() => {}}

--- a/dashboard/components/SkillDetail.tsx
+++ b/dashboard/components/SkillDetail.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import type { Skill, Run } from '../lib/types'
-import { MODELS, DEPARTMENTS } from '../lib/constants'
+import { MODELS, BANKR_EXTRA_MODELS, DEPARTMENTS } from '../lib/constants'
 import { displayName, initials, getSkillStatus, cronLabel, statusDot, inputCls } from '../lib/utils'
 import { ScheduleEditor } from './ScheduleEditor'
 import { timeAgo } from '../lib/utils'
@@ -11,6 +11,7 @@ interface SkillDetailProps {
   skill: Skill
   runs: Run[]
   model: string
+  gateway: 'direct' | 'bankr'
   busy: Record<string, boolean>
   onToggle: (name: string, enabled: boolean) => void
   onRun: (name: string, v?: string, m?: string) => void
@@ -21,7 +22,8 @@ interface SkillDetailProps {
   onViewRun: (run: Run) => void
 }
 
-export function SkillDetail({ skill, runs, model, busy, onToggle, onRun, onDelete, onUpdateSchedule, onUpdateVar, onUpdateModel, onViewRun }: SkillDetailProps) {
+export function SkillDetail({ skill, runs, model, gateway, busy, onToggle, onRun, onDelete, onUpdateSchedule, onUpdateVar, onUpdateModel, onViewRun }: SkillDetailProps) {
+  const modelOptions = gateway === 'bankr' ? [...MODELS, ...BANKR_EXTRA_MODELS] : MODELS
   const [editingSchedule, setEditingSchedule] = useState(false)
   const [editingVar, setEditingVar] = useState(false)
   const [varDraft, setVarDraft] = useState('')
@@ -90,8 +92,8 @@ export function SkillDetail({ skill, runs, model, busy, onToggle, onRun, onDelet
       <div className="card-hst p-[var(--space-md)]">
         <div className="text-label mb-[var(--space-sm)]">Capability Level</div>
         <select value={skill.model} onChange={(e) => onUpdateModel(skill.name, e.target.value)} className="bg-white text-eva-black text-xs px-3 py-2 border-2 border-[rgba(10,10,10,0.08)] outline-none font-mono w-full cursor-pointer focus:border-eva-orange transition-colors">
-          <option value="">Default ({MODELS.find(m => m.id === model)?.label})</option>
-          {MODELS.map(m => <option key={m.id} value={m.id}>{m.label}</option>)}
+          <option value="">Default ({modelOptions.find(m => m.id === model)?.label ?? model})</option>
+          {modelOptions.map(m => <option key={m.id} value={m.id}>{m.label}</option>)}
         </select>
       </div>
 

--- a/dashboard/components/TopBar.tsx
+++ b/dashboard/components/TopBar.tsx
@@ -1,5 +1,5 @@
 import type { Skill } from '../lib/types'
-import { MODELS, DEPARTMENTS } from '../lib/constants'
+import { MODELS, BANKR_EXTRA_MODELS, DEPARTMENTS } from '../lib/constants'
 import { displayName } from '../lib/utils'
 
 interface TopBarProps {
@@ -7,6 +7,7 @@ interface TopBarProps {
   view: 'hq' | 'secrets'
   repo: string
   model: string
+  gateway: 'direct' | 'bankr'
   authStatus: { authenticated: boolean } | null
   authLoading: boolean
   pulling: boolean
@@ -20,8 +21,9 @@ interface TopBarProps {
   onSync: () => void
 }
 
-export function TopBar({ skill, view, repo, model, authStatus, authLoading, pulling, syncing, hasChanges, behind, onSetupAuth, onUpdateModel, onShowImport, onPull, onSync }: TopBarProps) {
+export function TopBar({ skill, view, repo, model, gateway, authStatus, authLoading, pulling, syncing, hasChanges, behind, onSetupAuth, onUpdateModel, onShowImport, onPull, onSync }: TopBarProps) {
   const dept = skill?.tags?.[0] ? DEPARTMENTS[skill.tags[0]] : null
+  const modelOptions = gateway === 'bankr' ? [...MODELS, ...BANKR_EXTRA_MODELS] : MODELS
 
   return (
     <div className="h-12 border-b-2 border-[rgba(10,10,10,0.06)] flex items-center justify-between px-5 shrink-0 bg-white">
@@ -30,9 +32,10 @@ export function TopBar({ skill, view, repo, model, authStatus, authLoading, pull
         {skill && dept && <span className="text-[11px] font-mono px-2 py-0.5" style={{ backgroundColor: dept.color + '15', color: dept.color }}>{dept.label}</span>}
       </div>
       <div className="flex items-center gap-2">
+        {gateway === 'bankr' && <span className="text-[11px] font-mono px-2 py-0.5 bg-eva-orange/15 text-eva-orange uppercase tracking-[1px]">Bankr</span>}
         {authStatus && !authStatus.authenticated && <button onClick={onSetupAuth} disabled={authLoading} className="bg-eva-orange text-white text-[11px] px-3 py-1.5 font-mono uppercase tracking-[1px] hover:opacity-90 transition-opacity disabled:opacity-50">{authLoading ? '...' : 'Auth'}</button>}
         <select value={model} onChange={(e) => onUpdateModel(e.target.value)} className="bg-white text-primary-70 text-[11px] px-2.5 py-1.5 border-2 border-[rgba(10,10,10,0.08)] outline-none cursor-pointer font-mono">
-          {MODELS.map(m => <option key={m.id} value={m.id}>{m.label}</option>)}
+          {modelOptions.map(m => <option key={m.id} value={m.id}>{m.label}</option>)}
         </select>
         <button onClick={onShowImport} className="bg-eva-black text-white text-[11px] px-3 py-1.5 font-mono uppercase tracking-[1px] hover:opacity-90 transition-opacity">+ Hire</button>
         {repo && <a href={`https://github.com/${repo}`} target="_blank" rel="noopener noreferrer" className="text-[11px] text-primary-40 font-mono border-2 border-[rgba(10,10,10,0.08)] px-3 py-1.5 hover:border-eva-orange hover:text-eva-orange transition-colors">GitHub</a>}

--- a/dashboard/lib/constants.ts
+++ b/dashboard/lib/constants.ts
@@ -4,6 +4,14 @@ export const MODELS = [
   { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5' },
 ]
 
+export const BANKR_EXTRA_MODELS = [
+  { id: 'gemini-3-pro', label: 'Gemini 3 Pro' },
+  { id: 'gemini-3-flash', label: 'Gemini 3 Flash' },
+  { id: 'gpt-5.2', label: 'GPT-5.2' },
+  { id: 'kimi-k2.5', label: 'Kimi K2.5' },
+  { id: 'qwen3-coder', label: 'Qwen3 Coder' },
+]
+
 export const DAYS = [
   { label: 'All', value: -1 }, { label: 'Mon', value: 1 }, { label: 'Tue', value: 2 },
   { label: 'Wed', value: 3 }, { label: 'Thu', value: 4 }, { label: 'Fri', value: 5 },


### PR DESCRIPTION
## Summary

The April Bankr Gateway commit (d992eff) introduced `gateway` state in `page.tsx` and passed it to `<TopBar>`, but the `TopBar` component itself was never updated to accept the prop. As a result, `dashboard/app/page.tsx:99` has been failing typecheck on `main` ever since:

```
Type '{ ...; gateway: "direct" | "bankr"; ... }' is not assignable to type 'IntrinsicAttributes & TopBarProps'.
  Property 'gateway' does not exist on type 'IntrinsicAttributes & TopBarProps'.
```

This PR finishes the work that commit message described ("show Bankr badge", "make model dropdowns gateway-aware").

## Changes

- `TopBar` accepts `gateway`, shows a "Bankr" badge when `gateway === 'bankr'`, and extends the model dropdown with the non-Claude Bankr models.
- `SkillDetail` does the same for the per-skill override dropdown.
- `BANKR_EXTRA_MODELS` added to `lib/constants.ts` — Gemini 3 Pro / Flash, GPT-5.2, Kimi K2.5, Qwen3 Coder (matches the gateway model table in `README.md`).
- The "Default (…)" label in `SkillDetail` now degrades to the raw model id if it isn't in either list (previously rendered `Default (undefined)` for unknown ids).

## Test plan

- [x] `tsc --noEmit` in `dashboard/` is clean (was failing on `page.tsx:99` before).
- [ ] On a fork with `gateway.provider: bankr` in `aeon.yml`, the "Bankr" badge appears in the header and the model dropdown lists Gemini / GPT / Kimi / Qwen alongside Claude.
- [ ] On a fork with the default direct gateway, dropdown still shows only Claude models (no behaviour change).