### PR TITLE
docs: add aeon-skill-pack-mythosforge to community skill packs

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,7 @@ To browse known packs without installing, run `./install-skill-pack --list` — 
 | [gitbounty-skill-pack](https://github.com/gitlawbounty/gitbounty-skill-pack) | 1 | Bounty hunting on the gitlawb network via gitbounty — discover open bounties, scout the best fit with the gitbounty LLM scout, draft a solution plan (read-only) |
 | [aeon-skills](https://github.com/AntFleet/aeon-skills) | 1 | Two-model-consensus PR review (Opus 4.7 + GPT-5) — per-review USDC drawdown on Base |
 | [aeon-skill-pack-liquidpad](https://github.com/liquidpadbot/aeon-skill-pack-liquidpad) | 4 | Track LiquidPad on Base — burn cycle alerts, new token launches with onchain provenance, daily protocol digest, and fee accrual tracking |
+| [aeon-skill-pack-mythosforge](https://github.com/ryjin111/aeon-skill-pack-mythosforge) | 1 | Read-only MythosForge ops monitoring — backlog, jury/payout health, degraded-juror notes, and stall alerts |
 
 **To list a pack here**, open a PR adding a row. Guidelines:
 

--- a/skill-packs.json
+++ b/skill-packs.json
@@ -95,6 +95,17 @@
         "liquidpad-token-alert",
         "liquidpad-fee-tracker"
       ]
+    },
+    {
+      "repo": "ryjin111/aeon-skill-pack-mythosforge",
+      "name": "aeon-skill-pack-mythosforge",
+      "description": "Read-only MythosForge ops monitoring — backlog, jury/payout health, degraded-juror notes, and stall alerts.",
+      "author": "ryjin111",
+      "license": "MIT",
+      "homepage": "https://mythosforge.xyz",
+      "category": "dev",
+      "trust_level": "community",
+      "skills": ["mythosforge-ops-report"]
     }
   ]
 }


### PR DESCRIPTION
Adds [aeon-skill-pack-mythosforge](https://github.com/ryjin111/aeon-skill-pack-mythosforge) to the community skill-pack registry.

**What it is:** a read-only ops-monitoring pack for [MythosForge](https://mythosforge.xyz). One skill — `mythosforge-ops-report` — produces a daily backlog / jury / payout health report and alerts only on a real stall. Silent when healthy, disabled by default.

**Follows the guidelines:**
- Own public repo, MIT license, per-skill `SKILL.md` + a `skills-pack.json` manifest. Installs via `./install-skill-pack ryjin111/aeon-skill-pack-mythosforge`.
- No Aeon-internal monkey-patching.
- Reads only a **public** endpoint (`https://www.mythosforge.xyz/api/v1/stats`) — no private endpoints, no secrets in the pack.

Updates both the README "Community skill packs" table and `skill-packs.json` (its machine-readable mirror).