### PR TITLE
ci: add capabilities taxonomy parity check (closes #301)

### DIFF
--- a/.github/workflows/ci-capabilities-parity.yml
+++ b/.github/workflows/ci-capabilities-parity.yml
@@ -1,0 +1,41 @@
+name: ci-capabilities-parity
+
+# Issue #301: the locked capabilities taxonomy lives in two places (three
+# counting the install-skill-pack header comment). This workflow fails any PR
+# that changes one side without the other, so drift can't ship silently.
+#
+# Runs on every PR or push that touches:
+#   - install-skill-pack            (ALLOWED_CAPABILITIES + header comment)
+#   - docs/CAPABILITIES.md          ("The taxonomy" table)
+#   - the parity script itself
+#   - this workflow file
+#
+# The check is also wired to workflow_dispatch so a maintainer can re-run it
+# against main without pushing a no-op change.
+
+on:
+  pull_request:
+    paths:
+      - 'install-skill-pack'
+      - 'docs/CAPABILITIES.md'
+      - 'scripts/check-capabilities-parity.sh'
+      - '.github/workflows/ci-capabilities-parity.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'install-skill-pack'
+      - 'docs/CAPABILITIES.md'
+      - 'scripts/check-capabilities-parity.sh'
+      - '.github/workflows/ci-capabilities-parity.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check capabilities taxonomy parity
+        run: bash scripts/check-capabilities-parity.sh

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -83,7 +83,9 @@ The taxonomy is intentionally narrow. New values must:
 
 1. Cover a **distinct** blast radius — something an operator would weigh differently from the existing six.
 2. Apply to **multiple** skills, current or planned. One-off cases stay inside `external_api`.
-3. Land in **one PR** that updates: this file, the `skills-pack.json` schema reference, and the `install-skill-pack` allow-list constant. PRs that add a capability without one of those three pieces will be sent back.
+3. Land in **one PR** that updates: this file, the `skills-pack.json` schema reference, and the `install-skill-pack` allow-list constant (both the `ALLOWED_CAPABILITIES` array and the header comment that cites the same values). PRs that add a capability without one of those three pieces will be sent back.
+
+The `ci-capabilities-parity` workflow (`.github/workflows/ci-capabilities-parity.yml`) runs on every PR that touches either file and fails the check when the three places disagree — so a half-PR can't merge silently. Run the same check locally with `bash scripts/check-capabilities-parity.sh`.
 
 Closing a capability (deprecating a value) follows the same protocol in reverse — open a PR that migrates every existing pack first, then removes the value from the allow-list and this file in a follow-up.
 

--- a/scripts/check-capabilities-parity.sh
+++ b/scripts/check-capabilities-parity.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# check-capabilities-parity.sh — assert the locked skill-capabilities taxonomy
+# is identical in all three places it currently lives:
+#
+#   1. ALLOWED_CAPABILITIES bash array in install-skill-pack (the runtime allow-list)
+#   2. The "## The taxonomy" markdown table in docs/CAPABILITIES.md (the operator docs)
+#   3. The "# Capabilities taxonomy" header comment in install-skill-pack (cited by
+#      the script body when emitting unknown-value errors)
+#
+# Drift between (1) and (2) is the failure mode Issue #301 flags: install rejects
+# valid manifests OR accepts invalid ones, silently, while the error message points
+# operators back at docs that are right while the script is wrong.
+#
+# This check runs in CI on every PR that touches either file so drift fails loud.
+# It's the cheapest of the three directions Issue #301 outlined: no schema decisions,
+# no source-of-truth move, both files stay where they are — but a divergent PR fails
+# the check until both halves are updated in the same diff.
+#
+# Run locally:  bash scripts/check-capabilities-parity.sh
+# Exit codes:   0 = parity OK, 1 = drift detected, 2 = script error (missing inputs).
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+INSTALL_SCRIPT="$ROOT_DIR/install-skill-pack"
+DOCS="$ROOT_DIR/docs/CAPABILITIES.md"
+
+if [ ! -f "$INSTALL_SCRIPT" ]; then
+  echo "::error::install-skill-pack not found at $INSTALL_SCRIPT" >&2
+  exit 2
+fi
+if [ ! -f "$DOCS" ]; then
+  echo "::error::docs/CAPABILITIES.md not found at $DOCS" >&2
+  exit 2
+fi
+
+# (1) ALLOWED_CAPABILITIES=(... ) block from install-skill-pack.
+# Reads every non-empty, non-comment line between the opening "ALLOWED_CAPABILITIES=("
+# and the closing ")". Trims leading/trailing whitespace and strips trailing comments.
+extract_script_caps() {
+  awk '
+    /^ALLOWED_CAPABILITIES=\(/ { in_array=1; next }
+    in_array && /^\)/          { in_array=0; next }
+    in_array {
+      sub(/^[[:space:]]+/, "")
+      sub(/[[:space:]]+$/, "")
+      sub(/[[:space:]]*#.*$/, "")
+      if (length($0)) print
+    }
+  ' "$INSTALL_SCRIPT"
+}
+
+# (2) "## The taxonomy" table rows from docs/CAPABILITIES.md.
+# Each row is `| \`value\` | meaning |`; we extract the backtick-quoted value only.
+# Stops at the next "## " heading so other tables/sections can't leak in.
+extract_docs_caps() {
+  awk '
+    /^## The taxonomy/ { section=1; next }
+    section && /^## /  { section=0 }
+    section && /^\|[[:space:]]*`[a-z_]+`[[:space:]]*\|/ {
+      line=$0
+      sub(/^\|[[:space:]]*`/, "", line)
+      sub(/`.*$/,            "", line)
+      if (length(line)) print line
+    }
+  ' "$DOCS"
+}
+
+# (3) The "# Capabilities taxonomy" header comment in install-skill-pack.
+# Only the comment lines that carry the unicode-middot-separated value list are
+# extracted; any subsequent prose line (e.g. "# See docs/CAPABILITIES.md...")
+# ends the scan so we don't slurp continuation words like "proposing" as values.
+extract_comment_caps() {
+  awk '
+    /^# Capabilities taxonomy/ { found=1; next }
+    found && /·/ {
+      line=$0
+      sub(/^#[[:space:]]+/, "", line)
+      gsub(/[[:space:]]*·[[:space:]]*/, "\n", line)
+      sub(/[[:space:]]+$/, "", line)
+      print line
+      next
+    }
+    found && /^#/ && !/·/ { exit }
+    found && !/^#/        { exit }
+  ' "$INSTALL_SCRIPT" | grep -E '^[a-z_]+$' || true
+}
+
+script_sorted=$(extract_script_caps    | sort -u)
+docs_sorted=$(extract_docs_caps        | sort -u)
+comment_sorted=$(extract_comment_caps  | sort -u)
+
+mismatches=0
+
+# (a) ALLOWED_CAPABILITIES vs docs/CAPABILITIES.md taxonomy table.
+if [ "$script_sorted" != "$docs_sorted" ]; then
+  {
+    echo "::error::Capabilities taxonomy drift: install-skill-pack ALLOWED_CAPABILITIES does not match docs/CAPABILITIES.md \"The taxonomy\" table."
+    echo ""
+    echo "ALLOWED_CAPABILITIES (install-skill-pack):"
+    echo "$script_sorted" | sed 's/^/  - /'
+    echo ""
+    echo "\"The taxonomy\" (docs/CAPABILITIES.md):"
+    echo "$docs_sorted" | sed 's/^/  - /'
+    echo ""
+    echo "Only in ALLOWED_CAPABILITIES (would be accepted by installer, undocumented for operators):"
+    comm -23 <(printf '%s\n' "$script_sorted") <(printf '%s\n' "$docs_sorted") | sed 's/^/  - /'
+    echo ""
+    echo "Only in docs/CAPABILITIES.md (documented but installer would reject as unknown):"
+    comm -13 <(printf '%s\n' "$script_sorted") <(printf '%s\n' "$docs_sorted") | sed 's/^/  - /'
+    echo ""
+    echo "Fix: update both files in the same PR. See docs/CAPABILITIES.md → \"Adding a new capability\"."
+  } >&2
+  mismatches=1
+fi
+
+# (b) ALLOWED_CAPABILITIES vs the header comment that cites the same set.
+if [ "$script_sorted" != "$comment_sorted" ]; then
+  {
+    echo "::error::Capabilities taxonomy comment drift: install-skill-pack's \"# Capabilities taxonomy\" header comment lists a different set than ALLOWED_CAPABILITIES."
+    echo ""
+    echo "ALLOWED_CAPABILITIES:"
+    echo "$script_sorted" | sed 's/^/  - /'
+    echo ""
+    echo "\"# Capabilities taxonomy\" header comment:"
+    echo "$comment_sorted" | sed 's/^/  - /'
+    echo ""
+    echo "Fix: update the header comment alongside ALLOWED_CAPABILITIES so the script's own self-description stays accurate."
+  } >&2
+  mismatches=1
+fi
+
+if [ "$mismatches" -ne 0 ]; then
+  exit 1
+fi
+
+count=$(printf '%s\n' "$script_sorted" | grep -c .)
+echo "capabilities-parity: OK ($count values aligned across install-skill-pack ALLOWED_CAPABILITIES, install-skill-pack header comment, and docs/CAPABILITIES.md \"The taxonomy\")."


### PR DESCRIPTION
## What

CI workflow + script that asserts the locked 6-value capabilities taxonomy stays identical across the **three** places it currently lives:

1. `ALLOWED_CAPABILITIES` bash array in `install-skill-pack` (the runtime allow-list, lines 73-80)
2. `## The taxonomy` markdown table in `docs/CAPABILITIES.md` (the operator docs)
3. `# Capabilities taxonomy` header comment in `install-skill-pack` (cited by the script's unknown-value error message)

Any PR that touches `install-skill-pack` or `docs/CAPABILITIES.md` runs the new `ci-capabilities-parity` workflow. Drift fails the check loud with side-A / side-B / set-diff in the GitHub error annotation.

Closes #301.

## Why

Issue #301 spelled out the failure mode: with the taxonomy declared in two places (three counting the header comment), a future PR that adds a 7th value has to touch all of them atomically. A half-PR makes `install-skill-pack` either reject valid manifests or accept invalid ones, silently — and the script's own error message points operators at the docs that would be right while the script is wrong.

The issue author outlined three directions. This takes **direction #3** — the cheapest, the one they themselves called out as not requiring schema/source-of-truth decisions:

> 3. **CI parity check.** Extend the lint workflow #268 touched with a check that asserts the values in `ALLOWED_CAPABILITIES` match the rows in `CAPABILITIES.md`'s taxonomy table. Cheapest option; keeps both files but makes drift loud.

Directions #1 (JSON schema as source of truth) and #2 (generate `ALLOWED_CAPABILITIES` from a canonical source) are both real options that could land later — this CI gate doesn't preclude either. It just stops the bleeding while the taxonomy is still small enough that fixing it is a one-PR job.

## Changes

| File | Change | Lines |
|------|--------|-------|
| `scripts/check-capabilities-parity.sh` | new | +138 |
| `.github/workflows/ci-capabilities-parity.yml` | new | +41 |
| `docs/CAPABILITIES.md` | "Adding a new capability" section | +4 / -1 |

**`scripts/check-capabilities-parity.sh`** — Bash + awk extractor for each of the three locations:
- `extract_script_caps`: reads non-empty, non-comment lines between `ALLOWED_CAPABILITIES=(` and `)`.
- `extract_docs_caps`: reads `\| \`value\` \| meaning \|` rows inside the `## The taxonomy` section only; stops at the next `## ` heading so other tables can't leak in.
- `extract_comment_caps`: reads the unicode-middot-separated continuation lines under `# Capabilities taxonomy`; exits as soon as it hits a comment line without `·` (e.g. `# See docs/CAPABILITIES.md...`) so words like "proposing" from the next prose line can't be slurped as values.

Sorted-set comparison; structured `::error::` output with both sides + `comm` diff when they disagree. Exit codes: `0` OK, `1` drift, `2` input-missing.

**`.github/workflows/ci-capabilities-parity.yml`** — runs on `pull_request` and `push` to `main` with `paths:` filter on the three files + the workflow itself; also `workflow_dispatch` for ad-hoc re-runs.

**`docs/CAPABILITIES.md` "Adding a new capability" edit** — explicitly calls out both the `ALLOWED_CAPABILITIES` array AND the header comment in the "one PR" rule, and points at the new CI gate so future contributors find it before they're surprised by it.

## Test plan

- [ ] CI workflow runs on this PR (it touches all three watched files).
- [ ] Workflow passes — current main is in parity (6 values aligned).
- [ ] Manual: edit `ALLOWED_CAPABILITIES` to add `test_only`, re-run the script locally → should fail with a clear `Only in ALLOWED_CAPABILITIES: test_only` line and `Only in docs/CAPABILITIES.md: (empty)`.
- [ ] Manual: edit the docs table to add `test_only`, re-run locally → should fail symmetrically.

## What this is NOT

- Not a source-of-truth move. Both files stay where they are.
- Not a schema decision. Direction #1 (JSON schema enum) and direction #2 (generate from canonical) can still happen later.
- Not a sandbox or runtime gate. This is a build-time invariant check.

---

*Built autonomously by Aeon — `feature` skill, 2026-05-30.*