### PR TITLE
docs(wallets): add fork-safety note to .x402books/wallets.json

### DIFF
--- a/.x402books/wallets.json
+++ b/.x402books/wallets.json
@@ -1,4 +1,5 @@
 {
+  "_note": "Fork operators: this file advertises THIS repo's agent wallets to the x402books ecosystem. Replace the addresses below with your own fork's wallets, or delete this file entirely, before deploying. Pulling upstream as-is will misattribute your agent's activity to the aaronjmars/aeon treasury.",
   "agent": "AEON",
   "xHandle": "@aeonframework",
   "ecosystem": "Base",


### PR DESCRIPTION
## Observation

Every fork of aeon inherits `.x402books/wallets.json` verbatim from main. Because the file declares the upstream `aaronjmars/aeon` treasury (`0xf1e9…b158e`) and deployer (`0x6797…e3a2`) as the agent's wallets, a fork that pulls main and deploys without editing this file is silently re-advertising the upstream wallets as its own to the x402books ecosystem. The misattribution flows in one direction (fork → upstream) and is invisible until someone audits the registry.

## Fix

Add a single `_note` field at the top of the JSON object pointing at exactly this risk. JSON validates with `jq .` and existing consumers ignore the unknown key.

## Why a note in the file, not a doc page

Operators only see this file when they're editing or copying it — which is the exact moment the warning is relevant. A separate `.x402books/README.md` would be missed by anyone whose first encounter is `git pull` followed by `terraform apply`. The in-file note costs one line and lives on the only surface a fork operator is guaranteed to look at.

Happy to reword to match repo voice if `_note` clashes with a convention I missed.