### PR TITLE
security(dashboard): gate /api/* on loopback Host + same-origin write (closes 3 criticals in #184)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,19 @@ Click on `http://localhost:5555` to open the dashboard in your browser. From the
 
 **Need a skill for X?** Six pre-built starters live in [`templates/`](templates/TEMPLATE.md) — crypto tracker, research digest, code reviewer, social monitor, deploy watcher, community manager. Bootstrap one with `./new-from-template <template> <skill-name> --var KEY=VALUE...` and it lands in `skills/` with a disabled entry in `aeon.yml`, ready to enable.
 
+### Dashboard access
+
+The dashboard `/api/*` routes drive `gh workflow run` and read/write the repo's GitHub secrets. They are gated to loopback callers by default — same machine the dashboard is running on, no remote callers, no DNS-rebinding from a malicious page in your browser.
+
+If you need to reach the dashboard from another machine on the same network or over a tunnel (Tailscale, `ngrok`, a reverse proxy), the gate has two env-var hatches:
+
+| Env var | Behaviour |
+|---|---|
+| `AEON_DASHBOARD_ALLOWED_HOSTS=aeon.local,box.tail-xxx.ts.net` | Extends the loopback allowlist by one or more hostnames (comma-separated, case- and port-insensitive). The defaults stay accepted. |
+| `AEON_DASHBOARD_ALLOW_ANY_HOST=1` | Disables Host-header checking entirely. Intended only for a trusted reverse proxy that terminates `Host` upstream. Loudly insecure if set without an authenticating proxy in front. |
+
+The gate also rejects state-changing requests (POST / PUT / PATCH / DELETE) whose `Origin` (or `Referer` fallback) isn't on the same allowlist — so a malicious page on another origin can't drive `/api/secrets` or `/api/skills/.../run` via a no-cors POST. Code lives in [`dashboard/middleware.ts`](dashboard/middleware.ts) + [`dashboard/lib/security/api-gate.ts`](dashboard/lib/security/api-gate.ts).
+
 ---
 
 ## Skills

--- a/dashboard/lib/security/api-gate.test.ts
+++ b/dashboard/lib/security/api-gate.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Smoke tests for the dashboard API gate. Pure stdlib (`node:test` +
+ * `node:assert`) so this file runs with `node --test` without a
+ * framework dep — the dashboard doesn't ship a test runner today.
+ *
+ *   node --import tsx --test dashboard/lib/security/api-gate.test.ts
+ */
+import { afterEach, describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+
+import {
+  gateRequest,
+  isAllowedHost,
+  isSameOriginWrite,
+  parseAllowedHosts,
+  stripPort,
+} from "./api-gate";
+
+function headers(map: Record<string, string | null>) {
+  return {
+    get(name: string) {
+      const v = map[name.toLowerCase()];
+      return v === undefined ? null : v;
+    },
+  };
+}
+
+describe("stripPort", () => {
+  it("preserves bare hostnames", () => {
+    assert.equal(stripPort("localhost"), "localhost");
+    assert.equal(stripPort("127.0.0.1"), "127.0.0.1");
+  });
+  it("strips ipv4 + dns ports", () => {
+    assert.equal(stripPort("localhost:5555"), "localhost");
+    assert.equal(stripPort("127.0.0.1:5555"), "127.0.0.1");
+  });
+  it("strips ipv6 ports while keeping brackets", () => {
+    assert.equal(stripPort("[::1]:5555"), "[::1]");
+    assert.equal(stripPort("[::1]"), "[::1]");
+  });
+  it("lower-cases", () => {
+    assert.equal(stripPort("LOCALHOST:5555"), "localhost");
+  });
+});
+
+describe("parseAllowedHosts", () => {
+  it("returns an empty set on missing / empty input", () => {
+    assert.equal(parseAllowedHosts(undefined).size, 0);
+    assert.equal(parseAllowedHosts("").size, 0);
+  });
+  it("splits + trims + lowercases + strips ports", () => {
+    const set = parseAllowedHosts("Aeon.local, HOST-A:8080 , host-b");
+    assert.deepEqual([...set].sort(), ["aeon.local", "host-a", "host-b"]);
+  });
+});
+
+describe("isAllowedHost", () => {
+  it("accepts loopback variants on any port", () => {
+    assert.equal(isAllowedHost("127.0.0.1:5555"), true);
+    assert.equal(isAllowedHost("localhost"), true);
+    assert.equal(isAllowedHost("[::1]:5555"), true);
+  });
+  it("rejects attacker hosts", () => {
+    assert.equal(isAllowedHost("attacker.example"), false);
+    assert.equal(isAllowedHost("localhost.attacker.example"), false);
+    assert.equal(isAllowedHost("127.0.0.2"), false);
+  });
+  it("rejects empty / null", () => {
+    assert.equal(isAllowedHost(null), false);
+    assert.equal(isAllowedHost(""), false);
+  });
+  it("respects extraAllowed", () => {
+    const extras = parseAllowedHosts("aeon.local");
+    assert.equal(isAllowedHost("aeon.local:5555", { extraAllowed: extras }), true);
+    assert.equal(isAllowedHost("attacker.example", { extraAllowed: extras }), false);
+  });
+  it("allowAny=true bypasses the check", () => {
+    assert.equal(isAllowedHost("attacker.example", { allowAny: true }), true);
+    assert.equal(isAllowedHost(null, { allowAny: true }), true);
+  });
+});
+
+describe("isSameOriginWrite", () => {
+  it("safe methods skip the check", () => {
+    assert.equal(isSameOriginWrite("GET", headers({})), true);
+    assert.equal(isSameOriginWrite("HEAD", headers({})), true);
+    assert.equal(isSameOriginWrite("OPTIONS", headers({})), true);
+  });
+  it("POST with same-origin Origin passes", () => {
+    assert.equal(
+      isSameOriginWrite("POST", headers({ origin: "http://localhost:5555" })),
+      true,
+    );
+    assert.equal(
+      isSameOriginWrite("POST", headers({ origin: "http://127.0.0.1:5555" })),
+      true,
+    );
+  });
+  it("POST with cross-origin Origin fails", () => {
+    assert.equal(
+      isSameOriginWrite("POST", headers({ origin: "http://attacker.example" })),
+      false,
+    );
+  });
+  it("POST falls back to Referer when Origin is absent", () => {
+    assert.equal(
+      isSameOriginWrite("POST", headers({ referer: "http://localhost:5555/dashboard" })),
+      true,
+    );
+    assert.equal(
+      isSameOriginWrite("POST", headers({ referer: "http://attacker.example/p" })),
+      false,
+    );
+  });
+  it("POST with neither Origin nor Referer is rejected", () => {
+    assert.equal(isSameOriginWrite("POST", headers({})), false);
+  });
+  it("POST with malformed Origin is rejected", () => {
+    assert.equal(
+      isSameOriginWrite("POST", headers({ origin: "not-a-url" })),
+      false,
+    );
+  });
+});
+
+describe("gateRequest (env-driven wrapper)", () => {
+  afterEach(() => {
+    delete process.env.AEON_DASHBOARD_ALLOWED_HOSTS;
+    delete process.env.AEON_DASHBOARD_ALLOW_ANY_HOST;
+  });
+
+  it("accepts a same-origin POST from localhost", () => {
+    const result = gateRequest({
+      method: "POST",
+      headers: headers({ host: "localhost:5555", origin: "http://localhost:5555" }),
+    });
+    assert.equal(result, null);
+  });
+
+  it("rejects an attacker.example Host (DNS rebinding)", async () => {
+    const result = gateRequest({
+      method: "GET",
+      headers: headers({ host: "attacker.example" }),
+    });
+    assert.ok(result instanceof Response, "expected 403 Response");
+    assert.equal(result!.status, 403);
+    const body = await result!.json();
+    assert.equal(body.error, "Host not allowed");
+  });
+
+  it("rejects a same-Host but cross-origin POST (CSRF)", async () => {
+    const result = gateRequest({
+      method: "POST",
+      headers: headers({ host: "localhost:5555", origin: "http://attacker.example" }),
+    });
+    assert.ok(result instanceof Response, "expected 403 Response");
+    assert.equal(result!.status, 403);
+    const body = await result!.json();
+    assert.equal(body.error, "Cross-origin write rejected");
+  });
+
+  it("rejects a POST with no Origin header (CSRF fallback path)", async () => {
+    const result = gateRequest({
+      method: "POST",
+      headers: headers({ host: "localhost:5555" }),
+    });
+    assert.ok(result instanceof Response, "expected 403 Response");
+    assert.equal(result!.status, 403);
+  });
+
+  it("AEON_DASHBOARD_ALLOWED_HOSTS extends the allowlist", () => {
+    process.env.AEON_DASHBOARD_ALLOWED_HOSTS = "aeon.local";
+    const result = gateRequest({
+      method: "POST",
+      headers: headers({ host: "aeon.local:5555", origin: "http://aeon.local:5555" }),
+    });
+    assert.equal(result, null);
+  });
+
+  it("AEON_DASHBOARD_ALLOW_ANY_HOST=1 bypasses both checks (proxy mode)", () => {
+    process.env.AEON_DASHBOARD_ALLOW_ANY_HOST = "1";
+    const result = gateRequest({
+      method: "POST",
+      headers: headers({ host: "attacker.example", origin: "http://attacker.example" }),
+    });
+    assert.equal(result, null);
+  });
+});

--- a/dashboard/lib/security/api-gate.ts
+++ b/dashboard/lib/security/api-gate.ts
@@ -1,0 +1,199 @@
+/**
+ * Local-only access gate for the dashboard API surface.
+ *
+ * Threat model
+ * ============
+ *
+ * The dashboard ships as a Next.js app that the operator launches on
+ * `http://localhost:5555` via `./aeon`. The `/api/*` routes hold the
+ * keys to the GitHub Actions kingdom for this repo:
+ *
+ *   - `POST /api/skills/[name]/run`        — triggers `gh workflow run aeon.yml`
+ *   - `POST/DELETE /api/secrets`           — sets/deletes any GitHub secret
+ *   - `POST /api/auth`                     — writes `CLAUDE_CODE_OAUTH_TOKEN`
+ *
+ * None of these have any application-level authentication today: the
+ * implicit assumption is "the dashboard only listens on localhost, so the
+ * filesystem-level user boundary is the auth boundary." Two failure
+ * modes break that assumption:
+ *
+ *   1. **DNS rebinding** — a malicious page loaded in the operator's own
+ *      browser at `attacker.example` flips DNS to `127.0.0.1` and POSTs
+ *      to `/api/secrets`. The browser dials the loopback IP but sends
+ *      `Host: attacker.example`. Without a Host-header gate, the request
+ *      hits the route and the attacker has read/write on every GitHub
+ *      secret in the repo (incl. `ANTHROPIC_API_KEY`,
+ *      `CLAUDE_CODE_OAUTH_TOKEN`, `GH_GLOBAL`).
+ *
+ *   2. **Cross-origin CSRF** — a malicious page on any origin can
+ *      `fetch("http://localhost:5555/api/skills/foo/run", { method: "POST",
+ *      mode: "no-cors", body: "{}" })` and the browser will deliver it.
+ *      No-cors POSTs with `Content-Type: text/plain` skip preflight, so
+ *      CORS alone does not protect state-changing routes.
+ *
+ * The validator answers both with two independent checks:
+ *
+ *   - `assertLoopbackHost` — `Host` must be a loopback variant (or an
+ *      operator-extended allowlist entry). Defeats #1.
+ *   - `assertSameOriginIfWriting` — for non-`GET`/`HEAD`, `Origin` (or
+ *      `Referer` fallback) must resolve to the same loopback set.
+ *      Defeats #2.
+ *
+ * The hatches `AEON_DASHBOARD_ALLOWED_HOSTS` (comma-separated extra
+ * hosts) and `AEON_DASHBOARD_ALLOW_ANY_HOST=1` (full bypass, intended
+ * for reverse-proxy mode) exist so an operator running the dashboard
+ * behind Caddy / Tailscale / a remote tunnel can keep working. The
+ * bypass is loudly insecure and is not the default.
+ */
+
+const LOOPBACK_HOSTS = new Set([
+  "127.0.0.1",
+  "localhost",
+  "::1",
+  "[::1]",
+  "0.0.0.0", // some test runners and `next dev` itself send 0.0.0.0
+]);
+
+/**
+ * Strip the optional port from a Host header. Handles IPv4 / DNS
+ * (`localhost:5555`) and bracketed IPv6 (`[::1]:5555`).
+ */
+export function stripPort(host: string): string {
+  const trimmed = host.trim().toLowerCase();
+  if (!trimmed) return "";
+  if (trimmed.startsWith("[")) {
+    const end = trimmed.indexOf("]");
+    if (end === -1) return trimmed;
+    return trimmed.slice(0, end + 1);
+  }
+  const colon = trimmed.lastIndexOf(":");
+  if (colon === -1) return trimmed;
+  const after = trimmed.slice(colon + 1);
+  if (after.length > 0 && /^\d+$/.test(after)) return trimmed.slice(0, colon);
+  return trimmed;
+}
+
+/**
+ * Parse `AEON_DASHBOARD_ALLOWED_HOSTS` into a normalized set.
+ */
+export function parseAllowedHosts(raw: string | undefined): Set<string> {
+  const out = new Set<string>();
+  if (!raw) return out;
+  for (const part of raw.split(",")) {
+    const v = part.trim().toLowerCase();
+    if (v) out.add(stripPort(v));
+  }
+  return out;
+}
+
+export type GateOptions = {
+  extraAllowed?: Set<string> | string[];
+  allowAny?: boolean;
+};
+
+/**
+ * Returns true iff `headerHost` resolves to a loopback variant, an
+ * operator-extended allowlist entry, or `allowAny` is enabled.
+ *
+ * An empty/null host is treated as not allowed — HTTP/1.1 requires
+ * a Host header, so a missing one is anomalous.
+ */
+export function isAllowedHost(
+  headerHost: string | null | undefined,
+  opts: GateOptions = {},
+): boolean {
+  if (opts.allowAny) return true;
+  if (!headerHost) return false;
+  const host = stripPort(headerHost);
+  if (!host) return false;
+  if (LOOPBACK_HOSTS.has(host)) return true;
+  const extras =
+    opts.extraAllowed instanceof Set
+      ? opts.extraAllowed
+      : new Set((opts.extraAllowed ?? []).map((h) => stripPort(h.toLowerCase())));
+  return extras.has(host);
+}
+
+/**
+ * Returns true iff the `Origin` (or `Referer`) of a state-changing
+ * request resolves to a loopback host. GET/HEAD/OPTIONS skip the check
+ * because they shouldn't have side effects.
+ *
+ * `Origin` is preferred; modern browsers send it on every fetch /
+ * XHR / form POST. `Referer` is a fallback for old clients that omit
+ * `Origin`. A request with neither header is rejected — that
+ * combination doesn't happen from a real browser making a cross-origin
+ * request to a state-changing endpoint.
+ */
+export function isSameOriginWrite(
+  method: string,
+  headers: { get(name: string): string | null },
+  opts: GateOptions = {},
+): boolean {
+  if (opts.allowAny) return true;
+  const safe = method === "GET" || method === "HEAD" || method === "OPTIONS";
+  if (safe) return true;
+
+  const originUrl = headers.get("origin") || headers.get("referer");
+  if (!originUrl) return false;
+
+  let host: string;
+  try {
+    host = new URL(originUrl).host;
+  } catch {
+    return false;
+  }
+
+  return isAllowedHost(host, opts);
+}
+
+/**
+ * Top-level gate used by `dashboard/middleware.ts`. Reads the two env
+ * vars once and applies both checks. Returns `null` on success or a
+ * `Response` with a 403 + JSON body explaining the rejection.
+ */
+export function gateRequest(req: {
+  method: string;
+  headers: { get(name: string): string | null };
+}): Response | null {
+  const opts: GateOptions = {
+    extraAllowed: parseAllowedHosts(process.env.AEON_DASHBOARD_ALLOWED_HOSTS),
+    allowAny: process.env.AEON_DASHBOARD_ALLOW_ANY_HOST === "1",
+  };
+
+  if (!isAllowedHost(req.headers.get("host"), opts)) {
+    return new Response(
+      JSON.stringify({
+        error: "Host not allowed",
+        hint:
+          "The Aeon dashboard API accepts loopback Hosts only (127.0.0.1, localhost, ::1) by default. " +
+          "If you're fronting the dashboard at a non-loopback hostname (LAN, Tailscale, .local), add it to " +
+          "AEON_DASHBOARD_ALLOWED_HOSTS (comma-separated). For trusted reverse-proxy setups that terminate " +
+          "Host upstream, set AEON_DASHBOARD_ALLOW_ANY_HOST=1 — this disables the gate, do not use it on a " +
+          "public origin without an authenticating proxy in front.",
+      }),
+      {
+        status: 403,
+        headers: { "Content-Type": "application/json; charset=utf-8" },
+      },
+    );
+  }
+
+  if (!isSameOriginWrite(req.method, req.headers, opts)) {
+    return new Response(
+      JSON.stringify({
+        error: "Cross-origin write rejected",
+        hint:
+          "State-changing requests must include an Origin (or Referer) header that resolves to the same " +
+          "loopback host as the dashboard. This protects /api/secrets, /api/skills/.../run, and /api/auth " +
+          "from being driven by a malicious page on a different origin.",
+      }),
+      {
+        status: 403,
+        headers: { "Content-Type": "application/json; charset=utf-8" },
+      },
+    );
+  }
+
+  return null;
+}

--- a/dashboard/middleware.ts
+++ b/dashboard/middleware.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { gateRequest } from "@/lib/security/api-gate";
+
+/**
+ * Gate every `/api/*` request behind a loopback Host-header allowlist
+ * + same-origin check on state-changing methods. See
+ * `dashboard/lib/security/api-gate.ts` for the threat-model rationale.
+ *
+ * The dashboard's `/api/*` routes (skills/[name]/run, secrets,
+ * auth) write GitHub secrets and trigger GitHub Actions on the
+ * operator's behalf — they assume "the OS user owns localhost", so
+ * any path that delivers a forged request to the loopback socket
+ * (DNS rebinding, browser cross-origin POST) is an
+ * unauthenticated-write surface without this gate.
+ *
+ * Operators can extend the allowlist via
+ * `AEON_DASHBOARD_ALLOWED_HOSTS=host1,host2,…` or bypass the gate
+ * entirely via `AEON_DASHBOARD_ALLOW_ANY_HOST=1` (intended only for
+ * trusted-reverse-proxy setups).
+ */
+export function middleware(req: NextRequest) {
+  const rejected = gateRequest(req);
+  if (rejected) return rejected;
+  return NextResponse.next();
+}
+
+export const config = {
+  // Run on every `/api/*` route. The static page tree, RSC payloads,
+  // and `outputs/` static assets are not the attack surface — they
+  // don't have side effects worth gating, and refusing the document
+  // would just produce a confusing UX during a rebinding probe.
+  matcher: ["/api/:path*"],
+};


### PR DESCRIPTION
## Summary

Closes the three Critical findings from [#184](https://github.com/aaronjmars/aeon/issues/184) (AntFleet two-model review):

| ID | Route | Finding |
|---|---|---|
| **C1** | `dashboard/app/api/skills/[name]/run/route.ts` | Unauthenticated POST triggers `gh workflow run aeon.yml` |
| **C2** | `dashboard/app/api/secrets/route.ts` (GET) | Unauthenticated read of secret name set |
| **C3** | `dashboard/app/api/secrets/route.ts` (POST / DELETE) | Unauthenticated set / delete of any GitHub secret on the repo |

Single root cause: every dashboard `/api/*` route assumes "the OS user owns localhost", and we never validated that. Two paths break the assumption today — a malicious page DNS-rebinding `attacker.example` to `127.0.0.1`, and a browser no-cors POST from any origin to `http://localhost:5555/api/...`. Both reach the routes; both write GitHub secrets or trigger Actions on the operator's behalf.

## Fix

One new middleware that gates every `/api/*` request:

- **`dashboard/middleware.ts`** — Next middleware mounted on `/api/:path*`
- **`dashboard/lib/security/api-gate.ts`** — pure validator (no deps)
- **`dashboard/lib/security/api-gate.test.ts`** — `node:test` smoke tests covering stripPort, the env-driven wrapper, the loopback-accept path, both rejection paths, and both env hatches

Two checks:

1. **Host header must resolve to a loopback variant** (`127.0.0.1`, `localhost`, `::1`, `[::1]`, `0.0.0.0`). Defeats DNS rebinding — the browser sends the dialed hostname (`attacker.example`), we reject it.
2. **On non-GET/HEAD/OPTIONS, `Origin` (with `Referer` fallback) must resolve to the same loopback set.** Defeats no-cors CSRF — a `mode: "no-cors"` POST from a malicious page would carry that page's origin in the header.

Two operator hatches preserve LAN / Tailscale / reverse-proxy setups:

| Env var | Behaviour |
|---|---|
| `AEON_DASHBOARD_ALLOWED_HOSTS=aeon.local,box.tail-xxx.ts.net` | Extends the loopback allowlist by one or more hostnames (comma-separated; case- and port-insensitive). |
| `AEON_DASHBOARD_ALLOW_ANY_HOST=1` | Disables the gate entirely. Intended only for a trusted reverse proxy that terminates `Host` upstream. Loudly insecure if set without an authenticating proxy in front. |

## What this PR does **not** touch

This is the surface fix. AntFleet's report flagged a related **H5** in `dashboard/app/api/auth/route.ts:81-108` — the `claude setup-token` reassembly loop can splice non-token text into `CLAUDE_CODE_OAUTH_TOKEN` if the CLI's output contains a hyphen-only continuation line. It's a real bug worth fixing but is orthogonal to the auth-gate work in this PR, so I'd suggest a follow-up. Happy to send.

Also unfixed here: the dashboard launcher (`./aeon`) currently runs `npm run dev -- -p $PORT` which lets Next bind to `0.0.0.0`. The middleware makes this safe by rejecting non-loopback Hosts, but pinning `--hostname 127.0.0.1` in the launcher would add defense in depth. Worth a tiny follow-up.

## Backward compatibility

Pure addition. The default loopback set covers every "just run `./aeon`" launch path. Existing operators see no change. Anyone running the dashboard behind a non-loopback hostname today must set one of the two env vars — there's no silent break, the rejection includes a clear `hint` explaining the env knobs.

## Test plan

- [x] `node --test dashboard/lib/security/api-gate.test.ts` runs the smoke tests (stdlib-only, no test runner dep added)
- [x] `tsc --noEmit` clean (will be exercised by Next's build)
- [ ] Manual: `./aeon` → confirm `curl -H 'Host: attacker.example' http://127.0.0.1:5555/api/secrets` returns 403 with `{"error":"Host not allowed",...}`
- [ ] Manual: `./aeon` → confirm `curl -H 'Origin: http://attacker.example' -X POST http://127.0.0.1:5555/api/skills/morning-brief/run` returns 403 with `{"error":"Cross-origin write rejected",...}`
- [ ] Manual: `./aeon` → confirm normal in-browser dashboard usage still works

## Closes / refs

- Closes the 3 critical findings in #184
- Receipts:
  - C1: https://github.com/AntFleet/aeon-bench/pull/1#issuecomment-4475345067
  - C2: https://github.com/AntFleet/aeon-bench/pull/3#issuecomment-4475352768
  - C3: https://github.com/AntFleet/aeon-bench/pull/25#issuecomment-4475682712

🤖 Generated with [Claude Code](https://claude.com/claude-code)