### PR TITLE
docs(community-packs): list zer0, gitbounty, AntFleet, LiquidPad

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,10 @@ To browse known packs without installing, run `./install-skill-pack --list` — 
 |------|--------|-------------|
 | [aeon-skill-pack-vvvkernel](https://github.com/baseddevoloper/aeon-skill-pack-vvvkernel) | 9 | Venice AI inference via VVVKernel — onchain, audit, growth, narrative, image gen, monitoring |
 | [luca-aeon-skills](https://github.com/danbuildss/luca-aeon-skills) | 4 | Financial intelligence via x402Books AI — wallet scanning, treasury monitoring, financial reports, and agent registry on Base |
+| [zer0-skill-pack](https://github.com/0xShak/zer0-skill-pack) | 6 | Polymarket intelligence — daily thesis, mispricing scanner, contrarian fades, narrative-vs-markets, paper-trade PnL journal, alpha comment curator |
+| [gitbounty-skill-pack](https://github.com/gitlawbounty/gitbounty-skill-pack) | 1 | Bounty hunting on the gitlawb network via gitbounty — discover open bounties, scout the best fit with the gitbounty LLM scout, draft a solution plan (read-only) |
+| [aeon-skills](https://github.com/AntFleet/aeon-skills) | 1 | Two-model-consensus PR review (Opus 4.7 + GPT-5) — per-review USDC drawdown on Base |
+| [aeon-skill-pack-liquidpad](https://github.com/liquidpadbot/aeon-skill-pack-liquidpad) | 4 | Track LiquidPad on Base — burn cycle alerts, new token launches with onchain provenance, daily protocol digest, and fee accrual tracking |
 
 **To list a pack here**, open a PR adding a row. Guidelines:
 

--- a/skill-packs.json
+++ b/skill-packs.json
@@ -79,6 +79,22 @@
       "category": "dev",
       "trust_level": "community",
       "skills": ["bounty-hunter"]
+    },
+    {
+      "repo": "liquidpadbot/aeon-skill-pack-liquidpad",
+      "name": "LiquidPad",
+      "description": "Track LiquidPad on Base — $LPAD burn cycle alerts, new token launches with onchain provenance, daily protocol digest, and fee-accrual tracking on every launched token.",
+      "author": "liquidpadbot",
+      "license": "MIT",
+      "homepage": "https://www.liquidpad.site",
+      "category": "crypto",
+      "trust_level": "community",
+      "skills": [
+        "liquidpad-burn-monitor",
+        "liquidpad-stats-digest",
+        "liquidpad-token-alert",
+        "liquidpad-fee-tracker"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Bundles four community pack listings that each landed as a separate README-only PR against the same table row. Each pack was independently quality-verified before bundling.

| Original PR | Pack | Author | Skills | Registry status |
|---|---|---|---|---|
| #208 | [zer0-skill-pack](https://github.com/0xShak/zer0-skill-pack) — Polymarket intelligence | @0xShak | 6 | Seed entry (from #215) |
| #212 | [gitbounty-skill-pack](https://github.com/gitlawbounty/gitbounty-skill-pack) — bounty hunting | @gitlawbounty | 1 | Seed entry (from #215) |
| #216 | [AntFleet/aeon-skills](https://github.com/AntFleet/aeon-skills) — two-model PR review | @antfleet-ops | 1 | Seed entry (from #215, trusted) |
| #217 | [aeon-skill-pack-liquidpad](https://github.com/liquidpadbot/aeon-skill-pack-liquidpad) — LiquidPad on Base | @liquidpadbot | 4 | **Added in this PR** |

## Why bundle

Each contributor PR inserts a row at the same location in the `## Community skill packs` table. After any one merges, the other three can no longer auto-merge — each later contributor would need to rebase their fork branch. Bundling here lets all four land atomically; the original PRs will be closed with comments pointing to this commit so attribution stays intact (each contributor is `Co-Authored-By` on the commit).

## Quality verification (per pack)

For each upstream repo I checked: `skills-pack.json` shape, declared MIT license, presence of every listed skill under `skills/` (or `pr-review-antfleet/` for AntFleet's flat layout), at least one full `SKILL.md` sampled for frontmatter quality, all skills declared `default_enabled: false`, public endpoints used (no private auth requirements). All four pass.

## Changes

- **`README.md`** — 4 rows added to the Community Skill Packs table, copy taken verbatim from each contributor's PR.
- **`skill-packs.json`** — LiquidPad entry added (the other 3 are already present from the seed registry in #215). Keeps `./install-skill-pack --list` and the README in lockstep — the dual-update rule the documentation calls for.

## Test plan

- [x] `python3 -c \"import json; json.load(open('skill-packs.json'))\"` parses (6 packs total)
- [ ] `./install-skill-pack --list` includes all 6 packs after merge
- [ ] CI green (GitGuardian)

## After merge

Closing #208, #212, #216, #217 with a comment linking to this commit and thanking each contributor by handle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)