### PR TITLE
Fix GitBounty handle in ECOSYSTEM.md

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -33,7 +33,7 @@ These are the projects we know of that run Aeon, extend it, or integrate with th
 | Clerk | [@clerk](https://x.com/clerk) |
 | Cobot | [@cobotgg](https://x.com/cobotgg) |
 | GitBlock | [@gitblock_](https://x.com/gitblock_) |
-| GitBounty | [@Git_Bounty](https://x.com/Git_Bounty) |
+| GitBounty | [@Gitlawbounty](https://x.com/Gitlawbounty) |
 | GitKernal | [@gitkernal](https://x.com/gitkernal) |
 | Gitlawb Terminal | [@Gitlawbterminal](https://x.com/Gitlawbterminal) |
 | LawbWorld | [@LawbWorld](https://x.com/LawbWorld) |


### PR DESCRIPTION
GitBounty reached out: their X handle in the ecosystem list is wrong.

- Listed as `@Git_Bounty`
- Correct handle is `@Gitlawbounty`

Updates the display text and the `x.com` link on the GitBounty row in `ECOSYSTEM.md`. No other references needed changing — the `gitlawbounty/...` paths elsewhere are GitHub repo paths and are already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)