### PR TITLE
Add HivemindOS to ecosystem

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -37,6 +37,7 @@ These are the projects we know of that run Aeon, extend it, or integrate with th
 | GitBounty | [@Gitlawbounty](https://x.com/Gitlawbounty) |
 | GitKernal | [@gitkernal](https://x.com/gitkernal) |
 | Gitlawb Terminal | [@Gitlawbterminal](https://x.com/Gitlawbterminal) |
+| HivemindOS | [repo](https://github.com/LiamVisionary/hivemindos) · [Bankr launch](https://bankr.bot/launches/0xa382c83e2a3b79368f372c2eb9b6925ffaf45ba3) |
 | Hound Flow | [@HoundFlow_](https://x.com/HoundFlow_) · [houndflow.com](https://houndflow.com) |
 | LawbWorld | [@LawbWorld](https://x.com/LawbWorld) |
 | LiquidPad | [@LiquidPadBot](https://x.com/LiquidPadBot) · [liquidpad.site](https://www.liquidpad.site) |

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -37,7 +37,7 @@ These are the projects we know of that run Aeon, extend it, or integrate with th
 | GitBounty | [@Gitlawbounty](https://x.com/Gitlawbounty) |
 | GitKernal | [@gitkernal](https://x.com/gitkernal) |
 | Gitlawb Terminal | [@Gitlawbterminal](https://x.com/Gitlawbterminal) |
-| HivemindOS | [website](https://hivemindos.liamvisionary.com) · [@thehivemindos](https://x.com/thehivemindos) · [@0xliamvisionary](https://x.com/0xliamvisionary) · [repo](https://github.com/LiamVisionary/hivemindos) · [Bankr launch](https://bankr.bot/launches/0xa382c83e2a3b79368f372c2eb9b6925ffaf45ba3) |
+| HivemindOS | [@thehivemindos](https://x.com/thehivemindos) · [hivemindos.liamvisionary.com](https://hivemindos.liamvisionary.com) |
 | Hound Flow | [@HoundFlow_](https://x.com/HoundFlow_) · [houndflow.com](https://houndflow.com) |
 | LawbWorld | [@LawbWorld](https://x.com/LawbWorld) |
 | LiquidPad | [@LiquidPadBot](https://x.com/LiquidPadBot) · [liquidpad.site](https://www.liquidpad.site) |

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -37,7 +37,7 @@ These are the projects we know of that run Aeon, extend it, or integrate with th
 | GitBounty | [@Gitlawbounty](https://x.com/Gitlawbounty) |
 | GitKernal | [@gitkernal](https://x.com/gitkernal) |
 | Gitlawb Terminal | [@Gitlawbterminal](https://x.com/Gitlawbterminal) |
-| HivemindOS | [repo](https://github.com/LiamVisionary/hivemindos) · [Bankr launch](https://bankr.bot/launches/0xa382c83e2a3b79368f372c2eb9b6925ffaf45ba3) |
+| HivemindOS | [website](https://hivemindos.liamvisionary.com) · [@thehivemindos](https://x.com/thehivemindos) · [@0xliamvisionary](https://x.com/0xliamvisionary) · [repo](https://github.com/LiamVisionary/hivemindos) · [Bankr launch](https://bankr.bot/launches/0xa382c83e2a3b79368f372c2eb9b6925ffaf45ba3) |
 | Hound Flow | [@HoundFlow_](https://x.com/HoundFlow_) · [houndflow.com](https://houndflow.com) |
 | LawbWorld | [@LawbWorld](https://x.com/LawbWorld) |
 | LiquidPad | [@LiquidPadBot](https://x.com/LiquidPadBot) · [liquidpad.site](https://www.liquidpad.site) |


### PR DESCRIPTION
## Summary

Adds HivemindOS to the Aeon ecosystem list.

HivemindOS is a local-first control room for private agent fleets, with Aeon runtime support for schedules, runs, outputs, memory, and shared skills.

## Links

- Website: https://hivemindos.liamvisionary.com
- X: https://x.com/thehivemindos
- Dev X: https://x.com/0xliamvisionary
- Repo: https://github.com/LiamVisionary/hivemindos
- Bankr launch: https://bankr.bot/launches/0xa382c83e2a3b79368f372c2eb9b6925ffaf45ba3

## Verification

- Checked the ecosystem table remains alphabetized.