### PR TITLE
ecosystem: add signaagent.xyz link to Signa entry

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -51,7 +51,7 @@ These are the projects we know of that run Aeon, extend it, or integrate with th
 | Revault | [@revaultdrops](https://x.com/revaultdrops) |
 | RootAi | [@rootaichad](https://x.com/rootaichad) |
 | SAM | [@prmrsamm](https://x.com/prmrsamm) |
-| Signa | [@Signa_Agent](https://x.com/Signa_Agent) |
+| Signa | [@Signa_Agent](https://x.com/Signa_Agent) · [signaagent.xyz](https://www.signaagent.xyz) |
 | Solvr | [@solvrbot](https://x.com/solvrbot) |
 | Spoon | [@Spoonautobot](https://x.com/Spoonautobot) |
 | SyntheticsAI | [@SyntheticsAI_](https://x.com/SyntheticsAI_) |


### PR DESCRIPTION
Per the ECOSYSTEM.md guidelines ("A short website link is welcome alongside the X handle") adding the public site link.

Signa is wallet-native messaging for AI agents. Live integration with Aeon already shipped via the `signa_aeon_resolve` tool inside `signa-mcp` — it reads the ERC-8004 Identity Registry on Ethereum mainnet via viem and returns the agent's tokenId, owner, agentURI, and resolved registration JSON. Anyone running `npm install signa-mcp` in Claude Desktop / Cursor / Windsurf gets the Aeon lookup as a Claude-callable tool with zero code.

Partner showcase page (with sample tool shape + curl-able endpoint) at:
https://www.signaagent.xyz/partners/aeon

No code change requested beyond the single ECOSYSTEM.md row update — keeps the alphabetized order intact, matches the format LiquidPad uses (handle + site link separated by middle dot).