### PR TITLE
feat: add Resend email-send step to morning-brief and weekly-review skills

### DIFF
--- a/skills/morning-brief/SKILL.md
+++ b/skills/morning-brief/SKILL.md
@@ -62,9 +62,28 @@ Style rules:
 - If fewer than 3 candidates survive the why-now bar, allow **up to 1 background item** (tagged `background:` instead of `why now:`) so the brief still surfaces something worth knowing on quiet days. Never invent items, and never include more than 1 background item.
 - If soul files under `soul/` are populated, match that voice; otherwise keep it direct and neutral (per CLAUDE.md).
 
-### 4. Send via `./notify` and log
+### 4. Send via `./notify` and email
 
 - Send the formatted brief with `./notify "..."`.
+- Send email via Resend:
+  - Build the brief as HTML (wrap each section in `<h2>` headers, `<ul>/<li>` bullets)
+  - Also keep a plain-text copy (the `./notify` content above, as-is)
+  - Parse `$BRIEF_RECIPIENTS` as a comma-separated list of addresses
+  - POST to `https://api.resend.com/emails`:
+    ```
+    Authorization: Bearer $RESEND_API_KEY
+    Content-Type: application/json
+
+    {
+      "from": "Aeon Briefings <onboarding@resend.dev>",
+      "to": ["<each recipient>"],
+      "subject": "[Aeon] Morning Brief — ${today}",
+      "html": "<html version>",
+      "text": "<plain-text version>"
+    }
+    ```
+  - Log the `id` field from the Resend response as a comment on the current Paperclip execution issue for traceability
+  - If Resend returns an error, log the full error body as a comment and fail loudly (do not silently continue)
 - Append to `memory/logs/${today}.md` under a `### morning-brief` heading: timestamp, the 3 focus items (one line each), headline count, and any skills flagged from cron-state. This becomes tomorrow's "since yesterday" input.
 
 ## Sandbox note

--- a/skills/weekly-review/SKILL.md
+++ b/skills/weekly-review/SKILL.md
@@ -128,7 +128,29 @@ Health: N/M skill runs ok, K new issues
 Full review: articles/weekly-review-${today}.md
 ```
 
-### 8. Log to memory
+### 8. Send email via Resend
+
+Send the full weekly review article (not just the `./notify` summary) to the board:
+- Build the full retrospective as HTML (wrap each section in `<h2>` headers, `<ul>/<li>` bullets)
+- Also keep a plain-text copy (the full weekly review text)
+- Parse `$BRIEF_RECIPIENTS` as a comma-separated list of addresses
+- POST to `https://api.resend.com/emails`:
+  ```
+  Authorization: Bearer $RESEND_API_KEY
+  Content-Type: application/json
+
+  {
+    "from": "Aeon Briefings <onboarding@resend.dev>",
+    "to": ["<each recipient>"],
+    "subject": "[Aeon] Weekly Review — week of ${today}",
+    "html": "<html version of full review>",
+    "text": "<plain-text version of full review>"
+  }
+  ```
+- Log the `id` field from the Resend response as a comment on the current Paperclip execution issue for traceability
+- If Resend returns an error, log the full error body as a comment and fail loudly (do not silently continue)
+
+### 9. Log to memory
 
 Append to `memory/logs/${today}.md`:
 


### PR DESCRIPTION
## Summary

Adds a board email delivery step (via Resend API) to both skills:

- **morning-brief**: After `./notify`, sends HTML+plain-text email to `$BRIEF_RECIPIENTS` via Resend
- **weekly-review**: After `./notify`, sends the full retrospective as HTML+plain-text email to `$BRIEF_RECIPIENTS` via Resend

Both skills log the Resend `id` to the Paperclip execution issue on success, and fail loudly on error.

## Why

These changes were applied locally in Paperclip company [AEO-6] but the skill files are sourced from this repo. Without this PR, the email step will be lost on next skill reinstall.

## Env vars required

- `RESEND_API_KEY` — Resend API key
- `BRIEF_RECIPIENTS` — comma-separated list of recipient addresses

Generated by Paperclip agent (Briefings Editor) for Aeon Intelligence — AEO-7.