### PR TITLE
fix(dashboard): pass -R repo to gh run list/view so multi-remote setups work

### DIFF
--- a/dashboard/app/api/analytics/route.ts
+++ b/dashboard/app/api/analytics/route.ts
@@ -1,9 +1,26 @@
 import { NextResponse } from 'next/server'
-import { execSync } from 'child_process'
+import { execFileSync, execSync } from 'child_process'
 import { resolve } from 'path'
 import { readdirSync, readFileSync } from 'fs'
 
 const REPO_ROOT = resolve(process.cwd(), '..')
+
+function ghRepo(): string | null {
+  try {
+    const repo = execSync('gh repo set-default --view', { stdio: 'pipe', cwd: REPO_ROOT }).toString().trim()
+    if (repo && !repo.startsWith('no default')) return repo
+  } catch {}
+  try {
+    const repo = execSync('gh repo view --json nameWithOwner -q .nameWithOwner', { stdio: 'pipe', cwd: REPO_ROOT }).toString().trim()
+    if (repo) return repo
+  } catch {}
+  return null
+}
+
+function ghArgsRepo(): string[] {
+  const repo = ghRepo()
+  return repo ? ['-R', repo] : []
+}
 
 interface RunRecord {
   name: string
@@ -35,8 +52,9 @@ interface Insight {
 export async function GET() {
   try {
     // Fetch up to 200 recent runs from GitHub Actions
-    const out = execSync(
-      'gh run list --json name,status,conclusion,createdAt,updatedAt --limit 200',
+    const out = execFileSync(
+      'gh',
+      ['run', 'list', ...ghArgsRepo(), '--json', 'name,status,conclusion,createdAt,updatedAt', '--limit', '200'],
       { stdio: 'pipe', cwd: REPO_ROOT, timeout: 30000 },
     ).toString()
     const raw: RunRecord[] = JSON.parse(out)

--- a/dashboard/app/api/runs/[id]/logs/route.ts
+++ b/dashboard/app/api/runs/[id]/logs/route.ts
@@ -1,8 +1,25 @@
 import { NextResponse } from 'next/server'
-import { execSync } from 'child_process'
+import { execFileSync, execSync } from 'child_process'
 import { resolve } from 'path'
 
 const REPO_ROOT = resolve(process.cwd(), '..')
+
+function ghRepo(): string | null {
+  try {
+    const repo = execSync('gh repo set-default --view', { stdio: 'pipe', cwd: REPO_ROOT }).toString().trim()
+    if (repo && !repo.startsWith('no default')) return repo
+  } catch {}
+  try {
+    const repo = execSync('gh repo view --json nameWithOwner -q .nameWithOwner', { stdio: 'pipe', cwd: REPO_ROOT }).toString().trim()
+    if (repo) return repo
+  } catch {}
+  return null
+}
+
+function ghArgsRepo(): string[] {
+  const repo = ghRepo()
+  return repo ? ['-R', repo] : []
+}
 
 export async function GET(
   _request: Request,
@@ -16,9 +33,12 @@ export async function GET(
       return NextResponse.json({ error: 'Invalid run ID' }, { status: 400 })
     }
 
+    const repoArgs = ghArgsRepo()
+
     // Get run status first
-    const infoRaw = execSync(
-      `gh run view ${id} --json status,conclusion,displayTitle,jobs`,
+    const infoRaw = execFileSync(
+      'gh',
+      ['run', 'view', id, ...repoArgs, '--json', 'status,conclusion,displayTitle,jobs'],
       { stdio: 'pipe', cwd: REPO_ROOT, timeout: 15000 },
     ).toString()
     const info = JSON.parse(infoRaw)
@@ -26,10 +46,8 @@ export async function GET(
     // Get logs — use --log-failed for failed runs, --log for completed
     let logs = ''
     try {
-      const logCmd = info.conclusion === 'failure'
-        ? `gh run view ${id} --log-failed`
-        : `gh run view ${id} --log`
-      logs = execSync(logCmd, {
+      const logFlag = info.conclusion === 'failure' ? '--log-failed' : '--log'
+      logs = execFileSync('gh', ['run', 'view', id, ...repoArgs, logFlag], {
         stdio: 'pipe',
         cwd: REPO_ROOT,
         timeout: 30000,

--- a/dashboard/app/api/runs/route.ts
+++ b/dashboard/app/api/runs/route.ts
@@ -1,13 +1,31 @@
 import { NextResponse } from 'next/server'
-import { execSync } from 'child_process'
+import { execFileSync, execSync } from 'child_process'
 import { resolve } from 'path'
 
 const REPO_ROOT = resolve(process.cwd(), '..')
 
+function ghRepo(): string | null {
+  try {
+    const repo = execSync('gh repo set-default --view', { stdio: 'pipe', cwd: REPO_ROOT }).toString().trim()
+    if (repo && !repo.startsWith('no default')) return repo
+  } catch {}
+  try {
+    const repo = execSync('gh repo view --json nameWithOwner -q .nameWithOwner', { stdio: 'pipe', cwd: REPO_ROOT }).toString().trim()
+    if (repo) return repo
+  } catch {}
+  return null
+}
+
+function ghArgsRepo(): string[] {
+  const repo = ghRepo()
+  return repo ? ['-R', repo] : []
+}
+
 export async function GET() {
   try {
-    const out = execSync(
-      'gh run list --json databaseId,name,status,conclusion,createdAt,url,displayTitle --limit 20',
+    const out = execFileSync(
+      'gh',
+      ['run', 'list', ...ghArgsRepo(), '--json', 'databaseId,name,status,conclusion,createdAt,url,displayTitle', '--limit', '20'],
       { stdio: 'pipe', cwd: REPO_ROOT },
     ).toString()
     const raw = JSON.parse(out)


### PR DESCRIPTION
## Summary
Finishes the multi-remote fix from #169 by extending it to the three dashboard API routes that still call `gh run list` / `gh run view` without `-R repo`. Same "multiple remotes detected" failure mode, same fix shape — the runs feed, the per-run logs viewer, and the analytics page all break the moment a fork adds `upstream` as a second remote.

## Changes
- `dashboard/app/api/runs/route.ts` — `gh run list` now resolves the active repo and passes `-R`; switched to `execFileSync` + array form.
- `dashboard/app/api/runs/[id]/logs/route.ts` — same fix on the two `gh run view` calls (status + logs). `id` was already validated to digits so this wasn't a shell-injection risk, but the array form matches the hardening style from #150/#158/#169.
- `dashboard/app/api/analytics/route.ts` — same fix on `gh run list --limit 200`.

Each route inlines the `ghRepo` / `ghArgsRepo` helpers exactly as #169 did, rather than extracting a shared module — keeps the diff surgical and matches the pattern already established in auth/secrets. A future refactor can DRY across all five.

## Context
Spotted by reading the recent commit thread on this file class: #150 (execFileSync for secret set/delete) → #158 (execFileSync for skill run) → #169 (\`-R repo\` for auth + secrets). The runs/analytics routes were the obvious miss — same \`gh\` shell-out, same \`cwd: REPO_ROOT\`, same multi-remote breakage.

Reproduction matches the #169 commit message verbatim: in a fork that follows the README's two-remote setup (origin = fork, upstream = \`aaronjmars/aeon\`), the dashboard's runs and analytics pages return empty arrays because \`gh run list\` errors with "multiple remotes detected" and the routes' \`catch\` blocks swallow it into an empty response.

---
Built by [Aeon](https://github.com/aaronjmars/aeon-aaron)