### PR TITLE
refactor(dashboard): dedupe helpers, consolidate + strengthen types, remove dead code

### DIFF
--- a/dashboard/app/api/analytics/route.ts
+++ b/dashboard/app/api/analytics/route.ts
@@ -1,26 +1,9 @@
 import { NextResponse } from 'next/server'
-import { execFileSync, execSync } from 'child_process'
+import { execFileSync } from 'child_process'
 import { resolve } from 'path'
-import { readdirSync, readFileSync } from 'fs'
-
-const REPO_ROOT = resolve(process.cwd(), '..')
-
-function ghRepo(): string | null {
-  try {
-    const repo = execSync('gh repo set-default --view', { stdio: 'pipe', cwd: REPO_ROOT }).toString().trim()
-    if (repo && !repo.startsWith('no default')) return repo
-  } catch {}
-  try {
-    const repo = execSync('gh repo view --json nameWithOwner -q .nameWithOwner', { stdio: 'pipe', cwd: REPO_ROOT }).toString().trim()
-    if (repo) return repo
-  } catch {}
-  return null
-}
-
-function ghArgsRepo(): string[] {
-  const repo = ghRepo()
-  return repo ? ['-R', repo] : []
-}
+import { readFileSync } from 'fs'
+import { REPO_ROOT, ghArgsRepo } from '@/lib/gh'
+import type { SkillMetrics, Insight } from '@/lib/types'
 
 interface RunRecord {
   name: string
@@ -28,25 +11,6 @@ interface RunRecord {
   conclusion: string | null
   createdAt: string
   updatedAt: string
-}
-
-interface SkillMetrics {
-  name: string
-  total: number
-  success: number
-  failure: number
-  cancelled: number
-  inProgress: number
-  successRate: number
-  lastRun: string | null
-  lastConclusion: string | null
-  avgDurationMin: number | null
-  streak: number // positive = consecutive successes, negative = consecutive failures
-}
-
-interface Insight {
-  type: 'warning' | 'info' | 'success'
-  message: string
 }
 
 export async function GET() {

--- a/dashboard/app/api/auth/route.ts
+++ b/dashboard/app/api/auth/route.ts
@@ -1,31 +1,6 @@
 import { NextResponse } from 'next/server'
 import { execFileSync, execSync } from 'child_process'
-
-function ghAvailable(): boolean {
-  try {
-    execSync('gh auth status', { stdio: 'pipe' })
-    return true
-  } catch {
-    return false
-  }
-}
-
-function ghRepo(): string | null {
-  try {
-    const repo = execSync('gh repo set-default --view', { stdio: 'pipe' }).toString().trim()
-    if (repo && !repo.startsWith('no default')) return repo
-  } catch {}
-  try {
-    const repo = execSync('gh repo view --json nameWithOwner -q .nameWithOwner', { stdio: 'pipe' }).toString().trim()
-    if (repo) return repo
-  } catch {}
-  return null
-}
-
-function ghArgsRepo(): string[] {
-  const repo = ghRepo()
-  return repo ? ['-R', repo] : []
-}
+import { ghAvailable, ghArgsRepo } from '@/lib/gh'
 
 export async function GET() {
   // Check if ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is set

--- a/dashboard/app/api/import/route.ts
+++ b/dashboard/app/api/import/route.ts
@@ -8,21 +8,7 @@ import {
   getDirectory,
 } from '@/lib/github'
 import { addSkillToConfig } from '@/lib/config'
-
-function extractDescription(content: string): string {
-  const fm = content.match(/^---\s*\n([\s\S]*?)\n---/)
-  if (fm) {
-    const desc = fm[1].match(/description:\s*(.+)/)
-    if (desc) return desc[1].trim().replace(/^['"]|['"]$/g, '')
-  }
-  for (const line of content.split('\n')) {
-    const t = line.trim()
-    if (t && !t.startsWith('#') && !t.startsWith('---')) {
-      return t.length > 120 ? t.slice(0, 117) + '...' : t
-    }
-  }
-  return ''
-}
+import { parseFrontmatter } from '@/lib/frontmatter'
 
 export async function POST(request: Request) {
   try {
@@ -51,7 +37,7 @@ export async function POST(request: Request) {
           if (!content) return null
           return {
             name: dir.name,
-            description: extractDescription(content),
+            description: parseFrontmatter(content).description,
             installed: localNames.has(dir.name),
           }
         }),

--- a/dashboard/app/api/runs/[id]/logs/route.ts
+++ b/dashboard/app/api/runs/[id]/logs/route.ts
@@ -1,24 +1,12 @@
 import { NextResponse } from 'next/server'
-import { execFileSync, execSync } from 'child_process'
-import { resolve } from 'path'
+import { execFileSync } from 'child_process'
+import { REPO_ROOT, ghArgsRepo } from '@/lib/gh'
 
-const REPO_ROOT = resolve(process.cwd(), '..')
-
-function ghRepo(): string | null {
-  try {
-    const repo = execSync('gh repo set-default --view', { stdio: 'pipe', cwd: REPO_ROOT }).toString().trim()
-    if (repo && !repo.startsWith('no default')) return repo
-  } catch {}
-  try {
-    const repo = execSync('gh repo view --json nameWithOwner -q .nameWithOwner', { stdio: 'pipe', cwd: REPO_ROOT }).toString().trim()
-    if (repo) return repo
-  } catch {}
-  return null
-}
-
-function ghArgsRepo(): string[] {
-  const repo = ghRepo()
-  return repo ? ['-R', repo] : []
+interface GhRunView {
+  status: string
+  conclusion: string | null
+  displayTitle: string
+  jobs: Array<{ name: string; status: string; conclusion: string | null }>
 }
 
 export async function GET(
@@ -41,7 +29,7 @@ export async function GET(
       ['run', 'view', id, ...repoArgs, '--json', 'status,conclusion,displayTitle,jobs'],
       { stdio: 'pipe', cwd: REPO_ROOT, timeout: 15000 },
     ).toString()
-    const info = JSON.parse(infoRaw)
+    const info: GhRunView = JSON.parse(infoRaw)
 
     // Get logs — use --log-failed for failed runs, --log for completed
     let logs = ''

--- a/dashboard/app/api/runs/route.ts
+++ b/dashboard/app/api/runs/route.ts
@@ -1,24 +1,15 @@
 import { NextResponse } from 'next/server'
-import { execFileSync, execSync } from 'child_process'
-import { resolve } from 'path'
+import { execFileSync } from 'child_process'
+import { REPO_ROOT, ghArgsRepo } from '@/lib/gh'
 
-const REPO_ROOT = resolve(process.cwd(), '..')
-
-function ghRepo(): string | null {
-  try {
-    const repo = execSync('gh repo set-default --view', { stdio: 'pipe', cwd: REPO_ROOT }).toString().trim()
-    if (repo && !repo.startsWith('no default')) return repo
-  } catch {}
-  try {
-    const repo = execSync('gh repo view --json nameWithOwner -q .nameWithOwner', { stdio: 'pipe', cwd: REPO_ROOT }).toString().trim()
-    if (repo) return repo
-  } catch {}
-  return null
-}
-
-function ghArgsRepo(): string[] {
-  const repo = ghRepo()
-  return repo ? ['-R', repo] : []
+interface GhRunListItem {
+  databaseId: number
+  name: string
+  status: string
+  conclusion: string | null
+  createdAt: string
+  url: string
+  displayTitle: string
 }
 
 export async function GET() {
@@ -28,8 +19,8 @@ export async function GET() {
       ['run', 'list', ...ghArgsRepo(), '--json', 'databaseId,name,status,conclusion,createdAt,url,displayTitle', '--limit', '20'],
       { stdio: 'pipe', cwd: REPO_ROOT },
     ).toString()
-    const raw = JSON.parse(out)
-    const runs = raw.map((r: Record<string, unknown>) => ({
+    const raw: GhRunListItem[] = JSON.parse(out)
+    const runs = raw.map((r) => ({
       id: r.databaseId,
       workflow: r.displayTitle || r.name,
       status: r.status,

--- a/dashboard/app/api/secrets/route.ts
+++ b/dashboard/app/api/secrets/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
-import { execFileSync, execSync } from 'child_process'
+import { execFileSync } from 'child_process'
+import { ghAvailable, ghArgsRepo } from '@/lib/gh'
 
 const BUILTIN_SECRETS = [
   { name: 'CLAUDE_CODE_OAUTH_TOKEN', group: 'Core', description: 'Claude Code OAuth token (set via Authenticate button)', either: 'auth' },
@@ -28,32 +29,6 @@ const BUILTIN_NAMES = new Set(BUILTIN_SECRETS.map(s => s.name))
 
 // Valid env var name pattern
 const VALID_SECRET_NAME = /^[A-Z][A-Z0-9_]{1,}$/
-
-function ghAvailable(): boolean {
-  try {
-    execSync('gh auth status', { stdio: 'pipe' })
-    return true
-  } catch {
-    return false
-  }
-}
-
-function ghRepo(): string | null {
-  try {
-    const repo = execSync('gh repo set-default --view', { stdio: 'pipe' }).toString().trim()
-    if (repo && !repo.startsWith('no default')) return repo
-  } catch {}
-  try {
-    const repo = execSync('gh repo view --json nameWithOwner -q .nameWithOwner', { stdio: 'pipe' }).toString().trim()
-    if (repo) return repo
-  } catch {}
-  return null
-}
-
-function ghArgsRepo(): string[] {
-  const repo = ghRepo()
-  return repo ? ['-R', repo] : []
-}
 
 function listSecrets(): string[] {
   try {

--- a/dashboard/app/api/skills/route.ts
+++ b/dashboard/app/api/skills/route.ts
@@ -10,6 +10,7 @@ import {
   removeSkillFromConfig,
 } from '@/lib/config'
 import { deleteDirectory } from '@/lib/github'
+import { parseFrontmatter } from '@/lib/frontmatter'
 
 function getRepoSlug(): string {
   if (process.env.GITHUB_REPO) return process.env.GITHUB_REPO
@@ -20,30 +21,6 @@ function getRepoSlug(): string {
   } catch {
     return ''
   }
-}
-
-function extractFrontmatter(content: string): { description: string; tags: string[] } {
-  const fm = content.match(/^---\s*\n([\s\S]*?)\n---/)
-  let description = ''
-  let tags: string[] = []
-  if (fm) {
-    const desc = fm[1].match(/description:\s*(.+)/)
-    if (desc) description = desc[1].trim().replace(/^['"]|['"]$/g, '')
-    const tagsMatch = fm[1].match(/tags:\s*\[([^\]]*)\]/)
-    if (tagsMatch) {
-      tags = tagsMatch[1].split(',').map(t => t.trim()).filter(Boolean)
-    }
-  }
-  if (!description) {
-    for (const line of content.split('\n')) {
-      const t = line.trim()
-      if (t && !t.startsWith('#') && !t.startsWith('---')) {
-        description = t.length > 120 ? t.slice(0, 117) + '...' : t
-        break
-      }
-    }
-  }
-  return { description, tags }
 }
 
 export async function GET() {
@@ -59,7 +36,8 @@ export async function GET() {
       dirNames.map(async (name) => {
         try {
           const { content } = await getFileContent(`skills/${name}/SKILL.md`)
-          return { name, ...extractFrontmatter(content) }
+          const { description, tags } = parseFrontmatter(content)
+          return { name, description, tags }
         } catch {
           return { name, description: '', tags: [] as string[] }
         }

--- a/dashboard/app/api/upload/route.ts
+++ b/dashboard/app/api/upload/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server'
 import { createFile, getFileContent, updateFile } from '@/lib/github'
 import { addSkillToConfig } from '@/lib/config'
+import { parseFrontmatter } from '@/lib/frontmatter'
+import type { UploadFile } from '@/lib/types'
 
 function detectSecretsFromContent(content: string): string[] {
   const matches = new Set<string>()
@@ -16,16 +18,9 @@ function detectSecretsFromContent(content: string): string[] {
 }
 
 function extractSkillName(content: string): string {
-  // Try frontmatter name field
-  const fm = content.match(/^---\s*\n([\s\S]*?)\n---/)
-  if (fm) {
-    const nameMatch = fm[1].match(/name:\s*(.+)/)
-    if (nameMatch) {
-      // Slugify: "Daily Article" → "daily-article"
-      return nameMatch[1].trim().replace(/^['"]|['"]$/g, '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
-    }
-  }
-  return ''
+  // Slugify the frontmatter name: "Daily Article" → "daily-article"
+  const { name } = parseFrontmatter(content)
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
 }
 
 function isSkillFile(path: string): boolean {
@@ -37,7 +32,7 @@ function stripSkillExt(name: string): string {
   return name.replace(/\.skill$/i, '')
 }
 
-function deriveSkillName(files: Array<{ path: string; content: string }>): { name: string; prefix: string } {
+function deriveSkillName(files: UploadFile[]): { name: string; prefix: string } {
   // First try SKILL.md
   const skillFile = files.find(f =>
     f.path === 'SKILL.md' ||
@@ -90,7 +85,7 @@ function deriveSkillName(files: Array<{ path: string; content: string }>): { nam
 export async function POST(request: Request) {
   try {
     const body = await request.json()
-    const files = body.files as Array<{ path: string; content: string }>
+    const files = body.files as UploadFile[]
     const overrideName = body.name as string | undefined
 
     if (!files || files.length === 0) {

--- a/dashboard/app/page.tsx
+++ b/dashboard/app/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react'
-import type { Skill, Run, Secret, SkillOutput } from '../lib/types'
+import type { Skill, Run, Secret, SkillOutput, GatewayProvider, UploadFile, AnalyticsData } from '../lib/types'
 import { MODELS } from '../lib/constants'
 import { displayName } from '../lib/utils'
 import TargetCursor from '../components/ui/TargetCursor'
@@ -24,7 +24,7 @@ export default function Dashboard() {
   const [runs, setRuns] = useState<Run[]>([])
   const [secrets, setSecrets] = useState<Secret[]>([])
   const [model, setModel] = useState('claude-sonnet-4-6')
-  const [gateway, setGateway] = useState<'direct' | 'bankr'>('direct')
+  const [gateway, setGateway] = useState<GatewayProvider>('direct')
   const [repo, setRepo] = useState('')
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
@@ -39,7 +39,7 @@ export default function Dashboard() {
 
   const [outputs, setOutputs] = useState<SkillOutput[]>([])
   const [feedLoading, setFeedLoading] = useState(false)
-  const [analyticsData, setAnalyticsData] = useState<{ skills: Array<{ name: string; total: number; success: number; failure: number; cancelled: number; inProgress: number; successRate: number; lastRun: string | null; lastConclusion: string | null; avgDurationMin: number | null; streak: number }>; insights: Array<{ type: 'warning' | 'info' | 'success'; message: string }>; summary: { totalRuns: number; totalSuccess: number; totalFailure: number; overallSuccessRate: number; uniqueSkills: number; periodDays: number } } | null>(null)
+  const [analyticsData, setAnalyticsData] = useState<AnalyticsData | null>(null)
 
   const [showImport, setShowImport] = useState(false)
   const [authStatus, setAuthStatus] = useState<{ authenticated: boolean } | null>(null)
@@ -71,7 +71,7 @@ export default function Dashboard() {
   const setupAuth = async (key?: string) => { setAuthLoading(true); try { const r = await fetch('/api/auth', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(key ? { key } : {}) }); if (r.ok) { flash('Authenticated'); setAuthStatus({ authenticated: true }); setShowAuthModal(false); fetchData() } else { const d = await r.json().catch(() => ({} as { error?: string })); const msg = typeof d?.error === 'string' ? d.error : (key ? 'Auth failed' : 'Auto-setup failed'); if (!key) setShowAuthModal(true); flash(msg) } } finally { setAuthLoading(false) } }
   const saveSecret = async (n: string, value: string) => { setBusy(b => ({ ...b, [`sec-${n}`]: true })); try { const r = await fetch('/api/secrets', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: n, value }) }); if (r.ok) { setSecrets(s => { const e = s.some(x => x.name === n); if (e) return s.map(x => x.name === n ? { ...x, isSet: true } : x); return [...s, { name: n, group: 'Skill Keys', description: 'Custom', isSet: true }] }); flash(`${n} saved`) } } finally { setBusy(b => ({ ...b, [`sec-${n}`]: false })) } }
   const deleteSecret = async (n: string) => { setBusy(b => ({ ...b, [`sec-${n}`]: true })); try { const r = await fetch('/api/secrets', { method: 'DELETE', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: n }) }); if (r.ok) { setSecrets(s => s.map(x => x.name === n ? { ...x, isSet: false } : x)); flash(`${n} removed`) } } finally { setBusy(b => ({ ...b, [`sec-${n}`]: false })) } }
-  const importSkill = async (files: Array<{ path: string; content: string }>, name?: string) => { const r = await fetch('/api/upload', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ files, name }) }); if (r.ok) { const d = await r.json(); flash(`${displayName(d.name)} hired`); fetchData() } }
+  const importSkill = async (files: UploadFile[], name?: string) => { const r = await fetch('/api/upload', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ files, name }) }); if (r.ok) { const d = await r.json(); flash(`${displayName(d.name)} hired`); fetchData() } }
 
   // --- Derived ---
   const skill = selectedSkill ? skills.find(s => s.name === selectedSkill) || null : null

--- a/dashboard/components/ImportModal.tsx
+++ b/dashboard/components/ImportModal.tsx
@@ -1,23 +1,24 @@
 'use client'
 
 import { useState, useRef } from 'react'
+import type { UploadFile } from '../lib/types'
 import { displayName } from '../lib/utils'
 import { inputCls } from '../lib/utils'
 
 interface ImportModalProps {
   onClose: () => void
-  onImport: (files: Array<{ path: string; content: string }>, name?: string) => Promise<void>
+  onImport: (files: UploadFile[], name?: string) => Promise<void>
 }
 
 export function ImportModal({ onClose, onImport }: ImportModalProps) {
-  const [uploadFiles, setUploadFiles] = useState<Array<{ path: string; content: string }>>([])
+  const [uploadFiles, setUploadFiles] = useState<UploadFile[]>([])
   const [uploadDragOver, setUploadDragOver] = useState(false)
   const [uploadName, setUploadName] = useState('')
   const [importLoading, setImportLoading] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   const readFilesFromInput = async (fl: FileList) => {
-    const files: Array<{ path: string; content: string }> = []
+    const files: UploadFile[] = []
     for (let i = 0; i < fl.length; i++) {
       const f = fl[i]
       files.push({ path: (f as { webkitRelativePath?: string }).webkitRelativePath || f.name, content: await f.text() })

--- a/dashboard/components/RightPanel.tsx
+++ b/dashboard/components/RightPanel.tsx
@@ -1,15 +1,9 @@
 'use client'
 
 import { useState } from 'react'
-import type { Run, SkillOutput } from '../lib/types'
+import type { Run, SkillOutput, AnalyticsData } from '../lib/types'
 import { timeAgo } from '../lib/utils'
 import { SpecNode } from './SpecNode'
-
-interface AnalyticsData {
-  skills: Array<{ name: string; total: number; success: number; failure: number; cancelled: number; inProgress: number; successRate: number; lastRun: string | null; lastConclusion: string | null; avgDurationMin: number | null; streak: number }>
-  insights: Array<{ type: 'warning' | 'info' | 'success'; message: string }>
-  summary: { totalRuns: number; totalSuccess: number; totalFailure: number; overallSuccessRate: number; uniqueSkills: number; periodDays: number }
-}
 
 interface RightPanelProps {
   runs: Run[]

--- a/dashboard/components/SkillDetail.tsx
+++ b/dashboard/components/SkillDetail.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import type { Skill, Run } from '../lib/types'
+import type { Skill, Run, GatewayProvider } from '../lib/types'
 import { MODELS, BANKR_EXTRA_MODELS, DEPARTMENTS } from '../lib/constants'
 import { displayName, initials, getSkillStatus, cronLabel, statusDot, inputCls } from '../lib/utils'
 import { ScheduleEditor } from './ScheduleEditor'
@@ -11,7 +11,7 @@ interface SkillDetailProps {
   skill: Skill
   runs: Run[]
   model: string
-  gateway: 'direct' | 'bankr'
+  gateway: GatewayProvider
   busy: Record<string, boolean>
   onToggle: (name: string, enabled: boolean) => void
   onRun: (name: string, v?: string, m?: string) => void

--- a/dashboard/components/TopBar.tsx
+++ b/dashboard/components/TopBar.tsx
@@ -1,4 +1,4 @@
-import type { Skill } from '../lib/types'
+import type { Skill, GatewayProvider } from '../lib/types'
 import { MODELS, BANKR_EXTRA_MODELS, DEPARTMENTS } from '../lib/constants'
 import { displayName } from '../lib/utils'
 
@@ -7,7 +7,7 @@ interface TopBarProps {
   view: 'hq' | 'secrets'
   repo: string
   model: string
-  gateway: 'direct' | 'bankr'
+  gateway: GatewayProvider
   authStatus: { authenticated: boolean } | null
   authLoading: boolean
   pulling: boolean

--- a/dashboard/lib/config.ts
+++ b/dashboard/lib/config.ts
@@ -1,4 +1,5 @@
 import { parseDocument, isMap, isSeq, isPair, isScalar, type Document } from 'yaml'
+import type { GatewayProvider } from './types'
 
 export interface SkillConfig {
   enabled: boolean
@@ -8,7 +9,7 @@ export interface SkillConfig {
 }
 
 export interface GatewayConfig {
-  provider: 'direct' | 'bankr'
+  provider: GatewayProvider
 }
 
 export interface AeonConfig {
@@ -160,7 +161,7 @@ export function addSkillToConfig(
   })
   // Set flow style to match inline format
   if (isMap(entry)) {
-    (entry as any).flow = true
+    entry.flow = true
   }
 
   // Find the fallback skill (heartbeat, last entry) and insert before it
@@ -171,7 +172,7 @@ export function addSkillToConfig(
 
   if (fallbackIdx >= 0) {
     const pair = doc.createPair(name, entry)
-    items.splice(fallbackIdx, 0, pair as any)
+    items.splice(fallbackIdx, 0, pair)
   } else {
     skillsNode.set(name, entry)
   }
@@ -181,7 +182,7 @@ export function addSkillToConfig(
 
 // --- Helpers ---
 
-function getMapValue(map: any, key: string): unknown {
+function getMapValue(map: unknown, key: string): unknown {
   if (!isMap(map)) return undefined
   for (const item of map.items) {
     if (isPair(item) && isScalar(item.key) && item.key.value === key) {

--- a/dashboard/lib/frontmatter.ts
+++ b/dashboard/lib/frontmatter.ts
@@ -1,0 +1,33 @@
+export interface Frontmatter {
+  name: string
+  description: string
+  tags: string[]
+}
+
+// Parse a SKILL.md's leading `--- ... ---` block. When `description:` is absent,
+// fall back to the first non-heading line (truncated to 120 chars).
+export function parseFrontmatter(content: string): Frontmatter {
+  const block = content.match(/^---\s*\n([\s\S]*?)\n---/)?.[1] ?? ''
+
+  const name = unquote(block.match(/name:\s*(.+)/)?.[1] ?? '')
+
+  let description = unquote(block.match(/description:\s*(.+)/)?.[1] ?? '')
+  if (!description) {
+    for (const line of content.split('\n')) {
+      const t = line.trim()
+      if (t && !t.startsWith('#') && !t.startsWith('---')) {
+        description = t.length > 120 ? t.slice(0, 117) + '...' : t
+        break
+      }
+    }
+  }
+
+  const tagsMatch = block.match(/tags:\s*\[([^\]]*)\]/)
+  const tags = tagsMatch ? tagsMatch[1].split(',').map(t => t.trim()).filter(Boolean) : []
+
+  return { name, description, tags }
+}
+
+function unquote(value: string): string {
+  return value.trim().replace(/^['"]|['"]$/g, '')
+}

--- a/dashboard/lib/gh.ts
+++ b/dashboard/lib/gh.ts
@@ -1,0 +1,34 @@
+import { execSync } from 'child_process'
+import { resolve } from 'path'
+
+// The dashboard runs from dashboard/; the repo it manages is one level up.
+export const REPO_ROOT = resolve(process.cwd(), '..')
+
+// Whether the `gh` CLI is installed and authenticated.
+export function ghAvailable(): boolean {
+  try {
+    execSync('gh auth status', { stdio: 'pipe' })
+    return true
+  } catch {
+    return false
+  }
+}
+
+// Resolve the active repo: explicit `gh` default first, inferred remote second.
+function ghRepo(): string | null {
+  try {
+    const repo = execSync('gh repo set-default --view', { stdio: 'pipe', cwd: REPO_ROOT }).toString().trim()
+    if (repo && !repo.startsWith('no default')) return repo
+  } catch {}
+  try {
+    const repo = execSync('gh repo view --json nameWithOwner -q .nameWithOwner', { stdio: 'pipe', cwd: REPO_ROOT }).toString().trim()
+    if (repo) return repo
+  } catch {}
+  return null
+}
+
+// `-R owner/repo` args for `gh` subcommands, or empty when the repo is unresolved.
+export function ghArgsRepo(): string[] {
+  const repo = ghRepo()
+  return repo ? ['-R', repo] : []
+}

--- a/dashboard/lib/github.ts
+++ b/dashboard/lib/github.ts
@@ -1,10 +1,14 @@
-import { readFile, writeFile, readdir, mkdir, stat, rm } from 'fs/promises'
+import { readFile, writeFile, readdir, mkdir, rm } from 'fs/promises'
 import { join, resolve } from 'path'
 
 const GITHUB_API = 'https://api.github.com'
 
 // Resolve the repo root (one level up from dashboard/)
 const REPO_ROOT = resolve(process.cwd(), '..')
+
+// Minimal shapes for the GitHub "Get repository content" REST responses.
+interface GitHubContentFile { content: string; sha: string; encoding: string }
+interface GitHubContentEntry { name: string; type: 'file' | 'dir' | 'symlink' | 'submodule'; path: string }
 
 function isLocal() {
   return !process.env.GITHUB_TOKEN || !process.env.GITHUB_REPO
@@ -37,10 +41,10 @@ export async function getFileContent(path: string): Promise<{ content: string; s
     cache: 'no-store',
   })
   if (!res.ok) throw new Error(`GitHub API ${res.status}: failed to read ${path}`)
-  const data = await res.json()
+  const data = (await res.json()) as GitHubContentFile
   return {
     content: Buffer.from(data.content, 'base64').toString('utf-8'),
-    sha: data.sha as string,
+    sha: data.sha,
   }
 }
 
@@ -111,37 +115,8 @@ export async function getDirectory(path: string): Promise<Array<{ name: string; 
     cache: 'no-store',
   })
   if (!res.ok) return []
-  const data = await res.json()
+  const data = (await res.json()) as GitHubContentEntry[] | GitHubContentFile
   return Array.isArray(data) ? data : []
-}
-
-export async function triggerWorkflow(skill: string) {
-  if (isLocal()) {
-    throw new Error('Cannot trigger GitHub Actions locally — set GITHUB_TOKEN and GITHUB_REPO to enable remote runs')
-  }
-  const { token, repo } = getConfig()
-  const res = await fetch(`${GITHUB_API}/repos/${repo}/actions/workflows/aeon.yml/dispatches`, {
-    method: 'POST',
-    headers: authHeaders(token),
-    body: JSON.stringify({ ref: 'main', inputs: { skill } }),
-    cache: 'no-store',
-  })
-  if (!res.ok) throw new Error(`GitHub API ${res.status}: failed to trigger workflow`)
-}
-
-export async function getWorkflowRuns(perPage = 20) {
-  if (isLocal()) {
-    // Return empty — no GitHub Actions access locally
-    return []
-  }
-  const { token, repo } = getConfig()
-  const res = await fetch(
-    `${GITHUB_API}/repos/${repo}/actions/runs?per_page=${perPage}`,
-    { headers: authHeaders(token), cache: 'no-store' },
-  )
-  if (!res.ok) throw new Error(`GitHub API ${res.status}: failed to fetch runs`)
-  const data = await res.json()
-  return data.workflow_runs || []
 }
 
 // --- Remote repo helpers (for importing skills) ---
@@ -157,7 +132,7 @@ export async function getRemoteDirectory(remoteRepo: string, path: string): Prom
     : `${GITHUB_API}/repos/${remoteRepo}/contents`
   const res = await fetch(url, { headers, cache: 'no-store' })
   if (!res.ok) return []
-  const data = await res.json()
+  const data = (await res.json()) as GitHubContentEntry[] | GitHubContentFile
   return Array.isArray(data) ? data : []
 }
 
@@ -171,7 +146,7 @@ export async function getRemoteFileContent(remoteRepo: string, path: string): Pr
     cache: 'no-store',
   })
   if (!res.ok) return null
-  const data = await res.json()
+  const data = (await res.json()) as GitHubContentFile
   return Buffer.from(data.content, 'base64').toString('utf-8')
 }
 
@@ -196,22 +171,5 @@ export async function deleteDirectory(path: string, message: string): Promise<vo
       })
       if (!res.ok) throw new Error(`GitHub API ${res.status}: failed to delete ${path}/${file.name}`)
     }
-  }
-}
-
-export async function fileExists(path: string): Promise<boolean> {
-  if (isLocal()) {
-    try {
-      await stat(join(REPO_ROOT, path))
-      return true
-    } catch {
-      return false
-    }
-  }
-  try {
-    await getFileContent(path)
-    return true
-  } catch {
-    return false
   }
 }

--- a/dashboard/lib/types.ts
+++ b/dashboard/lib/types.ts
@@ -3,3 +3,41 @@ export interface Run { id: number; workflow: string; status: string; conclusion:
 export interface Secret { name: string; group: string; description: string; isSet: boolean; either?: string }
 export interface SkillOutput { filename: string; skill: string; timestamp: string; spec: { root: string; state?: Record<string, unknown>; elements: Record<string, SpecElement> } }
 export interface SpecElement { type: string; props?: Record<string, unknown>; children?: string[] }
+
+export type GatewayProvider = 'direct' | 'bankr'
+
+export interface UploadFile { path: string; content: string }
+
+export interface SkillMetrics {
+  name: string
+  total: number
+  success: number
+  failure: number
+  cancelled: number
+  inProgress: number
+  successRate: number
+  lastRun: string | null
+  lastConclusion: string | null
+  avgDurationMin: number | null
+  streak: number // positive = consecutive successes, negative = consecutive failures
+}
+
+export interface Insight {
+  type: 'warning' | 'info' | 'success'
+  message: string
+}
+
+interface AnalyticsSummary {
+  totalRuns: number
+  totalSuccess: number
+  totalFailure: number
+  overallSuccessRate: number
+  uniqueSkills: number
+  periodDays: number
+}
+
+export interface AnalyticsData {
+  skills: SkillMetrics[]
+  insights: Insight[]
+  summary: AnalyticsSummary
+}

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -11,7 +11,6 @@
         "@json-render/core": "^0.15.0",
         "@json-render/react": "^0.15.0",
         "@json-render/shadcn": "^0.15.0",
-        "geist": "^1.3.0",
         "gsap": "^3.14.2",
         "next": "^16.1.7",
         "react": "^19.0.0",
@@ -2729,15 +2728,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/geist": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/geist/-/geist-1.7.0.tgz",
-      "integrity": "sha512-ZaoiZwkSf0DwwB1ncdLKp+ggAldqxl5L1+SXaNIBGkPAqcu+xjVJLxlf3/S8vLt9UHx1xu5fz3lbzKCj5iOVdQ==",
-      "license": "SIL OPEN FONT LICENSE",
-      "peerDependencies": {
-        "next": ">=13.2.0"
-      }
-    },
     "node_modules/get-nonce": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
@@ -3131,7 +3121,6 @@
       "version": "8.5.15",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
       "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -11,7 +11,6 @@
     "@json-render/core": "^0.15.0",
     "@json-render/react": "^0.15.0",
     "@json-render/shadcn": "^0.15.0",
-    "geist": "^1.3.0",
     "gsap": "^3.14.2",
     "next": "^16.1.7",
     "react": "^19.0.0",

--- a/notify-jsonrender
+++ b/notify-jsonrender
@@ -56,8 +56,7 @@ CRITICAL RULES:
 9. Use Badge for tags, labels, categories, or short status indicators.
 10. Use Alert for warnings, errors, or notable callouts.
 11. Use Separator between major sections.
-12. Wrap the whole output in one Card. Use the first heading or skill name as the Card title.
-11. Wrap the whole output in one Card. Use the first heading or skill name as the Card title.'
+12. Wrap the whole output in one Card. Use the first heading or skill name as the Card title.'
 
 # Use claude CLI — works with both API key and OAuth token
 SPEC=$(echo "$CONTENT" | claude -p "Convert this skill output into a json-render spec. Skill: ${SKILL}" \


### PR DESCRIPTION
Code-quality cleanup driven by an 8-way audit of the code surface (3 TS packages, shell executables, scripts, examples). The codebase was already in very good shape — **3 of 8 audits found nothing high-confidence to change** (0 circular deps, disciplined error handling, clean comments). This PR applies the high-confidence findings.

## Changes
- **DRY:** new `lib/gh.ts` (collapses 5 copy-pasted `gh` helper blocks across routes **and fixes a latent `cwd` bug** — auth/secrets resolved the repo from `dashboard/` instead of repo root); new `lib/frontmatter.ts` (collapses 3 hand-rolled SKILL.md parsers).
- **Type consolidation → `lib/types.ts`:** analytics response shape (was duplicated 4×), `GatewayProvider` union (4×), `UploadFile` interface (6×).
- **Stronger types:** removed the only 3 `any` casts in the repo (`config.ts`, using correct `yaml` types); typed the `gh run list`/`gh run view` JSON parses (`GhRunListItem`/`GhRunView`) and the 4 GitHub REST content reads (`GitHubContentFile`/`GitHubContentEntry`).
- **Dead code:** removed unused `geist` dependency and the unreferenced `triggerWorkflow`/`getWorkflowRuns`/`fileExists` in `lib/github.ts`.
- **Legacy:** removed a byte-duplicate, mis-numbered system-prompt line in `notify-jsonrender`.

Net **−158 lines** across 18 files + 2 new shared modules.

## Validation
- `tsc --noEmit` clean on `dashboard`, `a2a-server`, `mcp-server`
- `next build` succeeds (17 routes)
- `api-gate.test.ts` 23/23 pass
- `madge --circular` 0 cycles · `knip` no new dead exports

## Deferred (MEDIUM/LOW, follow-ups)
- Annotate route producers + client `Response.json()`/`Request.json()` bodies with explicit interfaces.
- Shell-script dedup (`scripts/lib/skill-common.sh`).
- 3 GET routes return empty success payloads on exec failure; 4 `page.tsx` write handlers swallow save errors silently.
- `api-gate.test.ts` has no configured `test` script (runs via `npx tsx --test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)