### PR TITLE
feat(skill-packs): add capabilities array with locked 6-value taxonomy + docs/CAPABILITIES.md (closes #258 (1))

### DIFF
--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -1,0 +1,96 @@
+---
+layout: default
+title: Skill Capabilities Taxonomy
+---
+
+# Skill Capabilities Taxonomy
+
+A **capability** is a self-declared blast-radius hint that a skill carries in its pack manifest. Capabilities surface at install time (`./install-skill-pack` and `./install-skill-pack --list`) so an operator can glance at what a pack can do — read-only? touches the chain? sends Slack? — before approving a `community` pack on a live agent.
+
+Capabilities are **not** a gate. The trust boundary is still the operator + the security scanner + `trusted-sources.txt`. A skill that omits `capabilities` installs as before. A skill that declares them gets the listing surface for free.
+
+---
+
+## The taxonomy
+
+The set is **locked** to the six values below. Unknown values are rejected by `install-skill-pack` with a clear error pointing back at this file. Adding a new capability requires a separate PR with rationale — this keeps the vocabulary stable so operators learn it once.
+
+| Value | Meaning |
+|-------|---------|
+| `read_only` | No network writes, no on-chain calls, no notifications. The skill only reads (local files, public HTTP GETs to non-auth'd endpoints, on-chain reads). |
+| `external_api` | Reads or writes to non-Aeon HTTP APIs — any auth'd third-party call (OpenAI, Twitter/X API, Discord webhook, Slack bot token, Postgres-as-a-service, etc.). Use this for any call that uses a secret. |
+| `writes_external_host` | Modifies state on a non-Aeon host (POST/PUT/DELETE/PATCH against external services). Subset of `external_api` — declare both when the skill writes; declare only `external_api` when the calls are read-only. |
+| `onchain_writes` | Signs and broadcasts blockchain transactions. The skill holds or proxies a wallet key and can move funds. |
+| `agent_messaging` | Sends DMs, replies, or posts via X / Farcaster / Discord / Slack / Telegram or similar. Subset of `external_api` for the auth call, but called out separately because it speaks for the operator in public. |
+| `sends_notifications` | Calls `./notify` (or the equivalent operator-alert path) — pings the operator's own channel, not an external audience. Lower blast radius than `agent_messaging`. |
+
+### How to choose
+
+Pick the **narrowest set** that's still complete. Examples:
+
+- A skill that reads on-chain TVL and writes to `./notify` → `read_only`, `sends_notifications`.
+- A skill that posts to X via the v2 API → `external_api`, `writes_external_host`, `agent_messaging`.
+- A skill that fetches Coingecko prices and prints them in an article → `external_api` (Coingecko needs an API key for many endpoints; even free ones count as a third-party call).
+- A skill that signs a Base txn rebalancing an LP position → `external_api` (RPC), `writes_external_host` (RPC POST), `onchain_writes`.
+
+When in doubt, declare more than less. The listing surface only widens the operator's awareness — it never blocks.
+
+---
+
+## Schema placement
+
+### Per-skill in `skills-pack.json`
+
+```json
+"skills": [
+  {
+    "slug": "vvvkernel-onchain",
+    "capabilities": ["external_api", "writes_external_host", "onchain_writes"]
+  }
+]
+```
+
+### Pack-level in `skill-packs.json` (registry)
+
+```json
+{
+  "repo": "baseddevoloper/aeon-skill-pack-vvvkernel",
+  "capabilities": ["external_api", "writes_external_host", "onchain_writes", "agent_messaging", "sends_notifications"]
+}
+```
+
+The pack-level field is the **union** of every skill's capabilities — kept in sync with the per-skill declarations so `./install-skill-pack --list` can summarise without fetching every pack tarball.
+
+See [community-skill-packs.md](community-skill-packs.md) for the full schema reference for both files.
+
+---
+
+## Validation
+
+`./install-skill-pack` runs strict allow-list validation when a manifest declares `capabilities`:
+
+- Each value must match one of the six listed above (case-sensitive, exact match).
+- Unknown values abort the install with an error message naming the invalid value and pointing at this file.
+- An empty array (`"capabilities": []`) is treated as "not declared" — equivalent to omitting the field. A skill that genuinely does nothing externally should declare `["read_only"]` so the surface shows the intent.
+
+No runtime gating — the install proceeds for any allow-listed combination. Capabilities are documentation, not a sandbox.
+
+---
+
+## Adding a new capability
+
+The taxonomy is intentionally narrow. New values must:
+
+1. Cover a **distinct** blast radius — something an operator would weigh differently from the existing six.
+2. Apply to **multiple** skills, current or planned. One-off cases stay inside `external_api`.
+3. Land in **one PR** that updates: this file, the `skills-pack.json` schema reference, and the `install-skill-pack` allow-list constant. PRs that add a capability without one of those three pieces will be sent back.
+
+Closing a capability (deprecating a value) follows the same protocol in reverse — open a PR that migrates every existing pack first, then removes the value from the allow-list and this file in a follow-up.
+
+---
+
+## What this isn't
+
+- **Not a sandbox.** A skill declaring `read_only` is trusted to be read-only; the runtime doesn't enforce it. The operator-plus-scanner remains the trust boundary.
+- **Not a substitute for `trusted-sources.txt`.** Pack-level `trust_level: trusted` still requires the explicit trusted-sources listing — capabilities don't shortcut that.
+- **Not an exhaustive permission model.** It's a coarse-grained hint so the install surface is informative. If you need fine-grained policy, that's a different feature.

--- a/docs/community-skill-packs.md
+++ b/docs/community-skill-packs.md
@@ -61,7 +61,8 @@ The manifest lives at the pack root (or under `--path <subdir>` if the pack is n
       "schedule": "0 12 * * *",
       "default_enabled": false,
       "secrets_required": ["VENICE_API_KEY"],
-      "secrets_optional": ["VENICE_MODEL"]
+      "secrets_optional": ["VENICE_MODEL"],
+      "capabilities": ["external_api", "writes_external_host"]
     }
   ]
 }
@@ -86,6 +87,7 @@ The manifest lives at the pack root (or under `--path <subdir>` if the pack is n
 | `skills[].default_enabled` | boolean | optional | If `true`, the skill is added to `aeon.yml` with `enabled: true`. Default `false` (operator opts in explicitly). |
 | `skills[].secrets_required` | string[] | optional | Env vars the skill **cannot run without** (e.g. API keys). `install-skill-pack` warns loudly when any are unset before the first scheduled run, but does **not** gate the install — an operator may install dry-run or wire the secret afterward. |
 | `skills[].secrets_optional` | string[] | optional | Env vars that tune behaviour but aren't required (e.g. a model override). Surfaced at install for visibility; informational only. |
+| `skills[].capabilities` | string[] | optional | Self-declared blast-radius hints. **Locked taxonomy** — one or more of `read_only`, `external_api`, `writes_external_host`, `onchain_writes`, `agent_messaging`, `sends_notifications`. Surfaced in `install-skill-pack` listings; unknown values are rejected with an error pointing at [docs/CAPABILITIES.md](CAPABILITIES.md). |
 
 ### What's enforced
 
@@ -195,7 +197,8 @@ The operator is always the trust boundary. The install script does not auto-trus
       "category": "research|dev|crypto|social|productivity",
       "trust_level": "trusted|community",
       "skills": ["slug-1", "slug-2"],
-      "secrets_required": ["VENICE_API_KEY"]
+      "secrets_required": ["VENICE_API_KEY"],
+      "capabilities": ["external_api", "writes_external_host"]
     }
   ]
 }
@@ -215,6 +218,7 @@ The operator is always the trust boundary. The install script does not auto-trus
 | `trust_level` | string | optional | `trusted` (also requires the source in `skills/security/trusted-sources.txt`) or `community`. Default `community`. Listing here is a discovery hint — the actual scan-bypass behaviour is decided by the trusted-sources file. |
 | `skills[]` | array | **required** | Slugs the pack ships. Mirror the pack's own `skills-pack.json`. |
 | `secrets_required` | string[] | optional | Aggregated list of env vars the pack's skills declare as required. Drives the `./install-skill-pack --list --no-secrets` filter, which hides any pack with a non-empty `secrets_required`. Keep this in sync with the union of `skills[].secrets_required` in the pack's own `skills-pack.json`. |
+| `capabilities` | string[] | optional | Aggregated blast-radius hints across the pack's skills. **Locked taxonomy** — see [docs/CAPABILITIES.md](CAPABILITIES.md) for the six allowed values and how to choose. List-only metadata: surfaces as `[caps: ...]` on `./install-skill-pack --list` and is taxonomy-validated at print time; not read by install (per-skill `skills[].capabilities` in the pack's own `skills-pack.json` is the source of truth at install time). Keep this in sync with the union of `skills[].capabilities`. |
 
 ### Why two files (README table + skill-packs.json)?
 

--- a/install-skill-pack
+++ b/install-skill-pack
@@ -39,13 +39,20 @@ set -euo pipefail
 #         "schedule": "0 12 * * *",                            (optional, default 0 12 * * *)
 #         "default_enabled": false,                             (optional, default false)
 #         "secrets_required": ["VENICE_API_KEY"],               (optional — env vars the skill cannot run without)
-#         "secrets_optional": ["VENICE_MODEL"]                  (optional — env vars that tune behaviour but aren't required)
+#         "secrets_optional": ["VENICE_MODEL"],                 (optional — env vars that tune behaviour but aren't required)
+#         "capabilities": ["external_api"]                       (optional, locked taxonomy — see docs/CAPABILITIES.md)
 #       }
 #     ]
 #   }
 #
 # Fallback (no manifest): scans the pack root for skills/*/SKILL.md and installs
 # each one with safe defaults. The pack identity falls back to the repo name.
+#
+# Capabilities taxonomy (locked — unknown values are rejected at install time):
+#   read_only · external_api · writes_external_host · onchain_writes ·
+#   agent_messaging · sends_notifications
+# See docs/CAPABILITIES.md for the meaning of each value and the rule for
+# proposing additions.
 
 ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILLS_DIR="$ROOT_DIR/skills"
@@ -58,6 +65,27 @@ REGISTRY_FILE="$ROOT_DIR/skill-packs.json"
 REGISTRY_URL="https://raw.githubusercontent.com/aaronjmars/aeon/main/skill-packs.json"
 TMP_DIR=$(mktemp -d)
 trap 'rm -rf "$TMP_DIR"' EXIT
+
+# Locked capability taxonomy. Adding a value requires a separate PR that also
+# updates docs/CAPABILITIES.md + the skills-pack.json schema reference. Keep
+# this list in lockstep with docs/CAPABILITIES.md ("The taxonomy" table) —
+# unknown values are rejected at install time pointing back at that file.
+ALLOWED_CAPABILITIES=(
+  read_only
+  external_api
+  writes_external_host
+  onchain_writes
+  agent_messaging
+  sends_notifications
+)
+
+is_allowed_capability() {
+  local needle="$1" cap
+  for cap in "${ALLOWED_CAPABILITIES[@]}"; do
+    [[ "$cap" == "$needle" ]] && return 0
+  done
+  return 1
+}
 
 usage() {
   cat <<'EOF'
@@ -140,7 +168,7 @@ list_registry() {
   echo ""
   local shown=0 hidden=0
   for i in $(seq 0 $((total - 1))); do
-    local repo desc trust skill_count secrets_count secrets_marker
+    local repo desc trust skill_count secrets_count secrets_marker caps_type caps caps_marker
     repo=$(echo "$registry_json" | jq -r ".packs[$i].repo")
     desc=$(echo "$registry_json" | jq -r ".packs[$i].description // \"\"")
     trust=$(echo "$registry_json" | jq -r ".packs[$i].trust_level // \"community\"")
@@ -151,17 +179,39 @@ list_registry() {
       hidden=$((hidden + 1))
       continue
     fi
+    # capabilities at the pack level is the aggregate; missing/null means none
+    # declared. Validate each entry against the locked taxonomy so registry
+    # drift surfaces in the listing rather than silently leaking through.
+    caps_type=$(echo "$registry_json" | jq -r ".packs[$i].capabilities | type")
+    caps=""
+    if [[ "$caps_type" == "array" ]]; then
+      while IFS= read -r cap_line; do
+        local cap_kind="${cap_line%% *}"
+        local cap_value="${cap_line#* }"
+        if [[ "$cap_kind" != "string" ]] || ! is_allowed_capability "$cap_value"; then
+          echo "Registry pack '$repo' declares unknown or non-string capability '$cap_value' — see docs/CAPABILITIES.md." >&2
+          exit 1
+        fi
+        caps+="${caps:+,}$cap_value"
+      done < <(echo "$registry_json" | jq -r ".packs[$i].capabilities[]? | \"\(type) \(.)\"")
+    elif [[ "$caps_type" != "null" ]]; then
+      echo "Registry pack '$repo' has capabilities of type $caps_type (expected array) — see docs/CAPABILITIES.md." >&2
+      exit 1
+    fi
     local trust_badge=" "
     [[ "$trust" == "trusted" ]] && trust_badge="*"
     secrets_marker=""
     [[ "$secrets_count" != "0" ]] && secrets_marker=" [needs ${secrets_count} secret(s)]"
+    caps_marker=""
+    [[ -n "$caps" ]] && caps_marker=" [caps: $caps]"
     if [[ ${#desc} -gt 80 ]]; then desc="${desc:0:77}..."; fi
-    printf "  %s %-44s %2d skills  %s%s\n" "$trust_badge" "$repo" "$skill_count" "$desc" "$secrets_marker"
+    printf "  %s %-44s %2d skills  %s%s%s\n" "$trust_badge" "$repo" "$skill_count" "$desc" "$secrets_marker" "$caps_marker"
     shown=$((shown + 1))
   done
   echo ""
   echo "  * = trusted source (security scan skipped, format check still runs)"
   echo "  [needs N secret(s)] = pack declares N entries in secrets_required — set them in the workflow before first run"
+  echo "  [caps: ...] = declared capabilities — see docs/CAPABILITIES.md for the taxonomy"
   echo ""
   if [[ "$no_secrets" == "true" ]]; then
     echo "$shown of $total packs shown ($hidden hidden by --no-secrets). Install with: ./install-skill-pack <repo>"
@@ -267,6 +317,8 @@ fi
 # Reset declarations (no associative arrays — they require Bash 4+ which macOS lacks).
 # SKILL_SECRETS_REQ / SKILL_SECRETS_OPT hold space-separated env-var names per skill
 # (parallel arrays — same index as SLUGS). Empty string means none declared.
+# SKILL_CAPS holds the per-skill capabilities as a space-separated string
+# (parallel array, same index as SLUGS). Empty string means none declared.
 SLUGS=()
 SKILL_PATHS=()
 SKILL_DESCS=()
@@ -275,6 +327,7 @@ SKILL_SCHEDS=()
 SKILL_DEFAULT_ENABLED=()
 SKILL_SECRETS_REQ=()
 SKILL_SECRETS_OPT=()
+SKILL_CAPS=()
 MANIFEST_FOUND=false
 MANIFEST_PATH="$PACK_DIR/skills-pack.json"
 
@@ -332,6 +385,39 @@ if [[ -f "$MANIFEST_PATH" ]]; then
     # them as space-separated env-var names (the per-skill loop splits on " ").
     secrets_req=$(jq -r ".skills[$i].secrets_required // [] | join(\" \")" "$MANIFEST_PATH")
     secrets_opt=$(jq -r ".skills[$i].secrets_optional // [] | join(\" \")" "$MANIFEST_PATH")
+    # capabilities — optional string array. Iterate each element via jq so
+    # element boundaries survive (word-splitting on a joined string would
+    # mishandle empty / whitespace-bearing entries). Type-check the field
+    # and each element so non-array shapes and non-string entries surface our
+    # taxonomy pointer instead of an opaque jq error under `set -e`.
+    caps_type=$(jq -r ".skills[$i].capabilities | type" "$MANIFEST_PATH")
+    if [[ "$caps_type" != "null" ]] && [[ "$caps_type" != "array" ]]; then
+      echo "Manifest skill '$slug' has capabilities of type $caps_type (expected array)." >&2
+      echo "See docs/CAPABILITIES.md for the taxonomy and field shape." >&2
+      exit 1
+    fi
+    caps=""
+    if [[ "$caps_type" == "array" ]]; then
+      # Emit one line per element prefixed with its jq type ("string foo" /
+      # "number 7" / "boolean true" / ...). Reading line-by-line preserves
+      # element boundaries even if a manifest tries to sneak whitespace in.
+      while IFS= read -r cap_line; do
+        cap_kind="${cap_line%% *}"
+        cap_value="${cap_line#* }"
+        if [[ "$cap_kind" != "string" ]]; then
+          echo "Manifest skill '$slug' has a non-string entry in capabilities (got $cap_kind)." >&2
+          echo "Each value must be a string from the locked taxonomy — see docs/CAPABILITIES.md." >&2
+          exit 1
+        fi
+        if ! is_allowed_capability "$cap_value"; then
+          echo "Manifest skill '$slug' declares unknown capability '$cap_value'." >&2
+          echo "Allowed values: ${ALLOWED_CAPABILITIES[*]}." >&2
+          echo "See docs/CAPABILITIES.md for the taxonomy and how to propose additions." >&2
+          exit 1
+        fi
+        caps+="${caps:+ }$cap_value"
+      done < <(jq -r ".skills[$i].capabilities[]? | \"\(type) \(.)\"" "$MANIFEST_PATH")
+    fi
     SLUGS+=("$slug")
     SKILL_PATHS+=("$rel_path")
     SKILL_DESCS+=("$desc")
@@ -340,6 +426,7 @@ if [[ -f "$MANIFEST_PATH" ]]; then
     SKILL_DEFAULT_ENABLED+=("$default_enabled")
     SKILL_SECRETS_REQ+=("$secrets_req")
     SKILL_SECRETS_OPT+=("$secrets_opt")
+    SKILL_CAPS+=("$caps")
   done
 else
   echo "No skills-pack.json — falling back to scanning skills/ in $REPO"
@@ -360,6 +447,7 @@ else
     SKILL_DEFAULT_ENABLED+=("false")
     SKILL_SECRETS_REQ+=("")
     SKILL_SECRETS_OPT+=("")
+    SKILL_CAPS+=("")
   done < <(find "$scan_root" -mindepth 2 -maxdepth 2 -name SKILL.md -type f 2>/dev/null | sort)
 fi
 
@@ -402,6 +490,7 @@ if [[ ${#REQUESTED_SLUGS[@]} -gt 0 ]]; then
   FILTERED_DEFAULT=()
   FILTERED_SECRETS_REQ=()
   FILTERED_SECRETS_OPT=()
+  FILTERED_CAPS=()
   for want in "${REQUESTED_SLUGS[@]}"; do
     found=false
     for i in "${!SLUGS[@]}"; do
@@ -414,6 +503,7 @@ if [[ ${#REQUESTED_SLUGS[@]} -gt 0 ]]; then
         FILTERED_DEFAULT+=("${SKILL_DEFAULT_ENABLED[$i]}")
         FILTERED_SECRETS_REQ+=("${SKILL_SECRETS_REQ[$i]}")
         FILTERED_SECRETS_OPT+=("${SKILL_SECRETS_OPT[$i]}")
+        FILTERED_CAPS+=("${SKILL_CAPS[$i]}")
         found=true
         break
       fi
@@ -431,6 +521,7 @@ if [[ ${#REQUESTED_SLUGS[@]} -gt 0 ]]; then
   SKILL_DEFAULT_ENABLED=("${FILTERED_DEFAULT[@]}")
   SKILL_SECRETS_REQ=("${FILTERED_SECRETS_REQ[@]}")
   SKILL_SECRETS_OPT=("${FILTERED_SECRETS_OPT[@]}")
+  SKILL_CAPS=("${FILTERED_CAPS[@]}")
 fi
 
 # Check trusted-sources for the pack repo.
@@ -671,6 +762,12 @@ for i in "${!SLUGS[@]}"; do
   fi
 
   warn_missing_secrets "$slug" "${SKILL_SECRETS_REQ[$i]}" "${SKILL_SECRETS_OPT[$i]}"
+
+  # Surface declared capabilities (already validated upstream against the locked
+  # taxonomy). Informational only — no gate, no prompt.
+  if [[ -n "${SKILL_CAPS[$i]}" ]]; then
+    echo "  · capabilities for $slug: ${SKILL_CAPS[$i]}"
+  fi
 
   dest="$SKILLS_DIR/$slug"
 


### PR DESCRIPTION
Implements priority **(1) — `capabilities` array with the locked taxonomy** from #258 per your direction on https://github.com/aaronjmars/aeon/issues/258#issuecomment-4564790799.

Sequenced after #266 (priority 3) and #267 (priority 2). This is the last of the three.

## New file: `docs/CAPABILITIES.md`

Defines the locked six-value taxonomy verbatim from your spec:

| Value | Meaning |
|-------|---------|
| `read_only` | No network writes, no on-chain calls, no notifications. |
| `external_api` | Reads or writes to non-Aeon HTTP APIs — any auth'd third-party call. |
| `writes_external_host` | Modifies state on a non-Aeon host (POST/PUT/DELETE/etc.). |
| `onchain_writes` | Signs and broadcasts blockchain transactions. |
| `agent_messaging` | Sends DMs, replies, or posts via X / Farcaster / Discord / Slack / etc. |
| `sends_notifications` | Calls `./notify` or equivalent operator-alert path. |

Plus a "how to choose" section with examples, a "what this isn't" section (not a sandbox, not a substitute for `trusted-sources.txt`), and a strict three-piece protocol for adding new values (this file + schema reference + allow-list constant — all in one PR).

## Schema additions

Schema-only — existing manifests without the field keep working.

### Per-skill (`skills-pack.json`)

```json
"skills": [
  {
    "slug": "vvvkernel-onchain",
    "capabilities": ["external_api", "writes_external_host", "onchain_writes"]
  }
]
```

### Pack-level (`skill-packs.json` registry entries)

```json
{
  "repo": "baseddevoloper/aeon-skill-pack-vvvkernel",
  "capabilities": ["external_api", "writes_external_host", "onchain_writes", "agent_messaging", "sends_notifications"]
}
```

Union of the per-skill capabilities. List-only metadata — `--list` reads it; install reads per-skill.

## Wiring in `install-skill-pack`

### `ALLOWED_CAPABILITIES` constant

Mirrors the taxonomy table exactly. Single source of truth for the allow-list — adding a value here without also updating `docs/CAPABILITIES.md` is the kind of drift the spec is designed to prevent (the doc calls it out in the "Adding a new capability" section).

### Strict allow-list validation (per the spec)

When a per-skill manifest declares `capabilities`:

- The field must be `null` or `array`. Non-array shapes (`"capabilities": "external_api"`) abort with the taxonomy pointer instead of an opaque jq error.
- Each element is iterated via `jq -r ".skills[$i].capabilities[]? | \"\(type) \(.)\""` so element boundaries survive even when the manifest tries to sneak whitespace in. Word-splitting on a `join(" ")` would silently swallow empty / whitespace-bearing entries.
- Element kind must be `string`; numbers, booleans, nested arrays are rejected.
- Element value must match one of the six values exactly (case-sensitive).
- Unknown values abort the install **before** any file is written, with a clear error naming the invalid value and pointing at `docs/CAPABILITIES.md`.

### `--list` surfaces pack-level capabilities

```
Community skill pack registry (updated 2026-05-29)

  * AntFleet/aeon-skills                          1 skills  On-demand two-model-consensus PR review ...
    baseddevoloper/aeon-skill-pack-vvvkernel      9 skills  Venice AI inference via VVVKernel ...  [caps: external_api,onchain_writes,agent_messaging]

  * = trusted source (security scan skipped, format check still runs)
  [caps: ...] = declared capabilities — see docs/CAPABILITIES.md for the taxonomy
```

Registry capabilities are validated against the same allow-list **at print time** so a typo in the registry surfaces in the listing rather than silently leaking through.

### Pre-install per-skill surfacing

After `scan_and_prompt` clears, before the file copy:

```
  ✓ security scan passed: vvvkernel-onchain
  · capabilities for vvvkernel-onchain: external_api writes_external_host onchain_writes
  install: vvvkernel-onchain
    ...
```

No gate, no prompt — just the operator-facing surface the spec asked for.

## Constraints added

- `docs/CAPABILITIES.md` "Validation" section: case-sensitive exact match; unknown values aborts with pointer; empty array treated as "not declared".
- `docs/CAPABILITIES.md` "Adding a new capability" section: new values must (1) cover a distinct blast radius, (2) apply to multiple skills, (3) land in one PR that updates this file + schema reference + allow-list constant.

## Smoke tests

10-case manifest-validation suite, all pass:

| Case | Expect | Result |
|------|--------|--------|
| no field | ACCEPT | ✓ |
| empty array `[]` | ACCEPT | ✓ |
| valid single `["read_only"]` | ACCEPT | ✓ |
| valid multi | ACCEPT | ✓ |
| unknown value `["bogus"]` | REJECT (taxonomy pointer) | ✓ |
| case-mismatch `["READ_ONLY"]` | REJECT (taxonomy pointer) | ✓ |
| `type=string` `"read_only"` | REJECT (type pointer) | ✓ |
| `type=number` `7` | REJECT (type pointer) | ✓ |
| non-string element `[7]` | REJECT (non-string pointer) | ✓ |
| value with whitespace `["read only"]` | REJECT (taxonomy pointer) | ✓ |

`bash -n install-skill-pack` — syntax clean.
`./install-skill-pack --list` — renders all 16 current packs without errors. No annotations appear yet since no current pack declares `capabilities` (additive field).

## What this does NOT change

- No existing pack entries were modified — the field is additive. Pack maintainers opt in by adding it to their next manifest update.
- Scanner, trusted-sources, secrets handling, and HIGH-finding gate logic untouched.
- No new env vars.
- No runtime gating — capabilities are documentation, not a sandbox. The operator + scanner + `trusted-sources.txt` remain the trust boundary.

## #258 status after this PR

All three priorities from your direction are now landed in PRs:
- ✅ #266 — (3) `skill-update-check` re-scan gate + `memory/topics/skill-update-blocked.md` paper trail
- ✅ #267 — (2) `secrets_required` / `secrets_optional` fields + warn-no-gate + `--no-secrets` filter
- ✅ #268 — (1) `capabilities` array with locked taxonomy + `docs/CAPABILITIES.md`

cc @imancipate per your triage tag.
