### PR TITLE
Push dashboard restyle to match aeon.fun's editorial voice

### DIFF
--- a/dashboard/app/globals.css
+++ b/dashboard/app/globals.css
@@ -360,3 +360,40 @@ body::before {
 }
 .corner-markers { position: relative; }
 .corner-marker { display: none; } /* coral glow + hairline rules replace these */
+
+/* ──────────────────────────────────────────────────────────
+   SPOTLIGHT — coral glow that follows the cursor across grid
+   items (sets --mx / --my on the parent <li>).
+   ────────────────────────────────────────────────────────── */
+.spotlight::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.35s ease;
+  background: radial-gradient(
+    200px circle at var(--mx, 50%) var(--my, 50%),
+    rgba(210, 75, 64, 0.22),
+    transparent 62%
+  );
+}
+.spotlight:hover::before { opacity: 1; }
+.spotlight > * { position: relative; z-index: 1; }
+
+/* ──────────────────────────────────────────────────────────
+   MARQUEE — left-scrolling editorial band (matches the site's
+   bottom marquee).
+   ────────────────────────────────────────────────────────── */
+.aeon-marquee {
+  display: inline-block;
+  animation: aeonScroll 42s linear infinite;
+}
+@keyframes aeonScroll {
+  from { transform: translateX(0); }
+  to { transform: translateX(-50%); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .aeon-marquee { animation: none; }
+}

--- a/dashboard/components/HQOverview.tsx
+++ b/dashboard/components/HQOverview.tsx
@@ -1,3 +1,6 @@
+'use client'
+
+import { useRef } from 'react'
 import type { Skill, Run } from '../lib/types'
 import { DEPARTMENTS } from '../lib/constants'
 import { timeAgo } from '../lib/utils'
@@ -10,62 +13,142 @@ interface HQOverviewProps {
   onViewRun: (run: Run) => void
 }
 
+function Section({ index, label, children }: { index: string; label: string; children: React.ReactNode }) {
+  return (
+    <section className="border-t border-[rgba(250,250,250,0.10)] pt-6">
+      <div className="flex items-center gap-3 mb-5">
+        <span className="font-display text-[13px] tracking-[0.18em] text-aeon-red">{index} / {label}</span>
+        <span className="flex-1 h-px bg-[rgba(250,250,250,0.10)]" />
+      </div>
+      {children}
+    </section>
+  )
+}
+
 export function HQOverview({ skills, runs, enabledCount, workingCount, onViewRun }: HQOverviewProps) {
+  const spotRef = useRef<HTMLUListElement>(null)
+
+  const onMove = (e: React.MouseEvent<HTMLUListElement>) => {
+    const card = (e.target as HTMLElement).closest('li')
+    if (!card) return
+    const r = card.getBoundingClientRect()
+    card.style.setProperty('--mx', `${e.clientX - r.left}px`)
+    card.style.setProperty('--my', `${e.clientY - r.top}px`)
+  }
+
   const departments = new Map<string, Skill[]>()
   skills.forEach(s => { const t = s.tags?.[0] || 'meta'; if (!departments.has(t)) departments.set(t, []); departments.get(t)!.push(s) })
 
+  const stats: { label: string; value: number; tone?: string }[] = [
+    { label: 'Team', value: skills.length },
+    { label: 'On duty', value: enabledCount, tone: 'text-eva-green' },
+    { label: 'Working', value: workingCount, tone: 'text-eva-orange' },
+    { label: 'Departments', value: departments.size },
+  ]
+
   return (
-    <div className="max-w-3xl mx-auto space-y-[var(--space-lg)]">
-      {/* Stats */}
-      <div className="grid grid-cols-4 gap-[var(--space-sm)]">
-        {[
-          { label: 'Team Size', value: skills.length, color: '' },
-          { label: 'On Duty', value: enabledCount, color: 'text-eva-green' },
-          { label: 'Working', value: workingCount, color: 'text-eva-orange' },
-          { label: 'Departments', value: departments.size, color: '' },
-        ].map(s => (
-          <div key={s.label} className="card-hst p-[var(--space-md)]">
-            <div className="text-label">{s.label}</div>
-            <div className={`font-display text-3xl mt-1 ${s.color}`}>{s.value}</div>
+    <div className="max-w-5xl mx-auto pb-16 space-y-10">
+      {/* ───── HERO ───── */}
+      <section className="relative overflow-hidden border border-[rgba(250,250,250,0.10)] bg-aeon-panel">
+        <div className="dither" aria-hidden="true" />
+        <div className="relative z-10 px-8 pt-10 pb-8">
+          <div className="flex items-center gap-3 mb-4">
+            <span className="text-[11px] font-mono uppercase tracking-[0.28em] text-aeon-red inline-flex items-center gap-3">
+              <span className="w-7 h-px bg-aeon-red" /> Operations · Live
+            </span>
           </div>
-        ))}
-      </div>
+          <h1 className="font-display uppercase leading-[0.92] tracking-tight text-aeon-fg"
+              style={{ fontSize: 'clamp(48px, 8vw, 110px)' }}>
+            AEON <span className="text-aeon-red">HQ</span>
+          </h1>
+          <p className="mt-4 max-w-xl text-sm text-primary-70 leading-relaxed">
+            {enabledCount} skill{enabledCount === 1 ? '' : 's'} on duty across {departments.size} department{departments.size === 1 ? '' : 's'}. {workingCount > 0 ? `${workingCount} currently working.` : 'Idle — waiting for the next cron tick.'}
+          </p>
+        </div>
 
-      <div className="warning-stripes" />
+        {/* Stats strip — large editorial counters */}
+        <dl className="relative z-10 grid grid-cols-2 sm:grid-cols-4 border-t border-[rgba(250,250,250,0.10)]">
+          {stats.map((s, i) => (
+            <div
+              key={s.label}
+              className={`px-6 py-5 ${i < stats.length - 1 ? 'border-r border-[rgba(250,250,250,0.10)]' : ''}`}
+            >
+              <dt className="text-[10px] font-mono uppercase tracking-[0.22em] text-primary-35 mb-2">{s.label}</dt>
+              <dd className={`font-display leading-none ${s.tone || 'text-aeon-fg'}`} style={{ fontSize: 'clamp(32px, 3.5vw, 52px)' }}>
+                {s.value}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </section>
 
-      {/* Departments */}
-      <div>
-        <div className="text-label mb-[var(--space-sm)]">Departments</div>
-        <div className="grid grid-cols-2 gap-[var(--space-sm)]">
+      {/* ───── 01 / DEPARTMENTS ───── */}
+      <Section index="01" label="Departments">
+        <ul
+          ref={spotRef}
+          onMouseMove={onMove}
+          className="grid grid-cols-1 sm:grid-cols-2 gap-px bg-[rgba(250,250,250,0.10)] border border-[rgba(250,250,250,0.10)]"
+        >
           {[...departments.entries()].sort(([a], [b]) => a.localeCompare(b)).map(([tag, ts]) => {
-            const d = DEPARTMENTS[tag] || DEPARTMENTS.meta; const en = ts.filter(s => s.enabled).length
+            const d = DEPARTMENTS[tag] || DEPARTMENTS.meta
+            const en = ts.filter(s => s.enabled).length
             return (
-              <div key={tag} className="card-hst card-hst-orange p-[var(--space-md)] flex items-center gap-3">
-                <div className="w-9 h-9 flex items-center justify-center text-white text-xs font-bold font-mono" style={{ backgroundColor: d.color }}>{d.label.slice(0, 2).toUpperCase()}</div>
-                <div><div className="text-sm font-display">{d.label}</div><div className="text-[11px] text-primary-40 font-mono">{ts.length} members &middot; {en} active</div></div>
-              </div>
+              <li
+                key={tag}
+                className="spotlight relative overflow-hidden bg-aeon-bg px-6 py-5 flex items-center gap-5 transition-colors hover:bg-aeon-panel-2"
+              >
+                <span className="font-display leading-none text-aeon-red" style={{ fontSize: 'clamp(28px, 3vw, 44px)' }}>
+                  {ts.length.toString().padStart(2, '0')}
+                </span>
+                <div className="min-w-0">
+                  <div className="font-display uppercase tracking-wide text-aeon-fg text-base leading-tight">{d.label}</div>
+                  <div className="text-[11px] text-primary-40 font-mono mt-1 uppercase tracking-[0.14em]">{en} active · {ts.length - en} idle</div>
+                </div>
+                <span
+                  className="ml-auto w-2 h-2 rounded-full shrink-0"
+                  style={{ backgroundColor: en > 0 ? d.color : 'rgba(250,250,250,0.15)' }}
+                />
+              </li>
             )
           })}
-        </div>
-      </div>
+        </ul>
+      </Section>
 
-      {/* Activity */}
-      <div>
-        <div className="text-label mb-[var(--space-sm)]">Recent Activity</div>
-        <div className="card-hst divide-y divide-[rgba(250,250,250,0.10)]">
+      {/* ───── 02 / ACTIVITY ───── */}
+      <Section index="02" label="Recent activity">
+        <div className="border border-[rgba(250,250,250,0.10)] divide-y divide-[rgba(250,250,250,0.08)]">
           {runs.slice(0, 8).map(run => (
-            <button key={run.id} onClick={() => onViewRun(run)}
-              className="w-full flex items-center gap-3 px-[var(--space-md)] py-[var(--space-sm)] hover:bg-aeon-bg transition-colors text-left">
-              <span className={`text-sm ${run.conclusion === 'success' ? 'text-eva-green' : run.conclusion === 'failure' ? 'text-eva-red' : run.status === 'in_progress' ? 'text-eva-orange' : 'text-primary-35'}`}>
-                {run.conclusion === 'success' ? '\u2713' : run.conclusion === 'failure' ? '\u2717' : run.status === 'in_progress' ? '\u25cc' : '\u00b7'}
+            <button
+              key={run.id}
+              onClick={() => onViewRun(run)}
+              className="w-full flex items-center gap-4 px-5 py-3 hover:bg-aeon-panel transition-colors text-left group"
+            >
+              <span className={`text-sm w-4 shrink-0 ${run.conclusion === 'success' ? 'text-eva-green' : run.conclusion === 'failure' ? 'text-eva-red' : run.status === 'in_progress' ? 'text-eva-orange' : 'text-primary-35'}`}>
+                {run.conclusion === 'success' ? '✓' : run.conclusion === 'failure' ? '✗' : run.status === 'in_progress' ? '◌' : '·'}
               </span>
-              <span className="text-xs text-primary-70 truncate flex-1 font-mono">{run.workflow}</span>
-              <span className="text-[11px] text-primary-35 font-mono tabular-nums">{timeAgo(run.created_at)}</span>
+              <span className="text-xs text-primary-70 truncate flex-1 font-mono group-hover:text-aeon-fg transition-colors">{run.workflow}</span>
+              <span className="text-[10px] text-primary-35 font-mono tabular-nums uppercase tracking-[0.14em]">{timeAgo(run.created_at)}</span>
             </button>
           ))}
-          {!runs.length && <div className="px-[var(--space-md)] py-[var(--space-xl)] text-center text-xs text-primary-35 font-mono">No activity yet</div>}
+          {!runs.length && (
+            <div className="px-6 py-12 text-center">
+              <p className="font-display uppercase text-aeon-fg text-xl tracking-wide">Nothing yet</p>
+              <p className="text-[11px] text-primary-40 font-mono mt-2 uppercase tracking-[0.18em]">The fleet is waiting for its first run</p>
+            </div>
+          )}
         </div>
-      </div>
+      </Section>
+
+      {/* ───── MARQUEE BAND ───── */}
+      <section className="overflow-hidden border-y border-aeon-fg/30">
+        <div className="aeon-marquee py-3 whitespace-nowrap font-display uppercase tracking-wide text-base text-aeon-fg/85">
+          {Array.from({ length: 2 }).map((_, k) => (
+            <span key={k} aria-hidden={k === 1 ? 'true' : undefined} className="inline-block px-7">
+              AEON HQ <i className="not-italic text-aeon-red">★</i> {enabledCount} ON DUTY <i className="not-italic text-aeon-red">★</i> {departments.size} DEPARTMENTS <i className="not-italic text-aeon-red">★</i> {runs.length} RUNS LOGGED <i className="not-italic text-aeon-red">★</i> NO BABYSITTING <i className="not-italic text-aeon-red">★</i>
+            </span>
+          ))}
+        </div>
+      </section>
     </div>
   )
 }

--- a/dashboard/components/SecretsPanel.tsx
+++ b/dashboard/components/SecretsPanel.tsx
@@ -27,14 +27,39 @@ export function SecretsPanel({ secrets, busy, onSave, onDelete }: SecretsPanelPr
   }
 
   return (
-    <div className="max-w-2xl mx-auto space-y-[var(--space-lg)]">
-      <h2 className="font-display text-2xl">Access Credentials</h2>
-      {['Core', 'Telegram', 'Discord', 'Slack', 'Email', 'Skill Keys'].map(group => {
+    <div className="max-w-5xl mx-auto pb-16 space-y-10">
+      {/* ───── HERO ───── */}
+      <section className="relative overflow-hidden border border-[rgba(250,250,250,0.10)] bg-aeon-panel">
+        <div className="dither" aria-hidden="true" />
+        <div className="relative z-10 px-8 pt-10 pb-8">
+          <span className="text-[11px] font-mono uppercase tracking-[0.28em] text-aeon-red inline-flex items-center gap-3">
+            <span className="w-7 h-px bg-aeon-red" />
+            Credentials · Vault
+          </span>
+          <h1 className="mt-4 font-display uppercase leading-[0.92] tracking-tight text-aeon-fg"
+              style={{ fontSize: 'clamp(40px, 6.5vw, 88px)' }}>
+            Access <span className="text-aeon-red">keys</span>
+          </h1>
+          <p className="mt-4 max-w-xl text-sm text-primary-70 leading-relaxed">
+            Set a secret, the channel turns on. Unset secrets are silently skipped — every channel is opt-in.
+          </p>
+        </div>
+      </section>
+
+      {['Core', 'Telegram', 'Discord', 'Slack', 'Email', 'Skill Keys'].map((group, gi) => {
         const gs = secrets.filter(s => s.group === group); if (!gs.length) return null
         return (
-          <div key={group}>
-            <div className="text-label mb-[var(--space-sm)]">{group}</div>
-            <div className="card-hst divide-y divide-[rgba(250,250,250,0.10)]">
+          <section key={group} className="border-t border-[rgba(250,250,250,0.10)] pt-6">
+            <div className="flex items-center gap-3 mb-4">
+              <span className="font-display text-[13px] tracking-[0.18em] text-aeon-red">
+                {String(gi + 1).padStart(2, '0')} / {group}
+              </span>
+              <span className="flex-1 h-px bg-[rgba(250,250,250,0.10)]" />
+              <span className="text-[10px] font-mono uppercase tracking-[0.18em] text-primary-35">
+                {gs.filter(s => s.isSet).length} / {gs.length} set
+              </span>
+            </div>
+            <div className="border border-[rgba(250,250,250,0.10)] divide-y divide-[rgba(250,250,250,0.08)]">
               {gs.map(secret => (
                 <div key={secret.name} className="px-[var(--space-md)] py-[var(--space-sm)]">
                   <div className="flex items-center justify-between">
@@ -57,7 +82,7 @@ export function SecretsPanel({ secrets, busy, onSave, onDelete }: SecretsPanelPr
                 </div>
               ))}
             </div>
-          </div>
+          </section>
         )
       })}
       <div>{addingSecret ? (<div className="space-y-2"><input type="text" value={newSecretName} onChange={(e) => setNewSecretName(e.target.value.toUpperCase().replace(/[^A-Z0-9_]/g, ''))} placeholder="SECRET_NAME" autoFocus className={inputCls} />{newSecretName && <div className="flex gap-2"><input type="password" value={secretValue} onChange={(e) => setSecretValue(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && handleSave(newSecretName)} placeholder="value..." className={inputCls} /><button onClick={() => handleSave(newSecretName)} disabled={!secretValue.trim()} className="bg-eva-green text-white text-[11px] px-4 py-2 font-mono hover:opacity-90 disabled:opacity-50">Save</button></div>}<button onClick={() => { setAddingSecret(false); setNewSecretName(''); setSecretValue('') }} className="text-[11px] text-primary-40 font-mono hover:text-primary-70">Cancel</button></div>) : <button onClick={() => setAddingSecret(true)} className="text-[11px] text-primary-40 font-mono hover:text-eva-orange transition-colors">+ Add Credential</button>}</div>

--- a/dashboard/components/SkillDetail.tsx
+++ b/dashboard/components/SkillDetail.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react'
 import type { Skill, Run, GatewayProvider } from '../lib/types'
 import { MODELS, BANKR_EXTRA_MODELS, DEPARTMENTS } from '../lib/constants'
-import { displayName, initials, getSkillStatus, cronLabel, statusDot, inputCls } from '../lib/utils'
+import { displayName, getSkillStatus, cronLabel, statusDot, inputCls } from '../lib/utils'
 import { ScheduleEditor } from './ScheduleEditor'
 import { timeAgo } from '../lib/utils'
 
@@ -22,6 +22,19 @@ interface SkillDetailProps {
   onViewRun: (run: Run) => void
 }
 
+function Section({ index, label, action, children }: { index: string; label: string; action?: React.ReactNode; children: React.ReactNode }) {
+  return (
+    <section className="border-t border-[rgba(250,250,250,0.10)] pt-6">
+      <div className="flex items-center gap-3 mb-4">
+        <span className="font-display text-[13px] tracking-[0.18em] text-aeon-red">{index} / {label}</span>
+        <span className="flex-1 h-px bg-[rgba(250,250,250,0.10)]" />
+        {action}
+      </div>
+      {children}
+    </section>
+  )
+}
+
 export function SkillDetail({ skill, runs, model, gateway, busy, onToggle, onRun, onDelete, onUpdateSchedule, onUpdateVar, onUpdateModel, onViewRun }: SkillDetailProps) {
   const modelOptions = gateway === 'bankr' ? [...MODELS, ...BANKR_EXTRA_MODELS] : MODELS
   const [editingSchedule, setEditingSchedule] = useState(false)
@@ -30,90 +43,154 @@ export function SkillDetail({ skill, runs, model, gateway, busy, onToggle, onRun
 
   const dept = skill.tags?.[0] ? DEPARTMENTS[skill.tags[0]] : null
   const skillRuns = runs.filter(r => r.workflow.toLowerCase().includes(skill.name))
+  const st = getSkillStatus(skill.name, skill.enabled, runs)
 
   return (
-    <div className="max-w-2xl mx-auto space-y-[var(--space-md)]">
-      {/* Profile */}
-      <div className="card-hst p-[var(--space-lg)] corner-markers">
-        <div className="corner-marker corner-marker-sm top-left" /><div className="corner-marker corner-marker-sm top-right" />
-        <div className="corner-marker corner-marker-sm bottom-left" /><div className="corner-marker corner-marker-sm bottom-right" />
-        <div className="flex items-start gap-4">
-          <div className="w-14 h-14 flex items-center justify-center text-lg font-bold text-white shrink-0" style={{ backgroundColor: skill.enabled ? (dept?.color || '#6B7280') : 'rgba(250,250,250,0.15)' }}>
-            {initials(skill.name)}
+    <div className="max-w-5xl mx-auto pb-16 space-y-10">
+      {/* ───── HERO ───── */}
+      <section className="relative overflow-hidden border border-[rgba(250,250,250,0.10)] bg-aeon-panel">
+        <div className="dither" aria-hidden="true" />
+        <div className="relative z-10 px-8 pt-10 pb-8">
+          <div className="flex items-center gap-4 mb-4 flex-wrap">
+            <span className="text-[11px] font-mono uppercase tracking-[0.28em] text-aeon-red inline-flex items-center gap-3">
+              <span className="w-7 h-px bg-aeon-red" />
+              {dept ? dept.label : 'Skill'}
+            </span>
+            <span className="inline-flex items-center gap-2 text-[10px] font-mono uppercase tracking-[0.18em] text-primary-50">
+              <span className={statusDot(st.color)} />
+              {st.label}
+            </span>
           </div>
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-3">
-              <h2 className="font-display text-2xl">{displayName(skill.name)}</h2>
-              {(() => { const st = getSkillStatus(skill.name, skill.enabled, runs); return (
-                <span className={`inline-flex items-center gap-1.5 text-[11px] px-2.5 py-0.5 font-mono ${st.color === 'green' ? 'bg-aeon-green/10 text-eva-green' : st.color === 'orange' ? 'bg-aeon-red/10 text-eva-orange' : st.color === 'red' ? 'bg-aeon-red-alert/10 text-eva-red' : 'bg-aeon-bg text-primary-40'}`}>
-                  <span className={statusDot(st.color)} />{st.label}
-                </span>
-              )})()}
-            </div>
-            {skill.description && <p className="text-sm text-primary-50 mt-2 leading-relaxed font-display">{skill.description}</p>}
+          <h1 className="font-display uppercase leading-[0.92] tracking-tight text-aeon-fg break-words"
+              style={{ fontSize: 'clamp(40px, 6.5vw, 88px)' }}>
+            {displayName(skill.name)}
+          </h1>
+          {skill.description && (
+            <p className="mt-4 max-w-2xl text-sm text-primary-70 leading-relaxed">{skill.description}</p>
+          )}
+
+          <div className="mt-7 flex items-center gap-3 flex-wrap">
+            <button
+              onClick={() => onToggle(skill.name, !skill.enabled)}
+              disabled={!!busy[skill.name]}
+              className={skill.enabled ? 'btn-ghost' : 'btn-solid'}
+            >
+              {skill.enabled ? 'Off Duty' : 'On Duty'}
+            </button>
+            <button
+              onClick={() => onRun(skill.name, skill.var, skill.model)}
+              disabled={!!busy[`r-${skill.name}`]}
+              className="btn-solid disabled:opacity-50"
+              style={{ background: 'var(--aeon-red)', borderColor: 'var(--aeon-red)', color: 'var(--aeon-fg-pure)' }}
+            >
+              {busy[`r-${skill.name}`] ? '…' : 'Run now'}
+            </button>
+            <button
+              onClick={() => { if (confirm(`Remove ${displayName(skill.name)}?`)) onDelete(skill.name) }}
+              className="text-[11px] text-eva-red/50 hover:text-eva-red font-mono px-3 py-2 ml-auto transition-colors uppercase tracking-[0.18em]"
+            >
+              Remove
+            </button>
           </div>
         </div>
-        <div className="warning-stripes mt-[var(--space-md)]" />
-        <div className="flex items-center gap-2 mt-[var(--space-md)]">
-          <button onClick={() => onToggle(skill.name, !skill.enabled)} disabled={!!busy[skill.name]}
-            className={`text-[11px] px-5 py-2 font-mono uppercase tracking-[1px] transition-opacity hover:opacity-90 ${skill.enabled ? 'bg-aeon-bg text-primary-70 border border-[rgba(250,250,250,0.10)]' : 'bg-eva-green text-white'}`}>
-            {skill.enabled ? 'Off Duty' : 'On Duty'}
-          </button>
-          <button onClick={() => onRun(skill.name, skill.var, skill.model)} disabled={!!busy[`r-${skill.name}`]}
-            className="bg-eva-orange text-white text-[11px] px-5 py-2 font-mono uppercase tracking-[1px] hover:opacity-90 transition-opacity disabled:opacity-50">
-            {busy[`r-${skill.name}`] ? '...' : 'Run'}
-          </button>
-          <button onClick={() => { if (confirm(`Remove ${displayName(skill.name)}?`)) onDelete(skill.name) }}
-            className="text-[11px] text-eva-red/40 hover:text-eva-red font-mono px-3 py-2 ml-auto transition-colors">Remove</button>
-        </div>
-      </div>
+      </section>
 
-      {/* Shift */}
-      <div className="card-hst p-[var(--space-md)]">
-        <div className="flex items-center justify-between mb-[var(--space-sm)]">
-          <span className="text-label">Shift Schedule</span>
-          <button onClick={() => setEditingSchedule(!editingSchedule)} className="text-[11px] text-primary-40 font-mono hover:text-eva-orange transition-colors">{editingSchedule ? 'Cancel' : 'Edit'}</button>
-        </div>
-        {editingSchedule ? <ScheduleEditor cron={skill.schedule} onSave={(c) => { onUpdateSchedule(skill.name, c); setEditingSchedule(false) }} /> : <div className="font-display text-xl">{cronLabel(skill.schedule)}</div>}
-      </div>
+      {/* ───── 01 / SHIFT ───── */}
+      <Section
+        index="01"
+        label="Shift schedule"
+        action={
+          <button
+            onClick={() => setEditingSchedule(!editingSchedule)}
+            className="text-[11px] text-primary-40 font-mono uppercase tracking-[0.18em] hover:text-aeon-red transition-colors"
+          >
+            {editingSchedule ? 'Cancel' : 'Edit'}
+          </button>
+        }
+      >
+        {editingSchedule ? (
+          <div className="border border-[rgba(250,250,250,0.10)] p-5 bg-aeon-panel">
+            <ScheduleEditor cron={skill.schedule} onSave={(c) => { onUpdateSchedule(skill.name, c); setEditingSchedule(false) }} />
+          </div>
+        ) : (
+          <div className="font-display uppercase tracking-tight text-aeon-fg" style={{ fontSize: 'clamp(24px, 3vw, 36px)' }}>
+            {cronLabel(skill.schedule)}
+          </div>
+        )}
+      </Section>
 
-      {/* Brief */}
-      <div className="card-hst p-[var(--space-md)]">
-        <div className="flex items-center justify-between mb-[var(--space-sm)]">
-          <span className="text-label">Assignment Brief</span>
-          <button onClick={() => { setEditingVar(!editingVar); setVarDraft(skill.var) }} className="text-[11px] text-primary-40 font-mono hover:text-eva-orange transition-colors">{editingVar ? 'Cancel' : 'Edit'}</button>
-        </div>
+      {/* ───── 02 / BRIEF ───── */}
+      <Section
+        index="02"
+        label="Assignment brief"
+        action={
+          <button
+            onClick={() => { setEditingVar(!editingVar); setVarDraft(skill.var) }}
+            className="text-[11px] text-primary-40 font-mono uppercase tracking-[0.18em] hover:text-aeon-red transition-colors"
+          >
+            {editingVar ? 'Cancel' : 'Edit'}
+          </button>
+        }
+      >
         {editingVar ? (
-          <div className="flex gap-2"><input type="text" value={varDraft} onChange={(e) => setVarDraft(e.target.value)} onKeyDown={(e) => { if (e.key === 'Enter') { onUpdateVar(skill.name, varDraft); setEditingVar(false) } }} placeholder="e.g. AI, bitcoin" className={inputCls} /><button onClick={() => { onUpdateVar(skill.name, varDraft); setEditingVar(false) }} className="bg-aeon-fg text-aeon-bg text-[11px] px-4 py-2 font-mono hover:opacity-90">Save</button></div>
-        ) : <div className="font-display text-lg">{skill.var || <span className="text-primary-35">No assignment</span>}</div>}
-      </div>
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={varDraft}
+              onChange={(e) => setVarDraft(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') { onUpdateVar(skill.name, varDraft); setEditingVar(false) } }}
+              placeholder="e.g. AI, bitcoin, owner/repo"
+              className={inputCls}
+            />
+            <button onClick={() => { onUpdateVar(skill.name, varDraft); setEditingVar(false) }} className="btn-solid">Save</button>
+          </div>
+        ) : skill.var ? (
+          <div className="font-display uppercase tracking-tight text-aeon-fg" style={{ fontSize: 'clamp(22px, 2.4vw, 30px)' }}>
+            &ldquo;{skill.var}&rdquo;
+          </div>
+        ) : (
+          <div className="text-sm text-primary-35 font-mono uppercase tracking-[0.18em]">No assignment — falls back to defaults</div>
+        )}
+      </Section>
 
-      {/* Model */}
-      <div className="card-hst p-[var(--space-md)]">
-        <div className="text-label mb-[var(--space-sm)]">Capability Level</div>
-        <select value={skill.model} onChange={(e) => onUpdateModel(skill.name, e.target.value)} className="bg-aeon-panel text-aeon-bg text-xs px-3 py-2 border border-[rgba(250,250,250,0.10)] outline-none font-mono w-full cursor-pointer focus:border-eva-orange transition-colors">
+      {/* ───── 03 / MODEL ───── */}
+      <Section index="03" label="Capability level">
+        <select
+          value={skill.model}
+          onChange={(e) => onUpdateModel(skill.name, e.target.value)}
+          className="bg-aeon-panel text-aeon-fg text-sm px-4 py-3 border border-[rgba(250,250,250,0.10)] outline-none font-mono w-full max-w-md cursor-pointer hover:border-[rgba(250,250,250,0.22)] focus:border-aeon-red transition-colors"
+        >
           <option value="">Default ({modelOptions.find(m => m.id === model)?.label ?? model})</option>
           {modelOptions.map(m => <option key={m.id} value={m.id}>{m.label}</option>)}
         </select>
-      </div>
+      </Section>
 
-      {/* Activity */}
-      <div>
-        <div className="text-label mb-[var(--space-sm)]">Activity Log</div>
-        <div className="card-hst divide-y divide-[rgba(250,250,250,0.10)]">
+      {/* ───── 04 / ACTIVITY ───── */}
+      <Section index="04" label="Activity log">
+        <div className="border border-[rgba(250,250,250,0.10)] divide-y divide-[rgba(250,250,250,0.08)]">
           {skillRuns.slice(0, 10).map(run => (
-            <button key={run.id} onClick={() => onViewRun(run)}
-              className="w-full flex items-center gap-3 px-[var(--space-md)] py-[var(--space-sm)] hover:bg-aeon-bg transition-colors text-left">
-              <span className={`text-sm ${run.conclusion === 'success' ? 'text-eva-green' : run.conclusion === 'failure' ? 'text-eva-red' : run.status === 'in_progress' ? 'text-eva-orange' : 'text-primary-35'}`}>
-                {run.conclusion === 'success' ? '\u2713' : run.conclusion === 'failure' ? '\u2717' : run.status === 'in_progress' ? '\u25cc' : '\u00b7'}
+            <button
+              key={run.id}
+              onClick={() => onViewRun(run)}
+              className="w-full flex items-center gap-4 px-5 py-3 hover:bg-aeon-panel transition-colors text-left group"
+            >
+              <span className={`text-sm w-4 shrink-0 ${run.conclusion === 'success' ? 'text-eva-green' : run.conclusion === 'failure' ? 'text-eva-red' : run.status === 'in_progress' ? 'text-eva-orange' : 'text-primary-35'}`}>
+                {run.conclusion === 'success' ? '✓' : run.conclusion === 'failure' ? '✗' : run.status === 'in_progress' ? '◌' : '·'}
               </span>
-              <span className="text-xs text-primary-70 truncate flex-1 font-mono">{run.conclusion === 'success' ? 'Task completed' : run.conclusion === 'failure' ? 'Task failed' : run.status === 'in_progress' ? 'Working...' : 'Queued'}</span>
-              <span className="text-[11px] text-primary-35 font-mono tabular-nums">{timeAgo(run.created_at)}</span>
+              <span className="text-xs text-primary-70 truncate flex-1 font-mono group-hover:text-aeon-fg transition-colors">
+                {run.conclusion === 'success' ? 'Task completed' : run.conclusion === 'failure' ? 'Task failed' : run.status === 'in_progress' ? 'Working…' : 'Queued'}
+              </span>
+              <span className="text-[10px] text-primary-35 font-mono tabular-nums uppercase tracking-[0.14em]">{timeAgo(run.created_at)}</span>
             </button>
           ))}
-          {!skillRuns.length && <div className="px-[var(--space-md)] py-[var(--space-xl)] text-center text-xs text-primary-35 font-mono">No activity</div>}
+          {!skillRuns.length && (
+            <div className="px-6 py-12 text-center">
+              <p className="font-display uppercase text-aeon-fg text-xl tracking-wide">No activity</p>
+              <p className="text-[11px] text-primary-40 font-mono mt-2 uppercase tracking-[0.18em]">This skill hasn&apos;t fired yet</p>
+            </div>
+          )}
         </div>
-      </div>
+      </Section>
     </div>
   )
 }


### PR DESCRIPTION
## Why a second pass

The [first restyle](https://github.com/aaronjmars/aeon/pull/263) swapped palette + fonts but didn't carry the marketing site's swagger — it ended up as "dark UI with coral accents" rather than the editorial-magazine voice the site has.

This pass pushes the same vocabulary the site uses for its hero / sections into the dashboard's primary views.

## What changes

**HQOverview, SkillDetail, SecretsPanel** — each now opens with a proper editorial hero:
- dithered red halftone surface (the site's signature \`.dither\`)
- massive Dela Gothic headline clamped up to 110px / 88px with a coral accent word
- red-dash eyebrow + body dek
- oversized stat counters in Dela

**Numbered sections** like the marketing site:
- HQ: \`01 / Departments\`, \`02 / Recent activity\` plus a bottom marquee
- Skill: \`01 / Shift schedule\`, \`02 / Assignment brief\`, \`03 / Capability level\`, \`04 / Activity log\`
- Secrets: \`01 / Core\`, \`02 / Telegram\`, … with per-group \`set / total\` counters

**Spotlight cursor effect** on the department cards — same coral radial-gradient that follows the cursor on aeon.fun's skills grid.

**Marquee band** at the bottom of HQ: \`AEON HQ ★ N ON DUTY ★ N DEPARTMENTS ★ N RUNS LOGGED ★ NO BABYSITTING\` — uses the site's left-scrolling animation.

**globals.css** — adds \`.spotlight\` + \`.aeon-marquee\` utilities.

## Test plan

- [x] HQ overview renders the editorial hero + stat strip + numbered sections + marquee
- [x] Skill detail uses the hero + numbered sections + btn-solid/ghost actions
- [x] Secrets view uses the hero + numbered credential groups with set counters
- [x] Spotlight cursor visible when hovering over department cards
- [x] Marquee scrolls
- [ ] Verify with real data on a live instance after merge

## Screenshots

| Before (PR #263)                    | After (this PR)                            |
|-------------------------------------|--------------------------------------------|
| Dark + coral, otherwise unchanged   | Editorial hero, numbered sections, marquee |