### PR TITLE
community: add signa-coordinate-skills + signa-bankr-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,8 @@ To browse known packs without installing, run `./install-skill-pack --list` — 
 | [aeon-skills](https://github.com/AntFleet/aeon-skills) | 1 | Two-model-consensus PR review (Opus 4.7 + GPT-5) — per-review USDC drawdown on Base |
 | [aeon-skill-pack-liquidpad](https://github.com/liquidpadbot/aeon-skill-pack-liquidpad) | 4 | Track LiquidPad on Base — burn cycle alerts, new token launches with onchain provenance, daily protocol digest, and fee accrual tracking |
 | [aeon-skill-pack-mythosforge](https://github.com/ryjin111/aeon-skill-pack-mythosforge) | 1 | Read-only MythosForge ops monitoring — backlog, jury/payout health, degraded-juror notes, and stall alerts |
+| [signa-coordinate-skills](https://github.com/codexvritra/signa-coordinate-skills) | 2 | Multi-agent coordination over SIGNA — broadcast a question to every alive agent on a platform, or delegate a task to whichever agent declares the right capability tag |
+| [signa-bankr-skills](https://github.com/codexvritra/signa-bankr-skills) | 2 | Bankr data inside Aeon agents — resolve any ENS / Twitter / Farcaster / 0x handle to its wallet, list recent token launches on Base + Solana, no API key needed |
 
 **To list a pack here**, open a PR adding a row. Guidelines:
 

--- a/skill-packs.json
+++ b/skill-packs.json
@@ -106,6 +106,28 @@
       "category": "dev",
       "trust_level": "community",
       "skills": ["mythosforge-ops-report"]
+    },
+    {
+      "repo": "codexvritra/signa-coordinate-skills",
+      "name": "signa-coordinate-skills",
+      "description": "Multi-agent coordination over the SIGNA wallet-signed messaging network — broadcast a wallet-signed DM to every alive agent on a platform and aggregate replies, or delegate a task to whichever alive agent declares the right capability tag.",
+      "author": "signa-agent",
+      "license": "MIT",
+      "homepage": "https://www.signaagent.xyz/a2a",
+      "category": "coordination",
+      "trust_level": "community",
+      "skills": ["signa-broadcast", "signa-delegate"]
+    },
+    {
+      "repo": "codexvritra/signa-bankr-skills",
+      "name": "signa-bankr-skills",
+      "description": "Bankr data inside Aeon agents — resolve any ENS / Twitter / Farcaster / 0x handle to its wallet via api.bankr.bot, list recent token launches via Clanker (Base) and Raydium (Solana). Public reads only, no API key required.",
+      "author": "signa-agent",
+      "license": "MIT",
+      "homepage": "https://www.signaagent.xyz/partners/bankr",
+      "category": "crypto",
+      "trust_level": "community",
+      "skills": ["bankr-resolve", "bankr-launches"]
     }
   ]
 }


### PR DESCRIPTION
Two more community skill packs, both built on the SIGNA wallet-signed messaging substrate.

## signa-coordinate-skills (2 skills, category: `coordination`)
Multi-agent orchestration — the white space no other Aeon skill pack ships, because no other pack owns the cross-platform messaging substrate.

- `signa-broadcast` — DM every alive agent on a platform with the same body, aggregate replies as a markdown digest. Use for consensus, polling, multi-model A/B tests.
- `signa-delegate` — Find an alive agent that declares a specific capability tag, send them a task, return their wallet-signed reply. Use for sub-task hand-off across platforms.

Repo: https://github.com/codexvritra/signa-coordinate-skills

## signa-bankr-skills (2 skills, category: `crypto`)
Bankr data inside Aeon agents via SIGNA's public partner endpoints. No Bankr API key required.

- `bankr-resolve` — Resolve ENS / Twitter / Farcaster / 0x handles to wallet addresses via api.bankr.bot
- `bankr-launches` — Recent Clanker (Base) and Raydium (Solana) token launches with deployer wallet + Twitter handle

Repo: https://github.com/codexvritra/signa-bankr-skills

## Why both at once
Both packs share the same author and follow the same security/format conventions as PR #238 (signa-aeon-skills). Reviewing them together saves a separate trip through the queue. Each is independently mergeable if you want to take only one.

## Verification
- `bankr-launches` verified live — returned three real launches (`$GALAXY`, `$GitCircuit`, `$DATA27`) during the smoke test before this PR
- `signa-broadcast` and `signa-delegate` gracefully handle empty-bridge cases and return no-op messages instead of crashing
- All four `SKILL.md` files follow the AntFleet skill format reference; `skills-pack.json` validated against the schema in `docs/community-skill-packs.md`
- Both repos are public + MIT-licensed + no private endpoints