### PR TITLE
Add Noctel to ECOSYSTEM.md

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -42,6 +42,7 @@ These are the projects we know of that run Aeon, extend it, or integrate with th
 | Mei | [@MeiMighty1](https://x.com/MeiMighty1) |
 | MiroShark | [@miroshark_](https://x.com/miroshark_) |
 | MythosForge | [@mythosforgebot](https://x.com/mythosforgebot) |
+| Noctel | [@noctelxbt](https://x.com/noctelxbt) · [noctel.xyz](https://www.noctel.xyz) |
 | NoelClaw | [@noelclawfun](https://x.com/noelclawfun) |
 | PancakeSwap | [@PancakeSwap](https://x.com/PancakeSwap) |
 | Powerloom | [@Powerloom](https://x.com/Powerloom) |


### PR DESCRIPTION
Adding Noctel to the ecosystem list per your invitation in our chat thread.

**Noctel** is a free, public crypto intelligence terminal — one verified signal a day plus contextual columns (rising narratives, worth-reading articles with full LLM-written synthesis, on-chain pulse, market calendar). Architecture is heavily inspired by Aeon's skill pattern: 6+ autonomous skills, file-based outputs, public audit log on /agent, glass-box reasoning end to end.

Currently running as TypeScript scripts on a cron; actively planning a full native Aeon migration over the next ~2 weeks. Drafts of `aeon.yml`, `CLAUDE.md`, a first `SKILL.md`, and the Actions runner are already staged in the repo at `docs/migration/drafts/`.

- Live site: https://www.noctel.xyz
- Public agent dashboard: https://www.noctel.xyz/agent
- Methodology: https://www.noctel.xyz/methodology
- X: https://x.com/noctelxbt

Happy to adjust anything in the entry if a different format works better.