### PR TITLE
Support Anthropic-compatible API base URL

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -245,6 +245,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
           BANKR_LLM_KEY: ${{ secrets.BANKR_LLM_KEY }}
           GITHUB_TOKEN: ${{ secrets.GH_GLOBAL || secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GH_GLOBAL || secrets.GITHUB_TOKEN }}
@@ -305,6 +306,8 @@ jobs:
             unset ANTHROPIC_API_KEY
             unset CLAUDE_CODE_OAUTH_TOKEN
             echo "::notice::Routing through Bankr Gateway (https://llm.bankr.bot)"
+          elif [ -n "${ANTHROPIC_BASE_URL:-}" ]; then
+            echo "::notice::Using Anthropic-compatible API at ${ANTHROPIC_BASE_URL}"
           else
             echo "::notice::Using direct Anthropic API"
           fi
@@ -604,6 +607,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
           BANKR_LLM_KEY: ${{ secrets.BANKR_LLM_KEY }}
         run: |
           SKILL="${{ steps.skill.outputs.name }}"
@@ -705,6 +709,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
           BANKR_LLM_KEY: ${{ secrets.BANKR_LLM_KEY }}
         run: |
           if [ "${{ steps.run.outputs.GATEWAY }}" = "bankr" ] && [ -n "${BANKR_LLM_KEY:-}" ]; then

--- a/.github/workflows/messages.yml
+++ b/.github/workflows/messages.yml
@@ -622,6 +622,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
           GITHUB_TOKEN: ${{ secrets.GH_GLOBAL || secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GH_GLOBAL || secrets.GITHUB_TOKEN }}
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}

--- a/aeon.yml
+++ b/aeon.yml
@@ -277,6 +277,8 @@ model: claude-opus-4-8
 
 # AI Gateway — route Claude Code requests through an LLM gateway.
 # provider: direct (default, uses ANTHROPIC_API_KEY) | bankr (uses BANKR_LLM_KEY)
+# For Anthropic-compatible providers, set repo variable ANTHROPIC_BASE_URL
+# and repo secret ANTHROPIC_API_KEY. Example: https://api.deepseek.com/anthropic
 # Bankr docs: https://docs.bankr.bot/llm-gateway/overview
 gateway:
   provider: direct

--- a/dashboard/app/api/auth/route.ts
+++ b/dashboard/app/api/auth/route.ts
@@ -1,66 +1,70 @@
 import { NextResponse } from 'next/server'
 import { execFileSync, execSync } from 'child_process'
 import { ghAvailable, ghArgsRepo } from '@/lib/gh'
+import { normalizeAuthConfig } from '@/lib/auth-provider.mjs'
 
 export async function GET() {
-  // Check if ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is set
   try {
     if (!ghAvailable()) {
       return NextResponse.json({ authenticated: false, error: 'gh CLI not authenticated' })
     }
+
     const out = execFileSync('gh', ['secret', 'list', ...ghArgsRepo(), '--json', 'name', '-q', '.[].name'], {
       stdio: 'pipe',
     }).toString().trim()
     const secrets = out ? out.split('\n').filter(Boolean) : []
     const hasApiKey = secrets.includes('ANTHROPIC_API_KEY')
     const hasOauth = secrets.includes('CLAUDE_CODE_OAUTH_TOKEN')
-    return NextResponse.json({ authenticated: hasApiKey || hasOauth, hasApiKey, hasOauth })
+    let hasBaseUrl = false
+
+    try {
+      const vars = execFileSync('gh', ['variable', 'list', ...ghArgsRepo(), '--json', 'name', '-q', '.[].name'], {
+        stdio: 'pipe',
+      }).toString().trim()
+      hasBaseUrl = vars ? vars.split('\n').includes('ANTHROPIC_BASE_URL') : false
+    } catch {}
+
+    return NextResponse.json({ authenticated: hasApiKey || hasOauth, hasApiKey, hasOauth, hasBaseUrl })
   } catch {
     return NextResponse.json({ authenticated: false })
   }
 }
 
 export async function POST(request: Request) {
-  // Accept a manually provided API key or OAuth token
   try {
     if (!ghAvailable()) {
       return NextResponse.json({ error: 'gh CLI not authenticated. Run: gh auth login' }, { status: 503 })
     }
 
-    const body = await request.json().catch(() => ({})) as { key?: string }
+    const body = await request.json().catch(() => ({})) as { key?: string, baseUrl?: string }
+    const config = normalizeAuthConfig(body)
 
-    if (body.key) {
-      const key = body.key.trim()
-      // OAuth tokens (sk-ant-oat) → CLAUDE_CODE_OAUTH_TOKEN
-      // API keys (sk-ant-api) → ANTHROPIC_API_KEY
-      const isOauth = key.startsWith('sk-ant-oat')
-      const secretName = isOauth ? 'CLAUDE_CODE_OAUTH_TOKEN' : 'ANTHROPIC_API_KEY'
-      execFileSync('gh', ['secret', 'set', secretName, ...ghArgsRepo()], {
-        input: key,
+    if (config.baseUrl) {
+      execFileSync('gh', ['variable', 'set', 'ANTHROPIC_BASE_URL', ...ghArgsRepo(), '--body', config.baseUrl], {
         stdio: ['pipe', 'pipe', 'pipe'],
       })
-      return NextResponse.json({ ok: true, method: isOauth ? 'oauth' : 'api-key', secret: secretName })
     }
 
-    // No key provided — try claude setup-token and extract the sk-ant-oat token
+    if (config.key) {
+      execFileSync('gh', ['secret', 'set', config.secretName, ...ghArgsRepo()], {
+        input: config.key,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      })
+      return NextResponse.json({ ok: true, method: config.method, secret: config.secretName, baseUrl: Boolean(config.baseUrl) })
+    }
+
     const output = execSync('claude setup-token', {
       stdio: 'pipe',
       timeout: 60000,
     }).toString()
 
-    // Find the token line and any continuation (token wraps across lines in terminal output)
-    // First, strip all whitespace/newlines after "sk-ant-oat" to reassemble a wrapped token
     const tokenBlock = output.slice(output.indexOf('sk-ant-oat'))
     if (!tokenBlock.startsWith('sk-ant-oat')) {
       return NextResponse.json({
         error: 'Could not extract token. Paste your API key manually instead.',
       }, { status: 400 })
     }
-    // Extract only valid token characters from each line, stopping at the first
-    // line that contributes nothing. This handles terminal wrapping while
-    // rejecting any trailing prose, ANSI escapes, or other non-token bytes that
-    // the first line might contain after the token text.
-    // Token alphabet: A-Za-z0-9_-
+
     const tokenChars: string[] = []
     for (const line of tokenBlock.split('\n')) {
       const segment = line.trim().match(/^[A-Za-z0-9_\-]+/)?.[0] ?? ''
@@ -83,6 +87,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ ok: true, method: 'oauth' })
   } catch (error: unknown) {
     const msg = error instanceof Error ? error.message : 'Failed to setup auth'
-    return NextResponse.json({ error: msg }, { status: 500 })
+    const status = msg.includes('Base URL') || msg.includes('OAuth tokens') ? 400 : 500
+    return NextResponse.json({ error: msg }, { status })
   }
 }

--- a/dashboard/app/api/secrets/route.ts
+++ b/dashboard/app/api/secrets/route.ts
@@ -4,7 +4,7 @@ import { ghAvailable, ghArgsRepo } from '@/lib/gh'
 
 const BUILTIN_SECRETS = [
   { name: 'CLAUDE_CODE_OAUTH_TOKEN', group: 'Core', description: 'Claude Code OAuth token (set via Authenticate button)', either: 'auth' },
-  { name: 'ANTHROPIC_API_KEY', group: 'Core', description: 'Anthropic API key for Claude Code', either: 'auth' },
+  { name: 'ANTHROPIC_API_KEY', group: 'Core', description: 'Anthropic or Anthropic-compatible API key for Claude Code', either: 'auth' },
   { name: 'BANKR_LLM_KEY', group: 'Core', description: 'Bankr Gateway API key (bk_...) — enable at bankr.bot/api' },
   { name: 'TELEGRAM_BOT_TOKEN', group: 'Telegram', description: 'Bot token from @BotFather' },
   { name: 'TELEGRAM_CHAT_ID', group: 'Telegram', description: 'Your chat ID' },

--- a/dashboard/app/page.tsx
+++ b/dashboard/app/page.tsx
@@ -68,7 +68,7 @@ export default function Dashboard() {
   const deleteSkill = async (n: string) => { setBusy(b => ({ ...b, [`d-${n}`]: true })); try { const r = await fetch('/api/skills', { method: 'DELETE', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: n }) }); if (r.ok) { setSkills(s => s.filter(x => x.name !== n)); setSelectedSkill(null); flash(`${displayName(n)} removed`); setHasChanges(true) } } finally { setBusy(b => ({ ...b, [`d-${n}`]: false })) } }
   const syncToGithub = async () => { setSyncing(true); try { const r = await fetch('/api/sync', { method: 'POST' }); if (r.ok) { flash('Synced'); setHasChanges(false) } } finally { setSyncing(false) } }
   const pullFromGithub = async () => { setPulling(true); try { const r = await fetch('/api/outputs', { method: 'POST' }); if (r.ok) { flash('Pulled'); setFeedKey(k => k + 1); fetchData() } } finally { setPulling(false) } }
-  const setupAuth = async (key?: string) => { setAuthLoading(true); try { const r = await fetch('/api/auth', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(key ? { key } : {}) }); if (r.ok) { flash('Authenticated'); setAuthStatus({ authenticated: true }); setShowAuthModal(false); fetchData() } else { const d = await r.json().catch(() => ({} as { error?: string })); const msg = typeof d?.error === 'string' ? d.error : (key ? 'Auth failed' : 'Auto-setup failed'); if (!key) setShowAuthModal(true); flash(msg) } } finally { setAuthLoading(false) } }
+  const setupAuth = async (auth?: string | { key: string, baseUrl?: string }) => { setAuthLoading(true); try { const body = typeof auth === 'string' ? { key: auth } : (auth || {}); const r = await fetch('/api/auth', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }); if (r.ok) { flash('Authenticated'); setAuthStatus({ authenticated: true }); setShowAuthModal(false); fetchData() } else { const d = await r.json().catch(() => ({} as { error?: string })); const msg = typeof d?.error === 'string' ? d.error : (auth ? 'Auth failed' : 'Auto-setup failed'); if (!auth) setShowAuthModal(true); flash(msg) } } finally { setAuthLoading(false) } }
   const saveSecret = async (n: string, value: string) => { setBusy(b => ({ ...b, [`sec-${n}`]: true })); try { const r = await fetch('/api/secrets', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: n, value }) }); if (r.ok) { setSecrets(s => { const e = s.some(x => x.name === n); if (e) return s.map(x => x.name === n ? { ...x, isSet: true } : x); return [...s, { name: n, group: 'Skill Keys', description: 'Custom', isSet: true }] }); flash(`${n} saved`) } } finally { setBusy(b => ({ ...b, [`sec-${n}`]: false })) } }
   const deleteSecret = async (n: string) => { setBusy(b => ({ ...b, [`sec-${n}`]: true })); try { const r = await fetch('/api/secrets', { method: 'DELETE', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: n }) }); if (r.ok) { setSecrets(s => s.map(x => x.name === n ? { ...x, isSet: false } : x)); flash(`${n} removed`) } } finally { setBusy(b => ({ ...b, [`sec-${n}`]: false })) } }
   const importSkill = async (files: UploadFile[], name?: string) => { const r = await fetch('/api/upload', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ files, name }) }); if (r.ok) { const d = await r.json(); flash(`${displayName(d.name)} hired`); fetchData() } }
@@ -99,7 +99,7 @@ export default function Dashboard() {
           skill={skill} view={view} repo={repo} model={model} gateway={gateway}
           authStatus={authStatus} authLoading={authLoading}
           pulling={pulling} syncing={syncing} hasChanges={hasChanges} behind={behind}
-          onSetupAuth={() => setupAuth()} onUpdateModel={updateModel}
+          onSetupAuth={() => setShowAuthModal(true)} onUpdateModel={updateModel}
           onShowImport={() => setShowImport(true)} onPull={pullFromGithub} onSync={syncToGithub}
         />
 
@@ -129,7 +129,7 @@ export default function Dashboard() {
       />
 
       {showImport && <ImportModal onClose={() => setShowImport(false)} onImport={importSkill} />}
-      {showAuthModal && <AuthModal loading={authLoading} onClose={() => setShowAuthModal(false)} onAuth={(key) => setupAuth(key)} />}
+      {showAuthModal && <AuthModal loading={authLoading} onClose={() => setShowAuthModal(false)} onAuth={(auth) => setupAuth(auth)} />}
     </div>
   )
 }

--- a/dashboard/components/AuthModal.tsx
+++ b/dashboard/components/AuthModal.tsx
@@ -6,11 +6,13 @@ import { inputCls } from '../lib/utils'
 interface AuthModalProps {
   loading: boolean
   onClose: () => void
-  onAuth: (key: string) => void
+  onAuth: (payload?: { key: string, baseUrl?: string }) => void
 }
 
 export function AuthModal({ loading, onClose, onAuth }: AuthModalProps) {
   const [authKey, setAuthKey] = useState('')
+  const [baseUrl, setBaseUrl] = useState('')
+  const submit = () => authKey.trim() && onAuth({ key: authKey.trim(), baseUrl: baseUrl.trim() || undefined })
 
   return (
     <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/30 backdrop-blur-sm">
@@ -19,9 +21,14 @@ export function AuthModal({ loading, onClose, onAuth }: AuthModalProps) {
           <h2 className="font-display text-xl">Authenticate</h2>
           <button onClick={onClose} className="text-primary-35 hover:text-primary-100 text-lg">&times;</button>
         </div>
-        <p className="text-xs text-primary-50 font-mono mb-[var(--space-md)]">Paste your API key to enable deployments.</p>
-        <input type="password" value={authKey} onChange={(e) => setAuthKey(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && authKey.trim() && onAuth(authKey.trim())} placeholder="sk-ant-..." autoFocus className={`${inputCls} mb-[var(--space-md)]`} />
-        <button onClick={() => onAuth(authKey.trim())} disabled={!authKey.trim() || loading} className="w-full bg-aeon-fg text-aeon-bg text-sm py-3 font-mono uppercase tracking-[2px] hover:opacity-90 transition-opacity disabled:opacity-50">{loading ? '...' : 'Save'}</button>
+        <p className="text-xs text-primary-50 font-mono mb-[var(--space-md)]">Paste an Anthropic or Anthropic-compatible API key, or connect a Claude subscription token.</p>
+        <input type="password" value={authKey} onChange={(e) => setAuthKey(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && submit()} placeholder="API key" autoFocus className={`${inputCls} mb-[var(--space-sm)]`} />
+        <input type="url" value={baseUrl} onChange={(e) => setBaseUrl(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && submit()} placeholder="Optional base URL, e.g. https://api.deepseek.com/anthropic" className={`${inputCls} mb-[var(--space-md)]`} />
+        <button onClick={submit} disabled={!authKey.trim() || loading} className="w-full bg-aeon-fg text-aeon-bg text-sm py-3 font-mono uppercase tracking-[2px] hover:opacity-90 transition-opacity disabled:opacity-50">{loading ? '...' : 'Save API Key'}</button>
+        <div className="my-[var(--space-md)] border-t border-[rgba(250,250,250,0.10)]" />
+        <button onClick={() => onAuth()} disabled={loading} className="w-full bg-aeon-panel text-aeon-fg border border-[rgba(250,250,250,0.14)] text-sm py-3 font-mono uppercase tracking-[2px] hover:border-eva-orange transition-colors disabled:opacity-50">
+          {loading ? '...' : 'Use Claude Subscription'}
+        </button>
       </div>
     </div>
   )

--- a/dashboard/lib/auth-provider.mjs
+++ b/dashboard/lib/auth-provider.mjs
@@ -1,0 +1,37 @@
+export function normalizeAuthConfig(body = {}) {
+  const key = String(body.key || '').trim()
+  const baseUrl = String(body.baseUrl || '').trim()
+
+  if (!key) {
+    return { key: '', baseUrl: normalizeBaseUrl(baseUrl), method: 'oauth', secretName: 'CLAUDE_CODE_OAUTH_TOKEN' }
+  }
+
+  const isOauth = key.startsWith('sk-ant-oat')
+  if (isOauth && baseUrl) {
+    throw new Error('Claude OAuth tokens cannot be used with a custom base URL')
+  }
+
+  return {
+    key,
+    baseUrl: isOauth ? '' : normalizeBaseUrl(baseUrl),
+    method: isOauth ? 'oauth' : 'api-key',
+    secretName: isOauth ? 'CLAUDE_CODE_OAUTH_TOKEN' : 'ANTHROPIC_API_KEY',
+  }
+}
+
+function normalizeBaseUrl(value) {
+  if (!value) return ''
+
+  let url
+  try {
+    url = new URL(value)
+  } catch {
+    throw new Error('Base URL must be an http(s) URL')
+  }
+
+  if (url.protocol !== 'https:') {
+    throw new Error('Base URL must be an HTTPS URL')
+  }
+
+  return url.toString().replace(/\/$/, '')
+}

--- a/dashboard/lib/auth-provider.test.mjs
+++ b/dashboard/lib/auth-provider.test.mjs
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { normalizeAuthConfig } from './auth-provider.mjs'
+
+test('stores Anthropic-compatible API keys in ANTHROPIC_API_KEY', () => {
+  const config = normalizeAuthConfig({
+    key: 'deepseek-api-key',
+    baseUrl: 'https://api.deepseek.com/anthropic',
+  })
+
+  assert.equal(config.secretName, 'ANTHROPIC_API_KEY')
+  assert.equal(config.method, 'api-key')
+  assert.equal(config.baseUrl, 'https://api.deepseek.com/anthropic')
+})
+
+test('stores Claude OAuth tokens separately', () => {
+  const config = normalizeAuthConfig({ key: 'sk-ant-oat-abc123' })
+
+  assert.equal(config.secretName, 'CLAUDE_CODE_OAUTH_TOKEN')
+  assert.equal(config.method, 'oauth')
+  assert.equal(config.baseUrl, '')
+})
+
+test('rejects Claude OAuth tokens with custom base URLs', () => {
+  assert.throws(
+    () => normalizeAuthConfig({ key: 'sk-ant-oat-abc123', baseUrl: 'https://api.deepseek.com/anthropic' }),
+    /Claude OAuth tokens cannot be used with a custom base URL/,
+  )
+})
+
+test('keeps empty auth payload on the Claude OAuth setup path', () => {
+  const config = normalizeAuthConfig({})
+
+  assert.equal(config.key, '')
+  assert.equal(config.secretName, 'CLAUDE_CODE_OAUTH_TOKEN')
+  assert.equal(config.method, 'oauth')
+})
+
+test('rejects invalid Anthropic-compatible base URLs', () => {
+  assert.throws(
+    () => normalizeAuthConfig({ key: 'deepseek-api-key', baseUrl: 'file:///tmp/key' }),
+    /Base URL must be an HTTPS URL/,
+  )
+  assert.throws(
+    () => normalizeAuthConfig({ key: 'deepseek-api-key', baseUrl: 'http://api.deepseek.com/anthropic' }),
+    /Base URL must be an HTTPS URL/,
+  )
+})

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "node --test lib/*.test.mjs"
   },
   "dependencies": {
     "@json-render/core": "^0.15.0",


### PR DESCRIPTION
## Summary
- Add optional `ANTHROPIC_BASE_URL` support for Anthropic-compatible providers in Aeon and Messages workflows.
- Let dashboard auth save an Anthropic-compatible API key plus optional base URL (`ANTHROPIC_API_KEY` secret + `ANTHROPIC_BASE_URL` repo variable).
- Keep Claude OAuth tokens routed to `CLAUDE_CODE_OAUTH_TOKEN` and add a small auth normalization test.

## Usage
For providers such as DeepSeek's Anthropic-compatible API, configure:

```bash
gh secret set ANTHROPIC_API_KEY --body '<provider api key>'
gh variable set ANTHROPIC_BASE_URL --body 'https://api.deepseek.com/anthropic'
```

The dashboard Authenticate modal can also set both values.

## Verification
- `npm test` in `dashboard/`
- `npm run build` in `dashboard/`
- YAML parse check for `.github/workflows/aeon.yml`, `.github/workflows/messages.yml`, and `aeon.yml`