### PR TITLE
docs(readme): add Community Skill Packs section (closes #185)

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,24 @@ Label any GitHub issue `ai-build` → workflow fires → Claude reads the issue,
 
 ---
 
+## Community skill packs
+
+Third-party skill collections that live in their own repos. Aeon doesn't ship them in the core catalog, but they're installable via the same `add-skill <github-url>` flow as any other external skill.
+
+| Pack | Skills | Description |
+|------|--------|-------------|
+| [aeon-skill-pack-vvvkernel](https://github.com/baseddevoloper/aeon-skill-pack-vvvkernel) | 9 | Venice AI inference via VVVKernel — onchain, audit, growth, narrative, image gen, monitoring |
+
+**To list a pack here**, open a PR adding a row. Guidelines:
+
+- The pack must be in its own public repo with a clear license and a per-skill `SKILL.md`.
+- Skills should follow the conventions in [`add-skill`](add-skill) and the core catalog — no monkey-patching of Aeon internals, no skill that depends on private endpoints.
+- The README row should link to the repo, name the skill count, and one-line what the pack is for.
+
+This is the lightweight surface: it gives community packs visibility without coupling them to the core catalog's release cadence.
+
+---
+
 ## Publishing
 
 Aeon publishes articles to a GitHub Pages gallery and an RSS feed.


### PR DESCRIPTION
## Summary

Adds a new `## Community skill packs` section to the README, between Adding skills and Publishing. Lightweight surface for third-party skill collections that live in their own repos.

First entry: [aeon-skill-pack-vvvkernel](https://github.com/baseddevoloper/aeon-skill-pack-vvvkernel) (Venice AI, 9 skills) from @baseddevoloper, per #185.

## Why a separate section instead of expanding the catalog

- Community packs ship on their own cadence — coupling them to the core catalog's release would either slow the core or quietly stale-list packs.
- The existing `add-skill <github-url>` flow already installs them; the section is just visibility, not a registry.
- Sets a clear contribution path: open a PR for one row, follow the listed guidelines (public repo + license, per-skill SKILL.md, no internal monkey-patching, no private-endpoint deps).

## Closes

#185

## Test plan

- [x] README renders — the new heading sits cleanly between `## Adding skills` and `## Publishing`
- [x] Single-row table renders in GitHub's markdown
- [x] All cross-section links (`add-skill`) resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)