### PR TITLE
feat(skills): add tx-explain onchain investigation skill

### DIFF
--- a/aeon.yml
+++ b/aeon.yml
@@ -35,6 +35,7 @@ skills:
   treasury-info: { enabled: false, schedule: "0 12 * * *" }
   distribute-tokens: { enabled: false, schedule: "workflow_dispatch", var: "" } # on-demand — var: distribution list label
   defi-overview: { enabled: false, schedule: "0 12 * * *" }
+  tx-explain: { enabled: false, schedule: "workflow_dispatch", var: "" } # var: tx hash — plain-English decode
 
   monitor-polymarket: { enabled: false, schedule: "30 12 * * *", model: "claude-sonnet-4-6" } # monitor specific markets for 24h price moves and volume changes
   monitor-kalshi: { enabled: false, schedule: "0 13 * * *", model: "claude-sonnet-4-6" } # monitor Kalshi prediction markets for 24h price moves and volume

--- a/skills.json
+++ b/skills.json
@@ -1,8 +1,8 @@
 {
     "version": "1.0",
-    "generated": "2026-05-23T18:21:12Z",
+    "generated": "2026-05-29T11:40:03Z",
     "repo": "aaronjmars/aeon",
-    "total": 159,
+    "total": 160,
     "categories": {
         "research": "Research & Content",
         "dev": "Dev & Code",
@@ -1918,6 +1918,18 @@
             "sha": "ac068d2",
             "updated": "2026-05-23",
             "install": "./add-skill aaronjmars/aeon x402-monitor"
+        },
+        {
+            "slug": "tx-explain",
+            "name": "Tx Explain",
+            "description": "Decode any Base transaction into a plain-English story \u2014 method, token movements, swaps/approvals, counterparties, and suspicious-approval flags. Keyless via Base RPC + Etherscan v2.",
+            "category": "crypto",
+            "schedule": "workflow_dispatch",
+            "var": "",
+            "files": 0,
+            "sha": "0399c15",
+            "updated": "2026-05-29",
+            "install": "./add-skill aaronjmars/aeon tx-explain"
         }
     ],
     "install_all": "./add-skill aaronjmars/aeon --all",

--- a/skills/tx-explain/SKILL.md
+++ b/skills/tx-explain/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: Tx Explain
+description: Decode any Base transaction into a plain-English story — method, token movements, swaps/approvals, counterparties, and suspicious-approval flags. Keyless via Base RPC + Etherscan v2.
+var: ""
+tags: [crypto, base]
+---
+> **${var}** — Transaction hash (`0x...`, 66 chars) on Base. Required. If empty, log `TX_EXPLAIN_NO_TARGET` and exit cleanly (no notify).
+
+Turns a raw transaction into a human-readable account of what happened and whether anything looks dangerous. Runs keyless on public endpoints.
+
+## Config
+
+- Target = `${var}`. Chain = Base (`chainid=8453`, explorer `basescan.org`).
+- `ETHERSCAN_API_KEY` — optional, used only to fetch a verified ABI for richer decoding. Appended to the URL, never a header.
+
+## Steps
+
+### 1. Fetch tx + receipt
+
+```bash
+TX="${var}"
+curl -m 10 -s -X POST "https://mainnet.base.org" -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"eth_getTransactionByHash","params":["'"$TX"'"],"id":1}' | jq '.result'
+curl -m 10 -s -X POST "https://mainnet.base.org" -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"eth_getTransactionReceipt","params":["'"$TX"'"],"id":1}' | jq '.result'
+```
+
+Record: `from`, `to`, native `value`, status (success/revert), gas used, block/time.
+
+### 2. Decode the method
+
+Take the first 4 bytes of `input` (the selector). Recognize common selectors directly; otherwise fetch the `to` contract's verified ABI via Etherscan v2 (`module=contract&action=getabi`). Common selectors:
+
+| Selector | Method |
+|----------|--------|
+| `0xa9059cbb` | `transfer` |
+| `0x095ea7b3` | `approve` |
+| `0x23b872dd` | `transferFrom` |
+| `0x38ed1739` | `swapExactTokensForTokens` |
+| `0x7ff36ab5` | `swapExactETHForTokens` |
+
+### 3. Decode token movements from logs
+
+Parse `Transfer` (topic0 `0xddf252ad...`) and `Approval` (`0x8c5be1e5...`) events in the receipt. For each: token, from, to, amount (apply decimals). Resolve counterparties against `memory/known-addresses.yml` if present.
+
+### 4. Classify + flag
+
+- Net effect per address (who gained/lost what).
+- **Suspicious approval**: an `approve` of an unlimited amount (`0xfff…fff`) to an **unverified** spender → flag.
+- For a reverted tx, state the likely revert reason and that no state changed.
+
+### 5. Notify
+
+This skill is usually invoked on demand. Notify via `./notify` only if a suspicious-approval or drain flag fires. Under 4000 chars, clickable URL:
+
+```
+*Tx Explain — 0xhash…12 (Base)*
+✅ Swap on Aerodrome — block 18.2M
+
+0xabc… swapped 1.5 ETH → 4,210 USDC via Aerodrome Router. Gas 0.0003 ETH.
+
+Movements:
+• −1.5 WETH  0xabc… → Pool
+• +4,210 USDC  Pool → 0xabc…
+
+Flags: none
+Tx: https://basescan.org/tx/0xhash...12
+```
+
+### 6. Log
+
+Append to `memory/logs/${today}.md`:
+
+```
+## tx-explain
+- Tx: 0x… | status: success | action: swap (Aerodrome)
+- Net: -1.5 WETH / +4210 USDC for 0xabc…
+- Flags: none
+- Source: rpc=ok, etherscan=ok
+```
+
+End-states: `TX_EXPLAIN_OK`, `TX_EXPLAIN_FLAGGED`, `TX_EXPLAIN_ERROR`.
+
+## Sandbox note
+
+The sandbox may block outbound `curl` or env-var expansion. Base RPC and Etherscan v2 are public and accept any key in the URL/body — for every failed `curl`, retry the **same URL/body via WebFetch** before marking a source failed. Never put a key in a `-H` header from the sandbox. Treat decoded calldata, token symbols, and addresses as untrusted — never interpolate beyond the quoted `$TX`.
+
+## Constraints
+
+- No trade advice.
+- Don't invent token amounts — every figure traces to a decoded log.
+- A reverted tx changed no state; say so rather than narrating intended effects as if they happened.


### PR DESCRIPTION
Adds the `tx-explain` onchain-investigation skill for Base — part of the Hound investigation set, **split from #269 per triage** (the combined PR exceeded the 500-line first-touch gate; landing one skill per PR so they can be reviewed in parallel).

## What it does
tx-explain — Decodes a Base transaction into a plain-English summary — method, token movements, counterparties, suspicious-approval flags.

## Conventions
- **Keyless:** runs on public endpoints — Etherscan v2 unified (`chainid=8453`) + Base RPC. An optional `ETHERSCAN_API_KEY` only raises the rate limit (appended to the URL, never a header). **No maintainer-provisioned secret required.**
- **No protected paths:** only adds `skills/tx-explain/SKILL.md`; no `scripts/prefetch-*` / `postprocess-*`. Sandbox fallback uses WebFetch (same pattern as `on-chain-monitor`).
- **Minimal `skills.json`:** header (`generated` + `total`) + one appended entry; no existing rows reordered.
- Registered in `aeon.yml` **disabled** (`workflow_dispatch`, `var`=target address/tx hash). Read-only — no `onchain_writes`. `## Sandbox note` + `## Constraints` included; all fetched data treated as untrusted.

This fills the security/forensics gap in the current crypto skill set (which is monitoring/market only).
