### PR TITLE
feat(skill-packs): add secrets_required / secrets_optional manifest fields (closes #258 (2))

### DIFF
--- a/docs/community-skill-packs.md
+++ b/docs/community-skill-packs.md
@@ -59,7 +59,9 @@ The manifest lives at the pack root (or under `--path <subdir>` if the pack is n
       "description": "What this skill does",
       "category": "research",
       "schedule": "0 12 * * *",
-      "default_enabled": false
+      "default_enabled": false,
+      "secrets_required": ["VENICE_API_KEY"],
+      "secrets_optional": ["VENICE_MODEL"]
     }
   ]
 }
@@ -82,6 +84,8 @@ The manifest lives at the pack root (or under `--path <subdir>` if the pack is n
 | `skills[].category` | string | optional | One of `research`, `dev`, `crypto`, `social`, `productivity`. Defaults to `research` in `skills.json`. |
 | `skills[].schedule` | string | optional | Cron string written into `aeon.yml`. Default `0 12 * * *`. |
 | `skills[].default_enabled` | boolean | optional | If `true`, the skill is added to `aeon.yml` with `enabled: true`. Default `false` (operator opts in explicitly). |
+| `skills[].secrets_required` | string[] | optional | Env vars the skill **cannot run without** (e.g. API keys). `install-skill-pack` warns loudly when any are unset before the first scheduled run, but does **not** gate the install — an operator may install dry-run or wire the secret afterward. |
+| `skills[].secrets_optional` | string[] | optional | Env vars that tune behaviour but aren't required (e.g. a model override). Surfaced at install for visibility; informational only. |
 
 ### What's enforced
 
@@ -190,7 +194,8 @@ The operator is always the trust boundary. The install script does not auto-trus
       "homepage": "https://...",
       "category": "research|dev|crypto|social|productivity",
       "trust_level": "trusted|community",
-      "skills": ["slug-1", "slug-2"]
+      "skills": ["slug-1", "slug-2"],
+      "secrets_required": ["VENICE_API_KEY"]
     }
   ]
 }
@@ -209,6 +214,7 @@ The operator is always the trust boundary. The install script does not auto-trus
 | `category` | string | optional | Same vocabulary as per-skill category. |
 | `trust_level` | string | optional | `trusted` (also requires the source in `skills/security/trusted-sources.txt`) or `community`. Default `community`. Listing here is a discovery hint — the actual scan-bypass behaviour is decided by the trusted-sources file. |
 | `skills[]` | array | **required** | Slugs the pack ships. Mirror the pack's own `skills-pack.json`. |
+| `secrets_required` | string[] | optional | Aggregated list of env vars the pack's skills declare as required. Drives the `./install-skill-pack --list --no-secrets` filter, which hides any pack with a non-empty `secrets_required`. Keep this in sync with the union of `skills[].secrets_required` in the pack's own `skills-pack.json`. |
 
 ### Why two files (README table + skill-packs.json)?
 

--- a/install-skill-pack
+++ b/install-skill-pack
@@ -20,6 +20,7 @@ set -euo pipefail
 #   ./install-skill-pack <github-repo> --yes                 Auto-accept HIGH findings (CI/non-interactive)
 #   ./install-skill-pack <github-repo> --force               Install even if security scan finds HIGH issues
 #   ./install-skill-pack <github-repo> --dry-run             Preview without writing
+#   ./install-skill-pack --list --no-secrets                 List only registry packs whose skills declare no secrets_required
 #
 # Manifest format (skills-pack.json, at pack root or under --path):
 #   {
@@ -36,7 +37,9 @@ set -euo pipefail
 #         "description": "What the skill does",                (optional, falls back to SKILL.md frontmatter)
 #         "category": "research|dev|crypto|social|productivity", (optional)
 #         "schedule": "0 12 * * *",                            (optional, default 0 12 * * *)
-#         "default_enabled": false                              (optional, default false)
+#         "default_enabled": false,                             (optional, default false)
+#         "secrets_required": ["VENICE_API_KEY"],               (optional — env vars the skill cannot run without)
+#         "secrets_optional": ["VENICE_MODEL"]                  (optional — env vars that tune behaviour but aren't required)
 #       }
 #     ]
 #   }
@@ -117,6 +120,7 @@ load_registry() {
 }
 
 list_registry() {
+  local no_secrets="${1:-false}"
   if ! command -v jq >/dev/null 2>&1; then
     echo "jq is required to read the registry." >&2
     exit 1
@@ -132,37 +136,56 @@ list_registry() {
   total=$(echo "$registry_json" | jq '.packs | length')
   echo ""
   echo "Community skill pack registry${updated:+ (updated $updated)}"
+  [[ "$no_secrets" == "true" ]] && echo "Filter: --no-secrets (hiding packs whose skills declare any secrets_required)"
   echo ""
+  local shown=0 hidden=0
   for i in $(seq 0 $((total - 1))); do
-    local repo desc trust skill_count
+    local repo desc trust skill_count secrets_count secrets_marker
     repo=$(echo "$registry_json" | jq -r ".packs[$i].repo")
     desc=$(echo "$registry_json" | jq -r ".packs[$i].description // \"\"")
     trust=$(echo "$registry_json" | jq -r ".packs[$i].trust_level // \"community\"")
     skill_count=$(echo "$registry_json" | jq ".packs[$i].skills | length // 0")
+    # secrets_required at the pack level is the aggregate; missing/null means none.
+    secrets_count=$(echo "$registry_json" | jq ".packs[$i].secrets_required | length // 0")
+    if [[ "$no_secrets" == "true" ]] && [[ "$secrets_count" != "0" ]]; then
+      hidden=$((hidden + 1))
+      continue
+    fi
     local trust_badge=" "
     [[ "$trust" == "trusted" ]] && trust_badge="*"
+    secrets_marker=""
+    [[ "$secrets_count" != "0" ]] && secrets_marker=" [needs ${secrets_count} secret(s)]"
     if [[ ${#desc} -gt 80 ]]; then desc="${desc:0:77}..."; fi
-    printf "  %s %-44s %2d skills  %s\n" "$trust_badge" "$repo" "$skill_count" "$desc"
+    printf "  %s %-44s %2d skills  %s%s\n" "$trust_badge" "$repo" "$skill_count" "$desc" "$secrets_marker"
+    shown=$((shown + 1))
   done
   echo ""
   echo "  * = trusted source (security scan skipped, format check still runs)"
+  echo "  [needs N secret(s)] = pack declares N entries in secrets_required — set them in the workflow before first run"
   echo ""
-  echo "$total packs in registry. Install with: ./install-skill-pack <repo>"
+  if [[ "$no_secrets" == "true" ]]; then
+    echo "$shown of $total packs shown ($hidden hidden by --no-secrets). Install with: ./install-skill-pack <repo>"
+  else
+    echo "$total packs in registry. Install with: ./install-skill-pack <repo>"
+  fi
   exit 0
 }
 
-# Registry-list mode: `./install-skill-pack --list` (no repo, no other flags) prints
-# every pack in skill-packs.json. We do a focused detect-and-route here so the
-# original single-pack flow below is unchanged.
+# Registry-list mode: `./install-skill-pack --list` (no repo, optionally with
+# --no-secrets) prints the registry. We do a focused detect-and-route here so
+# the original single-pack flow below is unchanged. Any unrecognised flag or
+# positional argument disqualifies registry mode.
 detect_registry_list_mode() {
   local list_seen=false
+  REGISTRY_NO_SECRETS=false
   for arg in "$@"; do
     case "$arg" in
       --list) list_seen=true ;;
+      --no-secrets) REGISTRY_NO_SECRETS=true ;;
       --help|-h) return 1 ;;
       *)
-        # Any non-list flag OR any positional argument disqualifies registry mode
-        # — the user wants to operate on a specific pack.
+        # Any non-list/non-no-secrets flag OR any positional argument disqualifies
+        # registry mode — the user wants to operate on a specific pack.
         return 1
         ;;
     esac
@@ -171,7 +194,7 @@ detect_registry_list_mode() {
 }
 
 if detect_registry_list_mode "$@"; then
-  list_registry
+  list_registry "$REGISTRY_NO_SECRETS"
 fi
 
 if [[ $# -lt 1 ]] || [[ "$1" == "--help" ]] || [[ "$1" == "-h" ]]; then
@@ -242,12 +265,16 @@ if [[ -n "$SUBPATH" ]]; then
 fi
 
 # Reset declarations (no associative arrays — they require Bash 4+ which macOS lacks).
+# SKILL_SECRETS_REQ / SKILL_SECRETS_OPT hold space-separated env-var names per skill
+# (parallel arrays — same index as SLUGS). Empty string means none declared.
 SLUGS=()
 SKILL_PATHS=()
 SKILL_DESCS=()
 SKILL_CATS=()
 SKILL_SCHEDS=()
 SKILL_DEFAULT_ENABLED=()
+SKILL_SECRETS_REQ=()
+SKILL_SECRETS_OPT=()
 MANIFEST_FOUND=false
 MANIFEST_PATH="$PACK_DIR/skills-pack.json"
 
@@ -301,12 +328,18 @@ if [[ -f "$MANIFEST_PATH" ]]; then
     cat=$(jq -r ".skills[$i].category // \"\"" "$MANIFEST_PATH")
     sched=$(jq -r ".skills[$i].schedule // \"0 12 * * *\"" "$MANIFEST_PATH")
     default_enabled=$(jq -r ".skills[$i].default_enabled // false" "$MANIFEST_PATH")
+    # secrets_required / secrets_optional are optional string arrays. Render
+    # them as space-separated env-var names (the per-skill loop splits on " ").
+    secrets_req=$(jq -r ".skills[$i].secrets_required // [] | join(\" \")" "$MANIFEST_PATH")
+    secrets_opt=$(jq -r ".skills[$i].secrets_optional // [] | join(\" \")" "$MANIFEST_PATH")
     SLUGS+=("$slug")
     SKILL_PATHS+=("$rel_path")
     SKILL_DESCS+=("$desc")
     SKILL_CATS+=("$cat")
     SKILL_SCHEDS+=("$sched")
     SKILL_DEFAULT_ENABLED+=("$default_enabled")
+    SKILL_SECRETS_REQ+=("$secrets_req")
+    SKILL_SECRETS_OPT+=("$secrets_opt")
   done
 else
   echo "No skills-pack.json — falling back to scanning skills/ in $REPO"
@@ -325,6 +358,8 @@ else
     SKILL_CATS+=("")
     SKILL_SCHEDS+=("0 12 * * *")
     SKILL_DEFAULT_ENABLED+=("false")
+    SKILL_SECRETS_REQ+=("")
+    SKILL_SECRETS_OPT+=("")
   done < <(find "$scan_root" -mindepth 2 -maxdepth 2 -name SKILL.md -type f 2>/dev/null | sort)
 fi
 
@@ -365,6 +400,8 @@ if [[ ${#REQUESTED_SLUGS[@]} -gt 0 ]]; then
   FILTERED_CATS=()
   FILTERED_SCHEDS=()
   FILTERED_DEFAULT=()
+  FILTERED_SECRETS_REQ=()
+  FILTERED_SECRETS_OPT=()
   for want in "${REQUESTED_SLUGS[@]}"; do
     found=false
     for i in "${!SLUGS[@]}"; do
@@ -375,6 +412,8 @@ if [[ ${#REQUESTED_SLUGS[@]} -gt 0 ]]; then
         FILTERED_CATS+=("${SKILL_CATS[$i]}")
         FILTERED_SCHEDS+=("${SKILL_SCHEDS[$i]}")
         FILTERED_DEFAULT+=("${SKILL_DEFAULT_ENABLED[$i]}")
+        FILTERED_SECRETS_REQ+=("${SKILL_SECRETS_REQ[$i]}")
+        FILTERED_SECRETS_OPT+=("${SKILL_SECRETS_OPT[$i]}")
         found=true
         break
       fi
@@ -390,6 +429,8 @@ if [[ ${#REQUESTED_SLUGS[@]} -gt 0 ]]; then
   SKILL_CATS=("${FILTERED_CATS[@]}")
   SKILL_SCHEDS=("${FILTERED_SCHEDS[@]}")
   SKILL_DEFAULT_ENABLED=("${FILTERED_DEFAULT[@]}")
+  SKILL_SECRETS_REQ=("${FILTERED_SECRETS_REQ[@]}")
+  SKILL_SECRETS_OPT=("${FILTERED_SECRETS_OPT[@]}")
 fi
 
 # Check trusted-sources for the pack repo.
@@ -467,6 +508,45 @@ scan_and_prompt() {
 if [[ "$TRUSTED_SOURCE" == "false" ]] && [[ ! -x "$SCANNER" ]]; then
   echo "Warning: security scanner not found at $SCANNER — skipping per-skill scans."
 fi
+
+# Surface required/optional secrets declared by the manifest. Loud warning, no
+# gate — the operator may install dry-run, or wire the secret afterward before
+# the first scheduled run. Called after scan_and_prompt clears, before file copy.
+#
+# Names that don't look like POSIX env-var identifiers ([A-Za-z_][A-Za-z0-9_]*)
+# are flagged as malformed instead of being passed to `${!var}` — indirect
+# expansion of `FOO-BAR` or `1FOO` triggers a bad-substitution error that
+# `set -u` turns into a script abort, and a manifest is untrusted input.
+warn_missing_secrets() {
+  local skill="$1"
+  local req_list="$2"   # space-separated env var names, may be empty
+  local opt_list="$3"   # space-separated env var names, may be empty
+  if [[ -n "$req_list" ]]; then
+    local missing=() malformed=()
+    for var in $req_list; do
+      if ! [[ "$var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+        malformed+=("$var")
+        continue
+      fi
+      # Indirect expansion — empty means unset OR set-to-empty (both block the skill).
+      # Safe now: identifier was validated above.
+      if [[ -z "${!var:-}" ]]; then
+        missing+=("$var")
+      fi
+    done
+    if [[ ${#missing[@]} -gt 0 ]]; then
+      echo "  ⚠ secrets_required missing for $skill: ${missing[*]}"
+      echo "      set these in \`secrets:\` of your workflow before the first scheduled run"
+    fi
+    if [[ ${#malformed[@]} -gt 0 ]]; then
+      echo "  ⚠ secrets_required for $skill includes malformed env-var names (skipped): ${malformed[*]}"
+      echo "      pack maintainer: each entry must match [A-Za-z_][A-Za-z0-9_]*"
+    fi
+  fi
+  if [[ -n "$opt_list" ]]; then
+    echo "  · secrets_optional for $skill (tunes behaviour, not required): $opt_list"
+  fi
+}
 
 # skills.json mutation needs jq — same dependency as add-skill.
 if ! command -v jq >/dev/null 2>&1; then
@@ -589,6 +669,8 @@ for i in "${!SLUGS[@]}"; do
     FAILED=$((FAILED + 1))
     continue
   fi
+
+  warn_missing_secrets "$slug" "${SKILL_SECRETS_REQ[$i]}" "${SKILL_SECRETS_OPT[$i]}"
 
   dest="$SKILLS_DIR/$slug"
 


### PR DESCRIPTION
Implements priority **(2) — `secrets_required` / `secrets_optional`** from #258 per your direction on https://github.com/aaronjmars/aeon/issues/258#issuecomment-4564790799.

Sequenced after #266 (priority 3).

## Schema additions

Schema-only — existing manifests without these fields keep working.

### Per-skill (`skills-pack.json`)

```json
"skills": [
  {
    "slug": "vvvkernel",
    "secrets_required": ["VENICE_API_KEY"],
    "secrets_optional": ["VENICE_MODEL"]
  }
]
```

| Field | Notes |
|-------|-------|
| `secrets_required` | Env vars the skill **cannot run without**. `install-skill-pack` warns loudly on unset values; does **not** gate the install — operator may install dry-run or wire the secret afterward. |
| `secrets_optional` | Tuning vars (model overrides, alt endpoints). Surfaced at install for visibility; informational only. |

### Pack-level (`skill-packs.json` registry entries)

```json
{
  "repo": "baseddevoloper/aeon-skill-pack-vvvkernel",
  "secrets_required": ["VENICE_API_KEY"]
}
```

Aggregated across the pack's skills. Drives the new `--list --no-secrets` filter.

## Wiring

### 1. `install-skill-pack` per-skill warn (no gate)

After `scan_and_prompt` clears, **before** the file copy, the script checks each skill's `secrets_required` against the current env and warns on misses:

```
  ✓ security scan passed: vvvkernel
  ⚠ secrets_required missing for vvvkernel: VENICE_API_KEY
      set these in `secrets:` of your workflow before the first scheduled run
  · secrets_optional for vvvkernel (tunes behaviour, not required): VENICE_MODEL
  install: vvvkernel
    -> skills.lock updated (sha: abc1234)
    ...
```

Empty strings count as unset (operator likely set them to placeholder values in the workflow `secrets:` block). The install still proceeds — only the security scan can block.

### 2. `install-skill-pack --list --no-secrets`

Hides any registry pack with a non-empty `secrets_required`. Without the flag, `--list` now also annotates the requirement:

```
Community skill pack registry (updated 2026-05-29)

  * AntFleet/aeon-skills                          1 skills  On-demand two-model-consensus PR review ...
    baseddevoloper/aeon-skill-pack-vvvkernel      9 skills  Venice AI inference via VVVKernel ... [needs 1 secret(s)]

  * = trusted source (security scan skipped, format check still runs)
  [needs N secret(s)] = pack declares N entries in secrets_required — set them in the workflow before first run
```

With `--no-secrets` the vvvkernel pack would be filtered out and a `N of M shown (M-N hidden by --no-secrets)` footer prints.

Per your spec, **no `--list` filter on `secrets_optional`** — kept purely informational.

## What this does NOT change

- No existing pack entries were modified — the field is additive. Pack maintainers opt in by adding it to their next manifest update.
- Scanner, trusted-sources, and HIGH-finding gate logic untouched.
- No new env vars on the Aeon side.
- Schema docs in `docs/community-skill-packs.md` updated for both files.

## Smoke tests

- `bash -n install-skill-pack` — syntax clean
- `./install-skill-pack --list` — full registry prints; no annotations on current packs since none declare `secrets_required` yet
- `./install-skill-pack --list --no-secrets` — filter banner prints, current registry unchanged (no `secrets_required` declared anywhere yet)
- `./install-skill-pack --list --bogus` — still falls through to per-pack path and errors with `Unknown option: --bogus`

## Next

This is PR 2 of 3 from #258. Last up per your ordering:
- (1) `capabilities` array with the locked 6-value taxonomy + `docs/CAPABILITIES.md`

Happy to adjust the warn copy or the `[needs N secret(s)]` annotation if you'd prefer something different.

cc @imancipate per your triage tag.
