### PR TITLE
docs(community-packs): list aeon-skill-pack-liquidpad

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,7 @@ The script reads a `skills-pack.json` manifest from the pack root (or falls back
 |------|--------|-------------|
 | [aeon-skill-pack-vvvkernel](https://github.com/baseddevoloper/aeon-skill-pack-vvvkernel) | 9 | Venice AI inference via VVVKernel — onchain, audit, growth, narrative, image gen, monitoring |
 | [luca-aeon-skills](https://github.com/danbuildss/luca-aeon-skills) | 4 | Financial intelligence via x402Books AI — wallet scanning, treasury monitoring, financial reports, and agent registry on Base |
+| [aeon-skill-pack-liquidpad](https://github.com/liquidpadbot/aeon-skill-pack-liquidpad) | 4 | Track LiquidPad on Base — burn cycle alerts, new token launches with onchain provenance, daily protocol digest, and fee accrual tracking |
 
 **To list a pack here**, open a PR adding a row. Guidelines:
 


### PR DESCRIPTION
Adds a row to the Community skill packs table for [`aeon-skill-pack-liquidpad`](https://github.com/liquidpadbot/aeon-skill-pack-liquidpad).

## What it is

A 4-skill pack for LiquidPad — an independent token launchpad on Base built on Liquid Protocol's open-source primitives.

| Slug | Schedule | What it does |
|------|----------|--------------|
| `liquidpad-burn-monitor` | every 6h | Alert on every $LPAD buyback & burn cycle |
| `liquidpad-token-alert` | every 30m | Notify on new token launches, verify on-chain via /api/verify |
| `liquidpad-stats-digest` | daily 14:00 UTC | Daily protocol digest — tokens, momentum, top by volume |
| `liquidpad-fee-tracker` | daily 08:00 UTC | Surface top-earning deployers (estimated from 24h volume) |

## Compliance with the install protocol

- ✅ `skills-pack.json` manifest at root, valid JSON, all required fields present
- ✅ Slugs match `[A-Za-z0-9_-]+`, no `..` in paths
- ✅ All 4 `SKILL.md` files pass `install-skill-pack`'s untrusted-source security scan (no shell injection patterns, no env exfil patterns)
- ✅ `default_enabled: false` for every skill (operator opts in explicitly)
- ✅ Pack repo is public, MIT-licensed, single per-skill `SKILL.md` per the convention
- ✅ Tested: `./install-skill-pack liquidpadbot/aeon-skill-pack-liquidpad` installs cleanly

## Endpoints used

Every skill consumes only LiquidPad's public, CORS-enabled, no-auth endpoints (`/api/burn`, `/api/stats`, `/api/token-stats`, `/api/verify`). No external API keys, no rate-limit tokens, no shared state.

## Attribution / posture

LiquidPad is an independent third-party project on Liquid Protocol's open primitives. **Not affiliated with Aeon or Liquid Protocol.** The pack's README and the `SKILL.md` files all carry an explicit "not affiliated" disclaimer. Trademarks ("Aeon", "Liquid Protocol", "$LIQ") are referenced solely for accurate attribution.

Happy to revise wording, schedules, or any rendering detail if it doesn't fit the section's tone.