### PR TITLE
Add ECOSYSTEM.md — projects building on Aeon

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -1,0 +1,72 @@
+<p align="center">
+  <img src="assets/aeon.jpg" alt="Aeon" width="80" />
+</p>
+
+<h1 align="center">Ecosystem</h1>
+
+<p align="center">
+  Projects, agents, and products building on top of Aeon.
+</p>
+
+---
+
+## Building on Aeon
+
+These are the projects we know of that run Aeon, extend it, or integrate with the framework. The list is curated from operator self-disclosures and public mentions — it isn't exhaustive, and not every fork is listed here. For a leaderboard of active forks see [`SHOWCASE.md`](SHOWCASE.md); for installable skill collections see the [Community skill packs](README.md#community-skill-packs) section in the README.
+
+| Project | Links |
+|---------|-------|
+| aeonbook | [@aeonbook_](https://x.com/aeonbook_) |
+| AgentBounty | [@agentbountydev](https://x.com/agentbountydev) |
+| Amper | [@ampera_xyze](https://x.com/ampera_xyze) |
+| Autonomopoly | [@AUTONOMOPOLY_](https://x.com/AUTONOMOPOLY_) |
+| Bankr | [@bankrbot](https://x.com/bankrbot) |
+| Bankrsynth | [@bankrsynth](https://x.com/bankrsynth) |
+| BaseHouse | [@basehouse_org](https://x.com/basehouse_org) |
+| Baseline | [@BaselineMarkets](https://x.com/BaselineMarkets) |
+| Bean | [@minebean_](https://x.com/minebean_) |
+| Blue Agent | [@blueagent_](https://x.com/blueagent_) |
+| Capacitr | [@capacitr_](https://x.com/capacitr_) |
+| Claw Harbor | [@ClawHarbor](https://x.com/ClawHarbor) |
+| ClawBank | [@ClawBankHQ](https://x.com/ClawBankHQ) |
+| Clerk | [@clerk](https://x.com/clerk) |
+| Cobot | [@cobotgg](https://x.com/cobotgg) |
+| GitBlock | [@gitblock_](https://x.com/gitblock_) |
+| GitBounty | [@Git_Bounty](https://x.com/Git_Bounty) |
+| GitKernal | [@gitkernal](https://x.com/gitkernal) |
+| LawbWorld | [@LawbWorld](https://x.com/LawbWorld) |
+| Liq | [@_proxystudio](https://x.com/_proxystudio) |
+| Mei | [@MeiMighty1](https://x.com/MeiMighty1) |
+| MiroShark | [@miroshark_](https://x.com/miroshark_) |
+| NoelClaw | [@noelclawfun](https://x.com/noelclawfun) |
+| PancakeSwap | [@PancakeSwap](https://x.com/PancakeSwap) |
+| Powerloom | [@Powerloom](https://x.com/Powerloom) |
+| Precog | [@precog](https://x.com/precog) |
+| ResearchSwarm | [@ResearchSwarmAI](https://x.com/ResearchSwarmAI) |
+| Revault | [@revaultdrops](https://x.com/revaultdrops) |
+| RootAi | [@rootaichad](https://x.com/rootaichad) |
+| SAM | [@prmrsamm](https://x.com/prmrsamm) |
+| Signa | [@Signa_Agent](https://x.com/Signa_Agent) |
+| Solvr | [@solvrbot](https://x.com/solvrbot) |
+| Spoon | [@Spoonautobot](https://x.com/Spoonautobot) |
+| SyntheticsAI | [@SyntheticsAI_](https://x.com/SyntheticsAI_) |
+| Tachi | [@smolekoma](https://x.com/smolekoma) |
+| Venice Kernel | [@VeniceKernel](https://x.com/VeniceKernel) |
+| Vexor | [@Vexora_x](https://x.com/Vexora_x) |
+| Wake | [@WakeOnBase](https://x.com/WakeOnBase) |
+| x402Books | [@x402Books](https://x.com/x402Books) |
+| zer0 | [@Jaineon0G](https://x.com/Jaineon0G) |
+
+---
+
+## Add your project
+
+Building on top of Aeon? Open a PR adding a row to the table above.
+
+Guidelines:
+
+- Project should publicly identify as built on / using / extending Aeon.
+- One row per project. Keep rows alphabetized by project name.
+- Provide at least an X handle or a public link. A short website link is welcome alongside the X handle.
+- Forks that are mainly running stock skills belong on [`SHOWCASE.md`](SHOWCASE.md), not here. This page is for products and agents *built with* Aeon.
+- If your project also ships an installable skill pack, list the pack under [Community skill packs](README.md#community-skill-packs) in the README as well.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The key difference: **other agents are interactive tools you use. Aeon is an aut
 
 This isn't better for everything — you still want Claude Code for writing code interactively. But for the 90% of recurring tasks that don't need you in the loop, the most autonomous agent is the one that never asks.
 
-For a comparison against the broader agent ecosystem (AutoGen, CrewAI, n8n, LangGraph) and a list of active forks running in production, see [`SHOWCASE.md`](SHOWCASE.md).
+For a comparison against the broader agent ecosystem (AutoGen, CrewAI, n8n, LangGraph) and a list of active forks running in production, see [`SHOWCASE.md`](SHOWCASE.md). For products and agents built on top of Aeon, see [`ECOSYSTEM.md`](ECOSYSTEM.md).
 
 ![Autonomy spectrum](./assets/autonomy.jpg)
 


### PR DESCRIPTION
## Summary

- Adds `ECOSYSTEM.md` listing 39 projects, agents, and products building on top of Aeon (alphabetized table with X handles)
- Links the new page from the README alongside the existing `SHOWCASE.md` reference
- Documents the distinction between `ECOSYSTEM.md` (products built on Aeon) vs `SHOWCASE.md` (active forks) vs the community skill packs table (installable bundles)
- Contributor guidelines in `ECOSYSTEM.md` for opening a PR to add a row

## Test plan
- [ ] README link resolves to `ECOSYSTEM.md`
- [ ] All 39 X handles in the table link to valid `https://x.com/...` URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)