### PR TITLE
Adds gitbounty-skill-pack to the community skill packs table

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,7 @@ Third-party skill collections that live in their own repos. Aeon doesn't ship th
 |------|--------|-------------|
 | [aeon-skill-pack-vvvkernel](https://github.com/baseddevoloper/aeon-skill-pack-vvvkernel) | 9 | Venice AI inference via VVVKernel — onchain, audit, growth, narrative, image gen, monitoring |
 | [luca-aeon-skills](https://github.com/danbuildss/luca-aeon-skills) | 4 | Financial intelligence via x402Books AI — wallet scanning, treasury monitoring, financial reports, and agent registry on Base |
+| [gitbounty-skill-pack](https://github.com/gitlawbounty/gitbounty-skill-pack) | 1 | Bounty hunting on the gitlawb network via gitbounty — discover open bounties, scout the best fit with the gitbounty LLM scout, draft a solution plan (read-only) |
 
 **To list a pack here**, open a PR adding a row. Guidelines:
 


### PR DESCRIPTION
## What
Adds the gitbounty-skill-pack to the community skill packs table.

## Pack
[gitbounty-skill-pack](https://github.com/gitlawbounty/gitbounty-skill-pack) — 1 skill, MIT licensed.

- `bounty-hunter` — discovers open bounties on the gitlawb network via the public gitbounty firehose, scouts the best fit with the gitbounty LLM scout (difficulty, skills, alpha, pitfalls), and drafts a PR plan with a confidence score. Read-only: no on-chain claims, no private endpoints.

Install: `./add-skill gitlawbounty/gitbounty-skill-pack bounty-hunter`

Meets the listing guidelines: own public repo, MIT license, per-skill SKILL.md, uses only the public CORS-open gitbounty API.