### PR TITLE
Add opt-in Fleet Watcher authorization layer (preflight + postflight)

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -61,6 +61,11 @@ permissions:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   NODE_OPTIONS: '--no-deprecation'
+  # Fleet Watcher opt-in secrets — hoisted to workflow-level so that
+  # `if: env.FLEET_ENDPOINT != ''` in the preflight/postflight steps can
+  # actually see them. (Step-level env is NOT available in step `if:` clauses.)
+  FLEET_ENDPOINT: ${{ secrets.FLEET_ENDPOINT }}
+  FLEET_TOKEN:    ${{ secrets.FLEET_TOKEN }}
 
 concurrency:
   group: aeon-${{ inputs.skill || github.event.action || github.run_id }}
@@ -178,6 +183,55 @@ jobs:
             echo "Running $(basename "$script")..."
             ./"$script" "$SKILL" "$VAR" || echo "::notice::$(basename "$script") skipped or failed (non-fatal)"
           done
+
+      # ──────────────────────────────────────────────────────────────────────
+      # Fleet Watcher preflight (opt-in, fail-closed)
+      #
+      # If FLEET_ENDPOINT + FLEET_TOKEN repo secrets are set, ask the user's
+      # self-hosted Fleet Watcher control plane to ALLOW or BLOCK this skill
+      # before it runs. BLOCK = workflow exits non-zero, Claude never starts,
+      # no side-effects. ALLOW = audit ref is captured and passed to postflight.
+      #
+      # If the secrets are not set, this step no-ops — backward compatible
+      # with every existing AEON fork.
+      # ──────────────────────────────────────────────────────────────────────
+      - name: Fleet Watcher preflight
+        id: fleet_preflight
+        if: steps.work.outputs.mode != '' && env.FLEET_ENDPOINT != '' && env.FLEET_TOKEN != ''
+        env:
+          SKILL:     ${{ steps.skill.outputs.name }}
+          SKILL_VAR: ${{ inputs.var }}
+        run: |
+          set -euo pipefail
+          OP_ID="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-pre"
+          BODY=$(jq -n \
+            --arg skill  "$SKILL" \
+            --arg target "${SKILL_VAR:-}" \
+            --arg source "github-actions:${GITHUB_REPOSITORY}" \
+            --arg op     "$OP_ID" \
+            '{skill:$skill, target:$target, source:$source, clientOpId:$op, context:{runId:env.GITHUB_RUN_ID, attempt:env.GITHUB_RUN_ATTEMPT}}')
+          RESP=$(curl -sS -w "\n%{http_code}" -X POST "${FLEET_ENDPOINT}/api/aeon/preflight" \
+            -H "Authorization: Bearer ${FLEET_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "$BODY")
+          HTTP=$(echo "$RESP" | tail -1)
+          BODY=$(echo "$RESP" | sed '$d')
+          if [ "$HTTP" != "200" ]; then
+            echo "::error::Fleet Watcher unreachable or returned $HTTP — failing closed."
+            echo "$BODY"
+            exit 1
+          fi
+          ALLOW=$(echo "$BODY" | jq -r '.allow')
+          REASON=$(echo "$BODY" | jq -r '.reason')
+          AUDIT_REF=$(echo "$BODY" | jq -r '.auditRef // ""')
+          REF=$(echo "$BODY" | jq -r '.ref // ""')
+          echo "audit_ref=$AUDIT_REF" >> "$GITHUB_OUTPUT"
+          echo "action_ref=$REF"     >> "$GITHUB_OUTPUT"
+          if [ "$ALLOW" != "true" ]; then
+            echo "::error::Fleet Watcher BLOCKED skill '$SKILL' — $REASON  (audit: $AUDIT_REF)"
+            exit 1
+          fi
+          echo "::notice::Fleet Watcher ALLOWED skill '$SKILL' (audit: $AUDIT_REF, ref: $REF)"
 
       - name: Run
         id: run
@@ -447,6 +501,52 @@ jobs:
           echo "SKILL_TOTAL_TOKENS=$TOTAL_TOKENS" >> "$GITHUB_OUTPUT"
 
           echo "::notice::Token usage — input: $INPUT_TOKENS, output: $OUTPUT_TOKENS, cache_read: $CACHE_READ, cache_creation: $CACHE_CREATION, total: $TOTAL_TOKENS"
+
+      # ──────────────────────────────────────────────────────────────────────
+      # Fleet Watcher postflight (opt-in, always-runs)
+      #
+      # Reports skill completion to the user's Fleet Watcher ledger. Runs even
+      # if the skill failed — failure is itself a signal Fleet wants to record
+      # for taint chain detection.
+      # ──────────────────────────────────────────────────────────────────────
+      - name: Fleet Watcher postflight
+        if: always() && steps.work.outputs.mode != '' && env.FLEET_ENDPOINT != '' && env.FLEET_TOKEN != ''
+        env:
+          SKILL:       ${{ steps.skill.outputs.name }}
+          RUN_OUTCOME: ${{ steps.run.outcome }}
+          AUDIT_REF:   ${{ steps.fleet_preflight.outputs.audit_ref }}
+        run: |
+          set -euo pipefail
+          case "$RUN_OUTCOME" in
+            success) STATUS="ok" ;;
+            failure) STATUS="error" ;;
+            skipped) STATUS="blocked" ;;
+            *)       STATUS="error" ;;
+          esac
+          OP_ID="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-post"
+          BODY=$(jq -n \
+            --arg skill   "$SKILL" \
+            --arg status  "$STATUS" \
+            --arg source  "github-actions:${GITHUB_REPOSITORY}" \
+            --arg summary "aeon skill '$SKILL' finished with outcome=$RUN_OUTCOME" \
+            --arg op      "$OP_ID" \
+            --arg audit   "$AUDIT_REF" \
+            '{skill:$skill, status:$status, source:$source, summary:$summary, clientOpId:$op, auditRef:$audit, metadata:{runId:env.GITHUB_RUN_ID, attempt:env.GITHUB_RUN_ATTEMPT, runUrl:("\(env.GITHUB_SERVER_URL)/\(env.GITHUB_REPOSITORY)/actions/runs/\(env.GITHUB_RUN_ID)")}}')
+          RESP=$(curl -sS -w "\n%{http_code}" -X POST "${FLEET_ENDPOINT}/api/aeon/postflight" \
+            -H "Authorization: Bearer ${FLEET_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "$BODY" || true)
+          HTTP=$(echo "$RESP" | tail -1)
+          if [ "$HTTP" = "201" ]; then
+            EVENT_ID=$(echo "$RESP" | sed '$d' | jq -r '.eventId')
+            CHAINS=$(echo "$RESP" | sed '$d' | jq -r '.chainsDetected | length')
+            echo "::notice::Fleet Watcher recorded skill '$SKILL' (event $EVENT_ID, chains detected: $CHAINS)"
+            if [ "$CHAINS" -gt 0 ]; then
+              echo "::warning::Fleet Watcher detected $CHAINS new taint chain(s) — review at ${FLEET_ENDPOINT}/fleet"
+            fi
+          else
+            echo "::warning::Fleet Watcher postflight returned $HTTP (non-fatal)"
+          fi
 
       - name: Log token usage
         if: steps.work.outputs.mode != ''

--- a/README.md
+++ b/README.md
@@ -503,6 +503,26 @@ Start with [`examples/README.md`](examples/README.md) for the full setup walk-th
 
 ---
 
+## Fleet Watcher (optional authorization layer)
+
+Add inline ALLOW/BLOCK authorization in front of every skill run. Each skill workflow asks your self-hosted [Fleet Watcher](https://github.com/yourorg/fleet-watcher) control plane *"is this allowed?"* before Claude starts, and reports the outcome after Claude finishes. BLOCK = workflow exits non-zero, Claude never runs, no side-effects, audit ref recorded.
+
+Already wired into `.github/workflows/aeon.yml` as two opt-in steps (`Fleet Watcher preflight`, `Fleet Watcher postflight`). To enable:
+
+1. Stand up Fleet Watcher and mint an agent token via `POST /api/aeon/register`.
+2. Add two repo secrets:
+
+    | Secret           | Value                                           |
+    |------------------|-------------------------------------------------|
+    | `FLEET_ENDPOINT` | Base URL of your Fleet Watcher (e.g. `https://fleet.example.com`) |
+    | `FLEET_TOKEN`    | The `agnt_…` token returned by `/api/aeon/register` |
+
+3. Define your red lines in the Fleet Watcher dashboard (per-skill caps, counterparty allowlists, dangerous-string patterns, source-to-sink chain detection).
+
+If the secrets are not set, both steps no-op — fully backward compatible with every existing AEON install. If Fleet is unreachable when the secrets *are* set, the preflight step fails closed (skill does not run). The postflight step always runs (`if: always()`) so failed/blocked skills are still recorded for taint analysis.
+
+---
+
 ## Two-repo strategy
 
 This repo is a public template. Run your own instance as a **private fork** so memory, articles, and API keys stay private.


### PR DESCRIPTION
## What

Adds two new steps to `.github/workflows/aeon.yml` that wrap the existing `Run` (Claude Code execution) step with synchronous authorization against a self-hosted [Fleet Watcher](https://github.com/yourorg/fleet-watcher) control plane.

| Step | Position | Effect |
|---|---|---|
| **Fleet Watcher preflight** | Before `Run` | `POST /api/aeon/preflight`. If Fleet returns `allow: false`, the workflow exits 1 — Claude never starts, no side-effects. |
| **Fleet Watcher postflight** | After `Run`, `if: always()` | `POST /api/aeon/postflight`. Records outcome (`ok` / `error` / `blocked`) and feeds Fleet's source→sink taint chain detection. |

## Backward compatible

Both steps gate on `env.FLEET_ENDPOINT != '' && env.FLEET_TOKEN != ''`. Without those repo secrets, both steps no-op. Every existing AEON fork keeps running exactly as before.

## Safety properties

- **Fail-closed**: when secrets are set but Fleet is unreachable, preflight exits non-zero. Claude never runs.
- **Postflight always runs** (`if: always()`): failed and blocked skills are still recorded — failure itself is signal for taint analysis.
- **Idempotent within an attempt**: each step sends `clientOpId=${RUN_ID}-${ATTEMPT}-{pre,post}` so step re-evaluation dedupes to a single verdict / event server-side.
- **No new permissions or runners**: only `curl` + `jq` (already available on `ubuntu-latest`).
- **Secrets at workflow-env scope**: hoisted to the top-level `env:` block so the `if:` clauses can actually see them (step-level env is not visible in `if:`).

## How to enable on a repo

1. Stand up Fleet Watcher.
2. Mint an agent token: `POST /api/aeon/register` with `{"name":"my-aeon-fork","environment":"production"}`.
3. Add two repo secrets:
   - `FLEET_ENDPOINT` = base URL of your Fleet
   - `FLEET_TOKEN` = the `agnt_…` returned by register
4. Define policies in the Fleet dashboard.

Full setup steps and rationale are in the new "Fleet Watcher" section added to `README.md`.