### PR TITLE
docs(skill-packs): add pr-review-antfleet-x402 to AntFleet entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,7 +463,7 @@ To browse known packs without installing, run `./install-skill-pack --list` — 
 | [luca-aeon-skills](https://github.com/danbuildss/luca-aeon-skills) | 4 | Financial intelligence via x402Books AI — wallet scanning, treasury monitoring, financial reports, and agent registry on Base |
 | [zer0-skill-pack](https://github.com/0xShak/zer0-skill-pack) | 6 | Polymarket intelligence — daily thesis, mispricing scanner, contrarian fades, narrative-vs-markets, paper-trade PnL journal, alpha comment curator |
 | [gitbounty-skill-pack](https://github.com/gitlawbounty/gitbounty-skill-pack) | 1 | Bounty hunting on the gitlawb network via gitbounty — discover open bounties, scout the best fit with the gitbounty LLM scout, draft a solution plan (read-only) |
-| [aeon-skills](https://github.com/AntFleet/aeon-skills) | 1 | Two-model-consensus PR review (Opus 4.7 + GPT-5) — per-review USDC drawdown on Base |
+| [aeon-skills](https://github.com/AntFleet/aeon-skills) | 2 | Two-model-consensus PR review (Opus 4.7 + GPT-5) — channel drawdown for installed repos, x402 pay-per-call for public repos |
 | [aeon-skill-pack-liquidpad](https://github.com/liquidpadbot/aeon-skill-pack-liquidpad) | 4 | Track LiquidPad on Base — burn cycle alerts, new token launches with onchain provenance, daily protocol digest, and fee accrual tracking |
 | [aeon-skill-pack-mythosforge](https://github.com/ryjin111/aeon-skill-pack-mythosforge) | 5 | Read-only MythosForge monitoring — ops/backlog/jury/payout health, proof-of-creation integrity on Base, theme/round guard against silent relabels, jury-drift detection, and live gallery/proof-page QA |
 | [demo-pack](https://github.com/sparkleware/demo-pack) | 1 | Holographic demo skill — proves the Sparkleware registry install pipeline works |

--- a/docs/community-skill-packs.md
+++ b/docs/community-skill-packs.md
@@ -19,6 +19,10 @@ This page documents the **install protocol** — the `skills-pack.json` manifest
 
 Prints every pack declared in `skill-packs.json` (at the Aeon repo root) — repo, skill count, trust badge, one-line description. Trusted-source packs are marked with `*` (security scan skipped, format check still runs). The script reads the local `skill-packs.json` when present and falls back to fetching the file from `https://raw.githubusercontent.com/aaronjmars/aeon/main/skill-packs.json` when it isn't.
 
+Trusted AntFleet packs currently expose both `pr-review-antfleet` for
+installed repos with channel drawdown and `pr-review-antfleet-x402` for
+public repos with x402 pay-per-call USDC.
+
 ## One-command install
 
 ```bash

--- a/skill-packs.json
+++ b/skill-packs.json
@@ -6,13 +6,13 @@
     {
       "repo": "AntFleet/aeon-skills",
       "name": "AntFleet aeon-skills",
-      "description": "On-demand two-model-consensus PR review (Claude Opus + GPT) with on-chain USDC payment channel on Base. Pull-mode counterpart to AntFleet's auto-review GitHub App.",
+      "description": "On-demand two-model-consensus PR review with on-chain USDC payment on Base. Channel-rail variant for installed repos; x402-rail variant for public repos with pay-per-call USDC (v1 restricted to aeon-ecosystem callers).",
       "author": "AntFleet",
       "license": "MIT",
       "homepage": "https://www.antfleet.dev",
       "category": "dev",
       "trust_level": "trusted",
-      "skills": ["pr-review-antfleet"]
+      "skills": ["pr-review-antfleet", "pr-review-antfleet-x402"]
     },
     {
       "repo": "baseddevoloper/aeon-skill-pack-vvvkernel",


### PR DESCRIPTION
Adds AntFleet x402 pay-per-call PR review skill variant to the trusted AntFleet skill-pack registry entry.

Skill source PR: https://github.com/AntFleet/aeon-skills/pull/1
SPEC reference: SPEC-001 v0.5 § 5.4

Validation: node JSON.parse(skill-packs.json)