### PR TITLE
Add Atrium Skills to the community skill-pack registry

### DIFF
--- a/skill-packs.json
+++ b/skill-packs.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "updated": "2026-05-27",
+  "updated": "2026-06-01",
   "description": "Machine-readable registry of community skill packs installable via ./install-skill-pack. Mirrors the human-readable table in README.md.",
   "packs": [
     {
@@ -218,6 +218,17 @@
       "category": "crypto",
       "trust_level": "community",
       "skills": ["distribute-tokens-guarded"]
+    },
+    {
+      "repo": "Atrium-Hermes/aeon-atrium-skills",
+      "name": "Atrium Skills",
+      "description": "Publish, monetize & discover agent skills on Atrium — the onchain skill marketplace on Base. atrium-publish turns evolving skills into DID-signed, IPFS-pinned, USDC-earning assets (with royalty lineage to prior versions); atrium-scout rents skills that match open loops; atrium-earnings tracks and withdraws creator USDC.",
+      "author": "Atrium-Hermes",
+      "license": "MIT",
+      "homepage": "https://atriumhermes.tech",
+      "category": "crypto",
+      "trust_level": "community",
+      "skills": ["atrium-publish", "atrium-scout", "atrium-earnings"]
     }
   ]
 }


### PR DESCRIPTION
Adds **Atrium Skills** (`Atrium-Hermes/aeon-atrium-skills`) to the community
registry — a skill pack that lets an Aeon agent publish, monetize, and discover
agent skills on [Atrium](https://atriumhermes.tech), the onchain skill marketplace
on **Base mainnet**.

### What's in the pack
- **atrium-publish** — turn the skills your agent creates/evolves into DID-signed,
  IPFS-pinned, USDC-priced Atrium skills that earn per call. Declares the prior
  version as a royalty parent, so an evolving skill keeps its lineage (the
  "earn from what you learn" loop — pairs directly with Aeon's self-improve).
- **atrium-scout** — search Atrium for skills matching the agent's open loops /
  goals and recommend (or, if enabled, invoke) what's worth renting. Read-only by
  default via the public indexer.
- **atrium-earnings** — track creator earnings, withdraw USDC over a threshold,
  fold it into the brief.

### Conventions
Follows the pack format (`skills-pack.json` + `skills/<slug>/SKILL.md`) and the
core skill conventions (frontmatter, memory reads, graceful bootstrap, modes,
operator-opt-in, notify). Onchain actions are gated on an `ATRIUM_PRIVATE_KEY`
secret; discovery needs no key. Capabilities self-declared
(`onchain_writes`, `external_api`, `read_only`, `sends_notifications`).

Atrium is live + verified on Base mainnet (registry
`0xA713c88927523279B874640003Ed697e509732a7`); USDC settlement, no token required
to use it. Precedent for onchain-USDC packs: AntFleet, LiquidPad, luca.

### Changes
- `skill-packs.json`: add the `Atrium-Hermes/aeon-atrium-skills` entry.
- `README.md`: add the matching table row (below).

======================================================
| [Atrium Skills](https://github.com/Atrium-Hermes/aeon-atrium-skills) | Atrium-Hermes | crypto | Publish, monetize & discover agent skills on Atrium (onchain marketplace, Base) — `atrium-publish` / `atrium-scout` / `atrium-earnings` |