### PR TITLE
Adds zer0-skill-pack to the community skill packs table

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,7 @@ The script reads a `skills-pack.json` manifest from the pack root (or falls back
 |------|--------|-------------|
 | [aeon-skill-pack-vvvkernel](https://github.com/baseddevoloper/aeon-skill-pack-vvvkernel) | 9 | Venice AI inference via VVVKernel — onchain, audit, growth, narrative, image gen, monitoring |
 | [luca-aeon-skills](https://github.com/danbuildss/luca-aeon-skills) | 4 | Financial intelligence via x402Books AI — wallet scanning, treasury monitoring, financial reports, and agent registry on Base |
+| [zer0-skill-pack](https://github.com/0xShak/zer0-skill-pack) | 6 | Polymarket intelligence — daily thesis, mispricing scanner, contrarian fades, narrative-vs-markets, paper-trade PnL journal, alpha comment curator |
 
 **To list a pack here**, open a PR adding a row. Guidelines:
 


### PR DESCRIPTION
6 Polymarket skills focused on commentary + reasoning rather than raw monitoring. composes on top of the built-in `monitor-polymarket` and `polymarket-comments` instead of duplicating them.

  - `polymarket-thesis` - daily 3-market take
  - `polymarket-edge` - mispricing scanner
  - `polymarket-contrarian` - fades against heavy favorites
  - `narrative-vs-markets` - X discourse vs market odds gap
  - `prediction-journal` - paper-trade PnL with settlement
  - `polymarket-alpha-comments` - curated whale/insider/contrarian comments

All skills are paper-trade only - public Polymarket APIs only, no orders placed, no funds touched. Per-skill  `SKILL.md` follows the core catalog conventions.

Repo: https://github.com/0xShak/zer0-skill-pack
License: MIT