### PR TITLE
docs: update aeon-skill-pack-mythosforge listing (3 read-only safety skills, 5 total)

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ To browse known packs without installing, run `./install-skill-pack --list` — 
 | [gitbounty-skill-pack](https://github.com/gitlawbounty/gitbounty-skill-pack) | 1 | Bounty hunting on the gitlawb network via gitbounty — discover open bounties, scout the best fit with the gitbounty LLM scout, draft a solution plan (read-only) |
 | [aeon-skills](https://github.com/AntFleet/aeon-skills) | 1 | Two-model-consensus PR review (Opus 4.7 + GPT-5) — per-review USDC drawdown on Base |
 | [aeon-skill-pack-liquidpad](https://github.com/liquidpadbot/aeon-skill-pack-liquidpad) | 4 | Track LiquidPad on Base — burn cycle alerts, new token launches with onchain provenance, daily protocol digest, and fee accrual tracking |
-| [aeon-skill-pack-mythosforge](https://github.com/ryjin111/aeon-skill-pack-mythosforge) | 2 | Read-only MythosForge ops monitoring + proof-of-creation integrity — health/backlog monitoring plus continuous verification that paid + recent creations stay provably anchored on Base |
+| [aeon-skill-pack-mythosforge](https://github.com/ryjin111/aeon-skill-pack-mythosforge) | 5 | Read-only MythosForge monitoring — ops/backlog/jury/payout health, proof-of-creation integrity on Base, theme/round guard against silent relabels, jury-drift detection, and live gallery/proof-page QA |
 
 **To list a pack here**, open a PR adding a row. Guidelines:
 

--- a/skill-packs.json
+++ b/skill-packs.json
@@ -99,13 +99,13 @@
     {
       "repo": "ryjin111/aeon-skill-pack-mythosforge",
       "name": "aeon-skill-pack-mythosforge",
-      "description": "Read-only MythosForge ops monitoring + proof-of-creation integrity — backlog/jury/payout health, plus continuous verification that paid + recent creations stay provably anchored on Base.",
+      "description": "Read-only MythosForge monitoring — ops/backlog/jury/payout health, proof-of-creation integrity on Base, theme/round guard against silent relabels, jury-drift detection, and live gallery/proof-page QA.",
       "author": "ryjin111",
       "license": "MIT",
       "homepage": "https://mythosforge.xyz",
       "category": "dev",
       "trust_level": "community",
-      "skills": ["mythosforge-ops-report", "mythosforge-proof-integrity"]
+      "skills": ["mythosforge-ops-report", "mythosforge-proof-integrity", "mythosforge-theme-round-guard", "mythosforge-jury-drift-watcher", "mythosforge-gallery-qa-watcher"]
     }
   ]
 }


### PR DESCRIPTION
Brings the **aeon-skill-pack-mythosforge** listing current with skill-pack v1.3.0. The pack now ships **5 read-only, alert-only** skills:

| skill | what it watches |
|---|---|
| `mythosforge-ops-report` | backlog / jury / payout health, stall alerts |
| `mythosforge-proof-integrity` | paid + recent creations stay provably anchored on Base |
| `mythosforge-theme-round-guard` | a theme changed on a round that already has submissions (silent relabel) + missing next-day round |
| `mythosforge-jury-drift-watcher` | a single juror model degrading / scoring as an outlier / leaving submissions stuck below the 3-of-4 quorum |
| `mythosforge-gallery-qa-watcher` | live gallery + proof pages — broken loads, missing image/Hi-Res, status labels inconsistent with backend counts |

All skills observe and report only — no writes to MythosForge, no scoring, no FORGE movement; their only write is to Aeon's own `memory/`.

Changes: README pack row `2 → 5` + updated description; `skill-packs.json` skills array + description.

**Supersedes #236** (which added only `proof-integrity`); this row includes it, so #236 can be closed.