### PR TITLE
feat: add noelclaw skill pack (noelvault + noel-swarm)

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,7 @@ To browse known packs without installing, run `./install-skill-pack --list` — 
 | [hn-top](https://github.com/sparkleware/hn-top) | 1 | Daily digest of HackerNews top stories — dev / startup / AI conversation in one screen |
 | [eth-gas-watch](https://github.com/sparkleware/eth-gas-watch) | 1 | Ethereum gas-price status check on a schedule — flags cheap windows for batching on-chain ops |
 | [morning-briefing](https://github.com/sparkleware/morning-briefing) | 1 | Daily morning briefing — date, day-of-week, current weather, and a sparkly closer |
+| [aeon-skill-pack-noelclaw](https://github.com/noelclaw/aeon-skill-pack-noelclaw) | 2 | Persistent versioned memory and multi-agent swarm coordination — save typed artifacts to Noel Vault and manage shared agent session state across runs |
 
 **To list a pack here**, open a PR adding a row. Guidelines:
 

--- a/skill-packs.json
+++ b/skill-packs.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "updated": "2026-05-26",
+  "updated": "2026-05-27",
   "description": "Machine-readable registry of community skill packs installable via ./install-skill-pack. Mirrors the human-readable table in README.md.",
   "packs": [
     {
@@ -183,6 +183,17 @@
       "category": "productivity",
       "trust_level": "community",
       "skills": ["morning-briefing"]
+    },
+    {
+      "repo": "noelclaw/aeon-skill-pack-noelclaw",
+      "name": "aeon-skill-pack-noelclaw",
+      "description": "Persistent versioned memory and multi-agent swarm coordination — save typed artifacts to Noel Vault and manage shared agent session state across runs.",
+      "author": "noelclaw",
+      "license": "MIT",
+      "homepage": "https://noelclaw.com",
+      "category": "dev",
+      "trust_level": "community",
+      "skills": ["noelvault", "noel-swarm"]
     }
   ]
 }


### PR DESCRIPTION
Lands the registry row from #250 (by @noelclaw), conflict-resolved onto current main (the sparkleware packs from #249 had moved the array tail). Registry-only: one README row + one `skill-packs.json` entry. Closes #250.