### PR TITLE
fix(messages): correct Slack bot-message filter from string "null" to empty-string check

### DIFF
--- a/.github/workflows/messages.yml
+++ b/.github/workflows/messages.yml
@@ -534,7 +534,7 @@ jobs:
               BOT_ID=$(echo "$RESPONSE" | jq -r ".messages[$i].bot_id // empty")
               HAS_CHECK=$(echo "$RESPONSE" | jq -r ".messages[$i].reactions[]? | select(.name == \"white_check_mark\") | .name // empty")
 
-              if [ -n "$TEXT" ] && [ "$BOT_ID" = "null" ] && [ -z "$HAS_CHECK" ]; then
+              if [ -n "$TEXT" ] && [ -z "$BOT_ID" ] && [ -z "$HAS_CHECK" ]; then
                 curl -s -X POST -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
                   -H "Content-Type: application/json" \
                   -d "$(jq -n --arg ch "$SLACK_CHANNEL_ID" --arg ts "$TS" \


### PR DESCRIPTION
Fixes H2 from the AntFleet bench run — receipt: https://github.com/AntFleet/aeon-bench/pull/2#issuecomment-4475356633

## What was wrong

The Slack message loop filters out bot messages with:

```bash
BOT_ID=$(echo "$RESPONSE" | jq -r ".messages[$i].bot_id // empty")
if [ -n "$TEXT" ] && [ "$BOT_ID" = "null" ] && [ -z "$HAS_CHECK" ]; then
```

`jq -r '… // empty'` returns an **empty string** `""` when the field is absent — not the literal string `"null"`. Human messages don't have `bot_id` set, so `BOT_ID=""`. Bot messages have it set to something like `"B12345"`, so `BOT_ID="B12345"`.

The check `[ "$BOT_ID" = "null" ]` is therefore **never true**: neither `""` nor `"B12345"` equals `"null"`. No Slack messages were ever forwarded.

## Fix

Replace `[ "$BOT_ID" = "null" ]` with `[ -z "$BOT_ID" ]`. Empty string means `bot_id` was absent — i.e., the message is from a human. Non-empty means a bot sent it and should be filtered out.

One character change, but it's the difference between the Slack integration working and silently doing nothing.
