### PR TITLE
registry: add MandateSeal Guard pack (distribute-tokens-guarded)

### DIFF
--- a/skill-packs.json
+++ b/skill-packs.json
@@ -206,6 +206,18 @@
       "category": "messaging",
       "trust_level": "community",
       "skills": ["signa-message", "signa-inbox", "signa-discover", "signa-broadcast", "signa-delegate", "bankr-resolve", "bankr-launches", "gitlawb-stats", "miroshark-stats", "miroshark-fire"]
+    },
+    {
+      "repo": "mandateseal/mandateseal-guard",
+      "path": "aeon",
+      "name": "MandateSeal Guard",
+      "description": "Guard Aeon fund-moving skills with a MandateSeal mandate before each transfer (per-tx cap, chain/token allow-list, blocked recipients, human-approval queue) and a signed, Base-anchored receipt after — bounded, gated, provable.",
+      "author": "mandateseal",
+      "license": "MIT",
+      "homepage": "https://mandateseal.tech",
+      "category": "crypto",
+      "trust_level": "community",
+      "skills": ["distribute-tokens-guarded"]
     }
   ]
 }


### PR DESCRIPTION
Lands the registry entry from #295 (by @mandateseal) as a **minimal one-entry diff** to `skill-packs.json`, dropping the whole-file single→multi-line reformat that #295 carried (which conflicted with #270).

**Pack:** `mandateseal/mandateseal-guard` (path: `aeon`) — community trust, one skill `distribute-tokens-guarded`: a guarded variant of `distribute-tokens` that routes each Bankr transfer through a MandateSeal mandate (per-tx cap, allow-list, blocked recipients, human-approval queue) and executes APPROVED rows only. Scanned at install like any community pack.

Verified the upstream repo ships `aeon/skills/distribute-tokens-guarded/SKILL.md`. Closes #295.

🤖 Generated with [Claude Code](https://claude.com/claude-code)