### PR TITLE
docs(ecosystem): list LiquidPad

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -35,6 +35,7 @@ These are the projects we know of that run Aeon, extend it, or integrate with th
 | GitBounty | [@Git_Bounty](https://x.com/Git_Bounty) |
 | GitKernal | [@gitkernal](https://x.com/gitkernal) |
 | LawbWorld | [@LawbWorld](https://x.com/LawbWorld) |
+| LiquidPad | [@LiquidPadBot](https://x.com/LiquidPadBot) · [liquidpad.site](https://www.liquidpad.site) |
 | Liq | [@_proxystudio](https://x.com/_proxystudio) |
 | Mei | [@MeiMighty1](https://x.com/MeiMighty1) |
 | MiroShark | [@miroshark_](https://x.com/miroshark_) |


### PR DESCRIPTION
Adds a row to ECOSYSTEM.md for LiquidPad — an independent token launchpad on Base built on Liquid Protocol's open primitives.

## Why this row

ECOSYSTEM.md (introduced in #220) curates **products built with Aeon**, separate from:
- Community skill packs (`README.md`) — LiquidPad already listed there as `aeon-skill-pack-liquidpad` via #218
- SHOWCASE.md — for forks running stock skills

LiquidPad fits ECOSYSTEM.md's guidelines because it's a product:
- Uses Aeon's skill format
- Ships an installable pack co-authored on `0eed836`
- Publicly identifies as building on the Aeon ecosystem

## Row inserted

Alphabetically between **LawbWorld** and **Liq** (per the file's alphabetization rule):

```
| LiquidPad | [@LiquidPadBot](https://x.com/LiquidPadBot) · [liquidpad.site](https://www.liquidpad.site) |
```

## Compliance with file guidelines

- ✅ Alphabetized
- ✅ One row per project
- ✅ X handle + website link
- ✅ Project publicly identifies as built on Aeon (see [/built-on-liquid](https://www.liquidpad.site/built-on-liquid) for full attribution)
- ✅ Already shipping a community skill pack (cross-listed in README per the ECOSYSTEM.md guideline)

Happy to revise wording, link order, or any rendering detail if it doesn't fit.