### PR TITLE
List Echo Oracle in ecosystem

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -33,6 +33,7 @@ These are the projects we know of that run Aeon, extend it, or integrate with th
 | ClawBank | [@ClawBankHQ](https://x.com/ClawBankHQ) |
 | Clerk | [@clerk](https://x.com/clerk) |
 | Cobot | [@cobotgg](https://x.com/cobotgg) |
+| Echo Oracle | [@BuiltByEcho](https://x.com/BuiltByEcho) · [builtbyecho.xyz](https://www.builtbyecho.xyz/) |
 | GitBlock | [@gitblock_](https://x.com/gitblock_) |
 | GitBounty | [@Gitlawbounty](https://x.com/Gitlawbounty) |
 | GitKernal | [@gitkernal](https://x.com/gitkernal) |


### PR DESCRIPTION
Adds Echo Oracle to the Aeon ecosystem list as the active BuiltByEcho project tied to the MiroShark/Aeon ecosystem.