### PR TITLE
fix(skill-update-check): honor branch field in skills.lock when querying commits (closes AntFleet H7)

### DIFF
--- a/skills/skill-update-check/SKILL.md
+++ b/skills/skill-update-check/SKILL.md
@@ -34,11 +34,12 @@ Today is ${today}. Audit imported skills for upstream changes since installation
 
 ### 2. Per-skill drift detection
 
-For each entry, fetch the latest upstream commit SHA for the locked source path:
+For each entry, fetch the latest upstream commit SHA for the locked source path **on the tracked branch**:
 ```bash
-gh api "repos/${source_repo}/commits" -f path="${source_path}" -f per_page=1 \
+gh api "repos/${source_repo}/commits" -f path="${source_path}" -f sha="${branch}" -f per_page=1 \
   --jq '.[0] | if . == null then "MISSING" else {sha: .sha, message: .commit.message, date: .commit.author.date, author: .commit.author.name} end'
 ```
+The `-f sha="${branch}"` constraint is required: the `commits` API defaults to the repository's default branch, so skills locked to a non-default branch (e.g. `release`, `develop`) would otherwise be compared against the wrong history and produce false `UP-TO-DATE` / `CHANGED` results.
 - If output is `"MISSING"`, classify status as `MISSING_UPSTREAM` (file deleted or path renamed upstream — treat as a security signal in step 5).
 - If the API call fails:
   - On `429` or `5xx`: wait 60 seconds and retry once. If still failing, mark `UNREACHABLE` for this run.


### PR DESCRIPTION
## Summary

The drift-detection step in `skills/skill-update-check/SKILL.md` queries `gh api repos/${source_repo}/commits` without constraining the lookup to the tracked branch. The GitHub commits API defaults to the repository's default branch, so skills locked to a non-default branch (e.g. `release`, `develop`) get compared against the wrong commit history and produce false `UP-TO-DATE` / `CHANGED` results.

## Evidence

This issue was flagged by AntFleet's two-model unanimous review gate on a benchmark replay of #34:

- AntFleet receipt: https://github.com/AntFleet/aeon-bench/pull/30#issuecomment-4475378888
- Original PR (merged 2026-04-14): https://github.com/aaronjmars/aeon/pull/34
- Specific finding: **High · Bug** — Branch field in skills.lock is ignored when fetching latest commits
- Location: `skills/skill-update-check/SKILL.md:22` (step 2)

Indexed from Issue #184 (closed) as **H7**.

The finding was an agreement between two independent frontier reviewers (Claude Opus 4.7 + GPT-5). See https://antfleet.dev for context on the review methodology.

## Proposed fix

Adds `-f sha="${branch}"` to the `gh api repos/{repo}/commits` call so the latest-commit resolution matches the branch the skill is actually pinned to, and expands the inline note so a future edit doesn't drop the constraint again. Minimal one-flag change with no other surface area touched.

## Notes for the maintainer

- This is a responsible-disclosure PR; you are under no obligation to merge.
- If you prefer a different approach (or have already addressed this in a separate WIP), feel free to close — the receipt stays on the bench PR regardless.
- Happy to revise the patch to match your project conventions if requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
