### PR TITLE
fix(fleet-state): create .bak before write + validate TMP before promote (closes AntFleet H4)

### DIFF
--- a/skills/fleet-state/SKILL.md
+++ b/skills/fleet-state/SKILL.md
@@ -288,6 +288,12 @@ Cap the article at ~400 lines. If any section's bullet list exceeds the cap, tri
 ### 11. Persist state
 
 ```bash
+# Roll the .bak forward BEFORE we touch the live file. This is the only
+# place that creates the backup; without this line the rollback path
+# below (cp .bak ...) would have nothing to restore from on a corrupt
+# write — both the live file and the backup would be lost.
+[ -f memory/topics/fleet-state.json ] && cp memory/topics/fleet-state.json memory/topics/fleet-state.json.bak
+
 TMP=$(mktemp)
 jq --arg ts "$(date -u +%FT%TZ)" \
    --arg today "$(date -u +%F)" \
@@ -301,11 +307,22 @@ jq --arg ts "$(date -u +%FT%TZ)" \
   .snapshot = {totals: $totals, release_count: $release_count, spotlight_fork: $spotlight_fork} |
   .history = ((.history // []) + [{run_date: $today, totals: $totals, release_count: $release_count, spotlight_fork: $spotlight_fork}] | sort_by(.run_date) | .[-12:])
 ' memory/topics/fleet-state.json > "$TMP"
-mv "$TMP" memory/topics/fleet-state.json
-jq empty memory/topics/fleet-state.json || { cp memory/topics/fleet-state.json.bak memory/topics/fleet-state.json; exit 1; }
+
+# Validate the candidate write before promoting it. If jq produced
+# invalid JSON (interrupted pipe, disk error, malformed input), leave
+# the live file untouched — the .bak rotation above is the safety net
+# for the rarer case where the live file itself is corrupt at start.
+if jq empty "$TMP" 2>/dev/null; then
+  mv "$TMP" memory/topics/fleet-state.json
+else
+  rm -f "$TMP"
+  cp memory/topics/fleet-state.json.bak memory/topics/fleet-state.json 2>/dev/null || true
+  echo "FLEET_STATE_STATE_CORRUPT: jq build produced invalid JSON; restored from .bak" >&2
+  exit 1
+fi
 ```
 
-Keep one `.bak` rolling. If `jq empty` fails after write → log `FLEET_STATE_STATE_CORRUPT`, restore from `.bak`, exit `ERROR`.
+Keep one `.bak` rolling. The rotation runs every persist step so the rollback always has a non-empty backup to restore from.
 
 In `MODE=dry-run`: build the article + computed deltas + planned state diff, log everything, **do not** call `./notify`, **do** write the article and update state (so a real run later doesn't re-fire the same week with stale baselines).
 


### PR DESCRIPTION
## Summary

The persist-state step in `skills/fleet-state/SKILL.md` declares *"keep one `.bak` rolling. If `jq empty` fails after write → restore from `.bak`"* — but nothing in the step ever creates the `.bak`. The sequence is `mv $TMP ...json` first, then `jq empty` validation on the live file, with rollback attempting `cp ...json.bak ...json`. On a failed validate, the rollback `cp` silently fails (no source) and the operator is left with a corrupt `fleet-state.json` and no recovery path — and since the live file was already overwritten, the previous week's state is unrecoverable.

## Evidence

This issue was flagged by AntFleet's two-model unanimous review gate on a benchmark replay of #168:

- AntFleet receipt: https://github.com/AntFleet/aeon-bench/pull/24#issuecomment-4475370933
- Original PR (merged 2026-05-14): https://github.com/aaronjmars/aeon/pull/168
- Specific finding: **High · Data-loss** — State file rollback uses non-existent `.bak`, can cause data loss on write failure
- Location: `skills/fleet-state/SKILL.md:291-306` (step 11)

Indexed from Issue #184 (closed) as **H4**.

The finding was an agreement between two independent frontier reviewers (Claude Opus 4.7 + GPT-5). See https://antfleet.dev for context on the review methodology.

## Proposed fix

Two adjustments to the persist sequence, both minimal:

1. Add a `cp …json …json.bak` step **before** the write attempt, so the rollback path always has a non-empty backup. Runs every persist iteration as a rolling backup.
2. Move the `jq empty` check from *after* the `mv` to *before* the `mv` — the candidate JSON is validated in the temp file, and only promoted to the live file if valid. If it's invalid, the temp file is discarded and the live file is restored from `.bak` defensively. The error log is preserved.

Net effect: a malformed jq output now leaves the live file at the prior good state instead of replacing it with a corrupt blob.

## Notes for the maintainer

- This is a responsible-disclosure PR; you are under no obligation to merge.
- If you prefer a different approach (or have already addressed this in a separate WIP), feel free to close — the receipt stays on the bench PR regardless.
- Happy to revise the patch to match your project conventions if requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
