### PR TITLE
docs(ecosystem): add Reppo

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -52,6 +52,7 @@ These are the projects we know of that run Aeon, extend it, or integrate with th
 | Powerloom | [@Powerloom](https://x.com/Powerloom) |
 | Precog | [@precog](https://x.com/precog) |
 | Reg Terminal | [@regterminal](https://x.com/regterminal) |
+| Reppo | [@reppo](https://x.com/reppo) · [reppo.xyz](https://reppo.xyz) |
 | ResearchSwarm | [@ResearchSwarmAI](https://x.com/ResearchSwarmAI) |
 | Revault | [@revaultdrops](https://x.com/revaultdrops) |
 | RootAi | [@rootaichad](https://x.com/rootaichad) |


### PR DESCRIPTION
Adds Reppo to the Aeon ecosystem list.

- **Reppo** — AI training data using prediction markets
- [@reppo](https://x.com/reppo) · [reppo.xyz](https://reppo.xyz)

Alphabetized between Reg Terminal and ResearchSwarm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)