### PR TITLE
Adds **Atrium** to the ecosystem.

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -20,6 +20,7 @@ These are the projects we know of that run Aeon, extend it, or integrate with th
 | <img src="https://pbs.twimg.com/profile_images/2060437940493332485/VrIC7fKj_400x400.jpg" width="36" height="36" alt="AgentBounty logo"> | AgentBounty | [@agentbountydev](https://x.com/agentbountydev) |
 | <img src="https://pbs.twimg.com/profile_images/2030575047644188673/vaJqbpck_400x400.jpg" width="36" height="36" alt="Amper logo"> | Amper | [@helloamper](https://x.com/helloamper) |
 | <img src="https://pbs.twimg.com/profile_images/2055896281751633920/NeawiT3G_400x400.png" width="36" height="36" alt="AntFleet logo"> | AntFleet | [@AntFleetDev](https://x.com/AntFleetDev) |
+| <img src="https://atriumhermes.tech/atrium-mark.jpg" width="36" height="36" alt="Atrium logo"> | Atrium | [@atriumhermes](https://x.com/atriumhermes) · [atriumhermes.tech](https://atriumhermes.tech) |
 | <img src="https://coin-images.coingecko.com/coins/images/102173323/large/autonomopoly.jpg?1779000184" width="36" height="36" alt="Autonomopoly logo"> | Autonomopoly | [GeckoTerminal](https://www.geckoterminal.com/base/pools/0x84771828f44fcfbaae08e271ff74e272cc2934a3348ec724a475941185ce4eb9) |
 | <img src="https://pbs.twimg.com/profile_images/1951545493936545792/AriqgxQN_400x400.jpg" width="36" height="36" alt="Bankr logo"> | Bankr | [@bankrbot](https://x.com/bankrbot) |
 | <img src="https://pbs.twimg.com/profile_images/2054481928422862848/7AOz3CwK_400x400.jpg" width="36" height="36" alt="Bankrsynth logo"> | Bankrsynth | [@bankrsynth](https://x.com/bankrsynth) |


### PR DESCRIPTION
Atrium is an onchain skill marketplace for AI agents on Base — publish, discover, and
pay-per-call for skills, with DID-signed provenance and royalties. It integrates with
Aeon two ways:

- the **aeon-atrium-skills** pack (in the community registry, #316): publish / scout /
  earnings / attest — turn an Aeon agent's evolving skills into USDC-earning assets and
  rent the ones it's missing.
- the **Atrium Lighthouse** — an autonomous agent *built on Aeon* that scouts the
  marketplace and rents skills it lacks. It did its first fully autonomous, onchain
  rental this week (paid USDC on Base, no human in the loop).

Links: https://atriumhermes.tech · https://x.com/atriumhermes