### PR TITLE
docs: update aeon-skill-pack-mythosforge listing (add proof-integrity skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ To browse known packs without installing, run `./install-skill-pack --list` — 
 | [gitbounty-skill-pack](https://github.com/gitlawbounty/gitbounty-skill-pack) | 1 | Bounty hunting on the gitlawb network via gitbounty — discover open bounties, scout the best fit with the gitbounty LLM scout, draft a solution plan (read-only) |
 | [aeon-skills](https://github.com/AntFleet/aeon-skills) | 1 | Two-model-consensus PR review (Opus 4.7 + GPT-5) — per-review USDC drawdown on Base |
 | [aeon-skill-pack-liquidpad](https://github.com/liquidpadbot/aeon-skill-pack-liquidpad) | 4 | Track LiquidPad on Base — burn cycle alerts, new token launches with onchain provenance, daily protocol digest, and fee accrual tracking |
-| [aeon-skill-pack-mythosforge](https://github.com/ryjin111/aeon-skill-pack-mythosforge) | 1 | Read-only MythosForge ops monitoring — backlog, jury/payout health, degraded-juror notes, and stall alerts |
+| [aeon-skill-pack-mythosforge](https://github.com/ryjin111/aeon-skill-pack-mythosforge) | 2 | Read-only MythosForge ops monitoring + proof-of-creation integrity — health/backlog monitoring plus continuous verification that paid + recent creations stay provably anchored on Base |
 
 **To list a pack here**, open a PR adding a row. Guidelines:
 

--- a/skill-packs.json
+++ b/skill-packs.json
@@ -99,13 +99,13 @@
     {
       "repo": "ryjin111/aeon-skill-pack-mythosforge",
       "name": "aeon-skill-pack-mythosforge",
-      "description": "Read-only MythosForge ops monitoring — backlog, jury/payout health, degraded-juror notes, and stall alerts.",
+      "description": "Read-only MythosForge ops monitoring + proof-of-creation integrity — backlog/jury/payout health, plus continuous verification that paid + recent creations stay provably anchored on Base.",
       "author": "ryjin111",
       "license": "MIT",
       "homepage": "https://mythosforge.xyz",
       "category": "dev",
       "trust_level": "community",
-      "skills": ["mythosforge-ops-report"]
+      "skills": ["mythosforge-ops-report", "mythosforge-proof-integrity"]
     }
   ]
 }


### PR DESCRIPTION
## What

Updates the existing `aeon-skill-pack-mythosforge` listing to reflect a second skill now in the pack: **`mythosforge-proof-integrity`**.

- `skill-packs.json`: `skills` → `["mythosforge-ops-report", "mythosforge-proof-integrity"]`; description expanded to cover proof-of-creation integrity.
- README community skill-packs row: count `1` → `2`, description updated.

## The new skill

`mythosforge-proof-integrity` is a continuous, **read-only** proof-of-creation monitor: it verifies that MythosForge's paid set + recent rounds stay provably anchored on Base (manifest hash + anchor tx + NFT mint all resolving on-chain), and alerts only when a proof actually breaks.

- **Read-only**, **secret-free** — reads a single public, sanitized endpoint (`/api/v1/proof-report`); no API keys or tokens stored in Aeon.
- **Quiet by default** — silent on a healthy run; **disabled by default** (`default_enabled: false`).
- **Scoped** to paid + recent creations (not full-history every run), with the scope stated explicitly in the report.

Docs-only listing update — the skill itself lives in the pack repo.