### PR TITLE
chore(skills): Phase 1 capabilities frontmatter for high-blast-radius skills (#317)

### DIFF
--- a/skills/approval-audit/SKILL.md
+++ b/skills/approval-audit/SKILL.md
@@ -3,6 +3,7 @@ name: Approval Audit
 description: List a wallet's live ERC-20 token approvals on Base and flag unlimited / risky spender grants. Keyless via Base RPC (eth_getLogs + eth_call) — no explorer key needed.
 var: ""
 tags: [crypto, security, base]
+capabilities: [read_only, sends_notifications]
 ---
 > **${var}** — Wallet address (`0x...`) on Base to audit. Required. If empty, log `APPROVAL_AUDIT_NO_TARGET` and exit cleanly (no notify).
 

--- a/skills/contract-audit/SKILL.md
+++ b/skills/contract-audit/SKILL.md
@@ -3,6 +3,7 @@ name: Contract Audit
 description: Audit any contract on Base — verification, proxy/upgradeability, ownership/admin roles, and mint/freeze/pause/drain powers as a live capability matrix. Keyless via Etherscan v2 + Base RPC.
 var: ""
 tags: [crypto, security, base]
+capabilities: [external_api, sends_notifications]
 ---
 > **${var}** — Contract address (`0x...`) on Base to audit. Required. If empty, log `AUDIT_NO_TARGET` and exit cleanly (no notify).
 

--- a/skills/deployer-trace/SKILL.md
+++ b/skills/deployer-trace/SKILL.md
@@ -3,6 +3,7 @@ name: Deployer Trace
 description: Map every contract deployed by an address on Base, link reused patterns, and surface serial-rug signals. Keyless via Etherscan v2 + Base RPC.
 var: ""
 tags: [crypto, security, base]
+capabilities: [external_api, sends_notifications]
 ---
 > **${var}** — Deployer address (`0x...`) on Base. Required. May also be a token address — its creator is resolved first. If empty, log `DEPLOYER_TRACE_NO_TARGET` and exit cleanly (no notify).
 

--- a/skills/distribute-tokens/SKILL.md
+++ b/skills/distribute-tokens/SKILL.md
@@ -3,6 +3,7 @@ name: Distribute Tokens
 description: Send tokens to a list of contributors via Bankr Wallet API with per-recipient idempotency, two-phase resolve→execute, dry-run, and recovery from partial runs
 var: ""
 tags: [crypto]
+capabilities: [external_api, writes_external_host, onchain_writes, sends_notifications]
 ---
 <!-- autoresearch: variation C — robustness via per-recipient idempotency state, two-phase resolve→execute, dry-run, retries, 403/429 handling, recovery -->
 

--- a/skills/fund-flow/SKILL.md
+++ b/skills/fund-flow/SKILL.md
@@ -3,6 +3,7 @@ name: Fund Flow
 description: Trace where funds move to (or came from) across multiple hops from a Base address and render a Mermaid flow graph. Keyless — no explorer key needed.
 var: ""
 tags: [crypto, security, base]
+capabilities: [read_only, sends_notifications]
 ---
 > **${var}** — Address (`0x...`) on Base to trace. Required. If empty, log `FUNDFLOW_NO_TARGET` and exit cleanly (no notify).
 

--- a/skills/holder-concentration/SKILL.md
+++ b/skills/holder-concentration/SKILL.md
@@ -3,6 +3,7 @@ name: Holder Concentration
 description: Analyze token holder distribution on Base — top-N share, HHI concentration, LP/lock/burn exclusions, and whale clusters. Keyless via Etherscan v2 + Base RPC.
 var: ""
 tags: [crypto, security, base]
+capabilities: [external_api, sends_notifications]
 ---
 > **${var}** — Token contract address (`0x...`) on Base. Required. If empty, log `HOLDER_CONC_NO_TARGET` and exit cleanly (no notify).
 

--- a/skills/honeypot-check/SKILL.md
+++ b/skills/honeypot-check/SKILL.md
@@ -3,6 +3,7 @@ name: Honeypot Check
 description: Detect un-sellable / restricted (honeypot) tokens on Base by simulating a real holder's sell via eth_call. Keyless — no explorer key needed.
 var: ""
 tags: [crypto, security, base]
+capabilities: [read_only, sends_notifications]
 ---
 > **${var}** — Token contract address (`0x...`) on Base to check. Required. If empty, log `HONEYPOT_NO_TARGET` and exit cleanly (no notify).
 

--- a/skills/investigation-report/SKILL.md
+++ b/skills/investigation-report/SKILL.md
@@ -3,6 +3,7 @@ name: Investigation Report
 description: One-shot composite investigation of a Base token — runs rug-scan, contract-audit, deployer-trace and holder-concentration and merges them into a single report with an at-a-glance verdict. Keyless core; a Basescan key deepens it.
 var: ""
 tags: [crypto, security, base]
+capabilities: [external_api, sends_notifications]
 ---
 > **${var}** — Token contract address (`0x...`) on Base to investigate. Required. If empty, log `REPORT_NO_TARGET` and exit cleanly (no notify).
 

--- a/skills/linked-wallets/SKILL.md
+++ b/skills/linked-wallets/SKILL.md
@@ -3,6 +3,7 @@ name: Linked Wallets
 description: Cluster addresses likely controlled by the same entity on Base via shared-funder and co-spend heuristics. Keyless — no explorer key needed.
 var: ""
 tags: [crypto, security, base]
+capabilities: [read_only, sends_notifications]
 ---
 > **${var}** — Address (`0x...`) on Base to investigate. Required. If empty, log `LINKED_NO_TARGET` and exit cleanly (no notify).
 

--- a/skills/liquidpad-launch/SKILL.md
+++ b/skills/liquidpad-launch/SKILL.md
@@ -3,6 +3,7 @@ name: LiquidPad Launch
 description: Emit a LiquidPad token deploy payload through the prefetch/postprocess shim pair. Routes 80% fees to deployer, 15% to LPAD burn, 5% to LIQ buyback, contract-enforced.
 var: ""
 tags: [defi, base, launchpad, token-launch]
+capabilities: [external_api, writes_external_host, onchain_writes, sends_notifications]
 ---
 
 > **${var}** — Token concept (free-form vibe ≥ 6 chars, or a JSON object with `{name, symbol, theme}`). If empty, the skill derives a vibe from `memory/MEMORY.md` and `memory/topics/`.

--- a/skills/lp-lock-check/SKILL.md
+++ b/skills/lp-lock-check/SKILL.md
@@ -3,6 +3,7 @@ name: LP Lock Check
 description: Resolve a token's main liquidity pool on Base and classify whether its LP is burned/locked or removable (rug-pull risk). Keyless — no explorer key needed.
 var: ""
 tags: [crypto, security, base]
+capabilities: [read_only, sends_notifications]
 ---
 > **${var}** — Token contract address (`0x...`) on Base to check. Required. If empty, log `LPLOCK_NO_TARGET` and exit cleanly (no notify).
 

--- a/skills/on-chain-monitor/SKILL.md
+++ b/skills/on-chain-monitor/SKILL.md
@@ -3,6 +3,7 @@ name: On-Chain Monitor
 description: Monitor blockchain addresses and contracts for notable activity
 var: ""
 tags: [crypto]
+capabilities: [external_api, sends_notifications]
 ---
 <!-- autoresearch: variation B — sharper output (decoded transfers + counterparty labels + ranked USD-denominated one-liners + TL;DR lede); folds in A's Alchemy+Etherscan-v2 input path and C's persistent state + source-status footer + dedup. -->
 

--- a/skills/rug-scan/SKILL.md
+++ b/skills/rug-scan/SKILL.md
@@ -3,6 +3,7 @@ name: Rug Scan
 description: Assess rug-pull risk for any token on Base — ownership, mint/freeze powers, LP lock, and holder concentration rolled into one risk verdict. Keyless via Etherscan v2 + Base RPC.
 var: ""
 tags: [crypto, security, base]
+capabilities: [external_api, sends_notifications]
 ---
 > **${var}** — Token contract address (`0x...`) on Base to scan. Required. If empty, log `RUG_SCAN_NO_TARGET` and exit cleanly (no notify).
 

--- a/skills/token-alert/SKILL.md
+++ b/skills/token-alert/SKILL.md
@@ -3,6 +3,7 @@ name: Token Alert
 description: Notify on price or volume anomalies for tracked tokens
 var: ""
 tags: [crypto]
+capabilities: [external_api, sends_notifications]
 ---
 > **${var}** — Token symbol or CoinGecko ID. If empty, checks all tracked tokens.
 

--- a/skills/token-movers/SKILL.md
+++ b/skills/token-movers/SKILL.md
@@ -3,6 +3,7 @@ name: Token Movers
 description: Top movers, losers, and trending coins from CoinGecko — with signal enrichment and pump-risk flags
 var: ""
 tags: [crypto]
+capabilities: [external_api, sends_notifications]
 ---
 <!-- autoresearch: variation B — sharper output: enrich each mover with context, score signals, flag pump risk, add market commentary -->
 

--- a/skills/token-pick/SKILL.md
+++ b/skills/token-pick/SKILL.md
@@ -3,6 +3,7 @@ name: Token Pick
 description: One token recommendation and one prediction market pick — scored, quantified, with a skip branch when signals are weak
 var: ""
 tags: [crypto]
+capabilities: [external_api, sends_notifications]
 ---
 <!-- autoresearch: variation B — sharper output via signal scoring, edge calculation, conviction tiers, and a skip-day branch -->
 

--- a/skills/token-report/SKILL.md
+++ b/skills/token-report/SKILL.md
@@ -3,6 +3,7 @@ name: token-report
 description: Daily price performance report for the project's token — price, volume, liquidity, and context
 var: ""
 tags: [crypto]
+capabilities: [external_api]
 ---
 <!-- autoresearch: variation B — verdict-first template, threshold-based classification, true deltas from persistent STATE log, skip-when-empty sections -->
 

--- a/skills/tx-explain/SKILL.md
+++ b/skills/tx-explain/SKILL.md
@@ -3,6 +3,7 @@ name: Tx Explain
 description: Decode any Base transaction into a plain-English story — method, token movements, swaps/approvals, counterparties, and suspicious-approval flags. Keyless via Base RPC + Etherscan v2.
 var: ""
 tags: [crypto, base]
+capabilities: [external_api, sends_notifications]
 ---
 > **${var}** — Transaction hash (`0x...`, 66 chars) on Base. Required. If empty, log `TX_EXPLAIN_NO_TARGET` and exit cleanly (no notify).
 

--- a/skills/wallet-profile/SKILL.md
+++ b/skills/wallet-profile/SKILL.md
@@ -3,6 +3,7 @@ name: Wallet Profile
 description: Behavioral profile of any wallet on Base — age, activity class (bot/whale/sniper/trader), funding source, top counterparties, and risk flags. Keyless via Etherscan v2 + Base RPC.
 var: ""
 tags: [crypto, base]
+capabilities: [external_api, sends_notifications]
 ---
 > **${var}** — Wallet address (`0x...`) on Base to profile. Required. If empty, log `WALLET_PROFILE_NO_TARGET` and exit cleanly (no notify).
 


### PR DESCRIPTION
## Summary

Phase 1 of #317: declare `capabilities:` frontmatter on the highest-blast-radius first-party skills, so `capabilities-map` has a real declaration base. Combined with #319 (the undeclared-baseline gate), the next scheduled run transitions from `UNDECLARED_BASELINE` to live gap analysis (`became_assessable`) instead of a misleading all-gaps report.

19 skills, frontmatter only — no logic, no schema change, no `aeon.yml`/`skills.json`/`docs` touched (so the `ci-capabilities-parity` check isn't implicated). Each declaration uses the inline-array form the `capabilities-map` parser reads (`capabilities: [a, b]`), placed right after `tags:`.

## Classifications

| Skill | capabilities |
|-------|--------------|
| `liquidpad-launch` | `external_api, writes_external_host, onchain_writes, sends_notifications` |
| `distribute-tokens` | `external_api, writes_external_host, onchain_writes, sends_notifications` |
| `on-chain-monitor` | `external_api, sends_notifications` |
| `rug-scan` | `external_api, sends_notifications` |
| `contract-audit` | `external_api, sends_notifications` |
| `tx-explain` | `external_api, sends_notifications` |
| `deployer-trace` | `external_api, sends_notifications` |
| `holder-concentration` | `external_api, sends_notifications` |
| `wallet-profile` | `external_api, sends_notifications` |
| `investigation-report` | `external_api, sends_notifications` |
| `honeypot-check` | `read_only, sends_notifications` |
| `lp-lock-check` | `read_only, sends_notifications` |
| `linked-wallets` | `read_only, sends_notifications` |
| `fund-flow` | `read_only, sends_notifications` |
| `approval-audit` | `read_only, sends_notifications` |
| `token-report` | `external_api` |
| `token-alert` | `external_api, sends_notifications` |
| `token-movers` | `external_api, sends_notifications` |
| `token-pick` | `external_api, sends_notifications` |

## Methodology (and where it differs from the issue's proposed table)

Applied `docs/CAPABILITIES.md` §"How to choose" against each skill's actual behavior (verified by reading frontmatter + the data-source calls + the `./notify` steps), not a blanket tag:

1. **`writes_external_host` added to the two fund-movers.** `liquidpad-launch` POSTs a deploy to LiquidPad's API and `distribute-tokens` POSTs transfers to the Bankr Wallet API — both modify external state, so per the doc they get `external_api` + `writes_external_host` + `onchain_writes`, not just `onchain_writes`.
2. **`sends_notifications` added wherever `./notify` is actually called.** The Hound suite conditionally notifies (e.g. rug-scan "Notify only if verdict ≥ ELEVATED"), as do the alert/movers/pick skills — verified per file. `token-report` writes an article and does **not** call `./notify`, so it's `external_api` only.
3. **`read_only` reserved for pure-RPC readers.** `honeypot-check`, `lp-lock-check`, `linked-wallets`, `fund-flow`, `approval-audit` read only via Base RPC (`eth_call`/`eth_getLogs`) — on-chain reads, which the doc classifies as `read_only`. Skills that hit a third-party indexer API (Etherscan v2 / CoinGecko / DexScreener) are `external_api` per the doc's CoinGecko example, not `read_only`.

## Verification

- Format matches the `capabilities-map` step-4 parser (`^capabilities:[[:space:]]*\[`).
- All values are in the locked 6-value taxonomy (`install-skill-pack` allow-list).
- No file outside `skills/*/SKILL.md` touched.

Phase 2 (the long-tail `external_api`/`sends_notifications`/`read_only` annotations across the rest of the catalog) can follow separately.

Closes #317.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
