### PR TITLE
fix(admanage): write ad sets with direct campaignId to state via id->name map (closes AntFleet H9)

### DIFF
--- a/scripts/postprocess-admanage-create.sh
+++ b/scripts/postprocess-admanage-create.sh
@@ -63,6 +63,16 @@ while IFS=$'\t' read -r cfg_name cid; do
   [ -n "$cfg_name" ] && NAME_TO_ID["$cfg_name"]="$cid"
 done < <(jq -r '.campaigns[]? | [.configName, .campaignId] | @tsv' "$STATE_FILE")
 
+# Reverse map: campaign ID -> config name. Used by Phase 2 to find the state
+# entry for an ad set whose payload supplies a direct campaignId without a
+# parentCampaignConfigName — without this, the state-write `select` runs
+# against an empty $parent and silently appends the ad set under no
+# campaign, leaving .admanage-state/campaigns.json out of sync.
+declare -A ID_TO_NAME
+while IFS=$'\t' read -r cid cfg_name; do
+  [ -n "$cid" ] && ID_TO_NAME["$cid"]="$cfg_name"
+done < <(jq -r '.campaigns[]? | [.campaignId, .configName] | @tsv' "$STATE_FILE")
+
 campaign_success=0
 campaign_fail=0
 adset_success=0
@@ -163,9 +173,24 @@ for file in "${ADSET_FILES[@]}"; do
     continue
   fi
 
+  # Resolve the parent's configName for the state write. If the payload
+  # supplied a direct campaignId without parentCampaignConfigName, the
+  # ID->name reverse map (built from STATE_FILE at startup) tells us which
+  # campaign to attach the ad set to. Without this, the jq select below
+  # would run against an empty $parent and silently no-op.
+  state_parent="$parent_name"
+  if [ -z "$state_parent" ]; then
+    cid_for_lookup=$(echo "$payload" | jq -r '.campaignId // empty')
+    state_parent="${ID_TO_NAME[$cid_for_lookup]:-}"
+  fi
+  if [ -z "$state_parent" ]; then
+    echo "postprocess-admanage-create: WARNING ad-set '$cfg_name' created (id=$adset_id) but parent campaign is unknown — state not updated"
+    summary_lines+=("adset '$cfg_name' → $adset_id (state SKIPPED: parent campaign unknown)")
+  fi
+
   # Append to state under the right campaign
   tmp=$(mktemp)
-  jq --arg parent "$parent_name" --arg name "$cfg_name" --arg aid "$adset_id" \
+  jq --arg parent "$state_parent" --arg name "$cfg_name" --arg aid "$adset_id" \
      --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
      '(.campaigns[] | select(.configName == $parent) | .adSets) += [{configName:$name, adSetId:$aid, createdAt:$ts}]' \
      "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"


### PR DESCRIPTION
## Summary

Phase 2 of `scripts/postprocess-admanage-create.sh` builds the state-file entry for a newly created ad set using `select(.configName == $parent)`, where `$parent` is the `parentCampaignConfigName` from the payload. When a payload supplies a direct `campaignId` instead of a `parentCampaignConfigName` (the script allows this path — only the `__RESOLVE_FROM_PARENT__` sentinel or an empty id triggers the name-based resolution branch), `$parent` ends up empty, the jq `select` matches no campaign, and the ad set is never appended to `.admanage-state/campaigns.json`. Symptom: the ad set is created in AdManage and recorded in `creates-results/`, but the next Claude run reads stale state and may re-queue the same ad set.

## Evidence

This issue was flagged by AntFleet's two-model unanimous review gate on a benchmark replay of #138:

- AntFleet receipt: https://github.com/AntFleet/aeon-bench/pull/4#issuecomment-4475360859
- Original PR (merged 2026-04-21): https://github.com/aaronjmars/aeon/pull/138
- Specific finding: **High · Bug** — Ad sets with only `campaignId` (no `parentCampaignConfigName`) are not written to state
- Location: `scripts/postprocess-admanage-create.sh:121-123` (Phase 2 state write at ~L168-171)

Indexed from Issue #184 (closed) as **H9**.

The finding was an agreement between two independent frontier reviewers (Claude Opus 4.7 + GPT-5). See https://antfleet.dev for context on the review methodology.

## Proposed fix

Three changes, all contained within Phase 2:

1. Build a reverse `ID_TO_NAME` map from `STATE_FILE` alongside the existing `NAME_TO_ID` preload (one extra `jq` pass at startup).
2. Before the state-write `jq` call, resolve the campaign's `configName` from the reverse map when `parent_name` is empty. The resolved name (`state_parent`) is what the `select` filters on.
3. If the campaignId in the payload isn't in the reverse map either (e.g. it references a campaign created outside this skill's state), the ad set is still created via the API call above, but the state-write is skipped with a `WARNING` log line and a summary entry noting "state SKIPPED: parent campaign unknown" — the operator sees the missing-state message in the post-run notification instead of the bug silently dropping the ad set.

Other findings on the same source PR (medium `--argjson` non-JSON guard, medium docs/exit mismatch) are scoped out for this PR; happy to send focused follow-ups if useful.

## Notes for the maintainer

- This is a responsible-disclosure PR; you are under no obligation to merge.
- If you prefer a different approach (or have already addressed this in a separate WIP), feel free to close — the receipt stays on the bench PR regardless.
- Happy to revise the patch to match your project conventions if requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
