### PR TITLE
docs: add AntFleet skill pack to community packs table

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,7 @@ The script reads a `skills-pack.json` manifest from the pack root (or falls back
 |------|--------|-------------|
 | [aeon-skill-pack-vvvkernel](https://github.com/baseddevoloper/aeon-skill-pack-vvvkernel) | 9 | Venice AI inference via VVVKernel — onchain, audit, growth, narrative, image gen, monitoring |
 | [luca-aeon-skills](https://github.com/danbuildss/luca-aeon-skills) | 4 | Financial intelligence via x402Books AI — wallet scanning, treasury monitoring, financial reports, and agent registry on Base |
+| [aeon-skills](https://github.com/AntFleet/aeon-skills) | 1 | Two-model-consensus PR review (Opus 4.7 + GPT-5) — per-review USDC drawdown on Base |
 
 **To list a pack here**, open a PR adding a row. Guidelines:
 


### PR DESCRIPTION
## Summary

Adds AntFleet's skill pack to the Community Skill Packs table.

- **Pack repo:** https://github.com/AntFleet/aeon-skills
- **Manifest:** [`skills-pack.json`](https://github.com/AntFleet/aeon-skills/blob/main/skills-pack.json) (per the `install-skill-pack` protocol from #213)
- **Skills:** 1 (`pr-review-antfleet`) — on-demand two-model-consensus PR review with per-review USDC drawdown on Base

## Trust properties

Same surface reviewed in #211 (trusted-sources, merged 2026-05-22):

- Single npm dep (`viem`, for EIP-191 signing)
- Scoped wallet key: signs review-trigger challenges only, cannot move USDC out of the channel
- TLS-required API base (rejects `http://`)
- Output written under `.outputs/` with a path-traversal guard (`resolve()` + reject `..`)
- Local input validation before minting a server-side challenge nonce

**Audit surface:** the full skill runner is a single file at [`pr-review-antfleet/run.mjs`](https://github.com/AntFleet/aeon-skills/blob/main/pr-review-antfleet/run.mjs) (~400 LOC, self-contained).

## Live receipts

Two findings from the bench review that led to #211:

- https://www.antfleet.dev/receipts/e488cbca-0 — trusted-sources logic documented in SKILL.md not implemented in scan.sh (medium, docs-gap)
- https://www.antfleet.dev/receipts/e488cbca-1 — security scanner uses PCRE tokens with grep -E, causing false negatives (security)
