### PR TITLE
docs: add Careful Finance ecosystem listings

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -28,6 +28,7 @@ These are the projects we know of that run Aeon, extend it, or integrate with th
 | Bean | [@minebean_](https://x.com/minebean_) |
 | Blue Agent | [@blueagent_](https://x.com/blueagent_) |
 | Capacitr | [@capacitr_](https://x.com/capacitr_) |
+| Careful Finance | [@ZorrotChen](https://x.com/ZorrotChen) · [carefulfinance.txzy.net](https://carefulfinance.txzy.net/) |
 | Claw Harbor | [@ClawHarbor](https://x.com/ClawHarbor) |
 | ClawBank | [@ClawBankHQ](https://x.com/ClawBankHQ) |
 | Clerk | [@clerk](https://x.com/clerk) |

--- a/SHOWCASE.md
+++ b/SHOWCASE.md
@@ -22,6 +22,7 @@ A snapshot of the operators currently running their own Aeon instance. "Active" 
 | [davenamovich/aeon](https://github.com/davenamovich/aeon) | 3 | A small, deliberate selection — uses Aeon as a low-touch personal automation. |
 | [0xfreddy/aeon](https://github.com/0xfreddy/aeon) | 2 | Ships a fork-only custom skill (`macos-apps`) alongside heartbeat — first fork to add a local-context skill that doesn't exist upstream. |
 | [pezetel/aeon](https://github.com/pezetel/aeon) | 2 | `heartbeat` + `github-trending` — a focused dev-pulse instance. The first fork to break `github-trending` out of the long tail. |
+| [UIZorrot/aeon](https://github.com/UIZorrot/aeon) | 1 | Careful Finance fork - uses Aeon/GitHub Actions as the scheduled market-analysis layer behind a public DeFi-yield and perp-arb ChatUI. |
 
 The full ranking — including the per-week skill-divergence buckets and the contributor leaderboard — is regenerated every Sunday by the `fork-skill-digest` and `fork-contributor-leaderboard` skills, with the latest output published to [`articles/`](articles/).
 


### PR DESCRIPTION
Adds Careful Finance to the Aeon ecosystem surfaces.

## Why this belongs here

Careful Finance is a public DeFi-yield and perp-arb market intelligence product using Aeon/GitHub Actions as its scheduled market-analysis layer.

This PR follows the split described in the docs:

- `ECOSYSTEM.md` for products and agents built with or extending Aeon
- `SHOWCASE.md` for active Aeon forks in the wild
- Community skill packs are intentionally not included here because the installable Careful Finance skill pack has not been published as a standalone public repo yet

## Rows added

```md
| Careful Finance | [@ZorrotChen](https://x.com/ZorrotChen) · [carefulfinance.txzy.net](https://carefulfinance.txzy.net/) |
| [UIZorrot/aeon](https://github.com/UIZorrot/aeon) | 1 | Careful Finance fork - uses Aeon/GitHub Actions as the scheduled market-analysis layer behind a public DeFi-yield and perp-arb ChatUI. |
```

## Compliance with file guidelines

- Alphabetized in `ECOSYSTEM.md`
- Provides X handle + public website link
- One row per project in `ECOSYSTEM.md`
- SHOWCASE row points to the active fork
- Documentation only: no runtime, workflow, skill, or registry changes

## Validation

- Compared against `aaronjmars/aeon:main`
- Diff is limited to 2 insertions across `ECOSYSTEM.md` and `SHOWCASE.md`