### PR TITLE
fix: guard empty-array expansion in scan.sh for Bash 3.2

### DIFF
--- a/skills/skill-security-scan/scan.sh
+++ b/skills/skill-security-scan/scan.sh
@@ -277,15 +277,23 @@ scan_file() {
       PASS) echo -e "${GREEN}[PASS]${NC} $skill_name ($file)" ;;
     esac
 
-    for h in "${highs[@]}"; do
-      echo -e "  ${RED}HIGH${NC}: $h"
-    done
-    for m in "${mediums[@]}"; do
-      echo -e "  ${YELLOW}MEDIUM${NC}: $m"
-    done
-    for l in "${lows[@]}"; do
-      echo -e "  ${CYAN}LOW${NC}: $l"
-    done
+    # Bash 3.2 (macOS default) treats `"${arr[@]}"` as unbound under `set -u`
+    # when the array has zero elements, so each loop is gated on length first.
+    if [[ ${#highs[@]} -gt 0 ]]; then
+      for h in "${highs[@]}"; do
+        echo -e "  ${RED}HIGH${NC}: $h"
+      done
+    fi
+    if [[ ${#mediums[@]} -gt 0 ]]; then
+      for m in "${mediums[@]}"; do
+        echo -e "  ${YELLOW}MEDIUM${NC}: $m"
+      done
+    fi
+    if [[ ${#lows[@]} -gt 0 ]]; then
+      for l in "${lows[@]}"; do
+        echo -e "  ${CYAN}LOW${NC}: $l"
+      done
+    fi
   fi
 }
 


### PR DESCRIPTION
## What
Guards the `highs` / `mediums` / `lows` array expansions in `skills/skill-security-scan/scan.sh` with `[[ ${#arr[@]} -gt 0 ]]` length checks so the non-JSON output path doesn't trip Bash 3.2's nounset behaviour on empty arrays.

## Why
Closes #182.

On macOS Tahoe 26.3 (and any macOS with the default `/bin/bash` 3.2), `scan.sh` opens with `set -euo pipefail`. Bash 3.2 treats `"${arr[@]}"` as unbound when the array has zero elements, so the moment the scanner finishes a clean PASS and tries to print the findings list (lines 280–289 pre-fix), the script aborts with a non-zero exit. `add-skill` then surfaces that as `✗ BLOCKED: <skill> has security issues. Use --force to override.` — even though the scan reported `[PASS]` one line earlier.

The bug is silent churn for every macOS operator hitting `add-skill` on a fresh fork. With 78+ forks and the daily new-fork rate climbing, that's a real first-touch failure mode.

## Changes
- `skills/skill-security-scan/scan.sh`: wrap the human-readable findings loops in `[[ ${#arr[@]} -gt 0 ]]` gates. Mirrors the existing JSON-path guards at lines 250/253/256 — the JSON branch was already safe; only the human branch tripped. Added an inline comment noting the Bash 3.2 constraint so a future cleanup pass doesn't accidentally remove the guard.

## Test
Pre-fix repro on macOS Bash 3.2:
```
./add-skill powerloom/aeon-skills powerloom-bds
  [PASS] powerloom-bds (...)
  ✗ BLOCKED: powerloom-bds has security issues. Use --force to override.
```
Post-fix the PASS row is printed alone, exit code is 0, and `add-skill` proceeds to install. Bash 4+ tolerates the bare expansion already, so the guards are no-ops there.

---
*Built autonomously by Aeon*