### PR TITLE
fix(auth): extract only token characters per line during claude setup-token reassembly

### DIFF
--- a/dashboard/app/api/auth/route.ts
+++ b/dashboard/app/api/auth/route.ts
@@ -81,22 +81,24 @@ export async function POST(request: Request) {
         error: 'Could not extract token. Paste your API key manually instead.',
       }, { status: 400 })
     }
-    // Take everything until we hit a space, newline-then-non-alnum, or empty line
-    // The token chars are: A-Za-z0-9_-
+    // Extract only valid token characters from each line, stopping at the first
+    // line that contributes nothing. This handles terminal wrapping while
+    // rejecting any trailing prose, ANSI escapes, or other non-token bytes that
+    // the first line might contain after the token text.
+    // Token alphabet: A-Za-z0-9_-
     const tokenChars: string[] = []
     for (const line of tokenBlock.split('\n')) {
-      const trimmed = line.trim()
-      if (tokenChars.length === 0) {
-        // First line with the token
-        tokenChars.push(trimmed)
-      } else if (/^[A-Za-z0-9_\-]+$/.test(trimmed)) {
-        // Continuation line (all valid token chars — wrapped portion of token)
-        tokenChars.push(trimmed)
-      } else {
-        break
-      }
+      const segment = line.trim().match(/^[A-Za-z0-9_\-]+/)?.[0] ?? ''
+      if (!segment) break
+      tokenChars.push(segment)
     }
     const token = tokenChars.join('')
+
+    if (!token.startsWith('sk-ant-oat')) {
+      return NextResponse.json({
+        error: 'Could not extract a valid OAuth token. Paste your API key manually instead.',
+      }, { status: 400 })
+    }
 
     execFileSync('gh', ['secret', 'set', 'CLAUDE_CODE_OAUTH_TOKEN', ...ghArgsRepo()], {
       input: token,


### PR DESCRIPTION
Fixes H5 from the AntFleet bench run — receipt: https://github.com/AntFleet/aeon-bench/pull/25#issuecomment-4475682712

## What was wrong

`claude setup-token` output is captured as a string and sliced from `sk-ant-oat` onward. The reassembly loop then pushed `line.trim()` **unconditionally** for the first line, without restricting to token characters. If the terminal output included trailing prose after the token (e.g. `sk-ant-oat01-abc… (valid for 30 days)`) the whole trimmed string — including the non-token suffix — was appended, and subsequent continuation lines were concatenated on top of it. The result stored in `CLAUDE_CODE_OAUTH_TOKEN` was garbage.

Continuation lines used `/^[A-Za-z0-9_\-]+$/` correctly, but the first line had no such guard.

## Fix

Apply the same leading-match extraction (`/^[A-Za-z0-9_\-]+/`) to every line including the first. The regex takes only the token-alphabet prefix of the trimmed line and stops at the first foreign character — so prose, ANSI escapes, and spaces after the token are never included. A post-loop guard returns HTTP 400 if the assembled value doesn't start with `sk-ant-oat`, making extraction failures explicit instead of silently storing a malformed credential.
