### PR TITLE
fix(admanage): validate TODAY_SPEND is numeric before awk spend-cap check

### DIFF
--- a/scripts/postprocess-admanage.sh
+++ b/scripts/postprocess-admanage.sh
@@ -59,6 +59,15 @@ if [ "$STRICTEST_CAP" != "null" ] && [ -n "$STRICTEST_CAP" ]; then
     "$API_BASE/v1/spend/daily?startDate=$TODAY&endDate=$TODAY" \
     -H "$auth_hdr" || echo '{}')
   TODAY_SPEND=$(echo "$SPEND_RESP" | jq -r '.metadata.totalSpend // 0')
+  # Guard: if the API response was malformed or empty, jq may produce a
+  # non-numeric value. awk treats "" as 0, which would silently bypass the cap.
+  # Fail closed instead — block the launch until spend can be verified.
+  if ! [[ "$TODAY_SPEND" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+    MSG="ads NOT launched — daily spend could not be verified (unexpected API response). Failing safe."
+    echo "postprocess-admanage: $MSG"
+    ./notify "$MSG" || true
+    exit 0
+  fi
   if awk "BEGIN{exit !($TODAY_SPEND >= $STRICTEST_CAP)}"; then
     MSG="ads NOT launched — daily spend cap tripped. today=\$${TODAY_SPEND} cap=\$${STRICTEST_CAP} queued=${#LAUNCH_FILES[@]}"
     echo "postprocess-admanage: $MSG"


### PR DESCRIPTION
Fixes H8 from the AntFleet bench run — receipt: https://github.com/AntFleet/aeon-bench/pull/4#issuecomment-4475360859

## What was wrong

The daily-spend circuit breaker fetches spend from the AdManage API and passes it to `awk` for the cap comparison:

```bash
TODAY_SPEND=$(echo "$SPEND_RESP" | jq -r '.metadata.totalSpend // 0')
if awk "BEGIN{exit !($TODAY_SPEND >= $STRICTEST_CAP)}"; then
```

`awk` coerces non-numeric values (including empty string) to `0`. If the API returns malformed JSON, or if `jq` fails and produces no output, `TODAY_SPEND` is empty. `awk` then evaluates `"" >= CAP` as `0 >= CAP`, which is false for any positive cap — the circuit breaker never trips, and ads launch against a cap that could not be verified.

The `|| echo '{}'` guard on the curl call doesn't help here: `jq -r '.metadata.totalSpend // 0'` on `{}` returns `0` (correct), but if the API returns a non-JSON response body (HTML error page, truncated response, etc.) `jq` exits non-zero and writes nothing to stdout, leaving `TODAY_SPEND` empty.

## Fix

Validate `TODAY_SPEND` against a decimal-number regex before the `awk` call. On failure, fail closed: emit a notify and exit 0, leaving pending files intact for manual inspection — the same behavior as when the cap is actually tripped.
