### PR TITLE
feat: add noelclaw skill pack (noelvault + noel-swarm)

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,7 @@ To browse known packs without installing, run `./install-skill-pack --list` — 
 | [aeon-skills](https://github.com/AntFleet/aeon-skills) | 1 | Two-model-consensus PR review (Opus 4.7 + GPT-5) — per-review USDC drawdown on Base |
 | [aeon-skill-pack-liquidpad](https://github.com/liquidpadbot/aeon-skill-pack-liquidpad) | 4 | Track LiquidPad on Base — burn cycle alerts, new token launches with onchain provenance, daily protocol digest, and fee accrual tracking |
 | [aeon-skill-pack-mythosforge](https://github.com/ryjin111/aeon-skill-pack-mythosforge) | 5 | Read-only MythosForge monitoring — ops/backlog/jury/payout health, proof-of-creation integrity on Base, theme/round guard against silent relabels, jury-drift detection, and live gallery/proof-page QA |
+| [aeon-skill-pack-noelclaw](https://github.com/noelclaw/aeon-skill-pack-noelclaw) | 2 | Persistent versioned memory and multi-agent swarm coordination — save typed artifacts to Noel Vault and manage shared agent session state across runs |
 
 **To list a pack here**, open a PR adding a row. Guidelines:
 

--- a/skill-packs.json
+++ b/skill-packs.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "updated": "2026-05-23",
+  "updated": "2026-05-26",
   "description": "Machine-readable registry of community skill packs installable via ./install-skill-pack. Mirrors the human-readable table in README.md.",
   "packs": [
     {
@@ -106,6 +106,17 @@
       "category": "dev",
       "trust_level": "community",
       "skills": ["mythosforge-ops-report", "mythosforge-proof-integrity", "mythosforge-theme-round-guard", "mythosforge-jury-drift-watcher", "mythosforge-gallery-qa-watcher"]
+    },
+    {
+      "repo": "noelclaw/aeon-skill-pack-noelclaw",
+      "name": "aeon-skill-pack-noelclaw",
+      "description": "Persistent versioned memory and multi-agent swarm coordination — save typed artifacts to Noel Vault and manage shared agent session state across runs.",
+      "author": "noelclaw",
+      "license": "MIT",
+      "homepage": "https://noelclaw.com",
+      "category": "dev",
+      "trust_level": "community",
+      "skills": ["noelvault", "noel-swarm"]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds `noelclaw/aeon-skill-pack-noelclaw` to the community skill-pack registry.

**2 skills:**
- `noelvault` — persistent versioned memory across Aeon runs (save findings, recall by key or search)
- `noel-swarm` — shared memory bus for multi-agent coordination, with shared memory and execution scores

**Zero-friction setup — no registration:**
```bash
curl -X POST https://api.noelclaw.com/auth/key
# → { "apiKey": "noel_..." }
```
Two GitHub secrets: `NOELCLAW_URL` + `NOELCLAW_API_KEY`. Done.

## Compliance checklist

- [x] External repo, public
- [x] `NOELCLAW_URL` is explicit env var — no hardcoded fallback
- [x] Both skills exit cleanly (`exit 0`) when env vars not set
- [x] Endpoints in SKILL.md match README (`api.noelclaw.com`)
- [x] `## Sandbox note` present in both SKILL.md files
- [x] In-taxonomy tags: `[meta, memory, dev]` and `[meta, dev, infra]`
- [x] `skills-pack.json` at pack root with correct schema
- [x] Both skills `default_enabled: false`

## Changes

- `skill-packs.json` — new entry for `noelclaw/aeon-skill-pack-noelclaw`
- `README.md` — new row in community packs table