### PR TITLE
community: add signa-aeon-skills (3 messaging skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,7 @@ To browse known packs without installing, run `./install-skill-pack --list` — 
 | [aeon-skills](https://github.com/AntFleet/aeon-skills) | 1 | Two-model-consensus PR review (Opus 4.7 + GPT-5) — per-review USDC drawdown on Base |
 | [aeon-skill-pack-liquidpad](https://github.com/liquidpadbot/aeon-skill-pack-liquidpad) | 4 | Track LiquidPad on Base — burn cycle alerts, new token launches with onchain provenance, daily protocol digest, and fee accrual tracking |
 | [aeon-skill-pack-mythosforge](https://github.com/ryjin111/aeon-skill-pack-mythosforge) | 1 | Read-only MythosForge ops monitoring — backlog, jury/payout health, degraded-juror notes, and stall alerts |
+| [signa-aeon-skills](https://github.com/codexvritra/signa-aeon-skills) | 3 | Wallet-signed cross-platform agent messaging via SIGNA on Base — send DMs to any AI agent on the network, read your inbox, discover bridges to Ollama / OpenAI / Anthropic / LangChain agents |
 
 **To list a pack here**, open a PR adding a row. Guidelines:
 

--- a/skill-packs.json
+++ b/skill-packs.json
@@ -106,6 +106,17 @@
       "category": "dev",
       "trust_level": "community",
       "skills": ["mythosforge-ops-report"]
+    },
+    {
+      "repo": "codexvritra/signa-aeon-skills",
+      "name": "signa-aeon-skills",
+      "description": "Wallet-signed cross-platform agent messaging via SIGNA on Base — send DMs to any AI agent on the network, read your inbox, discover bridges to Ollama / OpenAI / Anthropic / LangChain agents.",
+      "author": "signa-agent",
+      "license": "MIT",
+      "homepage": "https://www.signaagent.xyz/partners/aeon",
+      "category": "messaging",
+      "trust_level": "community",
+      "skills": ["signa-message", "signa-inbox", "signa-discover"]
     }
   ]
 }


### PR DESCRIPTION
Adds the `signa-aeon-skills` community skill pack to the README table + `skill-packs.json` registry.

## What it ships

Three skills that give an Aeon agent a wallet on the SIGNA decentralized messaging network on Base:

- `signa-message` — send a wallet-signed DM to any AI agent on the network
- `signa-inbox` — read recent DMs received by this agent's wallet
- `signa-discover` — list alive bridges to other AI platforms (Ollama, OpenAI, Anthropic, LangChain, CrewAI, custom) the agent can DM

Each skill is a small ESM script that calls the `signa-agent` npm SDK (which I maintain). The whole pack uses public, CORS-open SIGNA endpoints — no private endpoints, no monkey-patching of Aeon internals, no API keys.

## Verification

All three skills tested live against `signaagent.xyz` before this PR. `signa-message` produced a real wallet-signed DM: `62ca4988-050d-4221-b67a-03a3896189f6` — anyone can curl `/api/dm/<id>` and re-verify with viem.

## Pack details

- Repo: <https://github.com/codexvritra/signa-aeon-skills>
- License: MIT
- Category: messaging
- Trust level: community
- skills-pack.json present at pack root
- Per-skill `SKILL.md` with the standard frontmatter shape

## Why this matters for Aeon agents

Aeon already has skill packs for inference, finance, code review, and ops. There is not yet one for cross-platform agent-to-agent messaging. `signa-aeon-skills` plugs that gap — an Aeon agent can now DM a Hermes-3 agent on Ollama, get a wallet-signed reply, all over a federated open-source substrate.