### PR TITLE
Add 7 community skill packs from sparkleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,13 @@ To browse known packs without installing, run `./install-skill-pack --list` — 
 | [aeon-skills](https://github.com/AntFleet/aeon-skills) | 1 | Two-model-consensus PR review (Opus 4.7 + GPT-5) — per-review USDC drawdown on Base |
 | [aeon-skill-pack-liquidpad](https://github.com/liquidpadbot/aeon-skill-pack-liquidpad) | 4 | Track LiquidPad on Base — burn cycle alerts, new token launches with onchain provenance, daily protocol digest, and fee accrual tracking |
 | [aeon-skill-pack-mythosforge](https://github.com/ryjin111/aeon-skill-pack-mythosforge) | 5 | Read-only MythosForge monitoring — ops/backlog/jury/payout health, proof-of-creation integrity on Base, theme/round guard against silent relabels, jury-drift detection, and live gallery/proof-page QA |
+| [demo-pack](https://github.com/sparkleware/demo-pack) | 1 | Holographic demo skill — proves the Sparkleware registry install pipeline works |
+| [aeon-pulse](https://github.com/sparkleware/aeon-pulse) | 1 | Daily activity summary for the Aeon framework — recent commits, releases, and open issues |
+| [registry-watch](https://github.com/sparkleware/registry-watch) | 1 | Daily digest of new packs added to the Sparkleware registry — discover community skills without manually browsing |
+| [arxiv-digest](https://github.com/sparkleware/arxiv-digest) | 1 | Daily digest of newest AI / autonomous-agent papers on arXiv — top submissions in cs.AI, cs.LG, cs.MA |
+| [hn-top](https://github.com/sparkleware/hn-top) | 1 | Daily digest of HackerNews top stories — dev / startup / AI conversation in one screen |
+| [eth-gas-watch](https://github.com/sparkleware/eth-gas-watch) | 1 | Ethereum gas-price status check on a schedule — flags cheap windows for batching on-chain ops |
+| [morning-briefing](https://github.com/sparkleware/morning-briefing) | 1 | Daily morning briefing — date, day-of-week, current weather, and a sparkly closer |
 
 **To list a pack here**, open a PR adding a row. Guidelines:
 

--- a/skill-packs.json
+++ b/skill-packs.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "updated": "2026-05-23",
+  "updated": "2026-05-26",
   "description": "Machine-readable registry of community skill packs installable via ./install-skill-pack. Mirrors the human-readable table in README.md.",
   "packs": [
     {
@@ -106,6 +106,83 @@
       "category": "dev",
       "trust_level": "community",
       "skills": ["mythosforge-ops-report", "mythosforge-proof-integrity", "mythosforge-theme-round-guard", "mythosforge-jury-drift-watcher", "mythosforge-gallery-qa-watcher"]
+    },
+    {
+      "repo": "sparkleware/demo-pack",
+      "name": "demo-pack",
+      "description": "Holographic demo skill — proves the Sparkleware registry install pipeline works.",
+      "author": "sparkleware",
+      "license": "MIT",
+      "homepage": "https://github.com/sparkleware/demo-pack",
+      "category": "meta",
+      "trust_level": "community",
+      "skills": ["sparkle-status"]
+    },
+    {
+      "repo": "sparkleware/aeon-pulse",
+      "name": "aeon-pulse",
+      "description": "Daily activity summary for the Aeon framework — recent commits, releases, and open issues.",
+      "author": "sparkleware",
+      "license": "MIT",
+      "homepage": "https://github.com/sparkleware/aeon-pulse",
+      "category": "dev",
+      "trust_level": "community",
+      "skills": ["aeon-activity"]
+    },
+    {
+      "repo": "sparkleware/registry-watch",
+      "name": "registry-watch",
+      "description": "Daily digest of new packs added to the Sparkleware registry — discover community skills without manually browsing.",
+      "author": "sparkleware",
+      "license": "MIT",
+      "homepage": "https://github.com/sparkleware/registry-watch",
+      "category": "meta",
+      "trust_level": "community",
+      "skills": ["new-packs-digest"]
+    },
+    {
+      "repo": "sparkleware/arxiv-digest",
+      "name": "arxiv-digest",
+      "description": "Daily digest of newest AI / autonomous-agent papers on arXiv — top submissions in cs.AI, cs.LG, cs.MA.",
+      "author": "sparkleware",
+      "license": "MIT",
+      "homepage": "https://github.com/sparkleware/arxiv-digest",
+      "category": "research",
+      "trust_level": "community",
+      "skills": ["daily-papers"]
+    },
+    {
+      "repo": "sparkleware/hn-top",
+      "name": "hn-top",
+      "description": "Daily digest of HackerNews top stories — dev / startup / AI conversation in one screen.",
+      "author": "sparkleware",
+      "license": "MIT",
+      "homepage": "https://github.com/sparkleware/hn-top",
+      "category": "social",
+      "trust_level": "community",
+      "skills": ["hn-daily"]
+    },
+    {
+      "repo": "sparkleware/eth-gas-watch",
+      "name": "eth-gas-watch",
+      "description": "Ethereum gas-price status check on a schedule — flags cheap windows for batching on-chain ops.",
+      "author": "sparkleware",
+      "license": "MIT",
+      "homepage": "https://github.com/sparkleware/eth-gas-watch",
+      "category": "crypto",
+      "trust_level": "community",
+      "skills": ["gas-status"]
+    },
+    {
+      "repo": "sparkleware/morning-briefing",
+      "name": "morning-briefing",
+      "description": "Daily morning briefing — date, day-of-week, current weather, and a sparkly closer. No API key required.",
+      "author": "sparkleware",
+      "license": "MIT",
+      "homepage": "https://github.com/sparkleware/morning-briefing",
+      "category": "productivity",
+      "trust_level": "community",
+      "skills": ["morning-briefing"]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds 7 community skill packs from the `sparkleware` org as `trust_level: "community"` entries, per discussion in #244.

Each pack:
- ✅ Public MIT repo
- ✅ `skills-pack.json` manifest at root
- ✅ Per-skill `SKILL.md` with frontmatter (name, description, tags)
- ✅ Tagged `aeon-skill-pack` on GitHub
- ✅ Installable via `./install-skill-pack sparkleware/<name>`

## Packs

| Pack | Category | Skills |
|---|---|---|
| [demo-pack](https://github.com/sparkleware/demo-pack) | meta | sparkle-status |
| [aeon-pulse](https://github.com/sparkleware/aeon-pulse) | dev | aeon-activity |
| [registry-watch](https://github.com/sparkleware/registry-watch) | meta | new-packs-digest |
| [arxiv-digest](https://github.com/sparkleware/arxiv-digest) | research | daily-papers |
| [hn-top](https://github.com/sparkleware/hn-top) | social | hn-daily |
| [eth-gas-watch](https://github.com/sparkleware/eth-gas-watch) | crypto | gas-status |
| [morning-briefing](https://github.com/sparkleware/morning-briefing) | productivity | morning-briefing |

## Context

Sparkleware (https://sparkleware.fun) is a community discovery catalog for Aeon skill packs — a layer that sits *on top of* `skill-packs.json`, not parallel to it. Installs continue to resolve through the canonical `./install-skill-pack <author>/<name>` flow against this registry.

These 7 packs serve as both reference implementations and the seed content for the catalog.

Refs #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)