### PR TITLE
community: add signa-skills (10 skills, 5 categories, single install)

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ To browse known packs without installing, run `./install-skill-pack --list` — 
 | [aeon-skills](https://github.com/AntFleet/aeon-skills) | 1 | Two-model-consensus PR review (Opus 4.7 + GPT-5) — per-review USDC drawdown on Base |
 | [aeon-skill-pack-liquidpad](https://github.com/liquidpadbot/aeon-skill-pack-liquidpad) | 4 | Track LiquidPad on Base — burn cycle alerts, new token launches with onchain provenance, daily protocol digest, and fee accrual tracking |
 | [aeon-skill-pack-mythosforge](https://github.com/ryjin111/aeon-skill-pack-mythosforge) | 1 | Read-only MythosForge ops monitoring — backlog, jury/payout health, degraded-juror notes, and stall alerts |
-| [signa-skills](https://github.com/codexvritra/signa-skills) | 10 | Full SIGNA suite — wallet-signed cross-platform agent messaging, multi-agent broadcast and delegate, plus Bankr resolver / launches, gitlawb activity, MiroShark sim stats and wallet-signed sim fire |
+| [signa](https://github.com/codexvritra/signa) (`--path aeon-skills`) | 10 | Full SIGNA suite — wallet-signed cross-platform agent messaging, multi-agent broadcast and delegate, plus Bankr resolver / launches, gitlawb activity, MiroShark sim stats and wallet-signed sim fire |
 
 **To list a pack here**, open a PR adding a row. Guidelines:
 

--- a/README.md
+++ b/README.md
@@ -458,6 +458,7 @@ To browse known packs without installing, run `./install-skill-pack --list` — 
 | [aeon-skills](https://github.com/AntFleet/aeon-skills) | 1 | Two-model-consensus PR review (Opus 4.7 + GPT-5) — per-review USDC drawdown on Base |
 | [aeon-skill-pack-liquidpad](https://github.com/liquidpadbot/aeon-skill-pack-liquidpad) | 4 | Track LiquidPad on Base — burn cycle alerts, new token launches with onchain provenance, daily protocol digest, and fee accrual tracking |
 | [aeon-skill-pack-mythosforge](https://github.com/ryjin111/aeon-skill-pack-mythosforge) | 1 | Read-only MythosForge ops monitoring — backlog, jury/payout health, degraded-juror notes, and stall alerts |
+| [signa-skills](https://github.com/codexvritra/signa-skills) | 10 | Full SIGNA suite — wallet-signed cross-platform agent messaging, multi-agent broadcast and delegate, plus Bankr resolver / launches, gitlawb activity, MiroShark sim stats and wallet-signed sim fire |
 
 **To list a pack here**, open a PR adding a row. Guidelines:
 

--- a/skill-packs.json
+++ b/skill-packs.json
@@ -108,9 +108,10 @@
       "skills": ["mythosforge-ops-report"]
     },
     {
-      "repo": "codexvritra/signa-skills",
-      "name": "signa-skills",
-      "description": "The full SIGNA skill suite — wallet-signed cross-platform agent messaging, multi-agent coordination (broadcast and delegate across the network), plus integrations with Aeon ecosystem partners already on Base: Bankr resolver and recent launches, gitlawb activity for any wallet, MiroShark sim stats and wallet-signed sim fire.",
+      "repo": "codexvritra/signa",
+      "path": "aeon-skills",
+      "name": "signa",
+      "description": "The full SIGNA skill suite — wallet-signed cross-platform agent messaging, multi-agent coordination (broadcast and delegate across the network), plus integrations with Aeon ecosystem partners already on Base: Bankr resolver and recent launches, gitlawb activity for any wallet, MiroShark sim stats and wallet-signed sim fire. Lives at aeon-skills/ inside the SIGNA monorepo so the wire format, SDKs, and skill pack all version together.",
       "author": "signa-agent",
       "license": "MIT",
       "homepage": "https://www.signaagent.xyz/partners",

--- a/skill-packs.json
+++ b/skill-packs.json
@@ -106,6 +106,28 @@
       "category": "dev",
       "trust_level": "community",
       "skills": ["mythosforge-ops-report"]
+    },
+    {
+      "repo": "codexvritra/signa-skills",
+      "name": "signa-skills",
+      "description": "The full SIGNA skill suite — wallet-signed cross-platform agent messaging, multi-agent coordination (broadcast and delegate across the network), plus integrations with Aeon ecosystem partners already on Base: Bankr resolver and recent launches, gitlawb activity for any wallet, MiroShark sim stats and wallet-signed sim fire.",
+      "author": "signa-agent",
+      "license": "MIT",
+      "homepage": "https://www.signaagent.xyz/partners",
+      "category": "messaging",
+      "trust_level": "community",
+      "skills": [
+        "signa-message",
+        "signa-inbox",
+        "signa-discover",
+        "signa-broadcast",
+        "signa-delegate",
+        "bankr-resolve",
+        "bankr-launches",
+        "gitlawb-stats",
+        "miroshark-stats",
+        "miroshark-fire"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Replaces my earlier PRs #238 / #239 / #240 — closed those in favor of consolidating the whole SIGNA skill suite into one pack so users only run `./install-skill-pack codexvritra/signa-skills` once and get everything.

## Ten skills

### Messaging
- `signa-message` — wallet-signed DM to any agent on the SIGNA network
- `signa-inbox` — read recent DMs received by this agent
- `signa-discover` — list bridges to other AI platforms (Ollama, OpenAI, Anthropic, LangChain, CrewAI, custom)

### Coordination (the white space)
- `signa-broadcast` — DM every alive agent on a platform, aggregate replies
- `signa-delegate` — find an agent by capability tag, delegate a task, return their wallet-signed reply

### Crypto (Bankr data)
- `bankr-resolve` — ENS / Twitter / Farcaster / 0x handle resolver via api.bankr.bot
- `bankr-launches` — recent Clanker (Base) and Raydium (Solana) token launches with deployer wallet + Twitter handle

### Dev (gitlawb activity)
- `gitlawb-stats` — repos / commits / open tasks / bounty totals for any SIGNA wallet bound to a gitlawb DID

### Research (MiroShark)
- `miroshark-stats` — sim activity for any wallet
- `miroshark-fire` — wallet-sign and trigger a swarm sim. Verdict posts back on the federated SIGNA feed via miroshark.bot.signa.

## Verification
- `bankr-launches` returns real `$PEARL` / `$shift` / `$Paynaptic` data live from api.bankr.bot (smoke-tested before this PR)
- `signa-discover` returns the live bridge directory from `/api/bridges`
- `signa-inbox` against a fresh wallet returns 0 DMs with the agent's derived address (graceful empty-state)
- All other skills gracefully handle empty/missing cases — `gitlawb-stats` reports "no DID bound", `miroshark-fire` reports "not configured" if MIROSHARK_BASE_URL isn't set

## Why not separate packs
My original instinct was one pack per partner for maximum visibility on the README. Talked through it again and a single `signa-skills` row reads cleaner, installs in one command, and matches the model VVVKernel uses (9 skills in one pack). Five rows would have fragmented the brand.

## Not shipping a MythosForge pack
Out of respect for [@ryjin111](https://github.com/ryjin111) who already ships [`aeon-skill-pack-mythosforge`](https://github.com/ryjin111/aeon-skill-pack-mythosforge). I'll ping them directly about a complementary skill if it makes sense later.