### PR TITLE
fix(fleet-state): guard empty spotlight history + reconcile Sandbox note

### DIFF
--- a/skills/fleet-state/SKILL.md
+++ b/skills/fleet-state/SKILL.md
@@ -108,12 +108,23 @@ RELEASES_THIS_WEEK=$(jq --arg cutoff "$SEVEN_DAYS_AGO" \
 RELEASE_COUNT=$(echo "$RELEASES_THIS_WEEK" | jq 'length')
 ```
 
-From `contributor-spotlight-history.json` — pick the newest entry:
+From `contributor-spotlight-history.json` — pick the newest entry. When
+`.history` is empty (fresh install, no spotlight has ever run) the first
+jq emits nothing, which makes `SPOTLIGHT_PICK` an empty string. Piping
+that into a second `jq` produces a parse error and aborts the digest —
+violating the "degrade gracefully" intent above. Guard the secondary
+extractions so missing history leaves both fields empty and the
+downstream `SPOTLIGHT_DATE` staleness check still works.
 
 ```bash
 SPOTLIGHT_PICK=$(jq -r '.history | sort_by(.featured_at) | .[-1] // empty' "$SPOTLIGHT_HISTORY")
-SPOTLIGHT_FORK=$(echo "$SPOTLIGHT_PICK" | jq -r '.fork // empty')
-SPOTLIGHT_DATE=$(echo "$SPOTLIGHT_PICK" | jq -r '.featured_at // empty')
+if [ -n "$SPOTLIGHT_PICK" ]; then
+  SPOTLIGHT_FORK=$(echo "$SPOTLIGHT_PICK" | jq -r '.fork // empty')
+  SPOTLIGHT_DATE=$(echo "$SPOTLIGHT_PICK" | jq -r '.featured_at // empty')
+else
+  SPOTLIGHT_FORK=""
+  SPOTLIGHT_DATE=""
+fi
 ```
 
 If `SPOTLIGHT_DATE` is older than 8 days → `spotlight=stale`. Render the section with a `(spotlight last ran $SPOTLIGHT_DATE)` note; the synthesis still works.
@@ -412,4 +423,4 @@ Full digest: articles/fleet-state-${today}.md
 
 ## Sandbox note
 
-Pure local file I/O — reads state files in `memory/topics/`, reads articles in `articles/`, writes a new article + state file + log entry. No `curl`, no `gh api` calls, no env-var-in-headers. The `./notify` path uses the existing `.pending-notify/` post-process pattern when run inside GitHub Actions.
+Almost-pure local file I/O — reads state files in `memory/topics/`, reads articles in `articles/`, writes a new article + state file + log entry. One `gh api repos/<self>` and one `gh repo view` call in Step 2 to resolve `PARENT_REPO` when `PARENT_OVERRIDE` is empty; skip both by exporting `PARENT_OVERRIDE=<owner>/<repo>` before running. No `curl`, no env-var-in-headers, no `gh api` against fork repos. The `./notify` path uses the existing `.pending-notify/` post-process pattern when run inside GitHub Actions.


### PR DESCRIPTION
Two small follow-ups to #203, both surfaced by an AntFleet review of the fleet-state skill on the post-#203 `main`.

## 1) `[Bug · High]` Empty spotlight history aborts the digest

`skills/fleet-state/SKILL.md` lines 113-117. When `contributor-spotlight-history.json`'s `.history` is empty (fresh install, no spotlight has ever run), the first jq emits nothing → `SPOTLIGHT_PICK` becomes the empty string → the subsequent `echo "$SPOTLIGHT_PICK" | jq -r '.fork // empty'` produces a parse error and the run aborts non-zero.

That contradicts the "degrade gracefully — a missing source produces a partial section, not a hard failure" intent stated a few lines up in the same section. Guarded with `if [ -n "$SPOTLIGHT_PICK" ]` so missing history leaves both fields empty and the existing `SPOTLIGHT_DATE older than 8 days` staleness branch handles the downstream render.

## 2) `[Docs-gap · Low]` Sandbox note contradicts Step 2's `gh api` calls

`skills/fleet-state/SKILL.md` lines 79-86 (Step 2 body) vs line 415 (Sandbox note). The Sandbox note claims `No curl, no gh api calls, no env-var-in-headers`. But Step 2 ("Resolve parent repo") calls both `gh api repos/<self>` and `gh repo view` when `PARENT_OVERRIDE` is empty.

An operator reading the security/sandbox section would believe the skill is hermetic local I/O when it actually shells out to GitHub on every non-override run. Note updated to disclose the one call honestly, with `PARENT_OVERRIDE` documented as the escape hatch.

---

Both findings surfaced by AntFleet review `1939cc1e` on bench replay of #203. Receipt: https://github.com/AntFleet/aeon-bench/pull/32

🤖 Generated with [Claude Code](https://claude.com/claude-code)
