### PR TITLE
chore: bump default model to claude-opus-4-8

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -15,7 +15,7 @@ on:
         default: '(config default)'
         options:
           - '(config default)'
-          - claude-opus-4-7
+          - claude-opus-4-8
           - claude-sonnet-4-6
           - claude-haiku-4-5-20251001
           - gemini-3-pro
@@ -283,7 +283,7 @@ jobs:
           elif [ -n "$SKILL_MODEL" ]; then
             MODEL="$SKILL_MODEL"
           else
-            MODEL="${CONFIG_MODEL:-claude-opus-4-7}"
+            MODEL="${CONFIG_MODEL:-claude-opus-4-8}"
           fi
           echo "Using model: $MODEL"
           echo "SKILL_MODEL=$MODEL" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/messages.yml
+++ b/.github/workflows/messages.yml
@@ -640,7 +640,7 @@ jobs:
         run: |
           TODAY=$(date -u +%Y-%m-%d)
           CONFIG_MODEL=$(grep -E '^model:' aeon.yml | sed 's/^model: *//' | tr -d ' ')
-          MODEL="${CONFIG_MODEL:-claude-opus-4-7}"
+          MODEL="${CONFIG_MODEL:-claude-opus-4-8}"
 
           cat > ./notify << 'NOTIFY_SCRIPT'
           #!/usr/bin/env bash

--- a/README.md
+++ b/README.md
@@ -247,10 +247,10 @@ If `var` is empty, each skill falls back to its default behavior (scan everythin
 The default model for all skills is set in `aeon.yml`:
 
 ```yaml
-model: claude-opus-4-7
+model: claude-opus-4-8
 ```
 
-You can change it from the dashboard header dropdown. Options: `claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5-20251001`. Per-run overrides are also available via workflow dispatch.
+You can change it from the dashboard header dropdown. Options: `claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5-20251001`. Per-run overrides are also available via workflow dispatch.
 
 Individual skills can override the default model to optimize cost:
 

--- a/aeon.yml
+++ b/aeon.yml
@@ -257,9 +257,9 @@ chains:
   #     - skill: daily-routine, consume: [token-movers, paper-pick, github-issues, hacker-news-digest]
 
 # Default model for all skills. Override per-run via workflow_dispatch.
-# Options: claude-opus-4-7, claude-sonnet-4-6, claude-haiku-4-5-20251001
+# Options: claude-opus-4-8, claude-sonnet-4-6, claude-haiku-4-5-20251001
 # Bankr gateway also supports: gemini-3-pro, gemini-3-flash, gpt-5.2, kimi-k2.5, qwen3-coder
-model: claude-opus-4-7
+model: claude-opus-4-8
 
 # AI Gateway — route Claude Code requests through an LLM gateway.
 # provider: direct (default, uses ANTHROPIC_API_KEY) | bankr (uses BANKR_LLM_KEY)

--- a/dashboard/lib/constants.ts
+++ b/dashboard/lib/constants.ts
@@ -1,5 +1,5 @@
 export const MODELS = [
-  { id: 'claude-opus-4-7', label: 'Opus 4.7' },
+  { id: 'claude-opus-4-8', label: 'Opus 4.8' },
   { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
   { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5' },
 ]


### PR DESCRIPTION
## Summary
- Bumps the top-level `model:` default in `aeon.yml` from `claude-opus-4-7` to `claude-opus-4-8`
- Updates the workflow dispatch dropdown + workflow/messages-handler fallbacks
- Updates dashboard header model options and the README snippet

cost-report pricing tables and skill prose that reference opus-4-7 as historical context are left unchanged.

## Test plan
- [ ] Trigger a manual workflow_dispatch with the `(config default)` model option and confirm logs show `Using model: claude-opus-4-8`
- [ ] Confirm dashboard header dropdown lists "Opus 4.8"
- [ ] Confirm at least one scheduled skill succeeds end-to-end on the new model

🤖 Generated with [Claude Code](https://claude.com/claude-code)