### PR TITLE
Add .x402books/wallets.json (AEON wallet declaration)

### DIFF
--- a/.x402books/wallets.json
+++ b/.x402books/wallets.json
@@ -1,0 +1,19 @@
+{
+  "agent": "AEON",
+  "xHandle": "@aeonframework",
+  "ecosystem": "Base",
+  "wallets": [
+    {
+      "address": "0xf1e958db7d1e4c074377946018ad645db4fb158e",
+      "role": "treasury",
+      "chain": "base",
+      "notes": "Main protocol treasury"
+    },
+    {
+      "address": "0x67976cebb5266b50a08c0dcb676e03baf305e3a2",
+      "role": "deployer",
+      "chain": "base",
+      "notes": "Contract deployer"
+    }
+  ]
+}


### PR DESCRIPTION
Adds `.x402books/wallets.json` declaring AEON's wallets so Luca can verify and upgrade the registry confidence level.

- **treasury**: `0xf1e958db7d1e4c074377946018ad645db4fb158e`
- **deployer**: `0x67976cebb5266b50a08c0dcb676e03baf305e3a2`

ecosystem: Base · xHandle: @aeonframework

🤖 Generated with [Claude Code](https://claude.com/claude-code)