### PR TITLE
docs(ecosystem): add VIGIL

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -65,6 +65,7 @@ These are the projects we know of that run Aeon, extend it, or integrate with th
 | USIC | [@USICAI](https://x.com/USICAI) |
 | Venice Kernel | [@VeniceKernel](https://x.com/VeniceKernel) |
 | Vexor | [@Vexora_x](https://x.com/Vexora_x) |
+| VIGIL | [@vigilcodes](https://x.com/vigilcodes) · [vigil.codes](https://vigil.codes) |
 | Wake | [@WakeOnBase](https://x.com/WakeOnBase) |
 | x402Books | [@x402Books](https://x.com/x402Books) |
 | zer0 | [@atzer0_BOT](https://x.com/atzer0_BOT) |


### PR DESCRIPTION
Lands just the **ECOSYSTEM.md** listing for VIGIL, split out from #323.

- **VIGIL** — onchain security scanner for Base
- [@vigilcodes](https://x.com/vigilcodes) · [vigil.codes](https://vigil.codes)

The project is real and the ecosystem row was already approved in #323. The `skills/vigil/SKILL.md` half of that PR stays open pending live-endpoint verification (the documented `POST /tools/call` returning 200 against `mcp.vigil.codes`).

Credit to @vigilcodes (extracted from #323).

🤖 Generated with [Claude Code](https://claude.com/claude-code)