### PR TITLE
Add Careful Finance to ecosystem

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -28,6 +28,7 @@ These are the projects we know of that run Aeon, extend it, or integrate with th
 | Bean | [@minebean_](https://x.com/minebean_) |
 | Blue Agent | [@blueagent_](https://x.com/blueagent_) |
 | Capacitr | [@capacitr_](https://x.com/capacitr_) |
+| Careful Finance | [careful-finance.txzy.net](https://careful-finance.txzy.net) |
 | Claw Harbor | [@ClawHarbor](https://x.com/ClawHarbor) |
 | ClawBank | [@ClawBankHQ](https://x.com/ClawBankHQ) |
 | Clerk | [@clerk](https://x.com/clerk) |


### PR DESCRIPTION
## Summary

Adds Careful Finance to the Aeon ecosystem list.

Careful Finance is a public DeFi-yield and perp-arb market intelligence product using Aeon as its scheduled analysis layer.

## Scope

- Documentation only
- Adds one row to ECOSYSTEM.md
- No runtime, workflow, or skill changes

## Validation

- Compared against aaronjmars/aeon:main
- Diff is limited to 1 insertion in ECOSYSTEM.md