### PR TITLE
feat: machine-readable skill-packs.json registry + --list browsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,8 @@ Third-party skill collections that live in their own repos. Aeon doesn't ship th
 
 The script reads a `skills-pack.json` manifest from the pack root (or falls back to scanning `skills/`), runs the security scanner on each declared `SKILL.md`, and copies approved skills into `skills/` with rows added to `skills.json`, entries in `aeon.yml` (disabled), and provenance in `skills.lock`. Full schema and trust model in [`docs/community-skill-packs.md`](docs/community-skill-packs.md).
 
+To browse known packs without installing, run `./install-skill-pack --list` — it reads the machine-readable registry in [`skill-packs.json`](skill-packs.json) (mirror of the table below).
+
 | Pack | Skills | Description |
 |------|--------|-------------|
 | [aeon-skill-pack-vvvkernel](https://github.com/baseddevoloper/aeon-skill-pack-vvvkernel) | 9 | Venice AI inference via VVVKernel — onchain, audit, growth, narrative, image gen, monitoring |
@@ -458,6 +460,7 @@ The script reads a `skills-pack.json` manifest from the pack root (or falls back
 - Skills should follow the conventions in [`add-skill`](add-skill) and the core catalog — no monkey-patching of Aeon internals, no skill that depends on private endpoints.
 - Add a `skills-pack.json` manifest at the pack root so `install-skill-pack` knows which skills the pack ships (see [docs](docs/community-skill-packs.md) for the schema).
 - The README row should link to the repo, name the skill count, and one-line what the pack is for.
+- In the same PR, add a matching entry to [`skill-packs.json`](skill-packs.json) at this repo's root — the machine-readable mirror of the table that `./install-skill-pack --list` reads (registry schema in [the docs](docs/community-skill-packs.md#skill-packsjson-community-registry)).
 
 This is the lightweight surface: it gives community packs visibility without coupling them to the core catalog's release cadence.
 

--- a/docs/community-skill-packs.md
+++ b/docs/community-skill-packs.md
@@ -11,6 +11,14 @@ This page documents the **install protocol** — the `skills-pack.json` manifest
 
 ---
 
+## Browse the registry
+
+```bash
+./install-skill-pack --list
+```
+
+Prints every pack declared in `skill-packs.json` (at the Aeon repo root) — repo, skill count, trust badge, one-line description. Trusted-source packs are marked with `*` (security scan skipped, format check still runs). The script reads the local `skill-packs.json` when present and falls back to fetching the file from `https://raw.githubusercontent.com/aaronjmars/aeon/main/skill-packs.json` when it isn't.
+
 ## One-command install
 
 ```bash
@@ -157,7 +165,57 @@ The operator is always the trust boundary. The install script does not auto-trus
 3. Skills follow Aeon's `SKILL.md` conventions (frontmatter `name:`, `description:`, etc.).
 4. `skills-pack.json` declares every skill the pack intends to install. Skills present in `skills/` but missing from the manifest are not installed.
 5. Optional but encouraged: a `README.md` that names each skill, explains scheduling assumptions, and lists any required environment variables.
-6. Open a PR against `aaronjmars/aeon` to add a row to the **Community Skill Packs** table in the project README.
+6. Open a PR against `aaronjmars/aeon` that does **two** things in one diff: adds a row to the **Community Skill Packs** table in the project README, AND adds a matching entry to `skill-packs.json` (the machine-readable registry — see schema below).
+
+---
+
+## skill-packs.json (community registry)
+
+`skill-packs.json` at the Aeon repo root is the machine-readable mirror of the README's Community Skill Packs table. `./install-skill-pack --list` reads it; future tooling (dashboards, third-party indexers) can read it without scraping the README.
+
+### Registry schema
+
+```json
+{
+  "version": "1.0",
+  "updated": "2026-05-23",
+  "description": "Machine-readable registry of community skill packs ...",
+  "packs": [
+    {
+      "repo": "owner/repo",
+      "name": "Pack Name",
+      "description": "One-line summary",
+      "author": "github-handle-or-name",
+      "license": "MIT",
+      "homepage": "https://...",
+      "category": "research|dev|crypto|social|productivity",
+      "trust_level": "trusted|community",
+      "skills": ["slug-1", "slug-2"]
+    }
+  ]
+}
+```
+
+### Field reference
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `repo` | string | **required** | `owner/repo` — the GitHub repo holding the pack. |
+| `name` | string | recommended | Human-readable display name. Falls back to repo name. |
+| `description` | string | recommended | One-line summary shown by `--list`. |
+| `author` | string | recommended | Maintainer handle or org. |
+| `license` | string | optional | SPDX identifier. |
+| `homepage` | string | optional | Project page or docs link. |
+| `category` | string | optional | Same vocabulary as per-skill category. |
+| `trust_level` | string | optional | `trusted` (also requires the source in `skills/security/trusted-sources.txt`) or `community`. Default `community`. Listing here is a discovery hint — the actual scan-bypass behaviour is decided by the trusted-sources file. |
+| `skills[]` | array | **required** | Slugs the pack ships. Mirror the pack's own `skills-pack.json`. |
+
+### Why two files (README table + skill-packs.json)?
+
+- The README table is for humans browsing GitHub.
+- `skill-packs.json` is for tooling: `./install-skill-pack --list`, dashboard widgets, third-party crawlers, future package-resolver tooling.
+
+Pack maintainers update both in the same PR so the two surfaces stay in lockstep.
 
 ---
 

--- a/install-skill-pack
+++ b/install-skill-pack
@@ -11,6 +11,7 @@ set -euo pipefail
 #   distribution surface that the Community Skill Packs README section describes.
 #
 # Usage:
+#   ./install-skill-pack --list                              List every pack in the community registry (skill-packs.json)
 #   ./install-skill-pack <github-repo>                       Install everything the pack manifest declares
 #   ./install-skill-pack <github-repo> --list                List skills in the pack
 #   ./install-skill-pack <github-repo> <skill> [skill...]    Install only the named skills from the pack
@@ -50,21 +51,27 @@ SKILLS_LOCK="$ROOT_DIR/skills.lock"
 AEON_YML="$ROOT_DIR/aeon.yml"
 SCANNER="$ROOT_DIR/skills/skill-security-scan/scan.sh"
 TRUSTED_FILE="$ROOT_DIR/skills/security/trusted-sources.txt"
+REGISTRY_FILE="$ROOT_DIR/skill-packs.json"
+REGISTRY_URL="https://raw.githubusercontent.com/aaronjmars/aeon/main/skill-packs.json"
 TMP_DIR=$(mktemp -d)
 trap 'rm -rf "$TMP_DIR"' EXIT
 
 usage() {
   cat <<'EOF'
-Usage: ./install-skill-pack <github-repo> [options] [skill-names...]
+Usage: ./install-skill-pack [<github-repo>] [options] [skill-names...]
 
-Install a curated community skill pack from a GitHub repository.
+Install a curated community skill pack from a GitHub repository, or browse the
+community registry.
 
 Arguments:
   <github-repo>          owner/repo (e.g. baseddevoloper/aeon-skill-pack-vvvkernel)
+                         Omit with --list to browse the community registry.
   [skill-names...]       Optional — limit install to specific slugs from the pack
 
 Options:
-  --list                 List skills declared by the pack (no install)
+  --list                 Without <github-repo>: list every pack in the community
+                         registry (skill-packs.json). With <github-repo>: list
+                         skills declared inside that pack (no install).
   --path <subdir>        Pack lives in a subdirectory (where skills-pack.json sits)
   --branch <branch>      Use a specific branch or tag (default: main)
   --yes                  Non-interactive — auto-accept HIGH-severity findings
@@ -77,14 +84,95 @@ Pack manifest:
   it falls back to scanning skills/*/SKILL.md. See docs/community-skill-packs.md
   for the manifest schema.
 
+Community registry:
+  skill-packs.json at the repo root is the machine-readable index of known
+  packs. Use --list (no repo arg) to enumerate it; the script reads the local
+  file when available and falls back to the upstream raw URL otherwise.
+
 Examples:
+  ./install-skill-pack --list
   ./install-skill-pack baseddevoloper/aeon-skill-pack-vvvkernel --list
   ./install-skill-pack baseddevoloper/aeon-skill-pack-vvvkernel
-  ./install-skill-pack baseddevoloper/aeon-skill-pack-vvvkernel vvv-onchain vvv-audit
+  ./install-skill-pack baseddevoloper/aeon-skill-pack-vvvkernel vvvkernel-onchain vvvkernel-audit
   ./install-skill-pack danbuildss/luca-aeon-skills --dry-run
 EOF
   exit 0
 }
+
+# --- Registry listing path -------------------------------------------------
+# When the only meaningful argument is --list (no repo, no path/branch/etc),
+# print the community registry and exit. This is a strict "no repo + only
+# --list flag" check so power flags still error if used incorrectly.
+load_registry() {
+  if [[ -f "$REGISTRY_FILE" ]]; then
+    cat "$REGISTRY_FILE"
+    return 0
+  fi
+  # Local file missing — try the upstream raw URL via curl. If curl is sandbox-
+  # blocked the caller can re-run the command from a clone with the file present.
+  if curl -sfL "$REGISTRY_URL" 2>/dev/null; then
+    return 0
+  fi
+  return 1
+}
+
+list_registry() {
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "jq is required to read the registry." >&2
+    exit 1
+  fi
+  local registry_json
+  if ! registry_json=$(load_registry); then
+    echo "Could not read skill-packs.json (local file missing and fetch from $REGISTRY_URL failed)." >&2
+    echo "Pass <github-repo> explicitly if you already know which pack to install." >&2
+    exit 1
+  fi
+  local updated total
+  updated=$(echo "$registry_json" | jq -r '.updated // ""')
+  total=$(echo "$registry_json" | jq '.packs | length')
+  echo ""
+  echo "Community skill pack registry${updated:+ (updated $updated)}"
+  echo ""
+  for i in $(seq 0 $((total - 1))); do
+    local repo desc trust skill_count
+    repo=$(echo "$registry_json" | jq -r ".packs[$i].repo")
+    desc=$(echo "$registry_json" | jq -r ".packs[$i].description // \"\"")
+    trust=$(echo "$registry_json" | jq -r ".packs[$i].trust_level // \"community\"")
+    skill_count=$(echo "$registry_json" | jq ".packs[$i].skills | length // 0")
+    local trust_badge=" "
+    [[ "$trust" == "trusted" ]] && trust_badge="*"
+    if [[ ${#desc} -gt 80 ]]; then desc="${desc:0:77}..."; fi
+    printf "  %s %-44s %2d skills  %s\n" "$trust_badge" "$repo" "$skill_count" "$desc"
+  done
+  echo ""
+  echo "  * = trusted source (security scan skipped, format check still runs)"
+  echo ""
+  echo "$total packs in registry. Install with: ./install-skill-pack <repo>"
+  exit 0
+}
+
+# Registry-list mode: `./install-skill-pack --list` (no repo, no other flags) prints
+# every pack in skill-packs.json. We do a focused detect-and-route here so the
+# original single-pack flow below is unchanged.
+detect_registry_list_mode() {
+  local list_seen=false
+  for arg in "$@"; do
+    case "$arg" in
+      --list) list_seen=true ;;
+      --help|-h) return 1 ;;
+      *)
+        # Any non-list flag OR any positional argument disqualifies registry mode
+        # — the user wants to operate on a specific pack.
+        return 1
+        ;;
+    esac
+  done
+  [[ "$list_seen" == "true" ]] && return 0 || return 1
+}
+
+if detect_registry_list_mode "$@"; then
+  list_registry
+fi
 
 if [[ $# -lt 1 ]] || [[ "$1" == "--help" ]] || [[ "$1" == "-h" ]]; then
   usage

--- a/skill-packs.json
+++ b/skill-packs.json
@@ -1,0 +1,84 @@
+{
+  "version": "1.0",
+  "updated": "2026-05-23",
+  "description": "Machine-readable registry of community skill packs installable via ./install-skill-pack. Mirrors the human-readable table in README.md.",
+  "packs": [
+    {
+      "repo": "AntFleet/aeon-skills",
+      "name": "AntFleet aeon-skills",
+      "description": "On-demand two-model-consensus PR review (Claude Opus + GPT) with on-chain USDC payment channel on Base. Pull-mode counterpart to AntFleet's auto-review GitHub App.",
+      "author": "AntFleet",
+      "license": "MIT",
+      "homepage": "https://www.antfleet.dev",
+      "category": "dev",
+      "trust_level": "trusted",
+      "skills": ["pr-review-antfleet"]
+    },
+    {
+      "repo": "baseddevoloper/aeon-skill-pack-vvvkernel",
+      "name": "aeon-skill-pack-vvvkernel",
+      "description": "Venice AI inference via VVVKernel — onchain, audit, growth, narrative, image gen, monitoring.",
+      "author": "baseddevoloper",
+      "license": "MIT",
+      "homepage": "https://github.com/baseddevoloper/aeon-skill-pack-vvvkernel",
+      "category": "crypto",
+      "trust_level": "community",
+      "skills": [
+        "vvvkernel",
+        "vvvkernel-audit",
+        "vvvkernel-brief",
+        "vvvkernel-digest",
+        "vvvkernel-growth",
+        "vvvkernel-image",
+        "vvvkernel-monitor",
+        "vvvkernel-narrative",
+        "vvvkernel-onchain"
+      ]
+    },
+    {
+      "repo": "danbuildss/luca-aeon-skills",
+      "name": "luca-aeon-skills",
+      "description": "Financial intelligence via x402Books AI — wallet scanning, treasury monitoring, financial reports, agent registry on Base.",
+      "author": "danbuildss",
+      "license": "MIT",
+      "homepage": "https://github.com/danbuildss/luca-aeon-skills",
+      "category": "crypto",
+      "trust_level": "community",
+      "skills": [
+        "check-agent",
+        "get-report",
+        "scan-wallet",
+        "treasury-monitor"
+      ]
+    },
+    {
+      "repo": "0xShak/zer0-skill-pack",
+      "name": "zer0-skill-pack",
+      "description": "Polymarket intelligence — daily theses, mispricing scans, contrarian fades, narrative-vs-markets gaps, paper-trade PnL journal, alpha comment curation.",
+      "author": "ZER0 LABS",
+      "license": "MIT",
+      "homepage": "https://atzer0.xyz",
+      "category": "crypto",
+      "trust_level": "community",
+      "skills": [
+        "prediction-journal",
+        "polymarket-thesis",
+        "polymarket-edge",
+        "polymarket-contrarian",
+        "narrative-vs-markets",
+        "polymarket-alpha-comments"
+      ]
+    },
+    {
+      "repo": "gitlawbounty/gitbounty-skill-pack",
+      "name": "GitBounty Skill Pack",
+      "description": "Bounty hunting on the gitlawb network — discovers open bounties via the gitbounty firehose, scouts the best fit, drafts a PR plan with a confidence score.",
+      "author": "gitlawbounty",
+      "license": "MIT",
+      "homepage": "https://github.com/gitlawbounty/gitbounty-skill-pack",
+      "category": "dev",
+      "trust_level": "community",
+      "skills": ["bounty-hunter"]
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds `skill-packs.json` at the repo root — a machine-readable mirror of the Community Skill Packs README table — and a registry-list mode in `./install-skill-pack` that reads it.

## Why

`install-skill-pack` shipped yesterday (PR #213). Within hours three community packs appeared: AntFleet/aeon-skills was added to trusted-sources (PR #211, merged), zer0-skill-pack (PR #208, open), gitbounty-skill-pack (PR #212, open). The current discovery surface is the README table — human-readable only, no `--list` flag, no third-party tooling can read it without scraping. A machine-readable index turns the growing table into a real package index that `./install-skill-pack --list`, dashboards, and future indexers can consume.

May-22 repo-actions idea #1.

## Changes

- **`skill-packs.json`** (new, at repo root): registry of 5 known packs with repo / name / description / author / license / homepage / category / trust_level / skills[]. Slug lists were sourced live from each pack's own `skills-pack.json` (for zer0 and gitbounty) or from `gh api .../contents/skills` listings (for vvvkernel and luca-aeon-skills).
- **`install-skill-pack`**: new `load_registry` + `list_registry` + `detect_registry_list_mode` functions. With no repo argument and only the `--list` flag, the script prints the registry (repo, skill count, trust badge, one-line description) and exits. The detector is strict — any other flag or any positional argument disqualifies registry mode and falls through to the existing single-pack `--list` path, so prior behaviour is preserved. Reads the local `skill-packs.json` when present; falls back to fetching from `https://raw.githubusercontent.com/aaronjmars/aeon/main/skill-packs.json` when the script runs outside a clone.
- **`docs/community-skill-packs.md`**: new "Browse the registry" section near the top, new "skill-packs.json (community registry)" section with full schema + field reference table + worked example, publishing-checklist updated so new pack PRs add BOTH a README row AND a `skill-packs.json` entry in the same diff.
- **`README.md`**: Community Skill Packs section now points to the new `--list` command and the registry file, and the listing guidelines call out the dual-update requirement.

## Notes

- `trust_level: "trusted"` in the registry is a discovery hint only — the actual scan-bypass behaviour is still gated by `skills/security/trusted-sources.txt`. Currently only `AntFleet/aeon-skills` qualifies.
- The 5 seed entries are sourced from PRs #208, #211, #212 + the two pre-existing README rows. Future pack PRs add a 6th, 7th, etc. row + entry in one diff.

---
*Built autonomously by Aeon*