### PR TITLE
docs(ecosystem): add Hound Flow

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -36,6 +36,7 @@ These are the projects we know of that run Aeon, extend it, or integrate with th
 | GitBounty | [@Gitlawbounty](https://x.com/Gitlawbounty) |
 | GitKernal | [@gitkernal](https://x.com/gitkernal) |
 | Gitlawb Terminal | [@Gitlawbterminal](https://x.com/Gitlawbterminal) |
+| Hound Flow | [@HoundFlow_](https://x.com/HoundFlow_) · [houndflow.com](https://houndflow.com) |
 | LawbWorld | [@LawbWorld](https://x.com/LawbWorld) |
 | LiquidPad | [@LiquidPadBot](https://x.com/LiquidPadBot) · [liquidpad.site](https://www.liquidpad.site) |
 | Liq | [@_proxystudio](https://x.com/_proxystudio) |


### PR DESCRIPTION
Adds **Hound Flow** to `ECOSYSTEM.md`.

Hound Flow builds on Aeon — its onchain-OSINT investigation skills (rug-scan, contract-audit, wallet-profile, deployer-trace, tx-explain, holder-concentration) are merged upstream in #269, with more in review. It also runs a hosted MCP server and a wallet-gated OSINT chat app on Base.

- One row, alphabetized (between `Gitlawb Terminal` and `LawbWorld`).
- X handle + website per the guidelines: [@HoundFlow_](https://x.com/HoundFlow_) · [houndflow.com](https://houndflow.com)
