### PR TITLE
fix(contributor-spotlight): extract FORK_DEFAULT_BRANCH from repo stats (closes AntFleet H3)

### DIFF
--- a/skills/contributor-spotlight/SKILL.md
+++ b/skills/contributor-spotlight/SKILL.md
@@ -87,6 +87,13 @@ gh api "repos/${FEATURED_FORK}" \
   --jq '{stars: .stargazers_count, forks: .forks_count, default_branch, created_at, pushed_at, description, html_url}' \
   > /tmp/contrib-repo.json 2>/dev/null || echo '{}' > /tmp/contrib-repo.json
 
+# Extract default branch into FORK_DEFAULT_BRANCH for later content fetches.
+# Fall back to "main" if the repo stats call was empty or default_branch was
+# absent — most aeon forks default to "main", but the fetch below should
+# still tolerate a wrong ref (404) without aborting the run.
+FORK_DEFAULT_BRANCH=$(jq -r '.default_branch // "main"' /tmp/contrib-repo.json 2>/dev/null)
+[ -z "$FORK_DEFAULT_BRANCH" ] && FORK_DEFAULT_BRANCH=main
+
 # Recent commit activity (last 30 days, default branch)
 SINCE=$(date -u -d "${today} - 30 days" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
     || date -u -j -v-30d -f %Y-%m-%dT%H:%M:%SZ "${today}T00:00:00Z" +%Y-%m-%dT%H:%M:%SZ)


### PR DESCRIPTION
## Summary

The aeon.yml fetch in step 5 of `skills/contributor-spotlight/SKILL.md` references `${FORK_DEFAULT_BRANCH}` but nothing in the skill ever assigns it. `default_branch` is retrieved into `/tmp/contrib-repo.json` a few lines earlier, but it isn't extracted into an environment variable, so the fetch lands at `repos/${FEATURED_FORK}/contents/aeon.yml?ref=` with an empty `ref` — which coincidentally falls back to the default branch for most forks but is silently wrong for any fork whose default is renamed, and fragile to anyone reading the skill expecting the variable to be set.

## Evidence

This issue was flagged by AntFleet's two-model unanimous review gate on a benchmark replay of #163:

- AntFleet receipt: https://github.com/AntFleet/aeon-bench/pull/21#issuecomment-4475668365
- Original PR (merged 2026-05-09): https://github.com/aaronjmars/aeon/pull/163
- Specific finding: **High · Bug** — Undefined `FORK_DEFAULT_BRANCH` used to fetch aeon.yml from the fork
- Location: `skills/contributor-spotlight/SKILL.md` (step 4 → step 5)

Indexed from Issue #184 (closed) as **H3**.

The finding was an agreement between two independent frontier reviewers (Claude Opus 4.7 + GPT-5). See https://antfleet.dev for context on the review methodology.

## Proposed fix

Adds a one-liner immediately after the `/tmp/contrib-repo.json` write that extracts `default_branch` from the JSON into `FORK_DEFAULT_BRANCH`, with a `// "main"` fallback for the case where the repo-stats call returned an empty object. The fetch in step 5 now resolves the variable correctly without changing any other logic.

## Notes for the maintainer

- This is a responsible-disclosure PR; you are under no obligation to merge.
- If you prefer a different approach (or have already addressed this in a separate WIP), feel free to close — the receipt stays on the bench PR regardless.
- Happy to revise the patch to match your project conventions if requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
