### PR TITLE
Port 8 skills from aeon-aaron + fix duplicate-H2 memory drift at the source

### DIFF
--- a/aeon.yml
+++ b/aeon.yml
@@ -234,10 +234,24 @@ skills:
   config-validator: { enabled: false, schedule: "30 16 * * 0" } # Sunday — lint aeon.yml + workflow for structural invariants (checkout order, dup keys, missing files)
   janitor: { enabled: false, schedule: "30 5 * * 0" } # Sunday — clean stale .notify-*, .pending-notify-temp/, expired .outputs/ artifacts
   memory-flush: { enabled: false, schedule: "30 21 * * *" } # daily — promote important recent log entries into MEMORY.md
-  memory-structural-dedupe: { enabled: false, schedule: "10 6 2/2 * *" } # every other day — collapse duplicate section rows in MEMORY.md
+  memory-structural-dedupe: { enabled: false, schedule: "10 6 2/2 * *" } # every other day — collapse duplicate section rows + duplicate H2 headings in MEMORY.md
   self-review: { enabled: false, schedule: "30 19 * * 0", model: "claude-sonnet-4-6" } # Sunday — audit what the agent did, what failed, what to improve
   signal-verdict: { enabled: false, schedule: "0 8 * * 1", model: "claude-sonnet-4-6" } # Monday — verify tracker skills produce citable signals; surface uncited trackers
   skill-enabler: { enabled: false, schedule: "workflow_dispatch", var: "" } # on-demand — flip skills enabled:true by slug list, validate, commit + open PR
+
+  # --- Ported from aeon-aaron ---
+  # Infra & health
+  api-health-probe: { enabled: false, schedule: "30 6 * * *", model: "claude-sonnet-4-6" } # daily 06:30 UTC — pre-batch health probe of every configured API provider key (credit exhaustion / auth failure / outage) via scripts/prefetch-api-probe.sh; files/updates issues; notifies only on degradation or recovery
+  # Markets & crypto
+  fear-divergence-scout: { enabled: false, schedule: "30 7 * * *", model: "claude-sonnet-4-6" } # daily 07:30 UTC — conditional: fires only when Fear & Greed < 25; surfaces assets diverging from the BTC drawdown with narrative catalysts from memory; silent skip otherwise. Reads market-context.md (enable market-context-refresh first).
+  picks-tracker: { enabled: false, schedule: "0 9 * * 0", model: "claude-sonnet-4-6" } # Sunday 09:00 UTC — 30-day retrospective scoring token + prediction-market picks from logs against current prices; W/H/L + hit rate; honest record-keeping. Pairs with token-pick / monitor-polymarket.
+  # Content pipeline
+  beat-tracker: { enabled: false, schedule: "0 9 * * 3", model: "claude-sonnet-4-6" } # Wednesday 09:00 UTC — persistent beat counts per news storyline; alerts when a thread hits 3 beats (article-ready). Event-level complement to topic-momentum + narrative-tracker.
+  article-queue: { enabled: false, schedule: "0 11 * * 0", model: "claude-sonnet-4-6" } # Sunday 11:00 UTC — synthesizes beat-tracker + topic-momentum + narrative-tracker into a ranked queue at memory/topics/article-queue.md that the article skill picks up via MEMORY.md
+  content-performance: { enabled: false, schedule: "0 10 * * 0", model: "claude-sonnet-4-6", var: "" } # Sunday 10:00 UTC — weekly engagement analysis of the operator's X account (topics, formats, breakouts); feeds article-queue/topic-momentum. var: X handle (no @); falls back to soul/SOUL.md. XAI_API_KEY optional (WebSearch fallback).
+  thread-writer: { enabled: false, schedule: "workflow_dispatch", var: "" } # on-demand — write a 5–10 tweet thread in the operator's voice on a topic/URL; picks the sharpest recent signal from memory if var empty
+  # Social
+  mention-radar: { enabled: false, schedule: "25 7 2/2 * *", model: "claude-sonnet-4-6", var: "" } # every other day — external web/social mentions of the operator's projects (discovery/confusion/friction/competitor taxonomy + engagement opportunities). var: comma-separated project names; falls back to MEMORY.md / memory/topics/projects.md
 
   # --- Fallback (must be last) ---
   heartbeat: { enabled: true, schedule: "0 8,14,20 * * *" }

--- a/scripts/prefetch-api-probe.sh
+++ b/scripts/prefetch-api-probe.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# API provider health probe — only executes for the api-health-probe skill; no-ops for all others.
+# Writes .api-probe/status.json (one entry per provider) so the skill can check API health
+# without making network calls from inside the sandbox.
+#
+# To probe another provider, add a guarded block at the bottom (see the XAI block).
+set -euo pipefail
+
+SKILL="${1:-}"
+[ "$SKILL" = "api-health-probe" ] || exit 0
+
+mkdir -p .api-probe
+CHECKED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+RESULTS="{}"
+
+add_result() { # provider http_code error_msg
+  RESULTS=$(echo "$RESULTS" | jq \
+    --arg p "$1" --argjson code "$2" --arg ts "$CHECKED_AT" --arg err "$3" \
+    '.[$p] = {http_code: $code, checked_at: $ts, error_msg: $err}')
+}
+
+probe() { # provider url auth_header body
+  local provider="$1" url="$2" auth="$3" body="$4"
+  local raw http_code body_excerpt err=""
+
+  raw=$(curl -s --max-time 30 -w "\n__HTTP_CODE__%{http_code}" \
+    -X POST "$url" \
+    -H "Content-Type: application/json" \
+    -H "$auth" \
+    -d "$body" 2>&1) || true
+
+  http_code=$(echo "$raw" | grep '__HTTP_CODE__' | sed 's/__HTTP_CODE__//' | tr -d '[:space:]')
+  # Normalize: curl emits "000" on connection failure; non-numeric → 0
+  if echo "$http_code" | grep -qE '^[0-9]+$'; then
+    http_code=$((10#$http_code))
+  else
+    http_code=0
+  fi
+
+  body_excerpt=$(echo "$raw" | grep -v '__HTTP_CODE__' | head -c 400)
+  if echo "$body_excerpt" | jq -e '.error // .message' >/dev/null 2>&1; then
+    err=$(echo "$body_excerpt" | jq -r '.error // .message' 2>/dev/null | head -c 200)
+  fi
+
+  add_result "$provider" "$http_code" "$err"
+  echo "prefetch-api-probe: $provider HTTP $http_code"
+}
+
+# --- xAI (used by refresh-x, tweet-roundup, list-digest, narrative-tracker, remix-tweets, content-performance) ---
+# Minimal 1-token completion against the same /v1/responses endpoint the skills use.
+# Credit exhaustion returns HTTP 403 ("has either used all available credits or
+# reached its monthly spending limit"); a revoked key returns 401.
+if [ -n "${XAI_API_KEY:-}" ]; then
+  probe "xai" "https://api.x.ai/v1/responses" \
+    "Authorization: Bearer $XAI_API_KEY" \
+    '{"model":"grok-4-fast","input":[{"role":"user","content":"ping"}],"max_output_tokens":1}'
+else
+  add_result "xai" 0 "XAI_API_KEY not configured"
+fi
+
+# Add more providers here, e.g.:
+# if [ -n "${OPENROUTER_API_KEY:-}" ]; then
+#   probe "openrouter" "https://openrouter.ai/api/v1/chat/completions" \
+#     "Authorization: Bearer $OPENROUTER_API_KEY" \
+#     '{"model":"openrouter/auto","messages":[{"role":"user","content":"ping"}],"max_tokens":1}'
+# fi
+
+echo "$RESULTS" > .api-probe/status.json
+echo "prefetch-api-probe: wrote .api-probe/status.json"

--- a/scripts/prefetch-xai.sh
+++ b/scripts/prefetch-xai.sh
@@ -181,6 +181,22 @@ case "$SKILL" in
     fi
     ;;
 
+  content-performance)
+    SEVEN_DAYS_AGO=$(date -u -d "7 days ago" +%Y-%m-%d 2>/dev/null || date -u -v-7d +%Y-%m-%d)
+    HANDLE="${VAR:-}"
+    if [ -z "$HANDLE" ] && [ -f soul/SOUL.md ]; then
+      HANDLE=$(grep -oE '@[A-Za-z0-9_]{2,15}' soul/SOUL.md | head -1 | tr -d '@')
+    fi
+    if [ -z "$HANDLE" ]; then
+      echo "xai-prefetch: content-performance — no handle (var empty, none found in soul/SOUL.md), skipping"
+    else
+      xai_search "content-performance.json" \
+        "Search X for all public tweets posted by @${HANDLE} between ${SEVEN_DAYS_AGO} and ${TODAY}. Include original tweets, replies, and quote tweets. For each tweet return: the full text (up to 150 chars), date posted (YYYY-MM-DD), like count, retweet count, quote tweet count, and reply count. Return up to 25 tweets sorted by total engagement (likes + retweets*2 + quotes*3) descending. If fewer tweets exist in the window, return all of them." \
+        "$SEVEN_DAYS_AGO" "$TODAY" \
+        "\"allowed_x_handles\": [\"${HANDLE}\"]"
+    fi
+    ;;
+
   vercel-projects)
     # Pre-fetch Vercel API data (requires auth — can't be done in sandbox)
     if [ -z "${VERCEL_TOKEN:-}" ]; then

--- a/skills/api-health-probe/SKILL.md
+++ b/skills/api-health-probe/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: api-health-probe
+description: Daily pre-batch API provider health check — detects credit exhaustion or auth failure for every configured provider key before the morning batch runs, giving the operator a window to act before skills degrade
+var: ""
+tags: [meta, health, infra]
+schedule: "30 6 * * *"
+---
+
+Today is ${today}. Read `memory/MEMORY.md` and `memory/issues/INDEX.md` for context.
+
+## Why this skill exists
+
+Skills that depend on a paid API key fail *silently* when credits run out or the key is revoked — the failure surfaces only days later in a self-review, after every dependent skill has degraded. This skill closes that gap.
+
+It runs ~30 minutes before the morning batch, reads the result of `scripts/prefetch-api-probe.sh` (which probes each provider with a configured key), and notifies immediately if a provider is down — so the operator has a window to top up credits or rotate the key before the batch starts.
+
+Currently probed: **xAI** (`XAI_API_KEY` — used by refresh-x, tweet-roundup, list-digest, narrative-tracker, remix-tweets, content-performance). To probe another provider, add a guarded block to `scripts/prefetch-api-probe.sh`.
+
+## Steps
+
+### 1. Read probe results
+
+Read `.api-probe/status.json`. Written by `scripts/prefetch-api-probe.sh` during this workflow's prefetch phase. Format: one entry per provider:
+
+```json
+{
+  "xai": { "http_code": 200, "checked_at": "...", "error_msg": "" }
+}
+```
+
+If the file is missing:
+- Log `API_PROBE_SKIP: prefetch-api-probe.sh did not write status — likely skill misconfiguration`
+- No notification. Stop.
+
+### 2. Interpret HTTP status — per provider
+
+For each provider entry, parse `http_code`:
+
+| Code | Meaning | Action |
+|------|---------|--------|
+| 200 | Healthy | Log OK, skip notification |
+| 0 | No key / network failure | Log warning, skip notification |
+| 401 | Invalid or revoked key | Notify + file/update issue |
+| 402 | Payment required | Notify + file/update issue |
+| 403 | Credits exhausted / billing limit | Notify + file/update issue |
+| 429 | Rate limited (transient) | Log warning, skip notification |
+| 5xx | API outage | Notify |
+
+### 3. Issue tracker integration — per degraded provider
+
+Determine the **affected skills**: grep `skills/*/SKILL.md` for the provider's env var name (e.g. `XAI_API_KEY`) and collect the skill slugs.
+
+Read `memory/issues/INDEX.md` and look for an **open** issue whose title mentions this provider's API (e.g. "xAI API").
+
+**If degraded (401/402/403) and a matching open issue exists:**
+Append a probe-result note to that issue file:
+```
+## Probe ${today}
+- HTTP: {code}
+- checked_at: [timestamp from status.json]
+- Status: still unresolved
+```
+
+**If degraded and no matching open issue exists:**
+Create a new issue file `memory/issues/ISS-{NNN}.md` (next available number — check INDEX.md for the highest ID):
+```
+---
+id: ISS-{NNN}
+title: {provider} API {credits exhausted | key invalid} — {code} on daily probe
+status: open
+severity: critical
+category: {missing-secret if 401 | rate-limit if 402/403}
+detected_by: api-health-probe
+detected_at: ${today}
+resolved_at: null
+affected_skills: [{affected skill slugs}]
+root_cause: "HTTP {code} on probe — {error_msg from status.json}"
+fix_pr: null
+---
+
+## Description
+
+Daily api-health-probe returned HTTP {code} for {provider} at [checked_at].
+
+## Fix
+
+{401: Rotate the provider's API key secret in GitHub repo Settings → Secrets.}
+{402/403: Top up credits or raise the spending limit in the provider's billing console.}
+```
+Add a row to `memory/issues/INDEX.md` Open table.
+
+**If HTTP 200 and a matching open issue exists (recovery detected):**
+Append a recovery note to the issue file:
+```
+## Recovery ${today}
+- HTTP: 200 (probe passing)
+- Provider restored — downstream batch should run clean
+```
+Then update the issue's YAML frontmatter: set `status: resolved` and `resolved_at: ${today}`. Move the row from Open to Resolved in `memory/issues/INDEX.md`.
+
+### 4. Send notification if degraded
+
+Only notify for HTTP codes that indicate a real problem (not 200, 0, or 429).
+
+Write notification to a temp file in `.pending-notify-temp/` (create the dir if missing), then send with `./notify -f`.
+
+**Credit exhausted (403 / 402):**
+```
+{provider} credits exhausted — morning batch will degrade.
+
+affected: {affected skill slugs}
+fix: provider billing console → add credits or raise spending limit
+batch starts in ~30 min
+```
+
+**Auth failure (401):**
+```
+{provider} API key invalid (HTTP 401) — all {provider} skills will fail.
+
+fix: rotate the key in GitHub repo Settings → Secrets → Actions
+affected: {affected skill slugs}
+```
+
+**API outage (5xx):**
+```
+{provider} API outage (HTTP [code]) — morning batch may degrade.
+
+not a credits issue — provider infra problem. retry expected to self-resolve.
+```
+
+**Recovery (open issue, now 200):**
+```
+{provider} back online — restored.
+
+{issue id} closed. morning batch should run clean.
+```
+
+### 5. Log to memory
+
+Append to `memory/logs/${today}.md` (one block per probed provider):
+
+```
+## API Health Probe
+- **Provider:** {provider}
+- **HTTP:** [code]
+- **Status:** [healthy|credit_exhausted|auth_failure|api_outage|no_key|unknown]
+- **Issue:** [{ISS-id} still_open|{ISS-id} resolved|filed {ISS-id}|not_applicable]
+- **Notification:** [sent|skipped — reason]
+- API_PROBE_OK
+```
+
+## Sandbox Note
+
+Reads `.api-probe/status.json` written by `scripts/prefetch-api-probe.sh`.
+No outbound API calls from the skill itself — all network happens in the prefetch phase.
+
+## Required Env Vars
+
+Provider keys (e.g. `XAI_API_KEY`) are needed by `scripts/prefetch-api-probe.sh` only — not by the skill itself. A provider with no key configured is recorded as `no_key` and skipped cleanly.

--- a/skills/article-queue/SKILL.md
+++ b/skills/article-queue/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: article-queue
+description: Weekly article idea synthesizer — ranks signals from topic-momentum, beat-tracker, and narrative-tracker into a prioritized queue the article skill reads on next run
+schedule: "0 11 * * 0"
+tags: [content, meta]
+---
+
+Today is ${today}. Read `memory/MEMORY.md` before starting.
+
+## Why this skill exists
+
+Three skills generate article signals, none of them feed the article skill:
+- **topic-momentum** — scores uncovered angles vs narrative frequency
+- **beat-tracker** — tracks multi-beat storylines, alerts at 3 beats (article-ready)
+- **narrative-tracker** — labels narratives EMERGING / RISING / PEAK / FADING
+
+The article skill reads `memory/MEMORY.md` but picks topics from scratch every run. This means a 3-beat thread can sit article-ready for days while the article skill writes about something else. This skill closes that gap: runs weekly (after topic-momentum finishes), synthesizes all three signal sources, and writes a ranked queue to `memory/topics/article-queue.md`. The article skill will encounter the queue via MEMORY.md naturally.
+
+A queue entry is only as good as its urgency. Priority order:
+1. **Beat-ready** (≥3 beats) — the story is cooked. Write it now.
+2. **Warming up** (2 beats, most recent beat ≤5 days ago) — one beat away.
+3. **topic-momentum picks** — scored by gap score, freshness, soul-fit.
+4. **Narrative-tracker RISING/EMERGING** not yet written about.
+
+## Steps
+
+### 1. Load beat-tracker state
+
+Read `memory/topics/beat-tracker.md`. If it doesn't exist, skip beat signals (log a note).
+
+Parse all active threads. For each thread extract:
+- Thread name
+- Status (active / article-ready / stale)
+- Beat count
+- Most recent beat date
+- Latest beat summary
+
+Flag threads with `status: article-ready` (≥3 beats) as **URGENT**. Flag threads with beat_count == 2 and last beat ≤5 days as **WARMING**.
+
+### 2. Load topic-momentum output
+
+Read `memory/logs/` — use Glob on `memory/logs/*.md`. Take the 7 most recent by filename. Scan each for a `## Topic Momentum` section. From the most recent such section, extract:
+- Top 3 ranked angles (title + gap score + one-line description)
+
+If no topic-momentum output found in logs, note it as "no recent topic-momentum run."
+
+### 3. Load narrative-tracker signals
+
+Same log scan as step 2. From the most recent `## Narrative Tracker` section, extract:
+- Narratives labeled `RISING` or `EMERGING`
+- Their current phase and momentum direction
+
+### 4. Load recent article coverage (dedup)
+
+Use Glob on `articles/*.md`. Sort by filename date descending. Take the 30 most recent.
+
+For each, extract the date from the filename and the H1 title from the first line. Build a **covered list**: `[{ date, title }]`.
+
+Any article filed in the last 7 days → suppress any queue entry that covers the same topic (fuzzy match: shared key noun or phrase).
+
+Any article filed 8–21 days ago → downrank matching queue entries by 2 points.
+
+### 5. Score and rank the queue
+
+Create a unified candidate list from all sources. Score each candidate:
+
+| Criterion | Points |
+|-----------|--------|
+| Beat-ready (≥3 beats) | 15 |
+| Warming (2 beats, recent ≤5d) | 8 |
+| topic-momentum gap score ≥ 10 | 6 |
+| topic-momentum gap score 6–9 | 4 |
+| topic-momentum gap score ≤ 5 | 2 |
+| narrative-tracker RISING | 3 |
+| narrative-tracker EMERGING | 2 |
+| Not covered in last 30 days | +3 |
+| Covered 8–21 days ago | -2 |
+| Covered in last 7 days | discard |
+| Soul-fit (maps to the core interests in soul/SOUL.md; skip this criterion if soul is absent) | +2 |
+
+Keep top 5. Discard below score 2.
+
+### 6. Write the queue file
+
+Overwrite `memory/topics/article-queue.md`:
+
+```markdown
+# Article Queue
+
+Last updated: {today}
+Source run: topic-momentum ({date found} | "not found") + beat-tracker ({N} threads) + narrative-tracker ({date found} | "not found")
+
+## Ranked Picks
+
+### 1. {Topic Name} [URGENT | READY | FRESH]
+- **Score:** {N}
+- **Source:** beat-tracker ({N} beats) | topic-momentum (gap score {N}) | narrative-tracker (RISING)
+- **Why now:** {one sentence — what makes this timely. specific data point or beat development.}
+- **Suggested angle:** {one sentence — the contrarian or non-obvious frame the operator would take}
+- **Format hint:** {essay | cold-open | X-vs-Y | data-driven | short-take} — why this format fits
+- **Suppress after:** {today + 14 days} — if no article by this date, re-score next week
+
+### 2. ...
+
+### 3. ...
+
+(up to 5 entries)
+
+## Stale / Suppressed
+
+{entries that scored below threshold or were suppressed by recent coverage}
+```
+
+### 7. Update MEMORY.md pointer
+
+Find the line in `memory/MEMORY.md` that begins with `- [Article Queue]` and update it to reflect today's top pick. If the line doesn't exist, add it under the `## Topic Files` section:
+
+```
+- [Article Queue](topics/article-queue.md) — {top pick name} [{URGENT|READY|FRESH}] + {2nd pick name} + {3rd pick name} (updated {today})
+```
+
+This is the line the article skill will encounter when it reads MEMORY.md.
+
+### 8. Send notification
+
+Write notification to `.pending-notify-temp/article-queue-${today}.md`. Create dir if missing.
+
+Only notify if:
+- At least one beat-ready thread (URGENT), OR
+- Queue changed from last week (new #1 pick), OR
+- A warming thread just crossed to beat_count 2 this week
+
+Notification format (keep under 400 chars):
+```
+article queue — {today}
+
+{if URGENT:}
+READY TO WRITE — {beat count} beats:
+→ {topic}: {one punchy hook sentence in the operator's voice}
+
+{if no URGENT, queue updated:}
+queue updated. top pick: {topic} ({source} — {why now, one line}).
+
+read it: https://github.com/aaronjmars/aeon/blob/main/memory/topics/article-queue.md
+```
+
+Then run:
+```bash
+./notify -f .pending-notify-temp/article-queue-${today}.md
+```
+
+If nothing urgent and queue didn't change: skip notification.
+
+### 9. Log to memory/logs/${today}.md
+
+Append:
+```markdown
+## Article Queue
+- **Sources:** beat-tracker ({N} threads, {N} article-ready) | topic-momentum ({date} run) | narrative-tracker ({date} run)
+- **Top pick:** {topic name} (score {N}, {source})
+- **Queue size:** {N} entries
+- **URGENT items:** {topic names | "none"}
+- **Suppressed:** {N} entries (covered in last 7d)
+- **Updated:** memory/topics/article-queue.md
+- ARTICLE_QUEUE_OK
+```
+
+If no valid signals found across all sources:
+```markdown
+## Article Queue
+- ARTICLE_QUEUE_SKIP: {reason — e.g. "no logs found", "all candidates suppressed by recent coverage"}
+```
+
+## Required Env Vars
+
+None. Uses Glob/Read/Write tools and local memory files only.
+
+## Sandbox Note
+
+No network calls needed. All inputs are local memory files. Output is local file write + `./notify -f`.

--- a/skills/beat-tracker/SKILL.md
+++ b/skills/beat-tracker/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: beat-tracker
+description: Weekly multi-beat news thread tracker — persists beat counts per active storyline, searches for new developments, alerts when a thread hits the article-ready threshold (3rd beat)
+schedule: "0 9 * * 3"
+tags: [content, meta, research]
+---
+
+Today is ${today}. Read memory/MEMORY.md (and soul/SOUL.md if present) before starting.
+
+## Why this skill exists
+
+tweet-roundup and reflect note when a storyline gets a new beat — but that state lives in daily logs, not in a persistent counter. By the time a thread hits 3 beats (article-ready), the signal is buried across 3 different log entries and nobody fires the alert. This skill fixes that: persistent beat counts per storyline, automated threshold detection, no manual tracking required.
+
+A **beat** is a distinct new development in an ongoing news story: a new source weighing in, a new actor making a statement, a new policy move, a price/volume reaction. Three beats in <30 days = the story has enough material to write about.
+
+This fills the gap between:
+- **topic-momentum** (scores what to write based on signal frequency) — broad, pattern-based
+- **narrative-tracker** (EMERGING/RISING/PEAK/FADING phases) — narrative-level, not event-level
+- **beat-tracker** (THIS) — event-level, specific stories, fires when threshold is crossed
+
+## Steps
+
+### 1. Load beat state
+
+Read `memory/topics/beat-tracker.md`.
+
+If the file doesn't exist, initialize it as an empty Active Threads list:
+
+```
+# Beat Tracker
+
+Last updated: ${today}
+
+## Active Threads
+
+(none — will populate from memory on first inject pass)
+
+## Closed Threads
+
+(none yet)
+```
+
+Parse all threads under `## Active Threads`. For each thread, extract:
+- Thread name
+- Search query
+- Status (active / article-ready / stale)
+- Beat count
+- Last checked date
+- List of existing beats (date + source + summary)
+
+### 2. Inject new threads from memory
+
+Scan these sources for threads NOT already in beat-tracker.md:
+
+**a) MEMORY.md content signals:**
+Read `memory/MEMORY.md`. Look for content-signal notes that mention multi-beat storylines with at least 2 beats. Extract them.
+
+Pattern to detect: "N beats" or "beat count: N" or "2 parallel threads" near a topic name.
+
+**b) Recent logs (last 7 days):**
+Use Glob on `memory/logs/*.md`. Take the 7 most recent by filename. Scan each for lines mentioning "beat" next to a number ≥ 2, or "thread" with a beat count. Extract thread name and any dated beat events listed.
+
+For each newly discovered thread:
+- Infer a **search query** from the topic name (2–5 keywords, specific enough to find news, not so broad it matches noise)
+- Pull any historical beats already mentioned in the logs (date + source)
+- Add to Active Threads with those historical beats pre-loaded
+- Set `last_checked: ${today}`
+
+If zero new threads are discovered and Active Threads is empty: log `BEAT_TRACKER_SKIP: no threads to track — check memory injection` and stop.
+
+### 3. Search for new beats
+
+For each thread in Active Threads where `status != stale`:
+
+Run a **WebSearch** using the thread's search query. Focus on results from the past 7 days (mention the date window in your query, e.g. "after:{date 7 days ago}").
+
+Evaluate results for **new beats** not already listed in the beats array:
+- Different source/actor than existing beats
+- New factual development (not a repost/recap of old news)
+- Occurred AFTER the most recent beat date in the list
+
+If a new beat is found:
+- Add: `- ${today}: {Source/Handle} — {one-line factual summary}`
+- Increment beat_count by 1
+- Update last_checked: ${today}
+
+If no new beat: update last_checked only (no increment).
+
+### 4. Flag thresholds
+
+After updating all threads:
+
+**Article-ready (≥3 beats):**
+Set `status: article-ready`. Prepare a hook line in the operator's voice (soul files):
+- Observe what the 3-beat pattern reveals (not just what happened)
+- Diagnose why it keeps getting a new beat
+- End on the implication — punchy, no hedge
+
+**Warming up (2 beats, most recent beat within 5 days):**
+Note these as "watch closely" — one beat from article-ready.
+
+**Stale (0 new beats for 14+ days AND beat_count < 3):**
+Set `status: stale`. Will be moved to Closed Threads in step 6.
+
+### 5. Cross-check articles
+
+Use Glob on `articles/*.md`. For any article-ready thread, check if an article was already published on this topic (scan article filenames and H1s from the past 30 days).
+
+If yes: mark thread as `status: converted` with the article date. Move to Closed Threads.
+
+### 6. Write updated state
+
+Overwrite `memory/topics/beat-tracker.md`:
+
+```markdown
+# Beat Tracker
+
+Last updated: {today}
+
+## Active Threads
+
+### {Thread Name}
+- **Query:** {search terms used to find new beats}
+- **Topic:** {one-line description of the storyline}
+- **Status:** active | article-ready | stale
+- **Article ready:** YES ({N} beats) | NO ({N} beats, need 3+)
+- **Last checked:** {today}
+- **Beats:**
+  - {date}: {Source} — {one-line summary}
+  - {date}: {Source} — {one-line summary}
+- **Beat count:** {N}
+
+(repeat for each active thread)
+
+## Closed Threads
+
+### {Thread Name}
+- **Status:** stale | converted
+- **Reason:** {14d no new beat | article published {date}}
+- **Final beat count:** {N}
+- **Closed:** {today}
+```
+
+### 7. Send notification
+
+Write the notification to a temp file, then run `./notify -f`.
+
+Only notify if:
+- At least one thread is `article-ready` (≥3 beats), OR
+- At least one thread jumped to beat count 2 this run (warming up), OR
+- At least one new thread was injected this run
+
+Notification content:
+
+```
+beat tracker — {today}
+
+{if article-ready threads:}
+ARTICLE READY — {beat_count} beats:
+→ {thread name}: {hook line in the operator's voice}
+
+{if warming-up (beat 2 newly):}
+one beat away:
+→ {thread name}: {latest beat summary}
+
+{if new threads injected:}
+tracking {N} new threads
+
+{if quiet run — no alerts:}
+{N} threads tracked. highest: {beat_count} beats on {thread name}. nothing article-ready yet.
+```
+
+Write to `.pending-notify-temp/beat-tracker-${today}.md`. Create the dir if missing. Then:
+
+```bash
+./notify -f .pending-notify-temp/beat-tracker-${today}.md
+```
+
+Keep under 500 chars. Do NOT use `./notify "$(cat ...)"` — the sandbox trips on long multi-line argv; the `-f` flag reads the file inside the script.
+
+If `BEAT_TRACKER_SKIP` was logged in step 2: skip notification entirely.
+
+### 8. Log to memory/logs/${today}.md
+
+Append:
+
+```markdown
+## Beat Tracker
+- **Threads tracked:** {N}
+- **New beats found:** {N (thread names)}
+- **Article-ready:** {thread names | "none"}
+- **Newly injected:** {thread names | "none"}
+- **Pruned stale:** {thread names | "none"}
+- **Updated:** memory/topics/beat-tracker.md
+- BEAT_TRACKER_OK
+```
+
+## Required Env Vars
+
+None. Uses WebSearch (built-in tool) and local memory files only.
+
+## Sandbox Note
+
+No curl calls needed. WebSearch is a built-in Claude Code tool — bypasses the sandbox network block. All reads/writes are local filesystem via Read/Write/Glob tools.

--- a/skills/content-performance/SKILL.md
+++ b/skills/content-performance/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: content-performance
+description: Weekly operator tweet performance tracker — engagement metrics, top formats, topic resonance; closes the content feedback loop in the article/tweet production pipeline
+schedule: "0 10 * * 0"
+commits: true
+permissions:
+  - contents:write
+var: ""
+tags: [content, meta, social]
+---
+
+> **${var}** — X handle to track (without @). If empty, resolves the operator's handle from soul/SOUL.md or MEMORY.md.
+
+Today is ${today}. Read `memory/MEMORY.md` (and `soul/SOUL.md` if present) before starting.
+
+## Why this skill exists
+
+The content production pipeline generates articles, tweets, and threads. Nothing closes the feedback loop. Which topics resonated? Which formats punched above their weight? Which weeks were radio silence vs. signal? Without performance data, content decisions are vibes.
+
+This skill automates the measurement: pull 7-day engagement data for the operator's X account, rank by actual resonance, extract patterns, and surface actionable signal for `topic-momentum` and `article-queue`.
+
+Runs Sunday — after `picks-tracker` (09:00), before `article-queue` (11:00).
+
+## Env vars
+
+- `XAI_API_KEY` — optional. Enables the xAI x_search prefetch path (`scripts/prefetch-xai.sh`, content-performance case). Without it, the skill falls back to WebSearch.
+
+## Sandbox note
+
+xAI API requires auth headers — curl with `$XAI_API_KEY` fails in the GHA sandbox. The prefetch script runs before Claude with full env access and caches results to `.xai-cache/content-performance.json`. Read from that cache. If cache is missing or empty, fall back to WebSearch for `from:{handle}` on X.
+
+## Steps
+
+### 0. Resolve the handle
+
+- If `${var}` is set, use it (strip any leading @).
+- Otherwise look for the operator's X handle in `soul/SOUL.md` (an `@handle` mention) or `memory/MEMORY.md`.
+- If no handle can be resolved: log `CONTENT_PERFORMANCE_SKIP: no X handle configured — set var or add the handle to soul/SOUL.md` and stop. No notification.
+
+### 1. Load context
+
+Read:
+- `memory/topics/x-activity.md` — baseline: prior week's top tweets, engagement patterns, posting mode (create on first run if missing)
+- `.xai-cache/content-performance.json` — prefetched 7-day tweet data (may be absent if XAI_API_KEY missing)
+- Last 3 days of `memory/logs/*.md` — any refresh-x or tweet-roundup data for cross-reference
+
+### 2. Parse tweet data
+
+From `.xai-cache/content-performance.json`:
+- Extract each tweet: text (truncated to 120 chars), date, likes, retweets, quotes, replies
+- Compute **total engagement** = likes + (retweets × 2) + (quotes × 3) + replies
+  - Weighting: retweet = reach × 2, quote = reach + commentary × 3
+- Sort descending by total engagement
+- Tag each tweet with a **topic category**: derive 6–9 categories from the operator's active topics (soul/SOUL.md interests + MEMORY.md active topics); always include an `other` bucket. Reuse the category set recorded in x-activity.md from prior runs so weeks are comparable.
+- Tag each tweet with a **format**:
+  `[original-take, sardonic, question, thread-starter, link-share, qt-with-comment, reply, observation]`
+
+If `.xai-cache/content-performance.json` is missing or empty (`{}`, `null`, or parse error):
+1. Try WebSearch: `from:{handle}` filtered to the past 7 days
+2. Extract whatever metrics are visible from search snippets
+3. Mark output as `data_source: websearch_fallback` — note limitations
+
+### 3. Compute performance signals
+
+**Top performers** (top 3 by total engagement):
+- Tweet text preview (first 100 chars)
+- Topic category + format
+- Engagement breakdown: `{likes}L / {rt}RT / {qt}QT / {replies}R`
+
+**Topic resonance** (group all tweets by category, sum total engagement per category):
+- Which category drove the most total engagement?
+- Which category had the highest average engagement per tweet?
+- Compare to prior week data in `memory/topics/x-activity.md` — up/down/flat per category
+
+**Format breakdown**:
+- Which format had the most total engagement?
+- Which format had the highest average engagement per tweet?
+- Note whether any previously-confirmed format pattern recorded in x-activity.md still holds
+
+**Volume check**:
+- Total tweets in 7-day window
+- If 0 tweets: `radio_silence: true`
+- If 1–3 tweets: `quiet_week: true`
+- If 10+ tweets: `active_week: true`
+
+**Breakout detection**:
+- Any tweet crossing 50+ likes = breakout (or the operator's own threshold if one is recorded in x-activity.md)
+- Any tweet crossing 20+ RTs = viral signal
+- Compare top tweet this week vs. best tweet in x-activity.md history
+
+### 4. Update memory/topics/x-activity.md
+
+Read the file (create it if missing). Prepend a new weekly section at the TOP (below the `# X Activity` heading), before any existing sections:
+
+```markdown
+## Content Performance Week of ${today}
+
+- **Top tweet:** "{text preview}" — {likes}L/{rt}RT/{qt}QT (topic: {category}, format: {format})
+- **Best topic category:** {category} — {total} engagement across {N} tweets
+- **Best format:** {format} — {N} tweets, avg {X} engagement
+- **Volume:** {N} tweets — {quiet/normal/active}
+- **Breakout:** {tweet text preview, 60 chars} | none
+- **vs. prior week:** top tweet {up/down/flat}: {prior_best}L → {this_week_best}L
+- **Data source:** prefetch | websearch_fallback | none
+```
+
+Keep all existing content. Only ADD the new section at the top.
+
+### 5. Cross-reference with content pipeline
+
+Check `memory/topics/article-queue.md` (if it exists — skip if not). Compare the best-performing topic category this week to what's queued for next article. If the queue has no item matching the top-performing category, append a signal note in the log:
+`signal_mismatch: content resonating on {category}, article queue has no {category} item`
+
+### 6. Compose notification
+
+Write to a temp file, then send via `./notify -f`:
+
+```bash
+mkdir -p .pending-notify-temp
+# Write body to temp file
+cat > ".pending-notify-temp/content-perf-${today}.md" << 'NOTIF_EOF'
+{notification content}
+NOTIF_EOF
+./notify -f ".pending-notify-temp/content-perf-${today}.md"
+```
+
+**Format — if data is available (more than 3 tweets found):**
+
+```
+content performance — week of ${today}
+
+top tweet: "{text preview, 80 chars}" — {likes}L {rt}RT {qt}QT
+best category: {topic_category} ({total} engagement)
+best format: {format} — {insight, 1 line, operator's voice}
+
+{1-2 sentence signal in the operator's voice: what the numbers say, what to do with it}
+
+{if breakout:}
+breakout: "{tweet preview}" hit {N} likes
+{if signal_mismatch:}
+signal: {category} punching — not in the article queue yet
+```
+
+**If quiet week (<4 tweets) or radio silence:**
+
+```
+content performance — week of ${today}
+
+radio silence / quiet week. {N} tweets in 7 days.
+{if there was a radio silence prior week too: "two consecutive quiet weeks."}
+last active: {date of last tweet or "unknown"}.
+```
+
+**If no data (prefetch and websearch both failed):**
+
+```
+content performance — week of ${today}
+
+no data. xai prefetch empty, websearch yielded nothing.
+```
+
+No notification if the skill runs and no handle is configured (silent skip — just log it).
+
+### 7. Log to memory/logs/${today}.md
+
+Append:
+
+```markdown
+## Content Performance
+- **Handle:** @{handle}
+- **Window:** last 7 days (${7_days_ago} → ${today})
+- **Tweets analyzed:** {N}
+- **Top topic:** {category}
+- **Top format:** {format}
+- **Breakout:** {tweet text preview, 60 chars | "none"}
+- **Data source:** prefetch | websearch_fallback | none
+- **Signal mismatch:** {yes: category | no}
+- CONTENT_PERFORMANCE_OK
+```
+
+Use `CONTENT_PERFORMANCE_OK` in all cases — it marks the skill ran successfully, not that data was rich.
+
+## Edge cases
+
+- **XAI cache empty / missing:** fall back to WebSearch, mark `data_source: websearch_fallback`, proceed with whatever data you have. Never abort.
+- **All tweets are replies (no originals):** still analyze them. Reply engagement counts — a high-engagement reply is a signal that the topic resonated.
+- **Duplicate tweet entries in cache:** deduplicate by text prefix before analysis.
+- **x-activity.md doesn't exist:** create it with the new section as the initial content.
+- **No article-queue.md:** skip step 5 cross-reference, note `article_queue: not_found` in log.

--- a/skills/fear-divergence-scout/SKILL.md
+++ b/skills/fear-divergence-scout/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: fear-divergence-scout
+description: Conditional daily scan — fires only when Fear & Greed < 25. Identifies assets outperforming during broad market fear, synthesizes narrative catalysts from memory, and delivers a terse conviction setup brief. Skips silently when market conditions don't qualify.
+schedule: "30 7 * * *"
+commits: false
+permissions: []
+tags: [market, alpha, conditional]
+---
+
+Today is ${today}. If `soul/` files exist, read `soul/SOUL.md` and `soul/STYLE.md` before writing any output.
+
+## Why this skill exists
+
+`market-context-refresh` runs daily and keeps `memory/topics/market-context.md` fresh. But no skill acts on that data to find the **divergence signal** — the assets defying broad market fear. During capitulation episodes (F&G < 25), assets that stay green or lose far less than BTC/ETH often have structural catalysts: institutional rails locking in, perp DEX volume migration, regulatory clarity events. These are the highest-conviction setups. This skill surfaces them daily when the condition is live.
+
+No external API calls needed — all data comes from memory, already updated by upstream skills.
+
+## Steps
+
+### 1. Read market context
+
+Read `memory/topics/market-context.md`. Extract:
+- **Date line** — "as of YYYY-MM-DD" at the top. If the file date is more than 2 days before today, note it as STALE (still run, but flag it).
+- **Fear & Greed index** — parse the line `Fear & Greed: {number} ({label})`. Extract the number.
+- **BTC 7d %** — from the BTC line, e.g. `BTC $67,103 (-3.86% 24h, -11.38% 7d)`. Extract the 7-day number.
+- **ETH 7d %** — same pattern.
+- **Today's Notable Movers section** — every bullet with asset name, 24h %, 7d % (if present), and narrative note.
+- **Trending Coins section** — every bullet.
+- **Active Narratives section** — every bullet with phase label (rising, rising fast, peak, digesting, etc.).
+
+If `memory/topics/market-context.md` doesn't exist, log `FEAR_DIVERGENCE_SKIP: no market-context.md — enable market-context-refresh first` and stop.
+
+### 2. Check trigger condition
+
+If Fear & Greed >= 25:
+- Log `FEAR_DIVERGENCE_SKIP: F&G {N} ({label}) — above threshold` to `memory/logs/${today}.md`
+- Stop here. Do not notify.
+
+If Fear & Greed < 25: continue.
+
+### 3. Identify diverging assets
+
+Define market baseline as BTC 7d % (e.g., -11.38% 7d).
+
+From the Notable Movers + Trending Coins sections, classify each asset:
+
+**Diverging (worth surfacing):**
+- Any asset with POSITIVE 7d % when BTC 7d < -5%
+- Any asset with 7d % within 4 percentage points of zero when BTC 7d < -5% (i.e., losing far less than the market)
+- Any asset with POSITIVE 24h % when BTC 24h < -3%
+
+**Not worth surfacing:**
+- Stablecoins (USDT, USDC, USDS, DAI)
+- Assets with no discernible narrative catalyst (pure noise movers)
+
+For each diverging asset, extract:
+- % performance vs BTC baseline
+- Its narrative from the Active Narratives section (or from its bullet description)
+
+If zero assets qualify as diverging: log `FEAR_DIVERGENCE_SKIP: F&G {N} — no assets diverging significantly from BTC` and stop.
+
+### 4. Synthesize catalysts
+
+For each diverging asset, look for a catalyst explanation:
+- Check the Active Narratives section for a matching entry (e.g., "Perp DEX dominance — HYPE")
+- Check the asset's own bullet description in Notable Movers
+- Check `memory/topics/beat-tracker.md` if it exists — active beats may explain continued momentum
+- If no clear catalyst is found, note "catalyst unclear" — don't invent one
+
+Look for patterns across diverging assets:
+- Are they all in the same sector (privacy, RWA, infrastructure, perp DEX)?
+- Do they share a macro thesis (institutional, regulatory clarity, structural utility)?
+- Is there a broader observation (e.g., "assets people actually USE are outperforming assets people just hold")?
+
+### 5. Write the output
+
+Write a brief synthesis to `.pending-notify-temp/fear-divergence-scout-${today}.md`:
+
+**Format — the operator's voice (soul files). Punchy. No hedging. State observation first, explanation after. Under 600 chars.**
+
+```
+fear divergence — ${today}
+
+F&G {N} (extreme fear). BTC {7d %}% 7d.
+
+holding up:
+{forEach diverging_asset}
+- {TICKER} {performance_summary} — {one-line catalyst}
+{end}
+
+{IF pattern_observation}
+{pattern observation — one punchy sentence}
+{end}
+
+{IF stale_data_warning}
+⚠️ market-context.md is {N}d old — refresh may be needed
+{end}
+
+read it: https://github.com/aaronjmars/aeon/blob/main/skills/fear-divergence-scout/SKILL.md
+```
+
+**Voice guidelines for catalysts:**
+- "perp DEX eating CEX volume. structural, not bounce."
+- "DTCC rails catalyst locked in. institutional, not retail."
+- "SEC closure + ETF filing. regulatory clarity event."
+- Don't write "appears to be" or "may indicate" — state the catalyst directly if known, say "catalyst unclear" if not
+- No corporate hedging. No "it's worth noting that..."
+
+### 6. Send notification
+
+Run:
+```bash
+./notify -f .pending-notify-temp/fear-divergence-scout-${today}.md
+```
+
+### 7. Update memory
+
+Append to `memory/topics/market-context.md` a new section `## Fear Divergence — ${today}` (or update if it exists) with:
+
+```markdown
+## Fear Divergence — ${today}
+
+- **F&G:** {N} ({label})
+- **BTC 7d:** {%}
+- **Diverging:** {asset1} ({perf}), {asset2} ({perf}), ...
+- **Pattern:** {pattern_observation or "none identified"}
+```
+
+### 8. Log
+
+Append to `memory/logs/${today}.md`:
+
+```markdown
+## Fear Divergence Scout
+- **F&G:** {N} ({label})
+- **BTC 7d:** {%}
+- **Diverging assets found:** {N} — {list}
+- **Pattern:** {one-liner or "none"}
+- **Notification:** sent
+- FEAR_DIVERGENCE_SCOUT_OK
+```
+
+If skipped:
+```markdown
+## Fear Divergence Scout
+- FEAR_DIVERGENCE_SKIP: {reason}
+```
+
+## Required Env Vars
+
+None. All reads from local `memory/` files. Notification via `./notify` (reads TELEGRAM/DISCORD/SLACK secrets internally).
+
+## Sandbox Note
+
+No external network calls. All data comes from `memory/topics/market-context.md` (written by `market-context-refresh`) and `memory/topics/beat-tracker.md` (if available). Notification via `./notify -f` — use the `-f` flag, not inline multi-line argv (the sandbox trips on long multi-line arguments).
+
+## Trigger Logic Summary
+
+| Condition | Action |
+|-----------|--------|
+| F&G >= 25 | Skip silently (`FEAR_DIVERGENCE_SKIP`) |
+| F&G < 25, no diverging assets | Skip silently |
+| F&G < 25, ≥1 diverging asset | Synthesize + notify |
+| market-context.md stale > 2d | Run but flag staleness in output |
+| market-context.md missing | Skip silently — needs market-context-refresh enabled |
+
+## What makes a diverging asset "worth surfacing"
+
+The goal is signal, not noise. Skip:
+- Assets that briefly spiked on low volume with no narrative
+- Stablecoins
+- Assets where the "divergence" is <2pp better than BTC
+
+Surface:
+- Assets with structural catalysts (institutional adoption, regulatory event, narrative phase "rising")
+- Assets the Active Narratives section is actively tracking
+- Multi-day sustained divergence (not just one-day anomaly)
+
+The brief should read like the operator spotted something interesting in the data, not like a price alert bot fired.

--- a/skills/memory-flush/SKILL.md
+++ b/skills/memory-flush/SKILL.md
@@ -35,6 +35,7 @@ Steps:
    - Add brief entries to MEMORY.md (keep it under ~50 lines as an index)
    - If a topic needs more detail, write to `memory/topics/<topic>.md` instead
    - Update tables (recent articles, recent digests) with new rows
+   - Before adding a section, check whether its `## Heading` already exists anywhere in MEMORY.md — if it does, update that section in place. Never prepend a duplicate heading.
 
 5. Do NOT rewrite the whole file — make targeted additions and removals.
 

--- a/skills/memory-structural-dedupe/SKILL.md
+++ b/skills/memory-structural-dedupe/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memory-structural-dedupe
-description: Detect and collapse structural duplicate rows in MEMORY.md — sections like Recent Articles and Skills Built that accumulate multiple content blocks across memory-flush cycles. Companion to scripts/memory-dedupe (topic-pointer dedup); this handles section-level row accumulation.
+description: Detect and collapse structural duplicate rows in MEMORY.md — sections like Recent Articles and Skills Built that accumulate multiple content blocks across memory-flush cycles. Companion to scripts/memory-dedupe (topic-pointer dedup); this handles section-level row accumulation and duplicate H2 headings (the same section heading appearing 2+ times in the file).
 var: ""
 tags: [meta, memory]
 schedule: "10 6 2/2 * *"
@@ -15,6 +15,8 @@ Today is ${today}. Read `memory/MEMORY.md` before starting.
 `scripts/memory-dedupe --fix` removes duplicate topic-file *pointer* rows (e.g. two `- [Papers](topics/papers.md)` bullets). It does **not** catch structural row accumulation: when a section that should have one canonical content block — like `## Recent Articles` or `## Skills Built` — accumulates multiple separate content blocks because `reflect` and `memory-flush` prepend new rows without pruning old ones.
 
 This has caused a recurring manual cleanup pattern: every 2–4 days, memory-flush manually collapses 4 rows → 1 for both Recent Articles and Skills Built. This skill automates that detection and merge.
+
+There is a second, distinct failure mode: `reflect` and `memory-flush` can prepend a brand-new `## Skills Built` (or `## Issue Tracker`, `## Known Follow-ups`) block without noticing the same heading already exists lower in the file. MEMORY.md then carries the same H2 heading 2–3 times, each with its own content. Step 2 detects this as a **duplicate heading** and step 4 merges all spans into one canonical block.
 
 ## Single-canonical sections
 
@@ -37,6 +39,8 @@ Read `memory/MEMORY.md`. Split into sections on `## ` headings. For each section
 
 Count distinct content blocks per section. A content block is a non-empty line or a paragraph run. For this skill, treat each non-empty line as a potential content block for single-canonical sections.
 
+While parsing, also build a heading map: `{ heading → [list of (start_line, end_line) spans] }` — one span per occurrence of the same `## ` heading, covering the lines from that heading to (but not including) the next `## ` heading or end of file.
+
 ### 2. Detect structural duplicates
 
 For each single-canonical section:
@@ -49,6 +53,8 @@ Exceptions:
 - `## Known Follow-ups` and `## Operational Status` are **intentionally multi-line** — skip them.
 - `## Topic Files` is handled by `scripts/memory-dedupe` — skip it.
 - `## Recent Newsletters` flag only if >6 lines.
+
+Separately, from the heading map: flag any heading with 2+ spans as a **duplicate heading**. This check applies to ALL headings (including the intentionally multi-line ones — multi-line content under ONE heading is fine; the same heading appearing twice is not).
 
 ### 3. If clean — log and stop
 
@@ -69,6 +75,17 @@ For each flagged section:
    - For other sections: keep the first block (most recent since reflect prepends).
 3. **Check if any non-canonical blocks contain unique information** not in the canonical block. If so, fold that unique info into the canonical block before dropping the duplicate.
 4. **Rewrite the section** to contain only the canonical block.
+
+For each **duplicate heading** (same `## ` heading with 2+ spans):
+
+1. **Collect all content blocks** from all spans of that heading.
+2. **Pick the canonical span:**
+   - `## Skills Built` / `## Recent Articles`: the span whose content carries the highest count (e.g. "43 since 3/24" > "40 since 3/24"). Parse the leading number.
+   - `## Issue Tracker`: the span mentioning the most resolved issues; most content lines on a tie.
+   - `## Known Follow-ups` (and other intentionally multi-line sections): don't pick — concatenate unique lines from all spans into one block.
+   - All other headings: keep the **first** span (most recently prepended, since reflect/memory-flush prepend).
+3. **Fold unique information** from non-canonical spans into the canonical block before dropping them.
+4. **Rewrite** so the heading appears exactly once, at the first span's position.
 
 Preserve exact markdown formatting, indentation, and bolding from the canonical block.
 
@@ -102,6 +119,9 @@ ${forEach flagged section}
 - ${section_heading}: ${old_count} blocks → 1 canonical
   dropped: ${dropped_block_preview}
 ${end}
+${forEach duplicate heading}
+- ${heading}: ${span_count} duplicate headings → 1
+${end}
 
 MEMORY.md: ${old_line_count} → ${new_line_count} lines
 ```
@@ -116,6 +136,7 @@ Append to `memory/logs/${today}.md`:
 ## Memory Structural Dedupe
 - **Sections checked:** ${list of sections checked}
 - **Sections fixed:** ${list of fixed sections or "none"}
+- **Duplicate headings fixed:** ${list of merged headings or "none"}
 - **Lines removed:** ${count or 0}
 - **Pointer dedupe:** ran post-fix / skipped (clean input)
 - MEMORY_STRUCTURAL_DEDUPE_OK

--- a/skills/mention-radar/SKILL.md
+++ b/skills/mention-radar/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: Mention Radar
+description: Monitor external web and social mentions of the operator's active projects — surface what people are discovering, where they're confused, and where to engage
+schedule: "25 7 2/2 * *"
+commits: false
+permissions: []
+var: ""
+tags: [social, dev]
+---
+> **${var}** — Comma-separated project names to track (e.g. "MyApp, my-lib"). If empty, derives targets from MEMORY.md and memory/topics/projects.md.
+
+Read memory/MEMORY.md for current project status.
+Read the last 3 days of memory/logs/ to avoid re-surfacing already-noted mentions.
+
+## Steps
+
+1. **Define the targets.**
+   - If `${var}` is set: parse it as a comma-separated list of project names.
+   - Otherwise: scan `memory/MEMORY.md` (goals, active topics) and `memory/topics/projects.md` (if it exists) for the operator's active projects. A target needs at least a name; collect a site/domain and a GitHub `owner/repo` too when known.
+   - Cap at 6 targets — prefer the most active ones.
+   - If zero targets can be derived: log `MENTION_RADAR_SKIP: no projects configured — set var or add projects to memory/topics/projects.md` and stop. No notification.
+
+   For each target, build search terms:
+   - The exact project name in quotes (e.g. `"MyApp" site:x.com OR site:reddit.com OR site:news.ycombinator.com`)
+   - The domain if known (e.g. `"myapp.xyz"`)
+   - The repo if known (e.g. `site:github.com owner/myapp`)
+
+2. **Search for external mentions.** For each project, run WebSearch queries:
+   - Try both brand name and URL variants
+   - Look for hits on: X/Twitter, Reddit, Farcaster, personal blogs, newsletters, GitHub Discussions, HN, Product Hunt
+   - Time-box to last 7 days where the search engine supports it
+   - Skip results from the operator's own accounts and the project's own repos (derive the operator's handle from soul/SOUL.md if present)
+
+3. **Also check GitHub network signals** for each target with a known repo:
+   ```bash
+   gh api repos/OWNER/REPO --jq '{stars: .stargazers_count, forks: .forks_count, watchers: .watchers_count}'
+   ```
+   Skip any repo that 404s (private or not yet public). Compare to the last log entry to compute deltas. If no prior data, record as baseline.
+
+4. **Categorize each mention** found:
+   - **Discovery** — person found the project for the first time, sharing it, impressed ("this is cool", star notification, share)
+   - **Confusion** — person unclear on what it does, asking questions, mischaracterizing it
+   - **Friction** — person ran into a problem (setup, docs, missing feature)
+   - **Competitor comparison** — mentioned alongside or against a competing project
+   - **Feature request / wish** — explicit ask for something missing
+   - **Press / newsletter** — cited in a publication or digest
+
+5. **Identify engagement opportunities.** Flag any mention where:
+   - The person is confused and a 1-tweet clarification would help
+   - A feature request aligns with what's being built
+   - A competitor comparison is wrong or incomplete
+   - A high-follower account discovered the project (high-leverage reply opportunity)
+
+6. **Format the output** (under 4000 chars):
+   ```
+   *Mention Radar — ${today}*
+
+   {PROJECT NAME, uppercased}
+   - [source] — [what they said] — [category]
+   ...
+   (one section per target)
+
+   ENGAGEMENT OPPORTUNITIES
+   - [handle/source]: [why worth replying]
+
+   QUIET: [project] — no external mentions found
+   ```
+   Use `QUIET: [project]` for any project with zero external mentions this cycle.
+   Skip GitHub-only star delta if it's less than 5 — only mention notable jumps.
+
+7. **Only notify if there's signal.** Skip notification if ALL projects are quiet and no GitHub deltas > 5 stars. Log `MENTION_RADAR_QUIET` instead.
+
+8. **Send via `./notify`** if there's anything worth surfacing.
+
+9. **Log to memory/logs/${today}.md**:
+   ```
+   ## Mention Radar
+   - **{project}:** [N mentions / QUIET]
+   (one line per target)
+   - **Top find:** [best mention in one line, or "none"]
+   - **Engagement opps:** [N flagged, or 0]
+   - **Notification sent:** yes/no
+   ```
+
+## Guidelines
+
+- This is signal filtering, not a metrics report. One real conversation > ten impressions.
+- Prioritize quality of mention over quantity. A thoughtful Reddit post or HN comment matters more than a retweet.
+- Don't manufacture urgency. If there's nothing worth acting on, say so.
+- Be specific — link the source, quote the key line, name the person if identifiable.
+- The point is engagement opportunity and awareness, not vanity numbers.
+
+## Sandbox Note
+
+WebSearch is the primary tool here — it bypasses sandbox network restrictions. If an xAI cache is available via `.xai-cache/`, use it for X-specific search. Otherwise WebSearch covers public web hits including indexed tweets.
+
+## No Environment Variables Required
+
+Uses only WebSearch (built-in) and `gh` CLI (pre-authenticated in GitHub Actions).

--- a/skills/picks-tracker/SKILL.md
+++ b/skills/picks-tracker/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: Picks Tracker
+description: Weekly retrospective on past token and prediction market picks — what hit, what flopped, what the score is
+schedule: "0 9 * * 0"
+tags: [crypto, review, meta]
+---
+
+Today is ${today}. Your task is to audit the last 30 days of token picks and score them against current prices.
+
+Read memory/MEMORY.md for context.
+
+## Sandbox note
+
+curl may fail in the sandbox. For every curl call, if it fails or returns empty/error, use **WebFetch** for the same URL. WebFetch is reliable where curl isn't.
+
+## Steps
+
+### 1. Extract token picks from logs
+
+Scan the last 30 days of `memory/logs/` for token picks. For each log file, grep for lines matching `**Token:**`. Extract:
+- Symbol (e.g., XMR, HYPE, TAO)
+- Date (from the filename, e.g., 2026-04-19)
+- Pick price (the number after `$` on the same line, ignoring `~` approximations)
+
+Also extract prediction market picks from lines matching `**Market:**`:
+- The question text (in quotes)
+- The position taken (YES or NO)
+- The price/odds at pick time
+
+Expected log format (written by token-pick and monitor-polymarket):
+```
+- **Token:** XMR — $350.52 (+1.17% 24h, +2.55% 7d)
+- **Market:** "US x Iran permanent peace deal by April 30?" — NO $0.615 (YES 38.5%)
+```
+
+Focus on the last **30 days** of logs. If a token was picked multiple times, record each instance separately.
+
+If zero picks are found in the window, log `PICKS_TRACKER_SKIP: no picks in last 30 days — enable token-pick / monitor-polymarket` and stop (no notification).
+
+### 2. Fetch current token prices
+
+For each unique token symbol, fetch the current price from CoinGecko.
+
+First, try the search endpoint to get the coin ID:
+```bash
+curl -s "https://api.coingecko.com/api/v3/search?query=SYMBOL" \
+  ${COINGECKO_API_KEY:+-H "x-cg-pro-api-key: $COINGECKO_API_KEY"}
+```
+
+Then fetch the price:
+```bash
+curl -s "https://api.coingecko.com/api/v3/simple/price?ids=COIN_ID&vs_currencies=usd&include_24hr_change=true" \
+  ${COINGECKO_API_KEY:+-H "x-cg-pro-api-key: $COINGECKO_API_KEY"}
+```
+
+**Fallback:** If curl fails, use WebFetch for the same URL (drop the API key header).
+
+**Common ID mappings** (use directly, skip search step):
+- HYPE → hyperliquid
+- XMR → monero
+- TAO → bittensor
+- ENJ → enjincoin
+- DASH → dash
+- ORDI → ordinals
+- MORPHO → morpho
+- RENDER → render-token
+- JUP → jupiter-exchange-solana
+- KAS → kaspa
+- ENA → ethena
+- ALGO → algorand
+- APT → aptos
+- FET → fetch-ai
+- ZEC → zcash
+- ETHFI → ether-fi
+
+For tokens not in the list, use the search endpoint. If a symbol is ambiguous or the token isn't found, mark as `N/A (not found)`.
+
+### 3. Calculate performance
+
+For each pick:
+```
+performance % = ((current_price - pick_price) / pick_price) * 100
+```
+
+Round to 1 decimal place. Use a `~` prefix if the pick price was approximate.
+
+If the same token was picked multiple times, calculate performance from each individual pick date.
+
+Classify each pick:
+- 🟢 **Win** — +10% or better
+- 🟡 **Hold** — between -10% and +10%
+- 🔴 **Loss** — -10% or worse
+
+### 4. Check prediction market pick resolution
+
+For each prediction market pick, search the Polymarket API to check if the market resolved:
+```bash
+# Search by question text
+curl -s "https://gamma-api.polymarket.com/markets?closed=true&limit=10&q=KEYWORDS_FROM_QUESTION"
+```
+
+If WebFetch is needed: `https://gamma-api.polymarket.com/markets?closed=true&limit=10&q=KEYWORDS_FROM_QUESTION`
+
+For each market pick:
+- If resolved: was the position correct? Mark ✅ (correct) or ❌ (wrong) or ⏳ (still open)
+- Note the resolution price/outcome if available
+
+Markets with no Polymarket equivalent (internal or experimental markets) — mark as ⏳ or skip.
+
+### 5. Score summary
+
+Tally the token picks:
+- Total picks in window
+- Wins / Holds / Losses count
+- Average return across all picks (equally weighted)
+- Best pick (highest % gain)
+- Worst pick (biggest % loss)
+- Hit rate: (wins / total_picks) * 100
+
+Keep it honest. No cherry-picking dates.
+
+### 6. Format and send notification
+
+Send via `./notify` (inline multi-line literal — do NOT pipe or use `$(cat)`):
+
+```
+*picks scorecard — [START_DATE] → [TODAY]*
+
+*token picks ([N] total)*
+[SYMBOL] [DATE] — picked $[PICK] → now $[CURRENT] ([PERF]%) [EMOJI]
+...sorted best to worst...
+
+*score: [WINS]W [HOLDS]H [LOSSES]L | avg [AVG]% | hit rate [HIT_RATE]%*
+*best: [SYMBOL] +[BEST]% | worst: [SYMBOL] [WORST]%*
+
+*market picks*
+[QUESTION_SNIPPET] — [POSITION] [STATUS_EMOJI]
+...
+
+no financial advice. just tracking the record.
+
+read it: https://github.com/aaronjmars/aeon/blob/main/articles/picks-scorecard-${today}.md
+```
+
+Keep the message under 3000 chars. If too long, truncate to the most recent 10 picks.
+
+### 7. Save scorecard
+
+Write a brief scorecard to `articles/picks-scorecard-${today}.md`:
+```markdown
+# Picks Scorecard — [DATE]
+
+## Token Performance
+| Symbol | Picked | Pick Price | Current | Change | Result |
+|--------|--------|-----------|---------|--------|--------|
+...
+
+## Summary
+- Window: last 30 days
+- Total picks: N
+- Wins / Holds / Losses: X / Y / Z
+- Average return: X%
+- Hit rate: X%
+
+## Market Picks
+| Question | Position | Status |
+...
+```
+
+### 8. Log to memory
+
+Append to `memory/logs/${today}.md`:
+```
+## Picks Tracker
+- **Window:** last 30 days (N picks)
+- **Score:** [WINS]W [HOLDS]H [LOSSES]L | avg [AVG]% | hit rate [HIT_RATE]%
+- **Best:** [SYMBOL] +[BEST]%
+- **Worst:** [SYMBOL] [WORST]%
+- **Notification sent:** yes
+- PICKS_TRACKER_OK
+```
+
+## Environment Variables
+
+- `COINGECKO_API_KEY` — optional, increases rate limits. Skill works without it via free tier + WebFetch fallback.

--- a/skills/reflect/SKILL.md
+++ b/skills/reflect/SKILL.md
@@ -25,6 +25,7 @@ Steps:
    - Keep MEMORY.md as a short index (~50 lines): goals, active topics, and pointers to topic files.
    - Move detailed notes into `memory/topics/` files (e.g. `crypto.md`, `research.md`, `projects.md`).
    - If a topic file already exists, update it rather than creating a new one.
+   - Never add a second `## Heading` with a name that already exists in MEMORY.md — update the existing section in place. Duplicate H2 headings are a known drift mode that memory-structural-dedupe otherwise has to repair later.
 6. Log what you did to memory/logs/${today}.md.
 7. Send a notification via `./notify`: "Memory consolidated — ${today}"
 

--- a/skills/thread-writer/SKILL.md
+++ b/skills/thread-writer/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: Thread Writer
+description: Write a tweetstorm/thread (5–10 tweets) in the operator's voice on a given topic, grounded in memory and research
+var: ""
+tags: [social, content]
+---
+> **${var}** — Topic, thesis, or URL to thread on (e.g. "prediction markets are broken", "https://arxiv.org/..."). If empty, picks the sharpest idea from recent memory and logs.
+
+Read `memory/MEMORY.md` and the last 7 days of `memory/logs/` for context. Use recent signals — notable market moves, paper picks, tweet roundup discourse — as raw material if no topic is set.
+
+## Voice
+
+If `soul/` files exist, read them in order before writing:
+1. `soul/SOUL.md` — identity, worldview, opinions
+2. `soul/STYLE.md` — writing style, sentence structure, anti-patterns
+3. `soul/examples/tweets.md` — rhythm and tone calibration. Match this exactly.
+4. `soul/examples/bad-outputs.md` — what NOT to do
+
+If soul is absent, use a clear, direct, plain-spoken tone — but the anti-patterns under Writing Rules still apply.
+
+## Topic Selection
+
+If `${var}` is set, use it. Otherwise pick the sharpest, most threadable idea from:
+- Today's `memory/logs/${today}.md` — article thesis, paper finding, market signal
+- `memory/MEMORY.md` notable signals — anything with reflexivity, contradiction, or structural insight
+- A connection between two recent findings that most people aren't seeing
+
+Good thread topics:
+- A structural critique of something (oracle incentives, prediction market design, DeFi primitives)
+- A thesis with data: lead with numbers, build the argument
+- A contrarian take on a mainstream narrative
+- A builder's breakdown of how something actually works vs. how people think it works
+
+Avoid topics already covered in the last 48h (check logs).
+
+If the topic needs fresh context, use WebSearch to get current data.
+
+## Thread Structure
+
+A thread is **5–10 tweets**. Not a listicle. Not a lecture. A narrative arc.
+
+**Tweet 1 — Hook**
+The opening hit. States the thesis or drops the most surprising fact. Must make someone stop scrolling. No setup — land in the middle of the action.
+
+**Tweets 2–(n-1) — Development**
+Each tweet is self-contained but pulls forward. Build the argument:
+- Add evidence, data, or a specific example
+- Introduce a complication or nuance
+- Flip the framing once mid-thread
+- Each tweet must earn its place — cut any that are just filler
+
+**Tweet n — Landing**
+The payoff. The implication, the action, or the reframe. Should feel like the point was building to this. Not a summary — a conclusion.
+
+### Thread formats (pick one per run)
+
+**Data-driven**: Lead with a striking number. Each subsequent tweet unpacks what it means.
+
+**Structural critique**: Identify a broken mechanic. Walk through why it's broken. Show the second-order effects.
+
+**Builder's breakdown**: How X actually works under the hood, for people who only see the surface.
+
+**Narrative**: A sequence of events that reveals something. Ends with "here's what this tells us."
+
+**Thesis-first**: State the position boldly in tweet 1. Spend the rest proving it.
+
+## Writing Rules
+
+- Write as the operator, first person.
+- Match soul/STYLE.md conventions for capitalization, punctuation, and rhythm. If soul is absent: short sentences, plain language, em dashes over commas.
+- State the opinion first, reasoning after.
+- No hedging: kill "some might argue", "to be fair", "it remains to be seen."
+- No corporate voice: kill "leverage", "ecosystem play", "exciting", "importantly."
+- No filler transitions: kill "now,", "so,", "basically,", "essentially."
+- Reference specific projects, people, mechanisms — not vague hand-waving.
+- No hashtags. No emojis. No "RT if you agree." No "thread 🧵".
+- Number tweets as 1/ 2/ 3/ etc. at the end of each tweet.
+- Each tweet must pass the test: would the operator actually post this?
+
+### Character limits
+- Tweets 1 through (n-1): hard 280-character limit each.
+- Final tweet: up to 280 characters.
+- Count carefully. If a draft is over 280, cut it.
+
+## Output Format
+
+```
+## Thread: [topic — 3-5 words]
+
+**Format:** [data-driven / structural critique / builder's breakdown / narrative / thesis-first]
+**Length:** [n] tweets
+
+---
+
+**1/**
+[tweet text — 280 chars max]
+
+**2/**
+[tweet text — 280 chars max]
+
+...
+
+**n/**
+[tweet text — 280 chars max]
+
+---
+
+**Why this thread:** [1-2 sentences on why this topic, why now, why the thread format (vs. single tweet)]
+```
+
+## Notify
+
+Send via `./notify`:
+```
+thread: [topic — 3-5 words]
+
+1/ [tweet 1]
+
+2/ [tweet 2]
+
+...
+
+n/ [tweet n]
+```
+
+## Log
+
+Append to `memory/logs/${today}.md`:
+```
+## Thread Writer
+- **Topic:** [topic]
+- **Format:** [format]
+- **Length:** [n] tweets
+- **Hook:** [first 60 chars of tweet 1]
+- **Notification sent:** yes
+```


### PR DESCRIPTION
## What

Ports the upstream-worthy skills from the `aeon-aaron` instance (de-personalized), and fixes the duplicate-H2 MEMORY.md drift in the architecture instead of porting it as a 9th skill.

## Memory architecture fix (no new skill)

The `aeon-aaron` instance grew a `memory-h2-dedupe` skill because `reflect`/`memory-flush` prepend `## Section` blocks without checking whether the heading already exists — MEMORY.md ends up with the same H2 2–3 times (it flagged 7 consecutive reflect cycles over there). Every fork inherits this failure mode. Instead of a new skill + cron slot:

- **`memory-structural-dedupe`** now detects **duplicate H2 headings** alongside row accumulation (its description explicitly excluded this case before): heading→spans map, canonical-span selection (highest count for Skills Built / Recent Articles, concatenate-unique for Known Follow-ups, first-span otherwise), unique-info folding, single-occurrence rewrite.
- **`reflect`** + **`memory-flush`** get a prevention rule: never prepend a `## Heading` that already exists — update the section in place. Root cause stops; the dedupe skill becomes the safety net.

## 8 ported skills (all `enabled: false` in aeon.yml)

| Skill | What it adds | De-personalization |
|---|---|---|
| `fear-divergence-scout` | Conditional daily scan — fires only when F&G < 25, surfaces assets diverging from the BTC drawdown with catalysts from memory. Consumes `market-context.md`. | soul-conditional voice, missing-file skip path |
| `beat-tracker` | Persistent event-level beat counts per news storyline; alerts at 3 beats (article-ready). Fills the gap between `topic-momentum` (pattern-level) and `narrative-tracker` (narrative-level). | soul-conditional voice, generic log globs |
| `article-queue` | Ranks beat-tracker + topic-momentum + narrative-tracker signals into `memory/topics/article-queue.md`, which the `article` skill picks up via MEMORY.md — article-ready stories stop sitting unwritten. | "Aaron-fit" → soul-fit (skipped if soul absent) |
| `picks-tracker` | Weekly 30-day W/H/L retrospective scoring token + PM picks from logs against current prices. `signal-verdict` checks if trackers get *cited*; nothing checked if picks were *right*. | generic markets wording, zero-picks skip path |
| `content-performance` | Weekly X engagement feedback loop (topic resonance, format breakdown, breakouts) feeding `article-queue`/`topic-momentum`. | handle via `var` → soul/SOUL.md fallback; topic categories derived from soul/MEMORY; XAI optional (WebSearch fallback); new `prefetch-xai.sh` case |
| `api-health-probe` (from `xai-probe`) | Pre-batch credit/auth probe of every configured provider key, ~30 min before the morning batch. HTTP-code → action table, dynamic issue filing/closing. New `scripts/prefetch-api-probe.sh` (XAI built-in, template for more). | provider-generic, ISS-number hardcoding → dynamic lookup |
| `mention-radar` (from `project-pulse`) | External web/social mentions of the operator's projects with a discovery/confusion/friction/competitor taxonomy + engagement-opportunity flagging. Complements repo-metric skills (`star-milestone` etc.). | targets via `var` → MEMORY.md / `topics/projects.md`; capped at 6, skip path |
| `thread-writer` | Composes a 5–10 tweet thread on an arbitrary topic/URL grounded in soul/ + memory. `thread-formatter` only formats the day's events. | soul-conditional voice with neutral fallback |

## Notes

- `aeon.yml` validated: 191 entries, no duplicate keys, all 8 registered under a `# --- Ported from aeon-aaron ---` section.
- `scripts/prefetch-api-probe.sh` syntax-checked, executable; also fixes a latent `"000"` http-code bug from the original probe.
- `skills.json` intentionally untouched — generated artifact (`generate-skills-json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)