### PR TITLE
Add VIGIL: Onchain security scanner for Base (MCP server)

### DIFF
--- a/skills/vigil/SKILL.md
+++ b/skills/vigil/SKILL.md
@@ -34,170 +34,111 @@ Read the last 2 days of `memory/logs/` so a repeat scan can note newly-granted o
 
 ## Steps
 
-### 1. Determine target type
+### 1. Validate input (strict — rejects injection)
+
+The target MUST be exactly `0x` followed by 40 hex characters. The regex
+below rejects any input containing quotes, spaces, or shell metacharacters,
+so it is safe to interpolate into the JSON payloads in later steps. Reject
+anything else and exit cleanly.
 
 ```bash
 TARGET="${var}"
-if [ ${#TARGET} -eq 42 ] && [[ "$TARGET" == 0x* ]]; then
-  # Could be wallet or token — try wallet scan first
-  TARGET_TYPE="wallet"
-else
-  echo "Invalid address: $TARGET"
+
+# Strict allowlist: 0x + exactly 40 hex chars. Nothing else can pass.
+if ! printf '%s' "$TARGET" | grep -qiE '^0x[0-9a-f]{40}$'; then
+  echo "VIGIL_INVALID_TARGET: not a valid 0x address"
   exit 0
 fi
+
+# Normalise to lowercase for consistent calls.
+TARGET="$(printf '%s' "$TARGET" | tr '[:upper:]' '[:lower:]')"
+```
+
+Because `$TARGET` is now guaranteed to match `^0x[0-9a-f]{40}$`, it contains
+no characters that could break the JSON body or the shell. A single address
+can be either a wallet or a token contract, so run the relevant tools and
+read each tool's own result — do not assume a type up front.
+
+### 1b. Safe call helper (checks errors before reading results)
+
+Every step below uses this helper. It fails loudly on a non-200 HTTP status
+or a JSON-RPC `error` body instead of silently passing `null` to `jq`, so a
+broken call is never reported as a clean scan.
+
+```bash
+VIGIL_API="https://mcp.vigil.codes/tools/call"
+
+vigil_call () {
+  # $1 = tool name, $2 = JSON arguments object
+  local name="$1" args="$2" body http code
+  body=$(curl -m 30 -s -w '\n%{http_code}' "$VIGIL_API" \
+    -H "Content-Type: application/json" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"$name\",\"arguments\":$args}}")
+  code=$(printf '%s' "$body" | tail -n1)
+  http=$(printf '%s' "$body" | sed '$d')
+
+  if [ "$code" != "200" ]; then
+    echo "VIGIL_HTTP_ERROR ($code) calling $name"; return 1
+  fi
+  if printf '%s' "$http" | jq -e '.error' >/dev/null 2>&1; then
+    echo "VIGIL_RPC_ERROR: $(printf '%s' "$http" | jq -c '.error')"; return 1
+  fi
+  printf '%s' "$http" | jq '.result'
+}
 ```
 
 ### 2. Scan approvals (wallet)
 
 ```bash
-RESULT=$(curl -m 30 -s "https://mcp.vigil.codes/tools/call" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "jsonrpc": "2.0",
-    "id": 1,
-    "method": "tools/call",
-    "params": {
-      "name": "scan_approvals",
-      "arguments": {"wallet": "'"$TARGET"'", "chain": "base"}
-    }
-  }')
-echo "$RESULT" | jq '.result'
+vigil_call scan_approvals '{"wallet": "'"$TARGET"'", "chain": "base"}'
 ```
 
 ### 3. Scan token safety
 
 ```bash
-RESULT=$(curl -m 30 -s "https://mcp.vigil.codes/tools/call" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "jsonrpc": "2.0",
-    "id": 1,
-    "method": "tools/call",
-    "params": {
-      "name": "scan_token",
-      "arguments": {"token": "'"$TARGET"'", "chain": "base"}
-    }
-  }')
-echo "$RESULT" | jq '.result'
+vigil_call scan_token '{"token": "'"$TARGET"'", "chain": "base"}'
 ```
 
 ### 4. Check honeypot
 
 ```bash
-RESULT=$(curl -m 30 -s "https://mcp.vigil.codes/tools/call" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "jsonrpc": "2.0",
-    "id": 1,
-    "method": "tools/call",
-    "params": {
-      "name": "detect_honeypot",
-      "arguments": {"token": "'"$TARGET"'", "chain": "base"}
-    }
-  }')
-echo "$RESULT" | jq '.result'
+vigil_call detect_honeypot '{"token": "'"$TARGET"'", "chain": "base"}'
 ```
 
 ### 5. Get safety score
 
 ```bash
-RESULT=$(curl -m 30 -s "https://mcp.vigil.codes/tools/call" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "jsonrpc": "2.0",
-    "id": 1,
-    "method": "tools/call",
-    "params": {
-      "name": "safety_score",
-      "arguments": {"contract": "'"$TARGET"'", "chain": "base"}
-    }
-  }')
-echo "$RESULT" | jq '.result'
+vigil_call safety_score '{"contract": "'"$TARGET"'", "chain": "base"}'
 ```
 
 ### 6. Generate wallet report
 
 ```bash
-RESULT=$(curl -m 30 -s "https://mcp.vigil.codes/tools/call" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "jsonrpc": "2.0",
-    "id": 1,
-    "method": "tools/call",
-    "params": {
-      "name": "wallet_report",
-      "arguments": {"wallet": "'"$TARGET"'", "chain": "base"}
-    }
-  }')
-echo "$RESULT" | jq '.result'
+vigil_call wallet_report '{"wallet": "'"$TARGET"'", "chain": "base"}'
 ```
 
 ### 7. Monitor wallet (real-time alerts)
 
 ```bash
-RESULT=$(curl -m 30 -s "https://mcp.vigil.codes/tools/call" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "jsonrpc": "2.0",
-    "id": 1,
-    "method": "tools/call",
-    "params": {
-      "name": "monitor_wallet",
-      "arguments": {"wallet": "'"$TARGET"'", "chain": "base", "lookback_blocks": 1000}
-    }
-  }')
-echo "$RESULT" | jq '.result'
+vigil_call monitor_wallet '{"wallet": "'"$TARGET"'", "chain": "base", "lookback_blocks": 1000}'
 ```
 
 ### 8. Token market context (price + liquidity)
 
 ```bash
-RESULT=$(curl -m 30 -s "https://mcp.vigil.codes/tools/call" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "jsonrpc": "2.0",
-    "id": 1,
-    "method": "tools/call",
-    "params": {
-      "name": "token_market",
-      "arguments": {"token": "'"$TARGET"'", "chain": "base"}
-    }
-  }')
-echo "$RESULT" | jq '.result'
+vigil_call token_market '{"token": "'"$TARGET"'", "chain": "base"}'
 ```
 
 ### 9. Deployer reputation (verification + age)
 
 ```bash
-RESULT=$(curl -m 30 -s "https://mcp.vigil.codes/tools/call" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "jsonrpc": "2.0",
-    "id": 1,
-    "method": "tools/call",
-    "params": {
-      "name": "deployer_check",
-      "arguments": {"contract": "'"$TARGET"'", "chain": "base"}
-    }
-  }')
-echo "$RESULT" | jq '.result'
+vigil_call deployer_check '{"contract": "'"$TARGET"'", "chain": "base"}'
 ```
 
 ### 10. Batch scan multiple tokens
 
 ```bash
-RESULT=$(curl -m 30 -s "https://mcp.vigil.codes/tools/call" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "jsonrpc": "2.0",
-    "id": 1,
-    "method": "tools/call",
-    "params": {
-      "name": "batch_scan",
-      "arguments": {"tokens": ["0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"], "chain": "base"}
-    }
-  }')
-echo "$RESULT" | jq '.result'
+vigil_call batch_scan '{"tokens": ["'"$TARGET"'"], "chain": "base"}'
 ```
 
 ## Output Format

--- a/skills/vigil/SKILL.md
+++ b/skills/vigil/SKILL.md
@@ -1,85 +1,142 @@
 ---
 name: VIGIL Security Scanner
-description: Onchain security scanner on Base — scan token approvals, detect honeypots, analyze contracts for rugpull indicators, score contract safety, and revoke dangerous approvals via MCP server.
+description: Onchain security scanner on Base — scan token approvals, detect honeypots, analyze contracts for rugpull indicators, and score contract safety. Keyless read-only scanning via VIGIL API. Revoke actions require Bankr auth and are gated separately.
 var: ""
 tags: [crypto, security, base, defi]
-capabilities: [read_only, sends_notifications, mcp]
+capabilities: [external_api, sends_notifications]
 ---
-> **${var}** — Wallet address (`0x...`) or token address on Base to scan. If empty, scan all connected wallets.
+> **${var}** — Wallet address (`0x...`) or token contract address on Base to scan. Required. If empty, log `VIGIL_NO_TARGET` and exit cleanly (no notify).
 
-VIGIL is an agent-based MCP security server for DeFi traders on Base. It provides six security tools:
+VIGIL is an onchain security scanner for DeFi traders on Base. It provides five read-only scanning tools and one write action (revoke) that requires explicit Bankr authentication.
 
-1. **Approval Scanner** — List all ERC-20/ERC-721 approvals, flag unlimited allowances, identify risky spenders
-2. **Token Scanner** — Analyze contracts for rugpull indicators (hidden mint, proxy patterns, tax manipulation, blacklist)
-3. **Honeypot Detector** — Simulate buy/sell to detect tokens that block selling
-4. **Safety Score** — 0-100 rating based on code analysis, ownership, liquidity, holder distribution
-5. **Approval Revoker** — Revoke dangerous approvals via Bankr transaction signing
-6. **Wallet Report** — Full security posture assessment
+**Read-only tools (this skill):**
+1. Approval Scanner — list all ERC-20/ERC-721 approvals, flag unlimited allowances
+2. Token Scanner — analyze contracts for rugpull indicators (hidden mint, proxy, tax manipulation, blacklist)
+3. Honeypot Detector — simulate buy/sell to detect trap tokens
+4. Safety Score — 0-100 composite rating based on code, ownership, liquidity, holders
+5. Wallet Report — full security posture assessment
+
+**Write action (separate, not included here):**
+6. Approval Revoker — revoke dangerous approvals via Bankr transaction signing. This is a state-changing onchain transaction and is NOT part of this read-only skill.
+
+Read the last 2 days of `memory/logs/` so a repeat scan can note newly-granted or newly-revoked approvals.
 
 ## Config
 
 - Target = `${var}`. Can be a wallet address or token contract address.
-- Chain = Base (`chainid=8453`).
-- MCP endpoint: `http://143.198.220.27:3100/sse` (SSE transport)
+- Chain = Base (`chainid=8453`, explorer `basescan.org`).
+- VIGIL API: `https://mcp.vigil.codes` (HTTPS, SSE transport)
 - GitHub: `https://github.com/vigilcodes/vigil-mcp`
 
 ## Steps
 
-### 1. Scan approvals
-
-If `${var}` is a wallet address (starts with `0x`, 42 chars):
+### 1. Determine target type
 
 ```bash
-WALLET="${var}"
-curl -s "http://143.198.220.27:3100/sse" -X POST \
-  -H "Content-Type: application/json" \
-  -d "{\"tool\": \"scan_approvals\", \"args\": {\"wallet\": \"$WALLET\", \"chain\": \"base\"}}"
+TARGET="${var}"
+if [ ${#TARGET} -eq 42 ] && [[ "$TARGET" == 0x* ]]; then
+  # Could be wallet or token — try wallet scan first
+  TARGET_TYPE="wallet"
+else
+  echo "Invalid address: $TARGET"
+  exit 0
+fi
 ```
 
-### 2. Scan token safety
-
-If `${var}` is a token contract:
+### 2. Scan approvals (wallet)
 
 ```bash
-TOKEN="${var}"
-curl -s "http://143.198.220.27:3100/sse" -X POST \
+RESULT=$(curl -m 30 -s "https://mcp.vigil.codes/tools/call" \
   -H "Content-Type: application/json" \
-  -d "{\"tool\": \"scan_token\", \"args\": {\"token\": \"$TOKEN\", \"chain\": \"base\"}}"
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "scan_approvals",
+      "arguments": {"wallet": "'"$TARGET"'", "chain": "base"}
+    }
+  }')
+echo "$RESULT" | jq '.result'
 ```
 
-### 3. Check honeypot
+### 3. Scan token safety
 
 ```bash
-curl -s "http://143.198.220.27:3100/sse" -X POST \
+RESULT=$(curl -m 30 -s "https://mcp.vigil.codes/tools/call" \
   -H "Content-Type: application/json" \
-  -d "{\"tool\": \"detect_honeypot\", \"args\": {\"token\": \"$TOKEN\", \"chain\": \"base\"}}"
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "scan_token",
+      "arguments": {"token": "'"$TARGET"'", "chain": "base"}
+    }
+  }')
+echo "$RESULT" | jq '.result'
 ```
 
-### 4. Get safety score
+### 4. Check honeypot
 
 ```bash
-curl -s "http://143.198.220.27:3100/sse" -X POST \
+RESULT=$(curl -m 30 -s "https://mcp.vigil.codes/tools/call" \
   -H "Content-Type: application/json" \
-  -d "{\"tool\": \"safety_score\", \"args\": {\"contract\": \"$TOKEN\", \"chain\": \"base\"}}"
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "detect_honeypot",
+      "arguments": {"token": "'"$TARGET"'", "chain": "base"}
+    }
+  }')
+echo "$RESULT" | jq '.result'
 ```
 
-### 5. Generate wallet report
+### 5. Get safety score
 
 ```bash
-curl -s "http://143.198.220.27:3100/sse" -X POST \
+RESULT=$(curl -m 30 -s "https://mcp.vigil.codes/tools/call" \
   -H "Content-Type: application/json" \
-  -d "{\"tool\": \"wallet_report\", \"args\": {\"wallet\": \"$WALLET\", \"chain\": \"base\"}}"
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "safety_score",
+      "arguments": {"contract": "'"$TARGET"'", "chain": "base"}
+    }
+  }')
+echo "$RESULT" | jq '.result'
+```
+
+### 6. Generate wallet report
+
+```bash
+RESULT=$(curl -m 30 -s "https://mcp.vigil.codes/tools/call" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "wallet_report",
+      "arguments": {"wallet": "'"$TARGET"'", "chain": "base"}
+    }
+  }')
+echo "$RESULT" | jq '.result'
 ```
 
 ## Output Format
 
-VIGIL returns structured JSON with:
+VIGIL returns JSON with:
 
-- `approvals` — list of token approvals with risk levels (CRITICAL/HIGH/MEDIUM/LOW/SAFE)
+- `approvals` — list of token approvals with risk levels
 - `safety_score` — 0-100 composite rating
 - `honeypot` — boolean + reason if detected
 - `rugpull_indicators` — list of suspicious patterns found
-- `recommendations` — action items (revoke, monitor, safe)
+- `recommendations` — action items
 
 ## Risk Levels
 
@@ -91,16 +148,6 @@ VIGIL returns structured JSON with:
 | LOW | 🟢 | Minor concern — monitor |
 | SAFE | ✅ | No issues detected |
 
-## Chaining
+## Important: Revocation is NOT included
 
-Chain with `token-movers` or `narrative-tracker` to get security context on trending tokens:
-
-```yaml
-chains:
-  security-sweep:
-    schedule: "0 */6 * * *"
-    steps:
-      - parallel: [token-movers, narrative-tracker]
-      - skill: vigil
-        consume: [token-movers]
-```
+The Approval Revoker tool performs state-changing onchain transactions via Bankr. It is intentionally excluded from this read-only skill. To revoke approvals, use the separate `vigil-revoke` skill (requires `BANKR_API_KEY` and explicit user confirmation).

--- a/skills/vigil/SKILL.md
+++ b/skills/vigil/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: VIGIL Security Scanner
+description: Onchain security scanner on Base — scan token approvals, detect honeypots, analyze contracts for rugpull indicators, score contract safety, and revoke dangerous approvals via MCP server.
+var: ""
+tags: [crypto, security, base, defi]
+capabilities: [read_only, sends_notifications, mcp]
+---
+> **${var}** — Wallet address (`0x...`) or token address on Base to scan. If empty, scan all connected wallets.
+
+VIGIL is an agent-based MCP security server for DeFi traders on Base. It provides six security tools:
+
+1. **Approval Scanner** — List all ERC-20/ERC-721 approvals, flag unlimited allowances, identify risky spenders
+2. **Token Scanner** — Analyze contracts for rugpull indicators (hidden mint, proxy patterns, tax manipulation, blacklist)
+3. **Honeypot Detector** — Simulate buy/sell to detect tokens that block selling
+4. **Safety Score** — 0-100 rating based on code analysis, ownership, liquidity, holder distribution
+5. **Approval Revoker** — Revoke dangerous approvals via Bankr transaction signing
+6. **Wallet Report** — Full security posture assessment
+
+## Config
+
+- Target = `${var}`. Can be a wallet address or token contract address.
+- Chain = Base (`chainid=8453`).
+- MCP endpoint: `http://143.198.220.27:3100/sse` (SSE transport)
+- GitHub: `https://github.com/vigilcodes/vigil-mcp`
+
+## Steps
+
+### 1. Scan approvals
+
+If `${var}` is a wallet address (starts with `0x`, 42 chars):
+
+```bash
+WALLET="${var}"
+curl -s "http://143.198.220.27:3100/sse" -X POST \
+  -H "Content-Type: application/json" \
+  -d "{\"tool\": \"scan_approvals\", \"args\": {\"wallet\": \"$WALLET\", \"chain\": \"base\"}}"
+```
+
+### 2. Scan token safety
+
+If `${var}` is a token contract:
+
+```bash
+TOKEN="${var}"
+curl -s "http://143.198.220.27:3100/sse" -X POST \
+  -H "Content-Type: application/json" \
+  -d "{\"tool\": \"scan_token\", \"args\": {\"token\": \"$TOKEN\", \"chain\": \"base\"}}"
+```
+
+### 3. Check honeypot
+
+```bash
+curl -s "http://143.198.220.27:3100/sse" -X POST \
+  -H "Content-Type: application/json" \
+  -d "{\"tool\": \"detect_honeypot\", \"args\": {\"token\": \"$TOKEN\", \"chain\": \"base\"}}"
+```
+
+### 4. Get safety score
+
+```bash
+curl -s "http://143.198.220.27:3100/sse" -X POST \
+  -H "Content-Type: application/json" \
+  -d "{\"tool\": \"safety_score\", \"args\": {\"contract\": \"$TOKEN\", \"chain\": \"base\"}}"
+```
+
+### 5. Generate wallet report
+
+```bash
+curl -s "http://143.198.220.27:3100/sse" -X POST \
+  -H "Content-Type: application/json" \
+  -d "{\"tool\": \"wallet_report\", \"args\": {\"wallet\": \"$WALLET\", \"chain\": \"base\"}}"
+```
+
+## Output Format
+
+VIGIL returns structured JSON with:
+
+- `approvals` — list of token approvals with risk levels (CRITICAL/HIGH/MEDIUM/LOW/SAFE)
+- `safety_score` — 0-100 composite rating
+- `honeypot` — boolean + reason if detected
+- `rugpull_indicators` — list of suspicious patterns found
+- `recommendations` — action items (revoke, monitor, safe)
+
+## Risk Levels
+
+| Level | Icon | Meaning |
+|-------|------|---------|
+| CRITICAL | 🔴 | Active threat — revoke immediately |
+| HIGH | 🟠 | Dangerous pattern — likely exploit vector |
+| MEDIUM | 🟡 | Suspicious — proceed with caution |
+| LOW | 🟢 | Minor concern — monitor |
+| SAFE | ✅ | No issues detected |
+
+## Chaining
+
+Chain with `token-movers` or `narrative-tracker` to get security context on trending tokens:
+
+```yaml
+chains:
+  security-sweep:
+    schedule: "0 */6 * * *"
+    steps:
+      - parallel: [token-movers, narrative-tracker]
+      - skill: vigil
+        consume: [token-movers]
+```

--- a/skills/vigil/SKILL.md
+++ b/skills/vigil/SKILL.md
@@ -90,55 +90,55 @@ vigil_call () {
 ### 2. Scan approvals (wallet)
 
 ```bash
-vigil_call scan_approvals '{"wallet": "'"$TARGET"'", "chain": "base"}'
+vigil_call vigil_scan_approvals '{"wallet": "'"$TARGET"'", "chain": "base"}'
 ```
 
 ### 3. Scan token safety
 
 ```bash
-vigil_call scan_token '{"token": "'"$TARGET"'", "chain": "base"}'
+vigil_call vigil_scan_token '{"token": "'"$TARGET"'", "chain": "base"}'
 ```
 
 ### 4. Check honeypot
 
 ```bash
-vigil_call detect_honeypot '{"token": "'"$TARGET"'", "chain": "base"}'
+vigil_call vigil_detect_honeypot '{"token": "'"$TARGET"'", "chain": "base"}'
 ```
 
 ### 5. Get safety score
 
 ```bash
-vigil_call safety_score '{"contract": "'"$TARGET"'", "chain": "base"}'
+vigil_call vigil_safety_score '{"contract": "'"$TARGET"'", "chain": "base"}'
 ```
 
 ### 6. Generate wallet report
 
 ```bash
-vigil_call wallet_report '{"wallet": "'"$TARGET"'", "chain": "base"}'
+vigil_call vigil_wallet_report '{"wallet": "'"$TARGET"'", "chain": "base"}'
 ```
 
 ### 7. Monitor wallet (real-time alerts)
 
 ```bash
-vigil_call monitor_wallet '{"wallet": "'"$TARGET"'", "chain": "base", "lookback_blocks": 1000}'
+vigil_call vigil_monitor_wallet '{"wallet": "'"$TARGET"'", "chain": "base", "lookback_blocks": 1000}'
 ```
 
 ### 8. Token market context (price + liquidity)
 
 ```bash
-vigil_call token_market '{"token": "'"$TARGET"'", "chain": "base"}'
+vigil_call vigil_token_market '{"token": "'"$TARGET"'", "chain": "base"}'
 ```
 
 ### 9. Deployer reputation (verification + age)
 
 ```bash
-vigil_call deployer_check '{"contract": "'"$TARGET"'", "chain": "base"}'
+vigil_call vigil_deployer_check '{"contract": "'"$TARGET"'", "chain": "base"}'
 ```
 
 ### 10. Batch scan multiple tokens
 
 ```bash
-vigil_call batch_scan '{"tokens": ["'"$TARGET"'"], "chain": "base"}'
+vigil_call vigil_batch_scan '{"tokens": ["'"$TARGET"'"], "chain": "base"}'
 ```
 
 ## Output Format

--- a/skills/vigil/SKILL.md
+++ b/skills/vigil/SKILL.md
@@ -7,7 +7,7 @@ capabilities: [external_api, sends_notifications]
 ---
 > **${var}** — Wallet address (`0x...`) or token contract address on Base to scan. Required. If empty, log `VIGIL_NO_TARGET` and exit cleanly (no notify).
 
-VIGIL is an onchain security scanner for DeFi traders on Base. It provides five read-only scanning tools and one write action (revoke) that requires explicit Bankr authentication.
+VIGIL is an onchain security scanner for DeFi traders on Base. It provides nine read-only scanning tools and one write action (revoke) that requires explicit Bankr authentication.
 
 **Read-only tools (this skill):**
 1. Approval Scanner — list all ERC-20/ERC-721 approvals, flag unlimited allowances
@@ -15,9 +15,13 @@ VIGIL is an onchain security scanner for DeFi traders on Base. It provides five 
 3. Honeypot Detector — simulate buy/sell to detect trap tokens
 4. Safety Score — 0-100 composite rating based on code, ownership, liquidity, holders
 5. Wallet Report — full security posture assessment
+6. Wallet Monitor — real-time alerts for new approvals, risky interactions, and balance changes
+7. Token Market — price, liquidity, 24h volume, and pool age via DexScreener (no API key)
+8. Deployer Check — contract verification, name, and deployer reputation via Basescan
+9. Batch Scan — score multiple tokens in one call, ranked by risk
 
 **Write action (separate, not included here):**
-6. Approval Revoker — revoke dangerous approvals via Bankr transaction signing. This is a state-changing onchain transaction and is NOT part of this read-only skill.
+10. Approval Revoker — revoke dangerous approvals via Bankr transaction signing. This is a state-changing onchain transaction and is NOT part of this read-only skill.
 
 Read the last 2 days of `memory/logs/` so a repeat scan can note newly-granted or newly-revoked approvals.
 
@@ -123,6 +127,74 @@ RESULT=$(curl -m 30 -s "https://mcp.vigil.codes/tools/call" \
     "params": {
       "name": "wallet_report",
       "arguments": {"wallet": "'"$TARGET"'", "chain": "base"}
+    }
+  }')
+echo "$RESULT" | jq '.result'
+```
+
+### 7. Monitor wallet (real-time alerts)
+
+```bash
+RESULT=$(curl -m 30 -s "https://mcp.vigil.codes/tools/call" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "monitor_wallet",
+      "arguments": {"wallet": "'"$TARGET"'", "chain": "base", "lookback_blocks": 1000}
+    }
+  }')
+echo "$RESULT" | jq '.result'
+```
+
+### 8. Token market context (price + liquidity)
+
+```bash
+RESULT=$(curl -m 30 -s "https://mcp.vigil.codes/tools/call" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "token_market",
+      "arguments": {"token": "'"$TARGET"'", "chain": "base"}
+    }
+  }')
+echo "$RESULT" | jq '.result'
+```
+
+### 9. Deployer reputation (verification + age)
+
+```bash
+RESULT=$(curl -m 30 -s "https://mcp.vigil.codes/tools/call" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "deployer_check",
+      "arguments": {"contract": "'"$TARGET"'", "chain": "base"}
+    }
+  }')
+echo "$RESULT" | jq '.result'
+```
+
+### 10. Batch scan multiple tokens
+
+```bash
+RESULT=$(curl -m 30 -s "https://mcp.vigil.codes/tools/call" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "batch_scan",
+      "arguments": {"tokens": ["0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"], "chain": "base"}
     }
   }')
 echo "$RESULT" | jq '.result'


### PR DESCRIPTION
## Summary

Adds VIGIL — an onchain security scanner MCP server for DeFi traders on Base.

### Skill: vigil

6 read-only security tools via MCP:

1. Approval Scanner — flag unlimited allowances
2. Token Scanner — rugpull indicators (mint, proxy, blacklist, tax)
3. Honeypot Detector — simulate buy/sell
4. Safety Score — 0-100 rating with verified blue-chip registry
5. Wallet Report — full assessment
6. Wallet Monitor — real-time alerts

*The Approval Revoker is intentionally split into a separate `vigil-revoke` skill — gated by `BANKR_API_KEY` and explicit user confirmation, since it is state-changing.*

### Live

- Site: https://vigil.codes
- MCP endpoint: **https://mcp.vigil.codes** (HTTPS, valid Let's Encrypt cert)
  - `GET  /health` — service heartbeat
  - `GET  /tools/list` — tool descriptors
  - `POST /tools/call` — JSON-RPC 2.0 tool invocation
  - `GET  /sse` — MCP-over-SSE transport
- GitHub: https://github.com/vigilcodes/vigil-mcp
- Bankr Skills PR: BankrBot/skills#438

### Verified responses (live)

USDC Base (`0x833589fc…02913`):
```
{"score":92,"risk_level":"safe","breakdown":[{"category":"Verified Registry","score":92,"note":"USD Coin (USDC) — Circle USDC on Base — fully backed stablecoin"}]}
```

WETH Base (`0x4200…0006`): score 90 / safe
AERO Base (`0x940181…98631`): score 78 / safe
No-code address: score 0 / critical
USDC Base honeypot: `is_honeypot:false, can_buy:true, can_sell:true`

### Review feedback addressed

- ✅ HTTPS endpoint on real domain — `mcp.vigil.codes` (Let's Encrypt, auto-renewing)
- ✅ Capabilities relabeled to `[external_api, sends_notifications]`; revoke split into separate BANKR-gated skill
- ✅ JSON-RPC 2.0 over `POST /tools/call` returns 200 with sane verdicts (no canned responses)
- ✅ Blue-chip verified registry corrects USDC/WETH/AERO scoring; the earlier `score:0/critical` for USDC was caused by a registry address typo, now fixed in vigilcodes/vigil-mcp@38f768f