### PR TITLE
Add `install-from-atrium` — install skills from the Atrium onchain marketplace

### DIFF
--- a/install-from-atrium
+++ b/install-from-atrium
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# install-from-atrium — Install skills from the Atrium onchain marketplace into Aeon
+#
+# Atrium serves every registered skill as a SKILL.md at a stable well-known endpoint,
+# so this is a thin fetcher: it pulls the skill, runs Aeon's own security scanner
+# (never bypassed), copies it into skills/, and records onchain provenance in
+# skills.lock. No Atrium SDK or wallet needed to install (paying is a separate,
+# opt-in step — see the atrium-scout skill / `atrium invoke`).
+#
+# Usage:
+#   ./install-from-atrium --list                     Browse the marketplace
+#   ./install-from-atrium 0x<64-hex-skillId>         Install by canonical onchain id
+#   ./install-from-atrium <skill-name>               Install by listed name
+#   ./install-from-atrium <id|name> --force          Install despite scan findings
+#
+# Env: ATRIUM_HOST (default https://atriumhermes.tech)
+
+ATRIUM_HOST="${ATRIUM_HOST:-https://atriumhermes.tech}"
+WELLKNOWN="$ATRIUM_HOST/.well-known/skills"
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+SKILLS_DIR="$ROOT/skills"
+SCANNER="$ROOT/skills/skill-security-scan/scan.sh"
+LOCK_FILE="$ROOT/skills.lock"
+
+die() { echo "error: $*" >&2; exit 1; }
+command -v curl >/dev/null || die "missing dependency: curl"
+
+# ── browse ──────────────────────────────────────────────────────────────────
+if [[ "${1:-}" == "--list" || -z "${1:-}" || "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  echo "Atrium marketplace — installable skills:"
+  curl -fsS "$WELLKNOWN/index.json" \
+    | grep -oE '"(name|skill_id|description)":"[^"]*"' \
+    | sed 's/^"name":/\n• /; s/^"skill_id":/  id:   /; s/^"description":/  /; s/"//g'
+  echo
+  echo "Install:  ./install-from-atrium <skill-name|0x-skillId> [--force]"
+  exit 0
+fi
+
+ARG="$1"; shift || true
+FORCE=false
+for f in "$@"; do [[ "$f" == "--force" ]] && FORCE=true; done
+
+# ── fetch ───────────────────────────────────────────────────────────────────
+if [[ "$ARG" =~ ^0x[0-9a-fA-F]{64}$ ]]; then
+  URL="$WELLKNOWN/by-id/$ARG/SKILL.md"     # canonical, collision-free
+else
+  URL="$WELLKNOWN/$ARG/SKILL.md"           # by listed name
+fi
+echo "Fetching $URL"
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+curl -fsS "$URL" -o "$TMP/SKILL.md" || die "could not fetch (check id/name at $WELLKNOWN/index.json)"
+
+fm() { sed -n '/^---$/,/^---$/p' "$TMP/SKILL.md" | grep -E "^[[:space:]]*$1:" | head -1 | sed "s/^[[:space:]]*$1:[[:space:]]*//; s/\"//g"; }
+SLUG="$(fm name | tr '[:upper:] ' '[:lower:]-')"
+[[ -n "$SLUG" ]] || die "SKILL.md has no name: in frontmatter"
+CID="$(fm cid)"; SKILL_ID="$(fm skill_id)"
+
+# ── security scan (Aeon's own; honor --force exactly like ./add-skill) ────────
+if [[ -x "$SCANNER" ]]; then
+  echo "  scanning: $SLUG ..."
+  if ! "$SCANNER" "$TMP/SKILL.md" 2>/dev/null; then
+    if [[ "$FORCE" == "true" ]]; then
+      echo "  ⚠ SECURITY ISSUES DETECTED — installing anyway (--force)"
+      mkdir -p "$ROOT/memory/logs"
+      echo "  $(date -u '+%Y-%m-%dT%H:%M:%SZ') FORCE_INSTALL: $SLUG from atrium:$SKILL_ID" >> "$ROOT/memory/logs/security.log"
+    else
+      die "BLOCKED: $SLUG has security issues. Re-run with --force to override."
+    fi
+  else
+    echo "  ✓ security scan passed"
+  fi
+fi
+
+# ── install ─────────────────────────────────────────────────────────────────
+DEST="$SKILLS_DIR/$SLUG"
+[[ -d "$DEST" ]] && { echo "  update: $SLUG (overwriting)"; rm -rf "$DEST"; } || echo "  install: $SLUG"
+mkdir -p "$DEST"; cp "$TMP/SKILL.md" "$DEST/SKILL.md"
+
+# ── provenance in skills.lock (same schema as ./add-skill; CID is the content hash) ──
+if command -v jq >/dev/null; then
+  [[ -s "$LOCK_FILE" ]] || echo "[]" > "$LOCK_FILE"
+  ENTRY="$(jq -n --arg name "$SLUG" --arg repo "atrium:$SKILL_ID" \
+    --arg path "$WELLKNOWN/by-id/$SKILL_ID/SKILL.md" --arg branch "base-mainnet" \
+    --arg sha "$CID" --arg at "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+    '{skill_name:$name, source_repo:$repo, source_path:$path, branch:$branch, commit_sha:$sha, imported_at:$at}')"
+  jq --argjson e "$ENTRY" '[.[] | select(.skill_name != $e.skill_name)] + [$e]' \
+    "$LOCK_FILE" > "$LOCK_FILE.tmp" && mv "$LOCK_FILE.tmp" "$LOCK_FILE"
+  echo "    -> provenance recorded in skills.lock (cid: ${CID:0:12}…)"
+fi
+
+echo "✓ Installed $SLUG → skills/$SLUG/SKILL.md"
+echo "  Next: enable it in aeon.yml. Onchain provenance (skill_id, cid, price) is in the SKILL.md frontmatter under metadata.atrium."


### PR DESCRIPTION
## Add `install-from-atrium` — install skills from the Atrium onchain marketplace

Follow-up to the merged `aeon-atrium-skills` pack (#316). This adds a single,
additive root script so an Aeon project can install a skill straight from the
**Atrium** onchain marketplace (publish/discover/monetize agent skills, Base) —
not just from a GitHub repo.

Atrium serves every registered skill as a standard `SKILL.md` at a well-known
endpoint (`/.well-known/skills/…` — the same shape Hermes' skills hub consumes), so
this is a thin fetcher. No Atrium SDK, no wallet needed to install (paying is a
separate, opt-in step via the existing `atrium-scout` skill / `atrium invoke`).

### Usage
```bash
./install-from-atrium --list                  # browse the marketplace
./install-from-atrium 0x<64-hex-skillId>      # install by canonical onchain id
./install-from-atrium pdf-toolkit             # install by listed name
./install-from-atrium <id|name> --force       # install despite scan findings
```

### Safety — it behaves exactly like `./add-skill`
- **Runs the same scanner** (`skills/skill-security-scan/scan.sh`) on the fetched
  SKILL.md. Untrusted by default — no bypass. `--force` has identical semantics
  (installs anyway + logs to `memory/logs/security.log`).
- **Records provenance** in `skills.lock` with your existing schema. Because Atrium
  is content-addressed on IPFS, the **CID is the `commit_sha`** — a verifiable
  content hash, not a mutable ref. `source_repo` is `atrium:<skillId>`.
- The installed SKILL.md carries onchain provenance under `metadata.atrium`
  (skill_id, cid, creator wallet, author DID, price_per_call_usdc, registry), so you
  can gate or display trust however you like.

### Why
Lets an Aeon agent install a capability it lacks straight from the marketplace, with
cryptographic provenance attached — discover → scan → install, end to end. It's
purely additive (one new script; nothing in `add-skill` / core changes).

Pure `curl` + `jq` (both already required by Aeon). Endpoints + design notes:
https://atriumhermes.tech and the Atrium repo's `integrations/aeon/ATRIUM_AS_SOURCE.md`.
