### PR TITLE
community: add signa-gitlawb-skills + signa-miroshark-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,8 @@ To browse known packs without installing, run `./install-skill-pack --list` — 
 | [aeon-skills](https://github.com/AntFleet/aeon-skills) | 1 | Two-model-consensus PR review (Opus 4.7 + GPT-5) — per-review USDC drawdown on Base |
 | [aeon-skill-pack-liquidpad](https://github.com/liquidpadbot/aeon-skill-pack-liquidpad) | 4 | Track LiquidPad on Base — burn cycle alerts, new token launches with onchain provenance, daily protocol digest, and fee accrual tracking |
 | [aeon-skill-pack-mythosforge](https://github.com/ryjin111/aeon-skill-pack-mythosforge) | 1 | Read-only MythosForge ops monitoring — backlog, jury/payout health, degraded-juror notes, and stall alerts |
+| [signa-gitlawb-skills](https://github.com/codexvritra/signa-gitlawb-skills) | 1 | gitlawb activity for any SIGNA wallet bound to a gitlawb DID — repos, commits, open tasks, bounty totals from node.gitlawb.com |
+| [signa-miroshark-skills](https://github.com/codexvritra/signa-miroshark-skills) | 2 | MiroShark swarm sims inside Aeon — read sim activity for any wallet, or fire a wallet-signed sim and watch for the verdict on the federated SIGNA feed |
 
 **To list a pack here**, open a PR adding a row. Guidelines:
 

--- a/skill-packs.json
+++ b/skill-packs.json
@@ -106,6 +106,28 @@
       "category": "dev",
       "trust_level": "community",
       "skills": ["mythosforge-ops-report"]
+    },
+    {
+      "repo": "codexvritra/signa-gitlawb-skills",
+      "name": "signa-gitlawb-skills",
+      "description": "gitlawb activity for any SIGNA wallet bound to a gitlawb DID — repos, commits, open tasks, bounty totals fetched live from node.gitlawb.com through SIGNA's public partner endpoint.",
+      "author": "signa-agent",
+      "license": "MIT",
+      "homepage": "https://www.signaagent.xyz/partners/gitlawb",
+      "category": "dev",
+      "trust_level": "community",
+      "skills": ["gitlawb-stats"]
+    },
+    {
+      "repo": "codexvritra/signa-miroshark-skills",
+      "name": "signa-miroshark-skills",
+      "description": "MiroShark swarm-intelligence simulations inside Aeon agents — read sim activity for any SIGNA wallet, or fire a wallet-signed sim and watch for the verdict on the federated SIGNA feed.",
+      "author": "signa-agent",
+      "license": "MIT",
+      "homepage": "https://www.signaagent.xyz/partners/miroshark",
+      "category": "research",
+      "trust_level": "community",
+      "skills": ["miroshark-stats", "miroshark-fire"]
     }
   ]
 }


### PR DESCRIPTION
Completes the SIGNA partner-skill-pack series. Each partner Aeon already lists in ECOSYSTEM.md now has a dedicated read (and write where applicable) skill pack.

## signa-gitlawb-skills (1 skill, category: `dev`)
`gitlawb-stats` — repos / commits / open tasks / bounty totals for any SIGNA wallet bound to a gitlawb DID. Read-only proxy through SIGNA's existing public endpoint at `/api/agents/<addr>/gitlawb-stats`. No gitlawb API key or DID custody required on the Aeon side.

Repo: https://github.com/codexvritra/signa-gitlawb-skills

## signa-miroshark-skills (2 skills, category: `research`)
- `miroshark-stats` — read sim activity for any SIGNA wallet (sims fired + verdicts received + recent verdict bodies)
- `miroshark-fire` — wallet-sign and trigger a new swarm sim. Verdict posts back to the federated SIGNA feed wallet-signed by `miroshark.bot.signa`.

The fire skill gracefully returns when the receiving SIGNA node doesn't have MiroShark configured — the calling Aeon agent can fall back without an exception.

Repo: https://github.com/codexvritra/signa-miroshark-skills

## Verification
- `gitlawb-stats` against an unbound wallet returns the graceful 404 message (verified)
- `miroshark-stats` against a wallet with no sims returns sims_fired=0, verdicts=0 (verified)
- `miroshark-fire` returns the "not configured" message when MIROSHARK_BASE_URL isn't set on the receiving node (verified)
- All four `SKILL.md` files follow the AntFleet skill format reference
- Both `skills-pack.json` manifests validated against `docs/community-skill-packs.md` schema

## Why I'm not shipping a MythosForge pack
Out of respect for [@ryjin111](https://github.com/ryjin111) who already ships [`aeon-skill-pack-mythosforge`](https://github.com/ryjin111/aeon-skill-pack-mythosforge). Their pack is the canonical MythosForge integration for Aeon — I don't want to fragment the ecosystem with a duplicate.