### PR TITLE
Fix zer0 X handle (@atzer0_BOT)

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -61,7 +61,7 @@ These are the projects we know of that run Aeon, extend it, or integrate with th
 | Vexor | [@Vexora_x](https://x.com/Vexora_x) |
 | Wake | [@WakeOnBase](https://x.com/WakeOnBase) |
 | x402Books | [@x402Books](https://x.com/x402Books) |
-| zer0 | [@Jaineon0G](https://x.com/Jaineon0G) |
+| zer0 | [@atzer0_BOT](https://x.com/atzer0_BOT) |
 
 ---
 


### PR DESCRIPTION
zer0 is listed with the wrong X handle in `ECOSYSTEM.md` — the row currently points to `@Jaineon0G`. The correct handle is **@atzer0_BOT** ([x.com/atzer0_BOT](https://x.com/atzer0_BOT)).

This PR fixes that single row, nothing else. Thanks for including zer0 in the ecosystem list!
