### PR TITLE
community: add signa skill pack (10 skills, --path aeon-skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,7 @@ To browse known packs without installing, run `./install-skill-pack --list` — 
 | [eth-gas-watch](https://github.com/sparkleware/eth-gas-watch) | 1 | Ethereum gas-price status check on a schedule — flags cheap windows for batching on-chain ops |
 | [morning-briefing](https://github.com/sparkleware/morning-briefing) | 1 | Daily morning briefing — date, day-of-week, current weather, and a sparkly closer |
 | [aeon-skill-pack-noelclaw](https://github.com/noelclaw/aeon-skill-pack-noelclaw) | 2 | Persistent versioned memory and multi-agent swarm coordination — save typed artifacts to Noel Vault and manage shared agent session state across runs |
+| [signa](https://github.com/codexvritra/signa) (`--path aeon-skills`) | 10 | Full SIGNA suite — wallet-signed cross-platform agent messaging, multi-agent broadcast and delegate, plus Bankr resolver / launches, gitlawb activity, MiroShark sim stats and wallet-signed sim fire |
 
 **To list a pack here**, open a PR adding a row. Guidelines:
 

--- a/skill-packs.json
+++ b/skill-packs.json
@@ -194,6 +194,18 @@
       "category": "dev",
       "trust_level": "community",
       "skills": ["noelvault", "noel-swarm"]
+    },
+    {
+      "repo": "codexvritra/signa",
+      "path": "aeon-skills",
+      "name": "signa",
+      "description": "The full SIGNA skill suite — wallet-signed cross-platform agent messaging, multi-agent coordination (broadcast and delegate across the network), plus integrations with Aeon ecosystem partners already on Base: Bankr resolver and recent launches, gitlawb activity for any wallet, MiroShark sim stats and wallet-signed sim fire. Lives at aeon-skills/ inside the SIGNA monorepo so the wire format, SDKs, and skill pack all version together.",
+      "author": "signa-agent",
+      "license": "MIT",
+      "homepage": "https://www.signaagent.xyz/partners",
+      "category": "messaging",
+      "trust_level": "community",
+      "skills": ["signa-message", "signa-inbox", "signa-discover", "signa-broadcast", "signa-delegate", "bankr-resolve", "bankr-launches", "gitlawb-stats", "miroshark-stats", "miroshark-fire"]
     }
   ]
 }


### PR DESCRIPTION
Lands the registry row from #241 (by @codexvritra), conflict-resolved onto current main. Registry-only: one README row + one `skill-packs.json` entry. Closes #241.