### PR TITLE
feat: add VVVKernel Venice AI skills

### DIFF
--- a/skills/vvvkernel-audit/SKILL.md
+++ b/skills/vvvkernel-audit/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: VVVKernel Audit
+description: Security review of a smart contract, repo URL, or code snippet via Venice AI Audit Expert — flags vulnerabilities, logic errors, and attack vectors
+var: "https://github.com/owner/repo"
+tags: [crypto, dev]
+---
+
+# VVVKernel Audit
+
+Run a security audit on a smart contract or code using VVVKernel's Audit Expert on Venice AI.
+
+## Input
+
+`$var` can be:
+- A GitHub URL (repo or specific file)
+- A contract address on Base (`0x...`)
+- A raw code snippet (paste directly)
+
+## Steps
+
+1. Determine input type from `$var`:
+   - If starts with `https://github.com` → fetch raw file content via WebFetch
+   - If starts with `0x` and is 42 chars → fetch contract source from Basescan API: `https://api.basescan.org/api?module=contract&action=getsourcecode&address=$var`
+   - Otherwise → treat as raw code
+
+2. If content exceeds 8000 chars, chunk into logical sections (by contract/file)
+
+3. For each chunk, call VVVKernel:
+
+```
+POST https://vvvkernel.com/api/agent/chat
+Content-Type: application/json
+
+{
+  "message": "You are a senior smart contract auditor. Review the following code for: (1) reentrancy vulnerabilities, (2) access control issues, (3) integer overflow/underflow, (4) front-running risks, (5) logic errors, (6) centralization risks, (7) any other critical or high severity findings. For each finding include: severity (CRITICAL/HIGH/MEDIUM/LOW/INFO), location (function/line), description, and recommended fix.\n\nCode:\n<content>",
+  "expert_role": "audit"
+}
+```
+
+4. Aggregate findings across chunks
+
+5. Deduplicate and rank by severity: CRITICAL → HIGH → MEDIUM → LOW → INFO
+
+6. Save full audit to `memory/audit-$today.md`
+
+7. If any CRITICAL or HIGH findings → notify immediately with finding summary
+
+8. Log to `memory/audit-log.md`:
+   ```
+   $today | $var | CRITICAL:<n> HIGH:<n> MEDIUM:<n>
+   ```
+
+## Output format
+
+```
+# Audit Report · $today
+**Target:** $var
+
+## Summary
+- 🔴 Critical: <n>
+- 🟠 High: <n>
+- 🟡 Medium: <n>
+- 🟢 Low: <n>
+- ℹ️ Info: <n>
+
+## Findings
+
+### [CRITICAL] <title>
+**Location:** <function/line>
+**Description:** <description>
+**Fix:** <recommendation>
+
+### [HIGH] <title>
+...
+
+---
+_VVVKernel Audit Expert · Venice AI · private inference_
+```
+
+## Sandbox note
+
+Calls Basescan API (read-only, no key needed for source fetch) and `vvvkernel.com`. Multiple chunks = multiple x402 payments. Estimate 1 USDC per 10k lines of code.

--- a/skills/vvvkernel-brief/SKILL.md
+++ b/skills/vvvkernel-brief/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: VVVKernel Morning Brief
+description: Daily AI-powered morning brief — onchain intel, growth pulse, and one narrative action item, all via Venice AI private inference
+var: ""
+tags: [crypto, productivity]
+---
+
+# VVVKernel Morning Brief
+
+A single daily brief combining onchain intelligence + growth pulse + one narrative action. Runs every morning. No approval needed.
+
+## Steps
+
+1. Read project context from `memory/project-context.md` if exists
+
+2. Run three parallel Venice queries:
+
+**Query A — Onchain:**
+```
+POST https://vvvkernel.com/api/agent/chat
+{
+  "message": "Today is $today. Give me 3 bullet points: most important onchain event on Base today, one DeFi yield opportunity, one risk to watch. Be specific.",
+  "expert_role": "onchain"
+}
+```
+
+**Query B — Growth:**
+```
+POST https://vvvkernel.com/api/agent/chat
+{
+  "message": "Today is $today. What is the single highest-leverage growth action a crypto project should take today? One sentence, actionable, crypto-native.",
+  "expert_role": "growth"
+}
+```
+
+**Query C — Narrative:**
+```
+POST https://vvvkernel.com/api/agent/chat
+{
+  "message": "Today is $today. Give me one tweet-length narrative move a crypto project can make today that would resonate with the current market mood. Max 240 chars.",
+  "expert_role": "narrative"
+}
+```
+
+3. Combine into unified brief
+
+4. Save to `memory/brief-$today.md`
+
+5. Notify with full brief
+
+6. Log:
+   ```
+   $today | morning-brief | done
+   ```
+
+## Output format
+
+```
+# Morning Brief · $today
+
+## ⛓ Onchain
+• <point 1>
+• <point 2>
+• <point 3>
+
+## 📈 Growth Move
+<one actionable sentence>
+
+## 📢 Narrative
+"<tweet-length content>"
+
+---
+_VVVKernel · Venice AI · private · Base_
+```
+
+## Sandbox note
+
+Three sequential calls to `vvvkernel.com` — 3 queries deducted (daily or USDC). Total cost: 0.03 USDC or 3 daily queries. Designed for daily schedule: `0 7 * * *`.

--- a/skills/vvvkernel-growth/SKILL.md
+++ b/skills/vvvkernel-growth/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: VVVKernel Growth
+description: Weekly growth analysis — monitor project metrics, holder counts, social sentiment, and get actionable growth recommendations via Venice AI
+var: ""
+tags: [crypto, research]
+---
+
+# VVVKernel Growth
+
+Run a weekly growth analysis for a crypto project using VVVKernel's Growth Expert on Venice AI.
+
+## Input
+
+Reads project config from `memory/project-context.md`. Must include at minimum:
+- Token contract address
+- Project name
+- Twitter/X handle (optional)
+- Key metric goals (optional)
+
+## Steps
+
+1. Read `memory/project-context.md` — abort with notify if missing
+
+2. Fetch on-chain metrics via WebFetch:
+   - Holder count: `https://api.basescan.org/api?module=token&action=tokenholderlist&contractaddress=<CA>&page=1&offset=1`
+   - Recent transfers count (last 7 days)
+
+3. Fetch social metrics if Twitter handle available:
+   - Search recent mentions via WebSearch: `"<project>" site:x.com since:$yesterday`
+
+4. Build growth brief:
+
+```
+POST https://vvvkernel.com/api/agent/chat
+Content-Type: application/json
+
+{
+  "message": "You are a crypto growth strategist. Analyze the following data for <project> and provide: (1) key growth observations this week, (2) top 3 actionable growth moves for next 7 days, (3) community/narrative opportunities to exploit, (4) any risks to growth momentum. Data: <metrics>",
+  "expert_role": "growth"
+}
+```
+
+5. Structure output into sections
+
+6. Compare with last week's report at `memory/growth-last-week.md` if exists — flag improvements or declines
+
+7. Save to `memory/growth-$today.md`
+   Copy to `memory/growth-last-week.md` (overwrite)
+
+8. Notify with top 3 actions
+
+9. Log:
+   ```
+   $today | growth-analysis | holders:<n> | done
+   ```
+
+## Output format
+
+```
+# Growth Report · $today
+**Project:** <name>
+
+## 📈 This Week
+<observations>
+
+## 🎯 Top 3 Actions (Next 7 Days)
+1. <action>
+2. <action>
+3. <action>
+
+## 💬 Narrative Opportunities
+<opportunities>
+
+## ⚠️ Risks
+<risks>
+
+---
+_VVVKernel Growth Expert · Venice AI_
+```
+
+## Sandbox note
+
+Calls Basescan API (read-only), WebSearch, and `vvvkernel.com`. Designed for weekly schedule: `0 9 * * 1` (Monday 9am).

--- a/skills/vvvkernel-narrative/SKILL.md
+++ b/skills/vvvkernel-narrative/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: VVVKernel Narrative
+description: Generate tweets, threads, announcements, or long-form content for a crypto project using Venice AI Narrative Expert — private, no logs
+var: "write a launch announcement thread for a new Base DeFi protocol"
+tags: [social, crypto]
+---
+
+# VVVKernel Narrative
+
+Generate polished content for a crypto project using VVVKernel's Narrative Expert on Venice AI.
+
+## Input
+
+`$var` is a content brief. Examples:
+- `"write a launch announcement thread for <project>"`
+- `"draft a whitepaper intro for <concept>"`
+- `"write 5 tweet variations announcing <feature>"`
+- `"create a Farcaster post about <milestone>"`
+
+If project context exists at `memory/project-context.md`, prepend it automatically.
+
+## Steps
+
+1. Check for project context: `memory/project-context.md`
+   - If exists, read it (max 2000 chars)
+   - If not, proceed without it
+
+2. Build enriched prompt:
+   ```
+   Context: <project-context if available>
+   
+   Task: $var
+   
+   Requirements:
+   - Crypto-native tone, not corporate
+   - Specific and direct — no vague buzzwords
+   - If thread: number tweets, max 280 chars each
+   - If announcement: punchy opening line, clear CTA at end
+   - If long-form: structured with headers, technical where appropriate
+   ```
+
+3. Call VVVKernel:
+
+```
+POST https://vvvkernel.com/api/agent/chat
+Content-Type: application/json
+
+{
+  "message": "<enriched prompt>",
+  "expert_role": "narrative"
+}
+```
+
+4. Parse and format output by content type detected:
+   - Thread → number each tweet, show char count
+   - Announcement → single block
+   - Long-form → preserve headers
+
+5. Save to `memory/narrative-$today.md`
+
+6. Notify: "Narrative ready: <first line of output>"
+
+7. Log to `memory/narrative-log.md`:
+   ```
+   $today | <first 60 chars of $var> | done
+   ```
+
+## Output format
+
+```
+# Narrative Output · $today
+**Brief:** $var
+
+---
+
+<formatted content>
+
+---
+_VVVKernel Narrative Expert · Venice AI · private inference_
+```
+
+## Sandbox note
+
+Single call to `vvvkernel.com`. All content generated privately — no prompt retention on Venice's infrastructure. 0.01 USDC per generation or 1 daily query from staking balance.

--- a/skills/vvvkernel-onchain/SKILL.md
+++ b/skills/vvvkernel-onchain/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: VVVKernel Onchain Brief
+description: Daily onchain intelligence briefing — Base ecosystem, DeFi yields, notable transactions, protocol updates via Venice AI
+var: ""
+tags: [crypto, research]
+---
+
+# VVVKernel Onchain Brief
+
+Generate a daily onchain intelligence report using VVVKernel's Onchain Expert running on Venice AI.
+
+## Steps
+
+1. Fetch today's context from memory if exists: `memory/onchain-context.md`
+
+2. Build query from today's date ($today) and any stored watchlist in `memory/onchain-watchlist.md`:
+
+```
+POST https://vvvkernel.com/api/agent/chat
+Content-Type: application/json
+
+{
+  "message": "Today is $today. Give me a comprehensive onchain briefing covering: (1) Base ecosystem notable activity, (2) top DeFi yield opportunities on Base, (3) any significant protocol updates or launches, (4) smart money wallet movements worth watching, (5) any risks or warnings for onchain participants today. Be specific with numbers and addresses where relevant.",
+  "expert_role": "onchain"
+}
+```
+
+3. If `$var` is set, append it as additional context to the query
+
+4. Parse response and structure into sections:
+   - 🔴 **Risks** — anything urgent
+   - 📊 **Markets** — price/yield data
+   - 🔩 **Protocol Updates** — new launches, upgrades
+   - 👁 **Watch** — addresses/tokens to monitor
+   - ✅ **Opportunities** — actionable items
+
+5. Save full report to `memory/onchain-brief-$today.md`
+
+6. Notify with summary (top 3 items max, one line each)
+
+7. Log to `memory/onchain-log.md`:
+   ```
+   $today | onchain-brief | completed
+   ```
+
+## Output format
+
+```
+# Onchain Brief · $today
+
+## 🔴 Risks
+<items>
+
+## 📊 Markets
+<items>
+
+## 🔩 Protocol Updates
+<items>
+
+## 👁 Watch
+<items>
+
+## ✅ Opportunities
+<items>
+
+---
+_VVVKernel Onchain Expert · Venice AI · Base_
+```
+
+## Sandbox note
+
+Single call to `vvvkernel.com`. x402 deducts 0.01 USDC or 1 daily query from staking balance. No fallback — if API is down, notify and exit cleanly.

--- a/skills/vvvkernel/SKILL.md
+++ b/skills/vvvkernel/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: VVVKernel Query
+description: Query any VVVKernel Venice AI expert — onchain, audit, growth, brand, narrative, community, or tier-design
+var: "onchain: what are the best yield strategies on Base right now?"
+tags: [crypto, research]
+---
+
+# VVVKernel Query
+
+Route a query to the appropriate VVVKernel Venice AI expert and return the response.
+
+## Input
+
+`$var` format: `<expert>: <query>`
+
+Supported experts: `onchain` · `audit` · `growth` · `brand` · `narrative` · `community` · `tier-design`
+
+If no expert prefix is given, default to `onchain`.
+
+## Steps
+
+1. Parse `$var` to extract expert role and query text
+2. Call VVVKernel MCP via WebFetch:
+
+```
+POST https://vvvkernel.com/api/agent/chat
+Content-Type: application/json
+
+{
+  "message": "<query>",
+  "expert_role": "<expert>"
+}
+```
+
+3. If response is 402, note insufficient balance and notify
+4. Extract `response` field from JSON
+5. Format output as markdown with expert label
+6. Save to `memory/vvvkernel-last.md`
+7. Notify with first 280 chars of response
+
+## Output format
+
+```
+## VVVKernel · <Expert> Expert
+
+<response>
+
+---
+_via Venice AI · x402 · Base_
+```
+
+## Sandbox note
+
+Calls `vvvkernel.com` — live API, x402 payments deducted automatically from configured wallet. No fallback if balance is zero.


### PR DESCRIPTION
6 skills for private Venice AI inference via VVVKernel on Base:

- vvvkernel: generic query router to any of 7 experts
- vvvkernel-brief: daily morning brief (onchain + growth + narrative)
- vvvkernel-onchain: daily onchain intelligence report
- vvvkernel-audit: smart contract security audit
- vvvkernel-narrative: tweet/thread/announcement generation
- vvvkernel-growth: weekly growth analysis

All skills use VVVKernel MCP at vvvkernel.com/mcp
x402 native payments on Base — agents pay autonomously Configure once, forget forever.