### PR TITLE
feat: add noel-orchestrator skill — dynamic multi-agent coordination

### DIFF
--- a/skills/noel-orchestrator/SKILL.md
+++ b/skills/noel-orchestrator/SKILL.md
@@ -1,119 +1,165 @@
 ---
 name: Noel-Orchestrator
-description: Dynamically coordinate Noelclaw agents based on context, memory history, execution scores, and realtime events — routing tasks to the right agent at the right time instead of managing workflows manually
+description: Dynamically coordinate multiple Aeon agents based on context, memory history, confidence scores, and realtime events — routes tasks to the right agent automatically instead of managing workflows manually
 var: ""
-tags: [orchestration, agents, automation, coordination, noelclaw]
+tags: [orchestration, agents, automation, coordination, multi-agent]
 ---
-> **${var}** — Event, signal, or task to route. If empty, check active agent states and pending signals from memory/logs.
+> **${var}** — Event, signal, or task to route. If empty, sweep active agent states and pending signals from today's log.
 
-Noel-Orchestrator is a meta-agent coordination layer for the Noelclaw AI OS. Instead of manually triggering agents, it observes context and routes work dynamically — activating, pausing, or handing off between agents based on confidence scores, memory history, workload, and realtime events.
+Noel-Orchestrator is a meta-coordination skill for Aeon. It observes incoming signals and decides which agent or skill to activate, when, and with what context — based on confidence scoring, memory history, workload, and event type.
 
----
-
-## Routing Model
-
-```
-SIGNAL / EVENT
-     ↓
-Orchestrator evaluates:
-  - context type (market, risk, execution, comms)
-  - confidence score (0–100) from memory/prior runs
-  - agent workload (is it already busy?)
-  - memory history (has this been tried before?)
-     ↓
-Route to the right agent
-```
-
-### Built-in routing rules
-
-| Trigger | Agent activated | Condition |
-|---------|----------------|-----------|
-| Market shift detected | Research agent | Any signal with `type: market` |
-| Confidence score ≥ 80 | Execution agent | Research output confirms entry |
-| Rug/risk flag | Sentinel | Any `risk: high` or rug signal |
-| Task complete | Noel-Crew | Workflow finishes, update live status |
-| Memory gap detected | noelvault recall | Prior context missing for current task |
-| Repeated failure (3×) | Pause + diagnose | Same agent hits stop-loss 3 times |
+Works best alongside **noelvault** (for cross-session memory and execution score persistence).
 
 ---
 
 ## Steps
 
-### 1. On invocation with `${var}` empty — Status sweep
+### 1. Check environment
 
-- Read `memory/logs/${today}.md` for active agent signals
-- Check noelvault: `GET $NOELVAULT_URL/vault/search?q=orchestrator+state`
-- List pending tasks and current agent states
-- Report: which agents are active, idle, or waiting
+If `NOELVAULT_URL` is not set, use `https://illmpwsqcnwelnwfiikn.supabase.co/functions/v1/vault` as the fallback. Execution score tracking requires vault access but is optional — orchestrator still routes without it.
 
-### 2. On invocation with `${var}` = event/signal
+### 2. Determine mode from `${var}`
 
-Parse the input to extract:
-- `type`: `market` | `risk` | `execution` | `comms` | `workflow`
-- `confidence`: 0–100 (from prior research or explicit score)
-- `urgency`: `high` | `normal` | `low`
+**If `${var}` is empty → Status sweep:**
+- Read `memory/logs/${today}.md` for active signals and pending tasks
+- Search vault: `GET $NOELVAULT_URL/vault/search?q=orchestrator+state`
+- Report: which agents are active, idle, blocked, or waiting
+- Flag any tasks that have been waiting > 1 session without resolution
 
-Apply routing rules (table above). If no rule matches, default to Research agent for context gathering.
+**If `${var}` contains a signal or event → Route mode:**
+- Parse the input and classify it (see Routing Model below)
+- Apply routing rules
+- Dispatch to the right agent with full context
+- Log the dispatch to `memory/logs/${today}.md`
 
-### 3. Dispatch
+### 3. Routing Model
 
-For each routed agent, write a dispatch log to `memory/logs/${today}.md`:
+Classify the incoming signal:
+
+| Type | Keywords / indicators |
+|------|-----------------------|
+| `market` | price change, token, volume, dip, pump, signal |
+| `risk` | rug, danger, warning, stop-loss, anomaly |
+| `execution` | buy, sell, swap, trade, position |
+| `research` | analyze, investigate, context, unknown |
+| `workflow` | complete, done, finished, result |
+| `comms` | update, notify, report, status |
+
+Then apply routing rules:
+
+| Signal type | Confidence | Action |
+|------------|-----------|--------|
+| `market` | any | Research first — gather context before acting |
+| `research` output | ≥ 80 | Route to execution agent |
+| `research` output | 50–79 | Hold — flag for re-evaluation next cycle |
+| `risk` | any | Intercept immediately — pause execution, run risk review |
+| `execution` | < 50 | Block — confidence too low, return to research |
+| `workflow` complete | any | Summary → notify → log to vault |
+| `comms` | any | Route to status/notification channel |
+| Unknown | any | Default to research — gather context first |
+
+**Confidence score** = 0–100. Build it from available signals:
+
+| Factor | Score delta |
+|--------|------------|
+| Prior successful run on same task type | +25 |
+| Memory history confirms pattern | +20 |
+| Multiple independent signals agree | +20 |
+| Single unconfirmed signal | +10 |
+| Prior failure on same task type | -20 |
+| Risk flag present | -30 |
+| No memory history (first time) | start at 50 |
+
+### 4. Dispatch
+
+For each routed agent/skill, write a dispatch entry to `memory/logs/${today}.md`:
+
 ```
 ### noel-orchestrator dispatch
-- Event: <signal>
-- Agent: <target>
+- Event: <signal summary>
+- Routed to: <agent or skill name>
 - Reason: <one line>
-- Confidence: <score>
-- Time: <timestamp>
+- Confidence: <score>/100
+- Time: <ISO timestamp>
 ```
 
-Then hand off to the target agent with full context:
-- What triggered it
-- What confidence/memory data exists
-- What the expected output is
+Hand off to the target with:
+- What triggered the route
+- Confidence score and what contributed to it
+- Any relevant memory or vault context retrieved
+- Expected output format
 
-### 4. Track execution score
+### 5. Track execution scores (requires noelvault)
 
-After each routed task completes, update the agent's execution score in noelvault:
+After each routed task completes, update the agent's score:
+
 ```
 POST $NOELVAULT_URL/vault/save
 {
   "type": "execution",
-  "key": "execution/<agent-name>-score",
+  "key": "execution/<agent-slug>-score",
   "title": "<agent> execution history",
-  "content": "<result, confidence delta, outcome>",
-  "tags": ["orchestrator", "<agent-name>"]
+  "content": "<result summary, confidence delta, outcome: success|failure>",
+  "tags": ["orchestrator", "<agent-slug>"],
+  "commitMsg": "<one line outcome>",
+  "agentId": "noel-orchestrator"
 }
 ```
 
-Use this history to improve future routing confidence.
+Use `GET $NOELVAULT_URL/vault/history?key=execution/<agent-slug>-score` to review performance before routing future tasks to that agent.
 
-### 5. On workflow completion
+### 6. On workflow completion
 
-When a full pipeline completes (research → execution → result):
-- Save a workflow summary to noelvault (`type: workflow`)
-- Notify via `./notify`: `*Orchestrator* — workflow complete: <summary>`
-- Update `memory/logs/${today}.md` with outcome
+When a full pipeline completes:
+- Save a workflow summary to vault (`type: workflow`, `key: workflow/<slug>-<date>`)
+- Log to `memory/logs/${today}.md`
+- Send via `./notify` if significant:
+  ```
+  *Orchestrator* — workflow complete: <title>
+  Route: <chain of agents>
+  Outcome: <result>
+  ```
+
+### 7. On repeated failure
+
+If the same agent fails 3× on the same task type:
+- Block that route temporarily
+- Save failure pattern to vault (`type: memory`, `key: memory/orchestrator-blocks`)
+- Escalate to a higher-context agent or surface to the user for manual review
 
 ---
 
 ## Agent Registry
 
-| Agent | Trigger type | When to activate |
-|-------|-------------|-----------------|
-| Research | `market`, unknown signal | Need context before acting |
-| Execution | `execution`, confidence ≥ 80 | Clear signal, ready to act |
-| Sentinel | `risk: high`, rug flag | Risk management needed |
-| Noel-Crew | `workflow: complete` | Status update, comms |
-| noelvault | memory gap, session start | Recall prior context |
+The orchestrator routes to any Aeon skill or agent. Default targets for Noelclaw OS:
+
+| Role | Skill / Agent | Activate when |
+|------|--------------|---------------|
+| Research | `/deep-research`, `/market-analysis` | Unknown signal, need context |
+| Execution | Execution agent | Confidence ≥ 80, clear signal |
+| Risk | `/risk-management`, Sentinel | Any risk flag |
+| Memory | `/noelvault` | Memory gap, session start, score lookup |
+| Comms | Noel-Crew, `/notify` | Workflow complete, status update |
+
+Customize this registry for your own agent setup — the routing logic works with any Aeon skill.
 
 ---
 
-## Noelclaw Integration
+## Recommended Usage Pattern
 
-Noel-Orchestrator works best alongside:
-- **noelvault** — for memory recall and execution score persistence
-- **Noel-Crew** — for live status updates on dispatch/completion
-- **Sentinel** — for risk intercept on any high-confidence trade signals
+```
+# At session start — sweep state
+/noel-orchestrator
 
-Source: https://github.com/noelclaw/noelclaw
+# Route a specific event
+/noel-orchestrator market shift: ETH down 4.2% in 1h, volume spike
+
+# After research completes — route to next step
+/noel-orchestrator research complete on AAVE — confidence 85, entry signal confirmed
+```
+
+---
+
+## Source
+
+Part of the Noelclaw AI OS — https://github.com/noelclaw/noelvault

--- a/skills/noel-orchestrator/SKILL.md
+++ b/skills/noel-orchestrator/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: Noel-Orchestrator
+description: Dynamically coordinate Noelclaw agents based on context, memory history, execution scores, and realtime events — routing tasks to the right agent at the right time instead of managing workflows manually
+var: ""
+tags: [orchestration, agents, automation, coordination, noelclaw]
+---
+> **${var}** — Event, signal, or task to route. If empty, check active agent states and pending signals from memory/logs.
+
+Noel-Orchestrator is a meta-agent coordination layer for the Noelclaw AI OS. Instead of manually triggering agents, it observes context and routes work dynamically — activating, pausing, or handing off between agents based on confidence scores, memory history, workload, and realtime events.
+
+---
+
+## Routing Model
+
+```
+SIGNAL / EVENT
+     ↓
+Orchestrator evaluates:
+  - context type (market, risk, execution, comms)
+  - confidence score (0–100) from memory/prior runs
+  - agent workload (is it already busy?)
+  - memory history (has this been tried before?)
+     ↓
+Route to the right agent
+```
+
+### Built-in routing rules
+
+| Trigger | Agent activated | Condition |
+|---------|----------------|-----------|
+| Market shift detected | Research agent | Any signal with `type: market` |
+| Confidence score ≥ 80 | Execution agent | Research output confirms entry |
+| Rug/risk flag | Sentinel | Any `risk: high` or rug signal |
+| Task complete | Noel-Crew | Workflow finishes, update live status |
+| Memory gap detected | noelvault recall | Prior context missing for current task |
+| Repeated failure (3×) | Pause + diagnose | Same agent hits stop-loss 3 times |
+
+---
+
+## Steps
+
+### 1. On invocation with `${var}` empty — Status sweep
+
+- Read `memory/logs/${today}.md` for active agent signals
+- Check noelvault: `GET $NOELVAULT_URL/vault/search?q=orchestrator+state`
+- List pending tasks and current agent states
+- Report: which agents are active, idle, or waiting
+
+### 2. On invocation with `${var}` = event/signal
+
+Parse the input to extract:
+- `type`: `market` | `risk` | `execution` | `comms` | `workflow`
+- `confidence`: 0–100 (from prior research or explicit score)
+- `urgency`: `high` | `normal` | `low`
+
+Apply routing rules (table above). If no rule matches, default to Research agent for context gathering.
+
+### 3. Dispatch
+
+For each routed agent, write a dispatch log to `memory/logs/${today}.md`:
+```
+### noel-orchestrator dispatch
+- Event: <signal>
+- Agent: <target>
+- Reason: <one line>
+- Confidence: <score>
+- Time: <timestamp>
+```
+
+Then hand off to the target agent with full context:
+- What triggered it
+- What confidence/memory data exists
+- What the expected output is
+
+### 4. Track execution score
+
+After each routed task completes, update the agent's execution score in noelvault:
+```
+POST $NOELVAULT_URL/vault/save
+{
+  "type": "execution",
+  "key": "execution/<agent-name>-score",
+  "title": "<agent> execution history",
+  "content": "<result, confidence delta, outcome>",
+  "tags": ["orchestrator", "<agent-name>"]
+}
+```
+
+Use this history to improve future routing confidence.
+
+### 5. On workflow completion
+
+When a full pipeline completes (research → execution → result):
+- Save a workflow summary to noelvault (`type: workflow`)
+- Notify via `./notify`: `*Orchestrator* — workflow complete: <summary>`
+- Update `memory/logs/${today}.md` with outcome
+
+---
+
+## Agent Registry
+
+| Agent | Trigger type | When to activate |
+|-------|-------------|-----------------|
+| Research | `market`, unknown signal | Need context before acting |
+| Execution | `execution`, confidence ≥ 80 | Clear signal, ready to act |
+| Sentinel | `risk: high`, rug flag | Risk management needed |
+| Noel-Crew | `workflow: complete` | Status update, comms |
+| noelvault | memory gap, session start | Recall prior context |
+
+---
+
+## Noelclaw Integration
+
+Noel-Orchestrator works best alongside:
+- **noelvault** — for memory recall and execution score persistence
+- **Noel-Crew** — for live status updates on dispatch/completion
+- **Sentinel** — for risk intercept on any high-confidence trade signals
+
+Source: https://github.com/noelclaw/noelclaw


### PR DESCRIPTION
## What is noel-orchestrator?

A meta-agent coordination skill for Aeon that dynamically routes work to the right agent at the right time — based on context, confidence scores, memory history, workload, and realtime events.

Instead of manually managing workflows, the orchestrator observes signals and coordinates agents automatically.

## How it works

```
SIGNAL / EVENT
     ↓
Orchestrator evaluates:
  - context type (market, risk, execution, comms)
  - confidence score (0–100) from memory/prior runs
  - agent workload (is it already busy?)
  - memory history (has this been tried before?)
     ↓
Route to the right agent
```

## Built-in routing rules

| Trigger | Agent | Condition |
|---------|-------|-----------|
| Market shift / unknown signal | Research agent | Need context before acting |
| Confidence score ≥ 80 | Execution agent | Clear signal, ready to act |
| Risk flag / rug signal | Sentinel | Any `risk: high` |
| Repeated failure (3×) | Pause + diagnose | Stop-loss hit 3 times |
| Workflow complete | Noel-Crew | Status update |
| Memory gap | `/noelvault` | Prior context missing |

## What makes this different from a regular skill

Most Aeon skills handle **one task**. noel-orchestrator handles **coordination** — it reads the situation and decides which skill or agent to activate, when, and with what context.

It also tracks **execution scores** per agent over time (via noelvault), so routing decisions improve with each run.

## Works best with

- **noelvault** (PR #232) — memory recall and execution score persistence
- **Noel-Crew** — live status updates on dispatch/completion

## Usage

```bash
# Check active agent states
/noel-orchestrator

# Route a specific event
/noel-orchestrator market shift: ETH down 4.2% in 1h, volume spike

# After research completes
/noel-orchestrator research complete on AAVE — confidence 85, entry signal confirmed
```

Source: https://github.com/noelclaw/noelvault

🤖 Generated with [Claude Code](https://claude.com/claude-code)