### PR TITLE
chore(aeon.yml): enable 4 stalled announcement skills

### DIFF
--- a/aeon.yml
+++ b/aeon.yml
@@ -66,8 +66,8 @@ skills:
   repo-article: { enabled: false, schedule: "0 15 * * *" }
   repo-actions: { enabled: false, schedule: "0 15 * * *" }
   repo-pulse: { enabled: false, schedule: "0 15 * * *" }
-  star-milestone: { enabled: false, schedule: "15 15 * * *" } # daily — announce when watched repos cross star-count milestones
-  star-momentum-alert: { enabled: false, schedule: "10 10 * * *", model: "claude-sonnet-4-6", var: "" } # daily — project next milestone crossing date from 14-day repo-pulse history; alert only when projected date lands in 7-14d window on Tue/Wed/Thu (Show HN dispatch slot)
+  star-milestone: { enabled: true, schedule: "15 15 * * *" } # daily — announce when watched repos cross star-count milestones
+  star-momentum-alert: { enabled: true, schedule: "10 10 * * *", model: "claude-sonnet-4-6", var: "" } # daily — project next milestone crossing date from 14-day repo-pulse history; alert only when projected date lands in 7-14d window on Tue/Wed/Thu (Show HN dispatch slot)
   project-lens: { enabled: false, schedule: "30 15 * * 1,3,5" } # articles through rotating analytical lenses
   repo-scanner: { enabled: false, schedule: "0 15 * * 0", model: "claude-sonnet-4-6", var: "" } # catalog all GitHub repos — set var to username
 
@@ -96,7 +96,7 @@ skills:
 
   # --- Feed generation (5:30 PM UTC, after content skills) ---
   rss-feed: { enabled: false, schedule: "30 17 * * *" }
-  thread-formatter: { enabled: false, schedule: "30 17 * * *", var: "" } # score today's events from memory/logs and format the top one as a 5-tweet thread ready to paste; no-op silently on quiet days
+  thread-formatter: { enabled: true, schedule: "30 17 * * *", var: "" } # score today's events from memory/logs and format the top one as a 5-tweet thread ready to paste; no-op silently on quiet days
 
   # --- Gallery update (Sunday 6 PM UTC, after content week) ---
   update-gallery: { enabled: false, schedule: "0 18 * * 0" }
@@ -144,7 +144,7 @@ skills:
   skill-graph: { enabled: false, schedule: "0 17 * * 0" } # Sunday — regenerate skill dependency map
   skill-freshness: { enabled: false, schedule: "0 8 * * *", model: "claude-sonnet-4-6", var: "" } # daily 08:00 UTC — audit enabled skills' upstream file dependencies for staleness; pass dry-run to skip notify; per-class thresholds (articles 28h / .outputs 4h / topics 7d / state 30d); fingerprint-based dedup, 7d re-emit window
   smithery-manifest: { enabled: false, schedule: "0 6 1/7 * *", model: "claude-sonnet-4-6" } # weekly — refresh docs/smithery-manifest.json + smithery.yaml + smithery-submission.md from skills.json + aeon-mcp; PR + notify only on diff
-  show-hn-draft: { enabled: false, schedule: "workflow_dispatch", var: "" } # one-shot — draft Show HN post + r/MachineLearning + r/selfhosted variants from live repo state, ready for the operator to paste at launch time. Set var to one of {show-hn, r/MachineLearning, r/selfhosted} to regenerate that single variant.
+  show-hn-draft: { enabled: true, schedule: "workflow_dispatch", var: "" } # one-shot — draft Show HN post + r/MachineLearning + r/selfhosted variants from live repo state, ready for the operator to paste at launch time. Set var to one of {show-hn, r/MachineLearning, r/selfhosted} to regenerate that single variant.
   v4-readiness: { enabled: false, schedule: "workflow_dispatch", model: "claude-sonnet-4-6", var: "" } # one-shot — per-fork v4 upgrade readiness checklist. Reads aeon.yml + skills.json + MEMORY.md against an embedded v4 change manifest; emits Safe / Review / Custom / Action breakdown. Pass dry-run to skip notify, or owner/repo to audit a fork remotely.
 
   # --- Utilities ---


### PR DESCRIPTION
## Summary
Escalation: 3 days unresolved. Flips `enabled: true` on four announcement skills that have been sitting disabled past the relevant trigger window.

| Skill | Source PR | Trigger / rationale |
|---|---|---|
| `star-milestone` | #39 | 300⭐️ crossed 2026-05-12; now 308⭐️ — daily milestone announcer should be live |
| `star-momentum-alert` | #159 | Projects next milestone date from 14d pulse — needed now that we're past 300 |
| `thread-formatter` | #148 | Scored 16+ on the ATH-crossing day — should have posted |
| `show-hn-draft` | #151 | One-shot (workflow_dispatch); immediately applicable |

## Test plan
- [ ] Confirm next scheduled run of `star-milestone` (15:15 UTC) fires
- [ ] Confirm `star-momentum-alert` (10:10 UTC) produces a projection
- [ ] Confirm `thread-formatter` (17:30 UTC) scores today's events
- [ ] Manually dispatch `show-hn-draft` workflow once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)