### PR TITLE
feat(skill-of-the-day): daily skill feature with tweet draft + live outcome

### DIFF
--- a/aeon.yml
+++ b/aeon.yml
@@ -218,6 +218,7 @@ skills:
 
   # Social
   engagement-act: { enabled: false, schedule: "30 9 * * *" } # daily — turn flagged engagement opportunities into copy-paste-ready replies
+  skill-of-the-day: { enabled: false, schedule: "workflow_dispatch", var: "" } # picks one skill from a rotation queue (memory/topics/skill-of-the-day.md), writes a paste-ready feature tweet in the "Aeon skill of the day 🌟" format, then dispatches the picked skill so its own ./notify delivers the live outcome. Two notifications per run: tweet draft + skill result. Set var=<skill-name> to override the queue. Recommended enabled cron: "0 8 * * *".
 
   # Ideas & productivity
   idea-pipeline: { enabled: false, schedule: "0 18 * * 1", model: "claude-sonnet-4-6" } # Monday — execution-gap audit: top 3 backlog ideas to build this week

--- a/memory/topics/skill-of-the-day.md
+++ b/memory/topics/skill-of-the-day.md
@@ -1,0 +1,136 @@
+# Skill of the Day — Rotation State
+
+Queue + history for `skills/skill-of-the-day/`. The picker reads top-down, skips anything covered in the last 30 days or in the blocklist.
+
+Edit freely — this file is operator-owned config, not auto-managed except for `## Covered (last 30 days)`, which the skill appends to and prunes each run.
+
+## Queue
+
+Ordered list of skills to feature next. The picker takes the first one not in `Covered (last 30 days)` and not in `Blocklist`. Append new entries at the bottom; the head moves down naturally as each is covered.
+
+The starter pack below targets *observable* skills with clear single-purpose output — the format works best when the "Result ⤵️" screenshot is something a reader can grok in one glance. Edit to taste.
+
+- morning-brief
+- paper-pick
+- repo-pulse
+- agentic-video-digest
+- reply-maker
+- hacker-news-digest
+- self-improve
+- narrative-tracker
+- paper-digest
+- weekly-shiplog
+- fork-skill-digest
+- tweet-roundup
+
+## Covered (last 30 days)
+
+The skill appends here after each successful run. Entries older than 30 days are pruned automatically.
+
+(empty)
+
+## Blocklist
+
+Never feature these — they are meta/internal/repair skills that don't read as user-facing features. Add or remove entries to taste.
+
+- skill-of-the-day
+- skill-health
+- skill-evals
+- skill-graph
+- skill-repair
+- skill-freshness
+- skill-analytics
+- skill-leaderboard
+- skill-security-scan
+- skill-update-check
+- heartbeat
+- onboard
+- fleet-control
+- fleet-state
+- fork-fleet
+- fork-cohort
+- fork-release-tracker
+- fork-contributor-leaderboard
+- contributor-reward
+- contributor-spotlight
+- operator-scorecard
+- spawn-instance
+- auto-merge
+- auto-workflow
+- distribute-tokens
+- workflow-security-audit
+- smithery-manifest
+- v4-readiness
+- update-gallery
+- search-skill
+- syndicate-article
+- pr-review
+- pr-triage
+- pr-skill-triage
+- pr-tracker
+- pr-merge-queue
+- issue-triage
+- reg-monitor
+- security-digest
+- vuln-scanner
+- vuln-tracker
+- disclosure-tracker
+- pvr-watchlist
+- pvr-triage-monitor
+- last30
+- rss-feed
+- rss-digest
+- batch-health
+- run-frequency-guard
+- config-validator
+- janitor
+- memory-flush
+- memory-structural-dedupe
+- self-review
+- signal-verdict
+- skill-enabler
+- show-hn-draft
+- product-hunt-launch
+- create-campaign
+- schedule-ads
+- motion-explainer
+- on-chain-monitor
+- price-threshold-alert
+- monitor-runners
+- monitor-kalshi
+- polymarket-comments
+- market-context-refresh
+- unlock-monitor
+- list-digest
+- refresh-x
+- fetch-tweets
+- remix-tweets
+- write-tweet
+- repo-scanner
+- repo-actions
+- project-lens
+- external-feature
+- technical-explainer
+- deploy-prototype
+- autoresearch
+- cost-report
+- skill-evals
+- vercel-projects
+- feature
+- rug-scan
+- investigation-report
+- fund-flow
+- linked-wallets
+- lp-lock-check
+- honeypot-check
+- approval-audit
+- contract-audit
+- wallet-profile
+- deployer-trace
+- tx-explain
+- holder-concentration
+
+## Notes
+
+- The starter queue is intentionally short (~12 skills, three weeks of daily posts). Extend it as the framework grows or as you discover skills that screenshot well.
+- If the format ever drifts (a new post doesn't visually match the prior days), check the SKILL.md anti-patterns section — the cadence is the brand.

--- a/skills/skill-of-the-day/SKILL.md
+++ b/skills/skill-of-the-day/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: Skill of the Day
+description: Pick one skill from a rotation, ship a paste-ready feature tweet in the "Aeon skill of the day" format, then dispatch the picked skill so the chosen channel also gets the live outcome
+var: ""
+tags: [meta, social, content]
+---
+
+> **${var}** — Optional skill name to feature. Overrides the queue. If empty, picks the next uncovered skill from `memory/topics/skill-of-the-day.md`.
+
+Today is ${today}. Read `memory/MEMORY.md` for context.
+Read `memory/topics/skill-of-the-day.md` for the queue, the covered list, and the blocklist.
+If `soul/` files exist, read them (`soul/SOUL.md`, `soul/STYLE.md`) to match the operator's voice. If `soul/` is empty or absent, use a clear, terse, neutral voice.
+
+## Goal
+
+A daily content cadence around the framework's observable feature surface. Each morning produces two notifications:
+
+1. A paste-ready feature tweet (long-form X post) in the **Aeon skill of the day** format — the operator copies this to X.
+2. The picked skill's live outcome — delivered through that skill's own `./notify` after dispatch. The operator screenshots that outcome as the "Result ⤵️" body of the tweet.
+
+Two separate notifications, not a combined message. Each notify stays under platform character limits, and the dispatched skill remains independently observable.
+
+## Steps
+
+### 1. Pick today's skill
+
+Priority order:
+
+1. If `${var}` is non-empty and `skills/${var}/SKILL.md` exists, pick `${var}`.
+2. Else read `memory/topics/skill-of-the-day.md`. Pick the first entry under `## Queue` that is not under `## Covered (last 30 days)` and not under `## Blocklist`.
+3. If the queue is exhausted, `ls skills/` and pick the first skill that has a `SKILL.md`, is not in the blocklist, and has not been covered in the last 30 days.
+
+If nothing qualifies, send a single notification (`./notify "skill-of-the-day: no candidates today — queue exhausted, all skills covered in last 30d"`) and exit. No filler post.
+
+Let `${PICK}` be the chosen skill name (the kebab-case directory name).
+
+### 2. Read the picked skill's SKILL.md
+
+Parse the frontmatter and body:
+
+- `name` (frontmatter) → use for the "▶️ Name" line. If absent, title-case the directory name.
+- `description` (frontmatter) → ground-truth one-liner; rewrite in clear, concrete language for the "What is it about?" paragraph.
+- `## Steps` body → source for the "How it works behind the scenes" bullets. Extract 5-7 real, concrete behaviors. Do not invent capabilities the skill does not have.
+
+### 3. Compose the tweet draft
+
+Write the following file: `.outputs/skill-of-the-day.md`. Use **exactly** this shape:
+
+```
+The @aeonframework skill of the day 🌟
+
+🗓️ {ordinal} {Month}
+
+▶️ Name: {Pretty-Name}
+
+▶️ What is it about?
+
+{2-3 sentence paragraph in operator voice. What it does, why it exists, the wedge it serves. No marketing fluff.}
+
+▶️ How it works behind the scenes
+
+✴️ It {verb}. {One concrete sentence about a real behavior in the SKILL.md.}
+
+✴️ It {verb}. {Another one.}
+
+✴️ It {verb}. {…}
+
+✴️ It {verb}. {…}
+
+✴️ It {verb}. {5-7 bullets total.}
+
+▶️ Demo: {One-line setup of what the live run will show.}
+
+Result ⤵️
+```
+
+Notes:
+
+- The header line `The @aeonframework skill of the day 🌟` is the brand of the series. Forks that want their own handle can edit this one string in the SKILL.md.
+- Date formatting: English ordinal (`1st`, `2nd`, `3rd`, `4th`, …, `21st`, `22nd`, `23rd`, `31st`). Month is full name (`June`, not `Jun`). No year.
+- Every `✴️` bullet starts with **`It {verb}.`** — keeps the cadence consistent across days and makes the series visually scannable.
+- Each bullet must trace to a real behavior in the SKILL.md. If the skill genuinely has only 5 distinct behaviors, ship 5 bullets, not 7.
+- No hashtags, no emoji other than what's in the template, no AI-tells ("dive in", "let's", "in summary", "robust", "seamless").
+- Prefer concrete nouns (file paths, env vars, CLI flags, API endpoints) over abstractions.
+- Don't quote the SKILL.md verbatim — paraphrase each bullet.
+- Don't link to the SKILL.md from the tweet. The format keeps the bait — DMs and replies are the conversion signal.
+
+### 4. Send the tweet to Telegram (or configured channels)
+
+```bash
+./notify "$(cat .outputs/skill-of-the-day.md)"
+```
+
+If the file exceeds 4000 characters, trim bullets (drop the weakest first) until it fits. Telegram caps single messages at 4096.
+
+### 5. Dispatch the picked skill (fire-and-forget)
+
+```bash
+gh workflow run aeon.yml -f skill="${PICK}"
+```
+
+Do not wait or poll. The dispatched skill's own `./notify` will deliver the outcome to the configured channels a few minutes later.
+
+If `gh workflow run` fails (permission denied, rate limit, etc.), send a single follow-up notification and stop:
+
+```bash
+./notify "skill-of-the-day: tweet drafted for ${PICK} but dispatch failed — run it manually: gh workflow run aeon.yml -f skill=${PICK}"
+```
+
+One attempt, one notification on failure. No retry loop.
+
+### 6. Update queue state
+
+Edit `memory/topics/skill-of-the-day.md`:
+
+- Append a line under `## Covered (last 30 days)`:
+  ```
+  - ${today} — ${PICK}
+  ```
+- If `${PICK}` appears under `## Queue` (i.e. it was picked via the queue, not via `var` override), remove that line from the queue.
+- Prune entries older than 30 days from `Covered` so the section stays small.
+
+### 7. Log
+
+Append to `memory/logs/${today}.md`:
+
+```markdown
+### skill-of-the-day
+
+- Picked: ${PICK} (source: queue | var-override | catalog-fallback)
+- Tweet draft: .outputs/skill-of-the-day.md
+- Dispatched run: <url or "FAILED — reason">
+```
+
+## Anti-patterns
+
+- **Padding bullets.** Five real bullets beat seven generic ones.
+- **Picking meta/internal skills.** They don't read as features. Keep them in `Blocklist`.
+- **Picking the same skill in a 30-day window.** The `Covered` list enforces this; do not bypass it.
+- **Dispatch-and-wait.** The dispatched skill is independently observable; polling here just burns runner minutes.
+- **Linking the SKILL.md in the tweet.** Keeps the bait — DMs and replies are the conversion signal.
+- **Auto-tweeting.** This skill produces a draft; the operator copies to X manually (the screenshot of the outcome goes into the tweet's "Result ⤵️" body).
+
+## Sandbox note
+
+`gh workflow run` works in the sandbox via the gh CLI (auth handled internally). `./notify` fans out to all configured channels. No prefetch needed.


### PR DESCRIPTION
## Summary

Adds a new meta-content skill, `skill-of-the-day`, that turns the framework's existing skill catalog into a daily content cadence on X.

Each run does two things, in order:

1. Picks one skill from a rotation queue and writes a paste-ready feature tweet in a fixed "Aeon skill of the day 🌟" long-form format. Sends it to the configured channels via `./notify`.
2. Dispatches the picked skill (`gh workflow run aeon.yml -f skill=<pick>`) so the skill's own `./notify` delivers the live outcome a few minutes later.

Two notifications per run — tweet draft + result. The operator copies the first to X and screenshots the second into the "Result ⤵️" body. No auto-tweeting.

## Why

The framework's wedge is observable, daily output. A skill that converts that output surface into one paste-ready X post per day:

- Compounds (numbered series — every new follower scrolls back to find #1).
- Stays cheap (one skill, no thread, no manual writing).
- Naturally rotates across the catalog so the feed doesn't look monotone.
- Lets each fork run its own rotation against its own enabled skills.

## Format (intentionally strict)

```
The @aeonframework skill of the day 🌟

🗓️ {ordinal} {Month}

▶️ Name: {Pretty-Name}

▶️ What is it about?

{2-3 sentence paragraph}

▶️ How it works behind the scenes

✴️ It {verb}. {…}
✴️ It {verb}. {…}
...

▶️ Demo: {one-liner}

Result ⤵️
```

The strict cadence (`✴️ It {verb}.`) is what makes the series visually compound across days. The header is the brand of the series — forks that want their own handle can edit one string in the SKILL.md.

## Design choices

- **Opt-in.** `enabled: false`, `schedule: "workflow_dispatch"`. Recommended cron once enabled: `0 8 * * *` (morning slot, lets the dispatched skill complete before midday).
- **Fire-and-forget dispatch.** No polling — the dispatched skill is independently observable via its own commit + notify. Saves runner minutes.
- **Two notifications, not one mega-message.** Keeps each under platform character caps; uses the dispatched skill's existing notify path instead of re-implementing it.
- **State is operator-owned.** `memory/topics/skill-of-the-day.md` holds the queue, the 30-day covered window (auto-pruned), and a blocklist. Starter queue is short (~12 skills, three weeks of posts) — extend as you go.
- **Soul-aware voice.** Reads `soul/` if populated; falls back to neutral + terse.
- **Anti-patterns documented.** No padding, no meta/internal skills, no same-skill-in-30-days, no linking to SKILL.md from the tweet, no auto-tweeting.

## Receipts

The format was prototyped manually over the past two days. Example outputs:

- 2026-06-03 — `tool-builder`
- 2026-06-04 — `paper-pick`

Both followed the same template the skill now generates.

## Files

- `skills/skill-of-the-day/SKILL.md` — new skill
- `memory/topics/skill-of-the-day.md` — rotation state (queue + covered + blocklist, edit-to-taste)
- `aeon.yml` — opt-in entry under the Social section

## Test plan

- [ ] Manual run via `gh workflow run aeon.yml -f skill=skill-of-the-day`
- [ ] Confirm two notifications arrive on configured channels (tweet draft + dispatched skill outcome)
- [ ] Confirm `memory/topics/skill-of-the-day.md` updates (Covered appended, queue head consumed)
- [ ] Confirm the tweet format matches the format documented in the SKILL.md (date format, bullet cadence, no AI tells)
- [ ] Override path: `gh workflow run aeon.yml -f skill=skill-of-the-day -f var=narrative-tracker` picks that skill regardless of queue
- [ ] Cron path: flip `enabled: true` + `schedule: "0 8 * * *"` and confirm next 08:00 UTC firing

🤖 Generated with [Claude Code](https://claude.com/claude-code)