### PR TITLE
Normalise TopBar button sizes; port aeon.fun motion

### DIFF
--- a/dashboard/app/globals.css
+++ b/dashboard/app/globals.css
@@ -271,15 +271,19 @@ body::before {
   background: var(--aeon-fg);
   padding: 10px 18px;
   border: 1.5px solid var(--aeon-fg);
-  transition: transform 0.2s ease, background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  transition: transform 0.22s cubic-bezier(0.2, 0.8, 0.2, 1),
+              background 0.22s ease,
+              color 0.22s ease,
+              border-color 0.22s ease,
+              box-shadow 0.22s ease;
   display: inline-flex; align-items: center; justify-content: center;
 }
 .btn-solid:hover:not(:disabled) {
   background: var(--aeon-red);
   border-color: var(--aeon-red);
   color: var(--aeon-fg-pure);
-  transform: translateY(-1px);
-  box-shadow: 0 6px 18px rgba(210, 75, 64, 0.35);
+  transform: translateY(-2px);
+  box-shadow: 0 10px 30px rgba(210, 75, 64, 0.35);
 }
 .btn-ghost {
   font-family: var(--font-display-dela), 'Arial Black', sans-serif;
@@ -290,12 +294,83 @@ body::before {
   background: transparent;
   padding: 10px 18px;
   border: 1.5px solid var(--aeon-rule-strong);
-  transition: border-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+  transition: transform 0.22s cubic-bezier(0.2, 0.8, 0.2, 1),
+              border-color 0.22s ease,
+              color 0.22s ease;
   display: inline-flex; align-items: center; justify-content: center;
 }
 .btn-ghost:hover:not(:disabled) {
   border-color: var(--aeon-fg);
   color: var(--aeon-fg);
+  transform: translateY(-2px);
+}
+
+/* compact variants used in the topbar — same hover swagger,
+   smaller padding to line up with the small select / icon
+   buttons next to them */
+.btn-solid-sm,
+.btn-ghost-sm {
+  font-family: var(--font-display-dela), 'Arial Black', sans-serif;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  padding: 8px 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid;
+  transition: transform 0.22s cubic-bezier(0.2, 0.8, 0.2, 1),
+              background 0.22s ease,
+              color 0.22s ease,
+              border-color 0.22s ease,
+              box-shadow 0.22s ease;
+}
+.btn-solid-sm {
+  color: var(--aeon-bg-pure);
+  background: var(--aeon-fg);
+  border-color: var(--aeon-fg);
+}
+.btn-solid-sm:hover:not(:disabled) {
+  background: var(--aeon-red);
+  border-color: var(--aeon-red);
+  color: var(--aeon-fg-pure);
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(210, 75, 64, 0.3);
+}
+.btn-ghost-sm {
+  color: var(--aeon-fg);
+  background: transparent;
+  border-color: var(--aeon-rule-strong);
+}
+.btn-ghost-sm:hover:not(:disabled) {
+  border-color: var(--aeon-fg);
+  color: var(--aeon-fg);
+  transform: translateY(-1px);
+}
+
+/* Quiet outline button — for tertiary actions (GitHub, Pull,
+   Push) where we want the same height as the others but a
+   dimmer presence. */
+.btn-quiet {
+  font-family: var(--font-mono-space), ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--aeon-gray);
+  background: transparent;
+  padding: 8px 12px;
+  border: 1px solid var(--aeon-rule);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.22s cubic-bezier(0.2, 0.8, 0.2, 1),
+              border-color 0.22s ease,
+              color 0.22s ease;
+  position: relative;
+}
+.btn-quiet:hover:not(:disabled) {
+  color: var(--aeon-fg);
+  border-color: var(--aeon-rule-strong);
   transform: translateY(-1px);
 }
 
@@ -360,6 +435,22 @@ body::before {
 }
 .corner-markers { position: relative; }
 .corner-marker { display: none; } /* coral glow + hairline rules replace these */
+
+/* ──────────────────────────────────────────────────────────
+   SHARED MOTION — smooth, consistent ease on interactive surfaces
+   ────────────────────────────────────────────────────────── */
+a,
+button,
+select,
+input[type='text'],
+input[type='password'],
+input[type='number'],
+[role='button'] {
+  transition: color 0.22s cubic-bezier(0.2, 0.8, 0.2, 1),
+              background-color 0.22s cubic-bezier(0.2, 0.8, 0.2, 1),
+              border-color 0.22s cubic-bezier(0.2, 0.8, 0.2, 1),
+              opacity 0.22s ease;
+}
 
 /* ──────────────────────────────────────────────────────────
    SPOTLIGHT — coral glow that follows the cursor across grid

--- a/dashboard/components/HQOverview.tsx
+++ b/dashboard/components/HQOverview.tsx
@@ -4,6 +4,7 @@ import { useRef } from 'react'
 import type { Skill, Run } from '../lib/types'
 import { DEPARTMENTS } from '../lib/constants'
 import { timeAgo } from '../lib/utils'
+import { Scramble, Flip, VelocityMarquee } from './ui/Animated'
 
 interface HQOverviewProps {
   skills: Skill[]
@@ -59,7 +60,8 @@ export function HQOverview({ skills, runs, enabledCount, workingCount, onViewRun
           </div>
           <h1 className="font-display uppercase leading-[0.92] tracking-tight text-aeon-fg"
               style={{ fontSize: 'clamp(48px, 8vw, 110px)' }}>
-            AEON <span className="text-aeon-red">HQ</span>
+            <Scramble text="AEON" />{' '}
+            <span className="text-aeon-red"><Scramble text="HQ" delay={180} /></span>
           </h1>
           <p className="mt-4 max-w-xl text-sm text-primary-70 leading-relaxed">
             {enabledCount} skill{enabledCount === 1 ? '' : 's'} on duty across {departments.size} department{departments.size === 1 ? '' : 's'}. {workingCount > 0 ? `${workingCount} currently working.` : 'Idle — waiting for the next cron tick.'}
@@ -75,7 +77,7 @@ export function HQOverview({ skills, runs, enabledCount, workingCount, onViewRun
             >
               <dt className="text-[10px] font-mono uppercase tracking-[0.22em] text-primary-35 mb-2">{s.label}</dt>
               <dd className={`font-display leading-none ${s.tone || 'text-aeon-fg'}`} style={{ fontSize: 'clamp(32px, 3.5vw, 52px)' }}>
-                {s.value}
+                <Flip value={s.value} />
               </dd>
             </div>
           ))}
@@ -98,7 +100,7 @@ export function HQOverview({ skills, runs, enabledCount, workingCount, onViewRun
                 className="spotlight relative overflow-hidden bg-aeon-bg px-6 py-5 flex items-center gap-5 transition-colors hover:bg-aeon-panel-2"
               >
                 <span className="font-display leading-none text-aeon-red" style={{ fontSize: 'clamp(28px, 3vw, 44px)' }}>
-                  {ts.length.toString().padStart(2, '0')}
+                  <Flip value={ts.length} />
                 </span>
                 <div className="min-w-0">
                   <div className="font-display uppercase tracking-wide text-aeon-fg text-base leading-tight">{d.label}</div>
@@ -140,15 +142,16 @@ export function HQOverview({ skills, runs, enabledCount, workingCount, onViewRun
       </Section>
 
       {/* ───── MARQUEE BAND ───── */}
-      <section className="overflow-hidden border-y border-aeon-fg/30">
-        <div className="aeon-marquee py-3 whitespace-nowrap font-display uppercase tracking-wide text-base text-aeon-fg/85">
-          {Array.from({ length: 2 }).map((_, k) => (
-            <span key={k} aria-hidden={k === 1 ? 'true' : undefined} className="inline-block px-7">
-              AEON HQ <i className="not-italic text-aeon-red">★</i> {enabledCount} ON DUTY <i className="not-italic text-aeon-red">★</i> {departments.size} DEPARTMENTS <i className="not-italic text-aeon-red">★</i> {runs.length} RUNS LOGGED <i className="not-italic text-aeon-red">★</i> NO BABYSITTING <i className="not-italic text-aeon-red">★</i>
-            </span>
-          ))}
-        </div>
-      </section>
+      <VelocityMarquee
+        className="overflow-hidden border-y border-aeon-fg/30 whitespace-nowrap py-3 font-display uppercase tracking-wide text-base text-aeon-fg/85"
+        trackClassName="inline-block will-change-transform"
+      >
+        {Array.from({ length: 2 }).map((_, k) => (
+          <span key={k} aria-hidden={k === 1 ? 'true' : undefined} className="inline-block px-7">
+            AEON HQ <i className="not-italic text-aeon-red">★</i> {enabledCount} ON DUTY <i className="not-italic text-aeon-red">★</i> {departments.size} DEPARTMENTS <i className="not-italic text-aeon-red">★</i> {runs.length} RUNS LOGGED <i className="not-italic text-aeon-red">★</i> NO BABYSITTING <i className="not-italic text-aeon-red">★</i>
+          </span>
+        ))}
+      </VelocityMarquee>
     </div>
   )
 }

--- a/dashboard/components/SecretsPanel.tsx
+++ b/dashboard/components/SecretsPanel.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import type { Secret } from '../lib/types'
 import { inputCls } from '../lib/utils'
+import { Scramble } from './ui/Animated'
 
 interface SecretsPanelProps {
   secrets: Secret[]
@@ -38,7 +39,8 @@ export function SecretsPanel({ secrets, busy, onSave, onDelete }: SecretsPanelPr
           </span>
           <h1 className="mt-4 font-display uppercase leading-[0.92] tracking-tight text-aeon-fg"
               style={{ fontSize: 'clamp(40px, 6.5vw, 88px)' }}>
-            Access <span className="text-aeon-red">keys</span>
+            <Scramble text="ACCESS" />{' '}
+            <span className="text-aeon-red"><Scramble text="KEYS" delay={180} /></span>
           </h1>
           <p className="mt-4 max-w-xl text-sm text-primary-70 leading-relaxed">
             Set a secret, the channel turns on. Unset secrets are silently skipped — every channel is opt-in.

--- a/dashboard/components/SkillDetail.tsx
+++ b/dashboard/components/SkillDetail.tsx
@@ -6,6 +6,7 @@ import { MODELS, BANKR_EXTRA_MODELS, DEPARTMENTS } from '../lib/constants'
 import { displayName, getSkillStatus, cronLabel, statusDot, inputCls } from '../lib/utils'
 import { ScheduleEditor } from './ScheduleEditor'
 import { timeAgo } from '../lib/utils'
+import { Scramble } from './ui/Animated'
 
 interface SkillDetailProps {
   skill: Skill
@@ -63,7 +64,7 @@ export function SkillDetail({ skill, runs, model, gateway, busy, onToggle, onRun
           </div>
           <h1 className="font-display uppercase leading-[0.92] tracking-tight text-aeon-fg break-words"
               style={{ fontSize: 'clamp(40px, 6.5vw, 88px)' }}>
-            {displayName(skill.name)}
+            <Scramble key={skill.name} text={displayName(skill.name)} />
           </h1>
           {skill.description && (
             <p className="mt-4 max-w-2xl text-sm text-primary-70 leading-relaxed">{skill.description}</p>

--- a/dashboard/components/TopBar.tsx
+++ b/dashboard/components/TopBar.tsx
@@ -45,43 +45,35 @@ export function TopBar({ skill, view, repo, model, gateway, authStatus, authLoad
           <span className="text-[10px] font-mono px-2 py-0.5 bg-aeon-red/10 text-eva-orange uppercase tracking-[0.18em] border border-aeon-red/30">Bankr</span>
         )}
         {authStatus && !authStatus.authenticated && (
-          <button onClick={onSetupAuth} disabled={authLoading} className="btn-solid disabled:opacity-50">
+          <button onClick={onSetupAuth} disabled={authLoading} className="btn-solid-sm disabled:opacity-50">
             {authLoading ? '…' : 'Auth'}
           </button>
         )}
         <select
           value={model}
           onChange={(e) => onUpdateModel(e.target.value)}
-          className="bg-aeon-panel text-primary-70 text-[11px] px-2.5 py-2 border border-[rgba(250,250,250,0.10)] outline-none cursor-pointer font-mono hover:border-[rgba(250,250,250,0.22)] transition-colors"
+          className="bg-aeon-panel text-primary-70 text-[11px] font-mono uppercase tracking-[0.14em] px-3 h-[32px] border border-[rgba(250,250,250,0.10)] outline-none cursor-pointer hover:border-[rgba(250,250,250,0.22)] transition-colors"
         >
           {modelOptions.map((m) => (
             <option key={m.id} value={m.id} className="bg-aeon-panel text-aeon-fg">{m.label}</option>
           ))}
         </select>
-        <button onClick={onShowImport} className="btn-ghost">+ Hire</button>
+        <button onClick={onShowImport} className="btn-ghost-sm">+ Hire</button>
         {repo && (
           <a
             href={`https://github.com/${repo}`}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-[11px] text-primary-40 font-mono border border-[rgba(250,250,250,0.10)] px-3 py-2 hover:border-aeon-red hover:text-eva-orange transition-colors uppercase tracking-[0.14em]"
+            className="btn-quiet"
           >
             GitHub
           </a>
         )}
-        <button
-          onClick={onPull}
-          disabled={pulling}
-          className="relative text-[11px] font-mono text-primary-40 border border-[rgba(250,250,250,0.10)] px-3 py-2 hover:border-[rgba(250,250,250,0.22)] hover:text-primary-70 transition-colors disabled:opacity-50 uppercase tracking-[0.14em]"
-        >
+        <button onClick={onPull} disabled={pulling} className="btn-quiet disabled:opacity-50">
           {behind > 0 && <span className="absolute -top-1 -right-1 w-2.5 h-2.5 rounded-full bg-aeon-red animate-pulse" />}
           {pulling ? '…' : 'Pull'}
         </button>
-        <button
-          onClick={onSync}
-          disabled={syncing || !hasChanges}
-          className="relative text-[11px] font-mono text-primary-40 border border-[rgba(250,250,250,0.10)] px-3 py-2 hover:border-[rgba(250,250,250,0.22)] hover:text-primary-70 transition-colors disabled:opacity-50 uppercase tracking-[0.14em]"
-        >
+        <button onClick={onSync} disabled={syncing || !hasChanges} className="btn-quiet disabled:opacity-40">
           {hasChanges && <span className="absolute -top-1 -right-1 w-2.5 h-2.5 rounded-full bg-aeon-green" />}
           {syncing ? '…' : 'Push'}
         </button>

--- a/dashboard/components/ui/Animated.tsx
+++ b/dashboard/components/ui/Animated.tsx
@@ -1,0 +1,271 @@
+'use client'
+
+import {
+  Fragment,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react'
+
+/* Effects ported from aeon-website/app/effects.tsx so the dashboard
+   uses the same motion vocabulary as the marketing site. */
+
+const prefersReducedMotion = () =>
+  typeof window !== 'undefined' &&
+  window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+const useIsoLayoutEffect =
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect
+
+/* ──────────────────────────────────────────────────────────
+   SCRAMBLE — headline letters decode from random glyphs.
+   ────────────────────────────────────────────────────────── */
+const GLYPHS = 'ABCDEFGHKNOPRSTUVXYZ0123456789#/'
+
+export function Scramble({
+  text,
+  delay = 0,
+  className,
+}: {
+  text: string
+  delay?: number
+  className?: string
+}) {
+  const rootRef = useRef<HTMLSpanElement>(null)
+
+  useIsoLayoutEffect(() => {
+    const root = rootRef.current
+    if (!root) return
+    const spans = Array.from(root.querySelectorAll<HTMLElement>('[data-c]'))
+    const finals = spans.map((s) => s.dataset.c ?? '')
+    if (prefersReducedMotion() || spans.length === 0) return
+
+    const rand = () => GLYPHS[(Math.random() * GLYPHS.length) | 0]
+
+    const settle = () => {
+      spans.forEach((s, i) => {
+        s.style.width = ''
+        s.textContent = finals[i]
+      })
+    }
+
+    spans.forEach((s) => {
+      s.style.width = `${s.getBoundingClientRect().width}px`
+      s.textContent = rand()
+    })
+
+    let raf = 0
+    let started: number | null = null
+    let lastSwap = 0
+    const duration = 440 + spans.length * 20
+
+    const tick = (now: number) => {
+      if (started === null) started = now + delay
+      const elapsed = now - started
+      const progress = elapsed <= 0 ? 0 : Math.min(elapsed / duration, 1)
+      const revealed = progress * spans.length
+      const swap = now - lastSwap > 48
+      if (swap) lastSwap = now
+
+      spans.forEach((s, i) => {
+        if (i < revealed) {
+          if (s.textContent !== finals[i]) s.textContent = finals[i]
+        } else if (swap) {
+          s.textContent = rand()
+        }
+      })
+
+      if (progress < 1) raf = requestAnimationFrame(tick)
+      else settle()
+    }
+
+    raf = requestAnimationFrame(tick)
+    return () => {
+      cancelAnimationFrame(raf)
+      settle()
+    }
+  }, [text, delay])
+
+  const words = text.split(' ')
+  return (
+    <span
+      ref={rootRef}
+      className={className}
+      aria-label={text}
+      role="text"
+    >
+      {words.map((word, wi) => (
+        <Fragment key={wi}>
+          <span style={{ display: 'inline-block', whiteSpace: 'nowrap' }}>
+            {[...word].map((ch, ci) => (
+              <span
+                key={ci}
+                data-c={ch}
+                style={{ display: 'inline-block', textAlign: 'center' }}
+              >
+                {ch}
+              </span>
+            ))}
+          </span>
+          {wi < words.length - 1 ? ' ' : null}
+        </Fragment>
+      ))}
+    </span>
+  )
+}
+
+/* ──────────────────────────────────────────────────────────
+   FLIP — odometer reel that rolls each digit up to its value
+   when scrolled into view.
+   ────────────────────────────────────────────────────────── */
+function Reel({ digit, delay }: { digit: number; delay: number }) {
+  const [offset, setOffset] = useState(digit)
+  const [animate, setAnimate] = useState(false)
+  const ref = useRef<HTMLSpanElement>(null)
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    if (prefersReducedMotion()) return
+
+    setOffset(0)
+
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          setAnimate(true)
+          setOffset(20 + digit)
+          io.disconnect()
+        }
+      },
+      { threshold: 0.4 }
+    )
+    io.observe(el)
+    return () => io.disconnect()
+  }, [digit])
+
+  return (
+    <span
+      ref={ref}
+      aria-hidden="true"
+      style={{
+        display: 'inline-block',
+        height: '1em',
+        lineHeight: 1,
+        overflow: 'hidden',
+        verticalAlign: 'text-bottom',
+      }}
+    >
+      <span
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          willChange: 'transform',
+          transform: `translateY(-${offset}em)`,
+          transition: animate
+            ? `transform 1.5s cubic-bezier(0.2, 0.85, 0.25, 1) ${delay}ms`
+            : 'none',
+        }}
+      >
+        {Array.from({ length: 31 }).map((_, i) => (
+          <span
+            key={i}
+            style={{
+              height: '1em',
+              lineHeight: 1,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            {i % 10}
+          </span>
+        ))}
+      </span>
+    </span>
+  )
+}
+
+export function Flip({
+  value,
+  className,
+}: {
+  value: number
+  className?: string
+}) {
+  const digits = String(value).split('')
+  return (
+    <span className={className} aria-label={String(value)} role="text">
+      {digits.map((d, i) => (
+        <Reel key={i} digit={Number(d)} delay={i * 90} />
+      ))}
+    </span>
+  )
+}
+
+/* ──────────────────────────────────────────────────────────
+   VELOCITY MARQUEE — scrolls left continuously; scroll input
+   boosts speed and momentarily drags it the other way.
+   ────────────────────────────────────────────────────────── */
+export function VelocityMarquee({
+  children,
+  className,
+  trackClassName,
+}: {
+  children: ReactNode
+  className?: string
+  trackClassName?: string
+}) {
+  const trackRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const track = trackRef.current
+    if (!track || prefersReducedMotion()) return
+
+    let x = 0
+    let raf = 0
+    let last = performance.now()
+    let boost = 0
+    let lastScroll = window.scrollY
+
+    const onScroll = () => {
+      const cur = window.scrollY
+      const delta = cur - lastScroll
+      lastScroll = cur
+      boost += -delta * 0.35
+      boost = Math.max(-26, Math.min(26, boost))
+    }
+    window.addEventListener('scroll', onScroll, { passive: true })
+
+    const base = -1.1
+    const tick = (now: number) => {
+      const dt = Math.min((now - last) / 16.67, 3)
+      last = now
+      x += (base + boost) * dt
+      const half = track.scrollWidth / 2
+      if (half > 0) {
+        if (x <= -half) x += half
+        else if (x > 0) x -= half
+      }
+      track.style.transform = `translate3d(${x}px,0,0)`
+      boost *= 0.9
+      raf = requestAnimationFrame(tick)
+    }
+    raf = requestAnimationFrame(tick)
+
+    return () => {
+      cancelAnimationFrame(raf)
+      window.removeEventListener('scroll', onScroll)
+    }
+  }, [])
+
+  return (
+    <div className={className}>
+      <div ref={trackRef} className={trackClassName}>
+        {children}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Two things

### 1. TopBar buttons now line up

Before, AUTH was towering over PULL / PUSH because \`btn-solid\` used 10px padding while the quieter buttons used \`px-3 py-2\`. Everything is now the same 32px height with consistent uppercase display labels:

| Button | Variant |
|---|---|
| Auth | \`.btn-solid-sm\` — filled white, coral on hover with translateY + box-shadow |
| Opus 4.x select | matches the same 32px height |
| + Hire | \`.btn-ghost-sm\` — outline, white border on hover with translateY |
| GitHub / Pull / Push | \`.btn-quiet\` — mono muted, lifts on hover |

### 2. Marketing-site motion ported to the dashboard

New \`components/ui/Animated.tsx\` ports the three motion components from \`aeon-website/app/effects.tsx\`:

- **Scramble** — headline letters decode from random glyphs (~440ms settle). Used on the HQ \`AEON HQ\`, Secrets \`ACCESS KEYS\`, and SkillDetail skill-name hero titles.
- **Flip** — odometer reel that rolls each digit up to the value when scrolled into view. Used on the HQ stat strip (Team / On duty / Working / Departments) and the per-department team-size counters.
- **VelocityMarquee** — scroll-velocity boosted marquee. Replaces the CSS-only \`.aeon-marquee\` on the HQ bottom band.

\`globals.css\` also gets a base \`transition\` on every interactive element (\`a, button, select, input, [role=button]\`) with \`cubic-bezier(0.2, 0.8, 0.2, 1)\` — the same ease the marketing site uses. Solid buttons lift 2px on hover with a coral box-shadow; ghost buttons lift 2px; quiet buttons lift 1px.

## Test plan

- [x] AUTH, OPUS, + HIRE, GITHUB, PULL, PUSH all render at the same 32px height
- [x] Scramble runs on HQ / Secrets / SkillDetail mount and on skill switch (via \`key={skill.name}\`)
- [x] Flip odometer rolls digits on scroll into view for the stat strip + dept counters
- [x] Hover on Auth → coral fill + lift + shadow, smooth not snappy
- [x] Hover on Pull / Push → border brightens, button lifts 1px
- [x] No console errors after navigation between HQ / Settings / skill detail