### PR TITLE
chore(skills.json): backfill fleet-skill-adoption sha post-merge

### DIFF
--- a/skills.json
+++ b/skills.json
@@ -583,7 +583,7 @@
             "schedule": "0 22 * * 0",
             "var": "",
             "files": 0,
-            "sha": "0000000",
+            "sha": "c8a6d44",
             "updated": "2026-05-26",
             "install": "./add-skill aaronjmars/aeon fleet-skill-adoption"
         },


### PR DESCRIPTION
Fills the placeholder `sha` (`0000000`) for the `fleet-skill-adoption` entry added in #245 with the real squash-merge short sha `c8a6d44`, matching the convention every other entry follows (sha = the skill's landing commit).

Single-line change; `files: 0` and `updated: 2026-05-26` were already correct. JSON validated with `jq`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)