### PR TITLE
README: bump skill catalog 156 → 193, showcase aeon-aaron ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <strong>The most autonomous agent framework.</strong><br>
-  Give it a direction — it'll leverage 156 skills like deep research, PR reviews, market monitoring, Vercel deploys, and more to get it done. No approval loops. No babysitting. Configure once, forget forever.
+  Give it a direction — it'll leverage 193 skills like deep research, PR reviews, market monitoring, Vercel deploys, and more to get it done. No approval loops. No babysitting. Configure once, forget forever.
 </p>
 
 <p align="center">
@@ -96,16 +96,26 @@ The gate also rejects state-changing requests (POST / PUT / PATCH / DELETE) whos
 
 ![Skills](./assets/skills-aeon.jpg)
 
-156 skills, grouped by what they do. Every skill is independently installable, schedulable, and chainable.
+193 skills, grouped by what they do. Every skill is independently installable, schedulable, and chainable.
 
 | Category | Skills |
 |----------|--------|
-| **Research & Content** (24) | `agent-displacement`, `ai-framework-watch`, `article`, `channel-recap`, `competitor-launch-radar`, `deep-research`, `digest`, `fetch-tweets`, `hacker-news-digest`, `huggingface-trending`, `last30`, `launch-radar`, `list-digest`, `paper-digest`, `paper-pick`, `reddit-digest`, `research-brief`, `rss-digest`, `security-digest`, `technical-explainer`, `telegram-digest`, `topic-momentum`, `tweet-digest`, `vibecoding-digest` |
-| **Dev & Code** (41) | `auto-merge`, `auto-workflow`, `autoresearch`, `builder-map`, `changelog`, `code-health`, `create-skill`, `deploy-prototype`, `disclosure-tracker`, `ecosystem-pulse`, `external-feature`, `feature`, `fleet-control`, `fork-cohort`, `fork-fleet`, `fork-release-tracker`, `github-issues`, `github-monitor`, `github-releases`, `github-trending`, `issue-triage`, `pr-review`, `pr-tracker`, `pr-triage`, `project-lens`, `push-recap`, `pvr-triage-monitor`, `pvr-watchlist`, `repo-actions`, `repo-article`, `repo-pulse`, `repo-revive`, `repo-scanner`, `search-skill`, `smithery-manifest`, `spawn-instance`, `star-milestone`, `vercel-projects`, `vuln-scanner`, `vuln-tracker`, `workflow-security-audit` |
-| **Crypto & Markets** (27) | `aixbt-pulse`, `compute-pulse`, `contributor-reward`, `defi-monitor`, `defi-overview`, `distribute-tokens`, `market-context-refresh`, `monitor-kalshi`, `monitor-polymarket`, `monitor-runners`, `narrative-tracker`, `on-chain-monitor`, `pm-intel`, `pm-manipulation`, `pm-pulse`, `polymarket`, `polymarket-comments`, `price-threshold-alert`, `rwa-pulse`, `token-alert`, `token-movers`, `token-pick`, `token-report`, `treasury-info`, `unlock-monitor`, `wallet-digest`, `x402-monitor` |
-| **Social & Writing** (14) | `agent-buzz`, `create-campaign`, `engagement-act`, `farcaster-digest`, `product-hunt-launch`, `refresh-x`, `remix-tweets`, `reply-maker`, `schedule-ads`, `show-hn-draft`, `syndicate-article`, `thread-formatter`, `tweet-roundup`, `write-tweet` |
-| **Productivity** (18) | `action-converter`, `daily-routine`, `deal-flow`, `evening-recap`, `goal-tracker`, `idea-capture`, `idea-pipeline`, `idea-validator`, `milestone-tracker`, `morning-brief`, `note-taking`, `reflect`, `reg-monitor`, `startup-idea`, `tool-builder`, `v4-readiness`, `weekly-review`, `weekly-shiplog` |
-| **Meta / Agent** (32) | `batch-health`, `config-validator`, `contributor-spotlight`, `cost-report`, `fleet-state`, `fork-contributor-leaderboard`, `fork-first-run-alert`, `fork-skill-digest`, `fork-skill-gap`, `heartbeat`, `janitor`, `memory-flush`, `memory-structural-dedupe`, `onboard`, `operator-scorecard`, `run-frequency-guard`, `rss-feed`, `self-improve`, `self-review`, `signal-verdict`, `skill-analytics`, `skill-enabler`, `skill-evals`, `skill-freshness`, `skill-graph`, `skill-health`, `skill-leaderboard`, `skill-repair`, `skill-security-scan`, `skill-update-check`, `star-momentum-alert`, `update-gallery` |
+| **Research & Content** (28) | `agent-displacement`, `ai-framework-watch`, `article`, `article-queue`, `beat-tracker`, `channel-recap`, `competitor-launch-radar`, `deep-research`, `digest`, `fetch-tweets`, `hacker-news-digest`, `huggingface-trending`, `last30`, `launch-radar`, `list-digest`, `mcp-pulse`, `narrative-convergence`, `paper-digest`, `paper-pick`, `reddit-digest`, `research-brief`, `rss-digest`, `security-digest`, `technical-explainer`, `telegram-digest`, `topic-momentum`, `tweet-digest`, `vibecoding-digest` |
+| **Dev & Code** (44) | `auto-merge`, `auto-workflow`, `autoresearch`, `builder-map`, `changelog`, `code-health`, `create-skill`, `deploy-prototype`, `disclosure-tracker`, `ecosystem-entrants`, `ecosystem-pulse`, `external-feature`, `feature`, `fleet-control`, `fork-cohort`, `fork-fleet`, `fork-release-tracker`, `github-issues`, `github-monitor`, `github-releases`, `github-trending`, `issue-triage`, `pr-merge-queue`, `pr-review`, `pr-skill-triage`, `pr-tracker`, `pr-triage`, `project-lens`, `push-recap`, `pvr-triage-monitor`, `pvr-watchlist`, `repo-actions`, `repo-article`, `repo-pulse`, `repo-revive`, `repo-scanner`, `search-skill`, `smithery-manifest`, `spawn-instance`, `star-milestone`, `vercel-projects`, `vuln-scanner`, `vuln-tracker`, `workflow-security-audit` |
+| **Crypto & Markets** (44) | `aixbt-pulse`, `approval-audit`, `compute-pulse`, `contract-audit`, `contributor-reward`, `defi-monitor`, `defi-overview`, `deployer-trace`, `distribute-tokens`, `fear-divergence-scout`, `fund-flow`, `holder-concentration`, `honeypot-check`, `investigation-report`, `linked-wallets`, `liquidpad-launch`, `lp-lock-check`, `market-context-refresh`, `monitor-kalshi`, `monitor-polymarket`, `monitor-runners`, `narrative-tracker`, `on-chain-monitor`, `picks-tracker`, `pm-intel`, `pm-manipulation`, `pm-pulse`, `polymarket`, `polymarket-comments`, `price-threshold-alert`, `rug-scan`, `rwa-pulse`, `token-alert`, `token-movers`, `token-pick`, `token-report`, `treasury-info`, `tx-explain`, `unlock-monitor`, `vigil`, `wallet-digest`, `wallet-profile`, `wallet-risk-weekly`, `x402-monitor` |
+| **Social & Writing** (18) | `agent-buzz`, `content-performance`, `create-campaign`, `engagement-act`, `farcaster-digest`, `mention-radar`, `product-hunt-launch`, `refresh-x`, `remix-tweets`, `reply-maker`, `schedule-ads`, `show-hn-draft`, `skill-of-the-day`, `syndicate-article`, `thread-formatter`, `thread-writer`, `tweet-roundup`, `write-tweet` |
+| **Productivity** (19) | `action-converter`, `daily-routine`, `deal-flow`, `evening-recap`, `follow-up-patrol`, `goal-tracker`, `idea-capture`, `idea-pipeline`, `idea-validator`, `milestone-tracker`, `morning-brief`, `note-taking`, `reflect`, `reg-monitor`, `startup-idea`, `tool-builder`, `v4-readiness`, `weekly-review`, `weekly-shiplog` |
+| **Meta / Agent** (40) | `api-health-probe`, `atrium-catalog-watcher`, `batch-health`, `capabilities-map`, `config-validator`, `contributor-spotlight`, `cost-report`, `fleet-scorecard`, `fleet-skill-adoption`, `fleet-state`, `fork-contributor-leaderboard`, `fork-first-run-alert`, `fork-health-score`, `fork-skill-digest`, `fork-skill-gap`, `heartbeat`, `janitor`, `memory-flush`, `memory-structural-dedupe`, `onboard`, `operator-scorecard`, `run-frequency-guard`, `rss-feed`, `self-improve`, `self-review`, `signal-verdict`, `skill-analytics`, `skill-enabler`, `skill-evals`, `skill-freshness`, `skill-graph`, `skill-health`, `skill-leaderboard`, `skill-repair`, `skill-security-scan`, `skill-update-check`, `sparkleware-catalog`, `spend-monitor`, `star-momentum-alert`, `update-gallery` |
+
+**New (June 2026)** — ported from the [aeon-aaron](https://github.com/aaronjmars/aeon-aaron) instance and de-personalized for any operator:
+
+- `beat-tracker` + `article-queue` — persistent event-level beat counts per news storyline, ranked into a queue the `article` skill actually reads. A story hits 3 beats → it gets written.
+- `picks-tracker` — honest weekly W/H/L scorecard of past token and prediction-market picks vs current prices. No cherry-picking.
+- `content-performance` — closes the content feedback loop: which topics and formats actually resonated on X this week, fed back into `article-queue`.
+- `fear-divergence-scout` — conditional: fires only when Fear & Greed < 25, surfaces the assets defying the drawdown. Silent otherwise.
+- `api-health-probe` — probes every configured provider key ~30 min before the morning batch; credits exhausted or key revoked → you know before skills degrade, not days after.
+- `mention-radar` — external web/social mentions of *your* projects, categorized (discovery / confusion / friction / competitor) with engagement opportunities flagged.
+- `thread-writer` — 5–10 tweet threads in your voice (soul-grounded), on demand.
 
 Full descriptions: [`skills.json`](skills.json) — or run `./add-skill aaronjmars/aeon --list`
 
@@ -308,7 +318,7 @@ Claude only installs and runs when a skill actually matches.
 ```
 CLAUDE.md                ← agent identity (auto-loaded by Claude Code)
 aeon.yml                 ← skill schedules, chains, reactive triggers, and enabled flags
-skills.json              ← machine-readable skill catalog (156 skills)
+skills.json              ← machine-readable skill catalog (193 skills)
 ./aeon                   ← launch the local dashboard (Next.js on port 5555)
 ./onboard                ← validate the fork's setup (secrets, workflows, channels) — see Quick start
 ./notify                 ← multi-channel notifications (Telegram, Discord, Slack, Email, json-render)
@@ -324,7 +334,7 @@ skills/                  ← each skill is a SKILL.md prompt file
   article/
   digest/
   heartbeat/
-  ...                    ← 156 skills total
+  ...                    ← 193 skills total
 workflows/               ← GitHub Agentic Workflow templates (.md)
 mcp-server/              ← MCP server — exposes skills as Claude tools
 a2a-server/              ← A2A protocol gateway — exposes skills to any agent framework
@@ -601,13 +611,13 @@ Aeon is "the most autonomous agent framework" — an AI agent system that runs u
 
 ### How many built-in skills does Aeon have?
 
-156 skills across 6 categories:
-- **Research & Content** (24): deep-research, paper-digest, rss-digest, etc.
-- **Dev & Code** (41): pr-review, github-monitor, auto-merge, etc.
-- **Crypto & Markets** (27): defi-monitor, token-alert, polymarket monitoring, etc.
-- **Social & Writing** (14): write-tweet, syndicate-article, product-hunt-launch, etc.
-- **Productivity** (18): morning-brief, weekly-review, goal-tracker, etc.
-- **Meta / Agent** (32): skill-repair, self-improve, fleet-state, etc.
+193 skills across 6 categories:
+- **Research & Content** (28): deep-research, paper-digest, beat-tracker, etc.
+- **Dev & Code** (44): pr-review, github-monitor, auto-merge, etc.
+- **Crypto & Markets** (44): defi-monitor, token-alert, rug-scan, picks-tracker, etc.
+- **Social & Writing** (18): write-tweet, syndicate-article, thread-writer, etc.
+- **Productivity** (19): morning-brief, weekly-review, goal-tracker, etc.
+- **Meta / Agent** (40): skill-repair, self-improve, api-health-probe, etc.
 
 ### How do I get started?
 
@@ -630,7 +640,7 @@ Aeon primarily uses Claude (Anthropic) via API key or OAuth token. Check the das
 
 ### What is the skill dependency graph?
 
-See [`docs/skill-graph.md`](docs/skill-graph.md) — a visual map showing how 156 skills connect, with the self-healing loop and content pipeline highlighted.
+See [`docs/skill-graph.md`](docs/skill-graph.md) — a visual map showing how 193 skills connect, with the self-healing loop and content pipeline highlighted.
 
 ### Can I create custom skills?
 

--- a/generate-skills-json
+++ b/generate-skills-json
@@ -59,6 +59,11 @@ get_category() {
     cost-report|rss-feed|update-gallery|onboard|operator-scorecard) echo "productivity" ;;
     v4-readiness) echo "productivity" ;;
     spend-monitor|follow-up-patrol) echo "productivity" ;;
+    # Ported from aeon-aaron (PR #343)
+    beat-tracker|article-queue) echo "research" ;;
+    fear-divergence-scout|picks-tracker) echo "crypto" ;;
+    content-performance|thread-writer|mention-radar) echo "social" ;;
+    api-health-probe) echo "productivity" ;;
     *) echo "other" ;;
   esac
 }

--- a/skills.json
+++ b/skills.json
@@ -1,8 +1,8 @@
 {
     "version": "1.0",
-    "generated": "2026-05-29T17:40:44Z",
+    "generated": "2026-06-05T18:16:25Z",
     "repo": "aaronjmars/aeon",
-    "total": 183,
+    "total": 193,
     "categories": {
         "research": "Research & Content",
         "dev": "Dev & Code",
@@ -19,8 +19,8 @@
             "schedule": "0 18 * * *",
             "var": "",
             "files": 0,
-            "sha": "e1f3362",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon action-converter"
         },
         {
@@ -31,8 +31,8 @@
             "schedule": "30 17 * * *",
             "var": "",
             "files": 0,
-            "sha": "39b5a88",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon agent-buzz"
         },
         {
@@ -40,11 +40,11 @@
             "name": "agent-displacement",
             "description": "Weekly tracker of AI agent substitution signals \u2014 which roles, companies, and industries show real headcount displacement. Named roles + real deployments only.",
             "category": "other",
-            "schedule": "",
+            "schedule": "0 11 * * 0",
             "var": "",
             "files": 0,
-            "sha": "ac068d2",
-            "updated": "2026-05-23",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon agent-displacement"
         },
         {
@@ -55,8 +55,8 @@
             "schedule": "30 8 * * 1",
             "var": "",
             "files": 0,
-            "sha": "8dd2270",
-            "updated": "2026-05-10",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon ai-framework-watch"
         },
         {
@@ -67,9 +67,45 @@
             "schedule": "0 9,21 * * *",
             "var": "",
             "files": 0,
-            "sha": "29b6558",
-            "updated": "2026-04-21",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon aixbt-pulse"
+        },
+        {
+            "slug": "api-health-probe",
+            "name": "api-health-probe",
+            "description": "Daily pre-batch API provider health check \u2014 detects credit exhaustion or auth failure for every configured provider key before the morning batch runs, giving the operator a window to act before skills degrade",
+            "category": "productivity",
+            "schedule": "30 6 * * *",
+            "var": "",
+            "files": 0,
+            "sha": "5386ace",
+            "updated": "2026-06-05",
+            "install": "./add-skill aaronjmars/aeon api-health-probe"
+        },
+        {
+            "slug": "approval-audit",
+            "name": "Approval Audit",
+            "description": "List a wallet's live ERC-20 token approvals on Base and flag unlimited / risky spender grants. Keyless via Base RPC (eth_getLogs + eth_call) \u2014 no explorer key needed.",
+            "category": "other",
+            "schedule": "workflow_dispatch",
+            "var": "",
+            "files": 0,
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
+            "install": "./add-skill aaronjmars/aeon approval-audit"
+        },
+        {
+            "slug": "article-queue",
+            "name": "article-queue",
+            "description": "Weekly article idea synthesizer \u2014 ranks signals from topic-momentum, beat-tracker, and narrative-tracker into a prioritized queue the article skill reads on next run",
+            "category": "research",
+            "schedule": "0 11 * * 0",
+            "var": "",
+            "files": 0,
+            "sha": "5386ace",
+            "updated": "2026-06-05",
+            "install": "./add-skill aaronjmars/aeon article-queue"
         },
         {
             "slug": "article",
@@ -79,19 +115,19 @@
             "schedule": "0 14 * * *",
             "var": "",
             "files": 0,
-            "sha": "2601d0e",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon article"
         },
         {
             "slug": "atrium-catalog-watcher",
             "name": "atrium-catalog-watcher",
-            "description": "Weekly Friday diff of the Atrium marketplace catalog (atriumhermes.tech/.well-known/skills/index.json) against the prior snapshot — surfaces newly-published / removed / renamed skills with one-click install-from-atrium commands. Supply-side complement to sparkleware-catalog (curated registry) and skill-update-check (installed-skill drift).",
-            "category": "dev",
+            "description": "Weekly diff of the Atrium marketplace catalog at https://atriumhermes.tech/.well-known/skills/index.json against the prior snapshot \u2014 surfaces newly-published skills, removed skills, and updated descriptions. Supply-side complement to sparkleware-catalog (curated skill-packs.json registry) and skill-update-check (version drift of installed skills).",
+            "category": "other",
             "schedule": "0 12 * * 5",
             "var": "",
             "files": 0,
-            "sha": "0000000",
+            "sha": "9cb91a7",
             "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon atrium-catalog-watcher"
         },
@@ -103,8 +139,8 @@
             "schedule": "0 14 * * *",
             "var": "",
             "files": 0,
-            "sha": "8552143",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon auto-merge"
         },
         {
@@ -115,8 +151,8 @@
             "schedule": "workflow_dispatch",
             "var": "",
             "files": 0,
-            "sha": "b16f312",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon auto-workflow"
         },
         {
@@ -127,8 +163,8 @@
             "schedule": "workflow_dispatch",
             "var": "",
             "files": 0,
-            "sha": "ba0143d",
-            "updated": "2026-04-15",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon autoresearch"
         },
         {
@@ -136,24 +172,48 @@
             "name": "batch-health",
             "description": "Daily post-batch audit \u2014 checks whether all enabled scheduled skills fired in their expected morning window, alerts on silent misses, files issues on batch-level outages",
             "category": "other",
-            "schedule": "",
+            "schedule": "30 8 * * *",
             "var": "",
             "files": 0,
-            "sha": "ac068d2",
-            "updated": "2026-05-23",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon batch-health"
+        },
+        {
+            "slug": "beat-tracker",
+            "name": "beat-tracker",
+            "description": "Weekly multi-beat news thread tracker \u2014 persists beat counts per active storyline, searches for new developments, alerts when a thread hits the article-ready threshold (3rd beat)",
+            "category": "research",
+            "schedule": "0 9 * * 3",
+            "var": "",
+            "files": 0,
+            "sha": "5386ace",
+            "updated": "2026-06-05",
+            "install": "./add-skill aaronjmars/aeon beat-tracker"
         },
         {
             "slug": "builder-map",
             "name": "builder-map",
             "description": "Weekly map of who's building on top of watched repos \u2014 forks, third-party ecosystem repos, builder announcements. Answers the \"who's building on top\" question.",
             "category": "other",
-            "schedule": "",
+            "schedule": "0 10 * * 2",
             "var": "",
             "files": 0,
-            "sha": "ac068d2",
-            "updated": "2026-05-23",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon builder-map"
+        },
+        {
+            "slug": "capabilities-map",
+            "name": "capabilities-map",
+            "description": "Weekly read-only audit of installed skills' capability coverage \u2014 maps every enabled/disabled skill against the locked 6-value taxonomy in docs/CAPABILITIES.md, flags any capability tier with zero enabled coverage as an actionable gap",
+            "category": "other",
+            "schedule": "30 11 * * 1",
+            "var": "",
+            "files": 0,
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
+            "install": "./add-skill aaronjmars/aeon capabilities-map"
         },
         {
             "slug": "changelog",
@@ -163,8 +223,8 @@
             "schedule": "0 16 * * *",
             "var": "",
             "files": 0,
-            "sha": "dc17852",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon changelog"
         },
         {
@@ -175,8 +235,8 @@
             "schedule": "0 17 * * 0",
             "var": "",
             "files": 0,
-            "sha": "ea61701",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon channel-recap"
         },
         {
@@ -187,8 +247,8 @@
             "schedule": "0 16 * * *",
             "var": "",
             "files": 0,
-            "sha": "2372300",
-            "updated": "2026-04-06",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon code-health"
         },
         {
@@ -199,8 +259,8 @@
             "schedule": "0 10 * * 1",
             "var": "",
             "files": 0,
-            "sha": "8ca965f",
-            "updated": "2026-05-19",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon competitor-launch-radar"
         },
         {
@@ -208,11 +268,11 @@
             "name": "compute-pulse",
             "description": "Weekly tracker for the AI compute market \u2014 GPU/hardware deals, inference pricing trends, decentralized compute token signals, and lab vs hyperscaler dynamics.",
             "category": "other",
-            "schedule": "",
+            "schedule": "0 11 * * 6",
             "var": "",
             "files": 0,
-            "sha": "ac068d2",
-            "updated": "2026-05-23",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon compute-pulse"
         },
         {
@@ -220,12 +280,36 @@
             "name": "Config Validator",
             "description": "Validate aeon.yml and .github/workflows/aeon.yml for structural invariants that have caused past outages \u2014 checkout step ordering, duplicate skill keys, missing skill files",
             "category": "other",
-            "schedule": "",
+            "schedule": "30 16 * * 0",
             "var": "",
             "files": 0,
-            "sha": "ac068d2",
-            "updated": "2026-05-23",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon config-validator"
+        },
+        {
+            "slug": "content-performance",
+            "name": "content-performance",
+            "description": "Weekly operator tweet performance tracker \u2014 engagement metrics, top formats, topic resonance; closes the content feedback loop in the article/tweet production pipeline",
+            "category": "social",
+            "schedule": "0 10 * * 0",
+            "var": "",
+            "files": 0,
+            "sha": "5386ace",
+            "updated": "2026-06-05",
+            "install": "./add-skill aaronjmars/aeon content-performance"
+        },
+        {
+            "slug": "contract-audit",
+            "name": "Contract Audit",
+            "description": "Audit any contract on Base \u2014 verification, proxy/upgradeability, ownership/admin roles, and mint/freeze/pause/drain powers as a live capability matrix. Keyless via Etherscan v2 + Base RPC.",
+            "category": "crypto",
+            "schedule": "workflow_dispatch",
+            "var": "",
+            "files": 0,
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
+            "install": "./add-skill aaronjmars/aeon contract-audit"
         },
         {
             "slug": "contributor-reward",
@@ -235,8 +319,8 @@
             "schedule": "30 9 * * 1",
             "var": "",
             "files": 0,
-            "sha": "46a7a24",
-            "updated": "2026-04-26",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon contributor-reward"
         },
         {
@@ -247,8 +331,8 @@
             "schedule": "0 20 * * 0",
             "var": "",
             "files": 0,
-            "sha": "db9d84f",
-            "updated": "2026-05-21",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon contributor-spotlight"
         },
         {
@@ -259,8 +343,8 @@
             "schedule": "0 7 * * 1",
             "var": "",
             "files": 0,
-            "sha": "1007f29",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon cost-report"
         },
         {
@@ -271,8 +355,8 @@
             "schedule": "workflow_dispatch",
             "var": "",
             "files": 1,
-            "sha": "29b6558",
-            "updated": "2026-04-21",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon create-campaign"
         },
         {
@@ -283,8 +367,8 @@
             "schedule": "workflow_dispatch",
             "var": "",
             "files": 0,
-            "sha": "f5914c4",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon create-skill"
         },
         {
@@ -295,8 +379,8 @@
             "schedule": "0 7 * * *",
             "var": "",
             "files": 0,
-            "sha": "ba0143d",
-            "updated": "2026-04-15",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon daily-routine"
         },
         {
@@ -307,8 +391,8 @@
             "schedule": "0 14 * * 1",
             "var": "",
             "files": 0,
-            "sha": "25b731d",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon deal-flow"
         },
         {
@@ -319,8 +403,8 @@
             "schedule": "workflow_dispatch",
             "var": "",
             "files": 0,
-            "sha": "0941651",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon deep-research"
         },
         {
@@ -331,8 +415,8 @@
             "schedule": "0 12 * * *",
             "var": "",
             "files": 0,
-            "sha": "ba0143d",
-            "updated": "2026-04-15",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon defi-monitor"
         },
         {
@@ -343,8 +427,8 @@
             "schedule": "0 12 * * *",
             "var": "",
             "files": 0,
-            "sha": "dcf9660",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon defi-overview"
         },
         {
@@ -355,9 +439,21 @@
             "schedule": "workflow_dispatch",
             "var": "",
             "files": 0,
-            "sha": "0906ac4",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon deploy-prototype"
+        },
+        {
+            "slug": "deployer-trace",
+            "name": "Deployer Trace",
+            "description": "Map every contract deployed by an address on Base, link reused patterns, and surface serial-rug signals. Keyless via Etherscan v2 + Base RPC.",
+            "category": "crypto",
+            "schedule": "workflow_dispatch",
+            "var": "",
+            "files": 0,
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
+            "install": "./add-skill aaronjmars/aeon deployer-trace"
         },
         {
             "slug": "digest",
@@ -367,8 +463,8 @@
             "schedule": "0 14 * * *",
             "var": "",
             "files": 0,
-            "sha": "07c4d62",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon digest"
         },
         {
@@ -376,11 +472,11 @@
             "name": "disclosure-tracker",
             "description": "Daily audit of pending vulnerability disclosure queue \u2014 tracks draft advisories in memory/pending-disclosures/, alerts on aging CRITICAL/HIGH findings.",
             "category": "other",
-            "schedule": "",
+            "schedule": "15 16 * * *",
             "var": "",
             "files": 0,
-            "sha": "ac068d2",
-            "updated": "2026-05-23",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon disclosure-tracker"
         },
         {
@@ -391,56 +487,44 @@
             "schedule": "workflow_dispatch",
             "var": "",
             "files": 0,
-            "sha": "7330f37",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon distribute-tokens"
         },
         {
             "slug": "ecosystem-entrants",
             "name": "ecosystem-entrants",
-            "description": "Weekly Monday diff of ECOSYSTEM.md against the prior snapshot \u2014 surfaces added / removed / updated entries since last run, attributes added rows to a merged PR when one can be found in the last 14 days. First-touch complement to ecosystem-pulse (liveness).",
-            "category": "research",
+            "description": "Weekly diff of ECOSYSTEM.md against last run \u2014 surfaces newly-added projects (and projects removed) as a discrete signal so new entrants aren't lost in the static list. Pairs with ecosystem-pulse (liveness) on Monday morning.",
+            "category": "other",
             "schedule": "45 11 * * 1",
             "var": "",
             "files": 0,
-            "sha": "0000000",
-            "updated": "2026-06-03",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon ecosystem-entrants"
         },
         {
             "slug": "ecosystem-pulse",
             "name": "ecosystem-pulse",
             "description": "Weekly liveness check of the projects listed in ECOSYSTEM.md \u2014 stars/forks/last-commit recency + new releases for any project that can be matched to a GitHub repo",
-            "category": "research",
+            "category": "other",
             "schedule": "0 11 * * 1",
             "var": "",
             "files": 0,
-            "sha": "0000000",
-            "updated": "2026-05-25",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon ecosystem-pulse"
-        },
-        {
-            "slug": "sparkleware-catalog",
-            "name": "sparkleware-catalog",
-            "description": "Weekly enriched export of skill-packs.json \u2014 joins the canonical community registry to live GitHub signals (stars, last-push, live manifest skill count) and writes a machine-readable skill-packs-catalog.json that external tools (e.g. Sparkleware) can consume without screen-scraping",
-            "category": "dev",
-            "schedule": "0 9 * * 2",
-            "var": "",
-            "files": 0,
-            "sha": "0000000",
-            "updated": "2026-05-27",
-            "install": "./add-skill aaronjmars/aeon sparkleware-catalog"
         },
         {
             "slug": "engagement-act",
             "name": "Engagement Act",
             "description": "Turn flagged engagement opportunities into ready-to-post replies \u2014 read recent logs, draft specific responses, send as copy-paste-ready output",
             "category": "other",
-            "schedule": "",
+            "schedule": "30 9 * * *",
             "var": "",
             "files": 0,
-            "sha": "ac068d2",
-            "updated": "2026-05-23",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon engagement-act"
         },
         {
@@ -451,8 +535,8 @@
             "schedule": "0 21 * * *",
             "var": "",
             "files": 0,
-            "sha": "b09f875",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon evening-recap"
         },
         {
@@ -463,8 +547,8 @@
             "schedule": "30 16 * * *",
             "var": "",
             "files": 0,
-            "sha": "ba0143d",
-            "updated": "2026-04-15",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon external-feature"
         },
         {
@@ -475,20 +559,32 @@
             "schedule": "0 17 * * *",
             "var": "",
             "files": 0,
-            "sha": "19eb504",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon farcaster-digest"
+        },
+        {
+            "slug": "fear-divergence-scout",
+            "name": "fear-divergence-scout",
+            "description": "Conditional daily scan \u2014 fires only when Fear & Greed < 25. Identifies assets outperforming during broad market fear, synthesizes narrative catalysts from memory, and delivers a terse conviction setup brief. Skips silently when market conditions don't qualify.",
+            "category": "crypto",
+            "schedule": "30 7 * * *",
+            "var": "",
+            "files": 0,
+            "sha": "5386ace",
+            "updated": "2026-06-05",
+            "install": "./add-skill aaronjmars/aeon fear-divergence-scout"
         },
         {
             "slug": "feature",
             "name": "Feature",
             "description": "Build a feature for every watched repo in one run \u2014 iterates the full repo list, picks one feature per repo from yesterday's repo-actions ideas first",
             "category": "other",
-            "schedule": "",
+            "schedule": "workflow_dispatch",
             "var": "",
             "files": 0,
-            "sha": "ac068d2",
-            "updated": "2026-05-23",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon feature"
         },
         {
@@ -499,8 +595,8 @@
             "schedule": "0 17 * * *",
             "var": "",
             "files": 0,
-            "sha": "8076542",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon fetch-tweets"
         },
         {
@@ -511,9 +607,33 @@
             "schedule": "0 9,15 * * *",
             "var": "",
             "files": 0,
-            "sha": "e3e02ec",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon fleet-control"
+        },
+        {
+            "slug": "fleet-scorecard",
+            "name": "Fleet Scorecard",
+            "description": "Daily fleet-wide scorecard across this instance and every managed instance in memory/instances.json \u2014 runs, tokens (OpenRouter shape), est. cost, skills, and reliability, with day-over-day deltas and alerts",
+            "category": "dev",
+            "schedule": "0 13 * * *",
+            "var": "",
+            "files": 0,
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
+            "install": "./add-skill aaronjmars/aeon fleet-scorecard"
+        },
+        {
+            "slug": "fleet-skill-adoption",
+            "name": "fleet-skill-adoption",
+            "description": "Weekly fleet skill-adoption leaderboard \u2014 per-slug count of how many POWER+ACTIVE forks have each upstream skill enabled, top-15 most-adopted and bottom-15 least-adopted by fleet penetration, silent when nothing moves",
+            "category": "other",
+            "schedule": "0 22 * * 0",
+            "var": "",
+            "files": 0,
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
+            "install": "./add-skill aaronjmars/aeon fleet-skill-adoption"
         },
         {
             "slug": "fleet-state",
@@ -523,9 +643,21 @@
             "schedule": "0 8 * * 1",
             "var": "",
             "files": 0,
-            "sha": "11cc2ef",
-            "updated": "2026-05-22",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon fleet-state"
+        },
+        {
+            "slug": "follow-up-patrol",
+            "name": "follow-up-patrol",
+            "description": "Weekly escalation audit \u2014 parses the follow-up / open-loop section of MEMORY.md plus the issue tracker, computes item ages, and alerts on items hitting urgency thresholds so nothing rots unattended",
+            "category": "productivity",
+            "schedule": "0 11 * * 2",
+            "var": "",
+            "files": 0,
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
+            "install": "./add-skill aaronjmars/aeon follow-up-patrol"
         },
         {
             "slug": "fork-cohort",
@@ -535,8 +667,8 @@
             "schedule": "0 19 * * 0",
             "var": "",
             "files": 0,
-            "sha": "4a6b037",
-            "updated": "2026-05-03",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon fork-cohort"
         },
         {
@@ -547,8 +679,8 @@
             "schedule": "30 17 * * 0",
             "var": "",
             "files": 0,
-            "sha": "da02f64",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon fork-contributor-leaderboard"
         },
         {
@@ -559,8 +691,8 @@
             "schedule": "30 20 * * *",
             "var": "",
             "files": 0,
-            "sha": "f6d6c6b",
-            "updated": "2026-05-17",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon fork-first-run-alert"
         },
         {
@@ -571,20 +703,20 @@
             "schedule": "0 10 * * 1",
             "var": "",
             "files": 0,
-            "sha": "1ea45d7",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon fork-fleet"
         },
         {
             "slug": "fork-health-score",
             "name": "fork-health-score",
-            "description": "Weekly per-fork health tier (ACTIVE/WARM/STALE/QUIET) blending push recency + enabled skill count + 30d PR throughput; top-10 ACTIVE leaderboard + fleet ACTIVE ratio with WoW deltas; silent when nothing moves",
-            "category": "dev",
+            "description": "Weekly per-fork health tier synthesizing push recency + enabled skill count + 30d PR activity into ACTIVE/WARM/STALE/QUIET buckets; fleet health ratio + top-10 ACTIVE table; silent when nothing moves",
+            "category": "other",
             "schedule": "45 10 * * 1",
             "var": "",
             "files": 0,
-            "sha": "",
-            "updated": "2026-05-29",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon fork-health-score"
         },
         {
@@ -595,8 +727,8 @@
             "schedule": "30 19 * * 0",
             "var": "",
             "files": 0,
-            "sha": "3404229",
-            "updated": "2026-05-12",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon fork-release-tracker"
         },
         {
@@ -607,8 +739,8 @@
             "schedule": "30 18 * * 0",
             "var": "",
             "files": 0,
-            "sha": "a14eb44",
-            "updated": "2026-04-23",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon fork-skill-digest"
         },
         {
@@ -619,21 +751,21 @@
             "schedule": "0 21 * * 0",
             "var": "",
             "files": 0,
-            "sha": "f587d30",
-            "updated": "2026-05-17",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon fork-skill-gap"
         },
         {
-            "slug": "fleet-skill-adoption",
-            "name": "fleet-skill-adoption",
-            "description": "Weekly fleet skill-adoption leaderboard \u2014 per-slug count of how many POWER+ACTIVE forks have each upstream skill enabled, top-15 most-adopted and bottom-15 least-adopted by fleet penetration, silent when nothing moves",
-            "category": "dev",
-            "schedule": "0 22 * * 0",
+            "slug": "fund-flow",
+            "name": "Fund Flow",
+            "description": "Trace where funds move to (or came from) across multiple hops from a Base address and render a Mermaid flow graph. Keyless \u2014 no explorer key needed.",
+            "category": "other",
+            "schedule": "workflow_dispatch",
             "var": "",
             "files": 0,
-            "sha": "c8a6d44",
-            "updated": "2026-05-26",
-            "install": "./add-skill aaronjmars/aeon fleet-skill-adoption"
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
+            "install": "./add-skill aaronjmars/aeon fund-flow"
         },
         {
             "slug": "github-issues",
@@ -643,8 +775,8 @@
             "schedule": "0 9 * * *",
             "var": "",
             "files": 0,
-            "sha": "b49325b",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon github-issues"
         },
         {
@@ -655,8 +787,8 @@
             "schedule": "0 9 * * *",
             "var": "",
             "files": 0,
-            "sha": "680fea6",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon github-monitor"
         },
         {
@@ -667,8 +799,8 @@
             "schedule": "30 9 * * *",
             "var": "",
             "files": 0,
-            "sha": "ef9621d",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon github-releases"
         },
         {
@@ -679,8 +811,8 @@
             "schedule": "0 9 * * *",
             "var": "",
             "files": 0,
-            "sha": "4c2bff0",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon github-trending"
         },
         {
@@ -691,8 +823,8 @@
             "schedule": "0 18 * * *",
             "var": "",
             "files": 0,
-            "sha": "ea94795",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon goal-tracker"
         },
         {
@@ -703,8 +835,8 @@
             "schedule": "0 7 * * *",
             "var": "",
             "files": 0,
-            "sha": "6d6d40c",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon hacker-news-digest"
         },
         {
@@ -715,9 +847,33 @@
             "schedule": "0 8,14,20 * * *",
             "var": "",
             "files": 0,
-            "sha": "4782c4a",
-            "updated": "2026-04-28",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon heartbeat"
+        },
+        {
+            "slug": "holder-concentration",
+            "name": "Holder Concentration",
+            "description": "Analyze token holder distribution on Base \u2014 top-N share, HHI concentration, LP/lock/burn exclusions, and whale clusters. Keyless via Etherscan v2 + Base RPC.",
+            "category": "crypto",
+            "schedule": "workflow_dispatch",
+            "var": "",
+            "files": 0,
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
+            "install": "./add-skill aaronjmars/aeon holder-concentration"
+        },
+        {
+            "slug": "honeypot-check",
+            "name": "Honeypot Check",
+            "description": "Detect un-sellable / restricted (honeypot) tokens on Base by simulating a real holder's sell via eth_call. Keyless \u2014 no explorer key needed.",
+            "category": "other",
+            "schedule": "workflow_dispatch",
+            "var": "",
+            "files": 0,
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
+            "install": "./add-skill aaronjmars/aeon honeypot-check"
         },
         {
             "slug": "huggingface-trending",
@@ -727,8 +883,8 @@
             "schedule": "30 9 * * *",
             "var": "",
             "files": 0,
-            "sha": "9c36154",
-            "updated": "2026-05-08",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon huggingface-trending"
         },
         {
@@ -739,8 +895,8 @@
             "schedule": "0 14 * * *",
             "var": "",
             "files": 0,
-            "sha": "45b7eec",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon idea-capture"
         },
         {
@@ -748,11 +904,11 @@
             "name": "idea-pipeline",
             "description": "Weekly execution gap audit \u2014 cross-references the startup idea backlog against shipped skills, prototypes, and cross-repo PRs. Surfaces the top 3 ideas to build this week based on narrative fit and operator fit.",
             "category": "other",
-            "schedule": "",
+            "schedule": "0 18 * * 1",
             "var": "",
             "files": 0,
-            "sha": "ac068d2",
-            "updated": "2026-05-23",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon idea-pipeline"
         },
         {
@@ -760,12 +916,24 @@
             "name": "idea-validator",
             "description": "Screen the startup idea backlog \u2014 research competitive landscape, score viability, surface the strongest picks from memory/topics/startup-ideas.md",
             "category": "other",
-            "schedule": "",
+            "schedule": "30 18 * * 1",
             "var": "",
             "files": 0,
-            "sha": "ac068d2",
-            "updated": "2026-05-23",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon idea-validator"
+        },
+        {
+            "slug": "investigation-report",
+            "name": "Investigation Report",
+            "description": "One-shot composite investigation of a Base token \u2014 runs rug-scan, contract-audit, deployer-trace and holder-concentration and merges them into a single report with an at-a-glance verdict. Keyless core; a Basescan key deepens it.",
+            "category": "other",
+            "schedule": "workflow_dispatch",
+            "var": "",
+            "files": 0,
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
+            "install": "./add-skill aaronjmars/aeon investigation-report"
         },
         {
             "slug": "issue-triage",
@@ -775,8 +943,8 @@
             "schedule": "0 9 * * *",
             "var": "",
             "files": 0,
-            "sha": "856735d",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon issue-triage"
         },
         {
@@ -784,11 +952,11 @@
             "name": "Janitor",
             "description": "Weekly cleanup of accumulated temp files \u2014 .notify-* root-level files, .pending-notify-temp/, and stale .outputs/ chain artifacts older than their TTL",
             "category": "other",
-            "schedule": "",
+            "schedule": "30 5 * * 0",
             "var": "",
             "files": 0,
-            "sha": "ac068d2",
-            "updated": "2026-05-23",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon janitor"
         },
         {
@@ -799,8 +967,8 @@
             "schedule": "workflow_dispatch",
             "var": "",
             "files": 0,
-            "sha": "ca3ad10",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon last30"
         },
         {
@@ -808,12 +976,36 @@
             "name": "launch-radar",
             "description": "Weekly competitive scan \u2014 searches ProductHunt, HN Show HN, and GitHub Trending for product launches matching the operator's startup idea backlog. Flags when someone ships an idea from the list.",
             "category": "other",
+            "schedule": "30 10 * * 1",
+            "var": "",
+            "files": 0,
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
+            "install": "./add-skill aaronjmars/aeon launch-radar"
+        },
+        {
+            "slug": "linked-wallets",
+            "name": "Linked Wallets",
+            "description": "Cluster addresses likely controlled by the same entity on Base via shared-funder and co-spend heuristics. Keyless \u2014 no explorer key needed.",
+            "category": "other",
+            "schedule": "workflow_dispatch",
+            "var": "",
+            "files": 0,
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
+            "install": "./add-skill aaronjmars/aeon linked-wallets"
+        },
+        {
+            "slug": "liquidpad-launch",
+            "name": "LiquidPad Launch",
+            "description": "Emit a LiquidPad token deploy payload through the prefetch/postprocess shim pair. Routes 80% fees to deployer, 15% to LPAD burn, 5% to LIQ buyback, contract-enforced.",
+            "category": "other",
             "schedule": "",
             "var": "",
             "files": 0,
-            "sha": "ac068d2",
-            "updated": "2026-05-23",
-            "install": "./add-skill aaronjmars/aeon launch-radar"
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
+            "install": "./add-skill aaronjmars/aeon liquidpad-launch"
         },
         {
             "slug": "list-digest",
@@ -823,9 +1015,21 @@
             "schedule": "0 17 * * *",
             "var": "",
             "files": 0,
-            "sha": "b35392a",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon list-digest"
+        },
+        {
+            "slug": "lp-lock-check",
+            "name": "LP Lock Check",
+            "description": "Resolve a token's main liquidity pool on Base and classify whether its LP is burned/locked or removable (rug-pull risk). Keyless \u2014 no explorer key needed.",
+            "category": "other",
+            "schedule": "workflow_dispatch",
+            "var": "",
+            "files": 0,
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
+            "install": "./add-skill aaronjmars/aeon lp-lock-check"
         },
         {
             "slug": "market-context-refresh",
@@ -835,44 +1039,68 @@
             "schedule": "0 13 * * *",
             "var": "",
             "files": 0,
-            "sha": "257212c",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon market-context-refresh"
+        },
+        {
+            "slug": "mcp-pulse",
+            "name": "mcp-pulse",
+            "description": "Weekly tracker for the Model Context Protocol (MCP) ecosystem \u2014 new server implementations, adoption velocity, npm/GitHub signals, and protocol evolution. Thesis check \u2014 is MCP becoming the default tool-call rail for agents?",
+            "category": "dev",
+            "schedule": "0 10 * * 5",
+            "var": "",
+            "files": 0,
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
+            "install": "./add-skill aaronjmars/aeon mcp-pulse"
         },
         {
             "slug": "memory-flush",
             "name": "Memory Flush",
             "description": "Promote important recent log entries into MEMORY.md",
             "category": "other",
-            "schedule": "",
+            "schedule": "30 21 * * *",
             "var": "",
             "files": 0,
-            "sha": "ac068d2",
-            "updated": "2026-05-23",
+            "sha": "5386ace",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon memory-flush"
         },
         {
             "slug": "memory-structural-dedupe",
             "name": "memory-structural-dedupe",
-            "description": "Detect and collapse structural duplicate rows in MEMORY.md \u2014 sections like Recent Articles and Skills Built that accumulate multiple content blocks across memory-flush cycles. Companion to scripts/memory-dedupe (topic-pointer dedup); this handles section-level row accumulation.",
+            "description": "Detect and collapse structural duplicate rows in MEMORY.md \u2014 sections like Recent Articles and Skills Built that accumulate multiple content blocks across memory-flush cycles. Companion to scripts/memory-dedupe (topic-pointer dedup); this handles section-level row accumulation and duplicate H2 headings (the same section heading appearing 2+ times in the file).",
             "category": "other",
-            "schedule": "",
+            "schedule": "10 6 2/2 * *",
             "var": "",
             "files": 0,
-            "sha": "ac068d2",
-            "updated": "2026-05-23",
+            "sha": "5386ace",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon memory-structural-dedupe"
+        },
+        {
+            "slug": "mention-radar",
+            "name": "Mention Radar",
+            "description": "Monitor external web and social mentions of the operator's active projects \u2014 surface what people are discovering, where they're confused, and where to engage",
+            "category": "social",
+            "schedule": "25 7 2/2 * *",
+            "var": "",
+            "files": 0,
+            "sha": "5386ace",
+            "updated": "2026-06-05",
+            "install": "./add-skill aaronjmars/aeon mention-radar"
         },
         {
             "slug": "milestone-tracker",
             "name": "milestone-tracker",
             "description": "Weekly progress tracking for key product and growth milestones \u2014 celebrates crossings, alerts on approaches, surfaces stalls",
             "category": "other",
-            "schedule": "",
+            "schedule": "0 19 * * 1",
             "var": "",
             "files": 0,
-            "sha": "ac068d2",
-            "updated": "2026-05-23",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon milestone-tracker"
         },
         {
@@ -883,8 +1111,8 @@
             "schedule": "0 13 * * *",
             "var": "",
             "files": 1,
-            "sha": "87a8e51",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon monitor-kalshi"
         },
         {
@@ -895,8 +1123,8 @@
             "schedule": "30 12 * * *",
             "var": "",
             "files": 1,
-            "sha": "ba0143d",
-            "updated": "2026-04-15",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon monitor-polymarket"
         },
         {
@@ -907,8 +1135,8 @@
             "schedule": "0 12 * * *",
             "var": "",
             "files": 0,
-            "sha": "f5cd2bf",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon monitor-runners"
         },
         {
@@ -919,9 +1147,21 @@
             "schedule": "0 7 * * *",
             "var": "",
             "files": 0,
-            "sha": "e7896e1",
-            "updated": "2026-05-21",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon morning-brief"
+        },
+        {
+            "slug": "narrative-convergence",
+            "name": "narrative-convergence",
+            "description": "Daily cross-skill signal detector \u2014 finds entities or themes surfaced independently by 3+ different skill categories in the last 48h and surfaces them as high-confidence write opportunities",
+            "category": "research",
+            "schedule": "0 13 * * *",
+            "var": "",
+            "files": 0,
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
+            "install": "./add-skill aaronjmars/aeon narrative-convergence"
         },
         {
             "slug": "narrative-tracker",
@@ -931,8 +1171,8 @@
             "schedule": "30 13 * * *",
             "var": "",
             "files": 0,
-            "sha": "dd782a4",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon narrative-tracker"
         },
         {
@@ -940,11 +1180,11 @@
             "name": "Note Taking",
             "description": "Save a note as a Supernotes card (if configured) or to a local memory/notes/ file",
             "category": "other",
-            "schedule": "",
+            "schedule": "workflow_dispatch",
             "var": "",
             "files": 0,
-            "sha": "ac068d2",
-            "updated": "2026-05-23",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon note-taking"
         },
         {
@@ -955,8 +1195,8 @@
             "schedule": "0 12 * * *",
             "var": "",
             "files": 0,
-            "sha": "7d51ad7",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon on-chain-monitor"
         },
         {
@@ -967,8 +1207,8 @@
             "schedule": "workflow_dispatch",
             "var": "",
             "files": 0,
-            "sha": "1a8a0b5",
-            "updated": "2026-04-22",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon onboard"
         },
         {
@@ -979,8 +1219,8 @@
             "schedule": "30 10 * * 1",
             "var": "",
             "files": 0,
-            "sha": "f7a048a",
-            "updated": "2026-05-03",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon operator-scorecard"
         },
         {
@@ -991,8 +1231,8 @@
             "schedule": "0 7 * * *",
             "var": "",
             "files": 0,
-            "sha": "5a5d2cb",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon paper-digest"
         },
         {
@@ -1003,20 +1243,32 @@
             "schedule": "0 14 * * *",
             "var": "",
             "files": 0,
-            "sha": "ba0143d",
-            "updated": "2026-04-15",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon paper-pick"
+        },
+        {
+            "slug": "picks-tracker",
+            "name": "Picks Tracker",
+            "description": "Weekly retrospective on past token and prediction market picks \u2014 what hit, what flopped, what the score is",
+            "category": "crypto",
+            "schedule": "0 9 * * 0",
+            "var": "",
+            "files": 0,
+            "sha": "5386ace",
+            "updated": "2026-06-05",
+            "install": "./add-skill aaronjmars/aeon picks-tracker"
         },
         {
             "slug": "pm-intel",
             "name": "PM Intel",
             "description": "Weekly competitive intelligence on the prediction market ecosystem \u2014 what major platforms and new entrants are shipping, funding, and building",
             "category": "other",
-            "schedule": "",
+            "schedule": "30 13 * * 1",
             "var": "",
             "files": 0,
-            "sha": "ac068d2",
-            "updated": "2026-05-23",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon pm-intel"
         },
         {
@@ -1024,11 +1276,11 @@
             "name": "PM Manipulation",
             "description": "Detect suspected manipulation on prediction markets over the past 3 days by cross-referencing price/volume/comment anomalies with multilingual local-press coverage",
             "category": "other",
-            "schedule": "",
+            "schedule": "15 13 * * *",
             "var": "",
             "files": 0,
-            "sha": "ac068d2",
-            "updated": "2026-05-23",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon pm-manipulation"
         },
         {
@@ -1036,11 +1288,11 @@
             "name": "pm-pulse",
             "description": "Weekly prediction-market & coordination-market tracker \u2014 volume on tracked platforms, new mechanism designs, reflexive market launches, regulatory moves",
             "category": "other",
-            "schedule": "",
+            "schedule": "0 13 * * 1",
             "var": "",
             "files": 0,
-            "sha": "ac068d2",
-            "updated": "2026-05-23",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon pm-pulse"
         },
         {
@@ -1051,8 +1303,8 @@
             "schedule": "0 13 * * *",
             "var": "",
             "files": 0,
-            "sha": "ba0143d",
-            "updated": "2026-04-15",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon polymarket-comments"
         },
         {
@@ -1060,23 +1312,23 @@
             "name": "Polymarket",
             "description": "Surface trending and top markets on Polymarket globally \u2014 volume leaders, biggest movers, new & notable markets. Complement to monitor-polymarket.",
             "category": "other",
-            "schedule": "",
+            "schedule": "45 12 * * *",
             "var": "",
             "files": 0,
-            "sha": "ac068d2",
-            "updated": "2026-05-23",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon polymarket"
         },
         {
             "slug": "pr-merge-queue",
             "name": "pr-merge-queue",
-            "description": "Daily operator-facing digest of open PRs on a target repo, bucketed by touched-file risk tier (FAST_TRACK / SKILL_PASS / INFRA_REVIEW / SKILL_WARN_OR_BLOCK / CORE_REVIEW / UNKNOWN). Reuses skill-security-scan verbatim for every changed SKILL.md. No merge action, no PR comment — surfaces the queue the operator still has to think about. Gated re-notify on head SHA. var: dry-run [owner/repo]",
-            "category": "dev",
+            "description": "Daily survey of open external PRs across watched repos \u2014 buckets each PR by touched-file risk tier (FAST_TRACK / INFRA_REVIEW / SKILL_PASS / SKILL_WARN_OR_BLOCK / CORE_REVIEW), runs skill-security-scan on every SKILL.md PR, emits one structured digest so the operator can clear the safest candidates first",
+            "category": "other",
             "schedule": "45 9 * * *",
             "var": "",
             "files": 0,
-            "sha": "0000000",
-            "updated": "2026-06-02",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon pr-merge-queue"
         },
         {
@@ -1087,20 +1339,32 @@
             "schedule": "0 9 * * *",
             "var": "",
             "files": 0,
-            "sha": "b8b3551",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon pr-review"
+        },
+        {
+            "slug": "pr-skill-triage",
+            "name": "pr-skill-triage",
+            "description": "Structured triage for inbound PRs that introduce or modify SKILL.md files \u2014 security scan per skill, required-secrets enumeration, cron slot-conflict check, basic quality signals, posted as one PR comment. The receipt that turns a 10-minute manual skill-PR review into a 10-second human decision",
+            "category": "other",
+            "schedule": "workflow_dispatch",
+            "var": "",
+            "files": 0,
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
+            "install": "./add-skill aaronjmars/aeon pr-skill-triage"
         },
         {
             "slug": "pr-tracker",
             "name": "PR Tracker",
             "description": "Track status of cross-repo PRs opened by this aeon instance \u2014 merges, stale open, and closures",
             "category": "other",
-            "schedule": "",
+            "schedule": "30 9 * * *",
             "var": "",
             "files": 0,
-            "sha": "ac068d2",
-            "updated": "2026-05-23",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon pr-tracker"
         },
         {
@@ -1111,21 +1375,9 @@
             "schedule": "30 9 * * *",
             "var": "",
             "files": 0,
-            "sha": "e26e7a2",
-            "updated": "2026-04-29",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon pr-triage"
-        },
-        {
-            "slug": "pr-skill-triage",
-            "name": "pr-skill-triage",
-            "description": "Structured triage for inbound PRs that introduce or modify SKILL.md files \u2014 per-skill security scan, required-secrets enumeration, cron slot-conflict check, basic quality signals, posted as one PR comment. workflow_dispatch only; var=PR_NUMBER",
-            "category": "dev",
-            "schedule": "workflow_dispatch",
-            "var": "",
-            "files": 0,
-            "sha": "0000000",
-            "updated": "2026-05-28",
-            "install": "./add-skill aaronjmars/aeon pr-skill-triage"
         },
         {
             "slug": "price-threshold-alert",
@@ -1135,8 +1387,8 @@
             "schedule": "*/30 * * * *",
             "var": "",
             "files": 0,
-            "sha": "32a48af",
-            "updated": "2026-05-11",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon price-threshold-alert"
         },
         {
@@ -1147,8 +1399,8 @@
             "schedule": "workflow_dispatch",
             "var": "",
             "files": 0,
-            "sha": "03057e2",
-            "updated": "2026-05-19",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon product-hunt-launch"
         },
         {
@@ -1159,8 +1411,8 @@
             "schedule": "30 15 * * 1,3,5",
             "var": "",
             "files": 0,
-            "sha": "420c07f",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon project-lens"
         },
         {
@@ -1171,8 +1423,8 @@
             "schedule": "0 15 * * *",
             "var": "",
             "files": 0,
-            "sha": "df0c036",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon push-recap"
         },
         {
@@ -1180,11 +1432,11 @@
             "name": "pvr-triage-monitor",
             "description": "Weekly lifecycle check on submitted private vulnerability reports \u2014 polls triage state, detects maintainer acceptance or rejection, surfaces action items when PVRs age past 30 days with no response",
             "category": "other",
-            "schedule": "",
+            "schedule": "30 16 * * 6",
             "var": "",
             "files": 0,
-            "sha": "ac068d2",
-            "updated": "2026-05-23",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon pvr-triage-monitor"
         },
         {
@@ -1192,11 +1444,11 @@
             "name": "pvr-watchlist",
             "description": "Weekly probe of repos on the security watchlist \u2014 check if private vulnerability reporting has been enabled, notify when status flips, re-submit any queued advisories or flag for re-research when draft was lost",
             "category": "other",
-            "schedule": "",
+            "schedule": "0 16 * * 6",
             "var": "",
             "files": 0,
-            "sha": "ac068d2",
-            "updated": "2026-05-23",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon pvr-watchlist"
         },
         {
@@ -1207,8 +1459,8 @@
             "schedule": "0 7 * * *",
             "var": "",
             "files": 0,
-            "sha": "0d27646",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon reddit-digest"
         },
         {
@@ -1219,8 +1471,8 @@
             "schedule": "0 18 * * *",
             "var": "",
             "files": 0,
-            "sha": "9acdfeb",
-            "updated": "2026-04-08",
+            "sha": "5386ace",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon reflect"
         },
         {
@@ -1231,8 +1483,8 @@
             "schedule": "0 17 * * *",
             "var": "",
             "files": 0,
-            "sha": "b8c8b85",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon refresh-x"
         },
         {
@@ -1243,8 +1495,8 @@
             "schedule": "0 14 * * 3",
             "var": "",
             "files": 0,
-            "sha": "0a709f9",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon reg-monitor"
         },
         {
@@ -1255,8 +1507,8 @@
             "schedule": "30 17 * * *",
             "var": "",
             "files": 0,
-            "sha": "4f6bf26",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon remix-tweets"
         },
         {
@@ -1267,8 +1519,8 @@
             "schedule": "0 17 * * *",
             "var": "",
             "files": 0,
-            "sha": "795a5a1",
-            "updated": "2026-05-07",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon reply-maker"
         },
         {
@@ -1279,8 +1531,8 @@
             "schedule": "0 15 * * *",
             "var": "",
             "files": 0,
-            "sha": "dde1789",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon repo-actions"
         },
         {
@@ -1291,8 +1543,8 @@
             "schedule": "0 15 * * *",
             "var": "",
             "files": 0,
-            "sha": "57b7a9c",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon repo-article"
         },
         {
@@ -1303,8 +1555,8 @@
             "schedule": "0 15 * * *",
             "var": "",
             "files": 0,
-            "sha": "825f52a",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon repo-pulse"
         },
         {
@@ -1312,11 +1564,11 @@
             "name": "Repo Revive",
             "description": "Pick the highest-\u2605 dormant watched repo and make one targeted improvement to reactivate it \u2014 refresh stale model references, README, or metadata",
             "category": "other",
-            "schedule": "",
+            "schedule": "0 10 * * 6",
             "var": "",
             "files": 0,
-            "sha": "ac068d2",
-            "updated": "2026-05-23",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon repo-revive"
         },
         {
@@ -1327,8 +1579,8 @@
             "schedule": "0 15 * * 0",
             "var": "",
             "files": 0,
-            "sha": "74ed4b2",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon repo-scanner"
         },
         {
@@ -1339,8 +1591,8 @@
             "schedule": "0 14 * * *",
             "var": "",
             "files": 0,
-            "sha": "0ee72dc",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon research-brief"
         },
         {
@@ -1351,8 +1603,8 @@
             "schedule": "0 7 * * *",
             "var": "",
             "files": 0,
-            "sha": "ba0143d",
-            "updated": "2026-04-15",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon rss-digest"
         },
         {
@@ -1363,20 +1615,32 @@
             "schedule": "30 17 * * *",
             "var": "",
             "files": 0,
-            "sha": "d270643",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon rss-feed"
+        },
+        {
+            "slug": "rug-scan",
+            "name": "Rug Scan",
+            "description": "Assess rug-pull risk for any token on Base \u2014 ownership, mint/freeze powers, LP lock, and holder concentration rolled into one risk verdict. Keyless via Etherscan v2 + Base RPC.",
+            "category": "crypto",
+            "schedule": "workflow_dispatch",
+            "var": "",
+            "files": 0,
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
+            "install": "./add-skill aaronjmars/aeon rug-scan"
         },
         {
             "slug": "run-frequency-guard",
             "name": "run-frequency-guard",
             "description": "Daily per-skill run-count watchdog \u2014 checks if any capped skills exceeded their configured daily limit and alerts on breach",
             "category": "other",
-            "schedule": "",
+            "schedule": "0 23 * * *",
             "var": "",
             "files": 0,
-            "sha": "ac068d2",
-            "updated": "2026-05-23",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon run-frequency-guard"
         },
         {
@@ -1384,11 +1648,11 @@
             "name": "rwa-pulse",
             "description": "Weekly Real World Asset tokenization momentum tracker \u2014 surfaces new protocol launches, TVL milestones, institutional adoption, and regulatory approvals",
             "category": "other",
-            "schedule": "",
+            "schedule": "0 12 * * 1",
             "var": "",
             "files": 0,
-            "sha": "ac068d2",
-            "updated": "2026-05-23",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon rwa-pulse"
         },
         {
@@ -1399,8 +1663,8 @@
             "schedule": "0 8 * * *",
             "var": "",
             "files": 1,
-            "sha": "29b6558",
-            "updated": "2026-04-21",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon schedule-ads"
         },
         {
@@ -1411,8 +1675,8 @@
             "schedule": "0 14 * * *",
             "var": "",
             "files": 0,
-            "sha": "84c88c5",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon search-skill"
         },
         {
@@ -1423,8 +1687,8 @@
             "schedule": "0 14 * * *",
             "var": "",
             "files": 0,
-            "sha": "cc0a62f",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon security-digest"
         },
         {
@@ -1435,8 +1699,8 @@
             "schedule": "0 18 1/2 * *",
             "var": "",
             "files": 0,
-            "sha": "ba0143d",
-            "updated": "2026-04-15",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon self-improve"
         },
         {
@@ -1444,11 +1708,11 @@
             "name": "Self Review",
             "description": "Weekly audit of what the agent did, what failed, and what to improve",
             "category": "other",
-            "schedule": "",
+            "schedule": "30 19 * * 0",
             "var": "",
             "files": 0,
-            "sha": "ac068d2",
-            "updated": "2026-05-23",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon self-review"
         },
         {
@@ -1459,8 +1723,8 @@
             "schedule": "workflow_dispatch",
             "var": "",
             "files": 0,
-            "sha": "56b39ea",
-            "updated": "2026-05-03",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon show-hn-draft"
         },
         {
@@ -1468,11 +1732,11 @@
             "name": "signal-verdict",
             "description": "Weekly accountability check on a configured set of tracker skills. Verifies each tracker is producing citable signals in articles/newsletters. Surfaces uncited trackers so the operator can demote or kill them.",
             "category": "other",
-            "schedule": "",
+            "schedule": "0 8 * * 1",
             "var": "",
             "files": 0,
-            "sha": "ac068d2",
-            "updated": "2026-05-23",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon signal-verdict"
         },
         {
@@ -1483,8 +1747,8 @@
             "schedule": "30 18 * * 3",
             "var": "",
             "files": 0,
-            "sha": "98193f9",
-            "updated": "2026-04-26",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon skill-analytics"
         },
         {
@@ -1492,11 +1756,11 @@
             "name": "skill-enabler",
             "description": "Flip enabled:false \u2192 enabled:true for a comma-separated list of skill slugs in aeon.yml \u2014 validate against skills/, fail loudly on already-enabled or missing slugs, commit, open a PR with per-skill rationale",
             "category": "other",
-            "schedule": "",
+            "schedule": "workflow_dispatch",
             "var": "",
             "files": 0,
-            "sha": "ac068d2",
-            "updated": "2026-05-23",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon skill-enabler"
         },
         {
@@ -1507,8 +1771,8 @@
             "schedule": "0 6 * * 0",
             "var": "",
             "files": 1,
-            "sha": "8f3d8d6",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon skill-evals"
         },
         {
@@ -1519,8 +1783,8 @@
             "schedule": "0 8 * * *",
             "var": "",
             "files": 0,
-            "sha": "32c77d7",
-            "updated": "2026-05-04",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon skill-freshness"
         },
         {
@@ -1531,8 +1795,8 @@
             "schedule": "0 17 * * 0",
             "var": "",
             "files": 0,
-            "sha": "cfcefdb",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon skill-graph"
         },
         {
@@ -1543,8 +1807,8 @@
             "schedule": "0 18 * * *",
             "var": "",
             "files": 1,
-            "sha": "da75399",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon skill-health"
         },
         {
@@ -1555,9 +1819,21 @@
             "schedule": "0 17 * * 0",
             "var": "",
             "files": 0,
-            "sha": "69dcc86",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon skill-leaderboard"
+        },
+        {
+            "slug": "skill-of-the-day",
+            "name": "Skill of the Day",
+            "description": "Pick one skill from a rotation, ship a paste-ready feature tweet in the \"Aeon skill of the day\" format, then dispatch the picked skill so the chosen channel also gets the live outcome",
+            "category": "other",
+            "schedule": "workflow_dispatch",
+            "var": "",
+            "files": 0,
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
+            "install": "./add-skill aaronjmars/aeon skill-of-the-day"
         },
         {
             "slug": "skill-repair",
@@ -1567,8 +1843,8 @@
             "schedule": "reactive",
             "var": "",
             "files": 0,
-            "sha": "676dfd2",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon skill-repair"
         },
         {
@@ -1579,8 +1855,8 @@
             "schedule": "0 16 * * 1",
             "var": "",
             "files": 1,
-            "sha": "7569894",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon skill-security-scan"
         },
         {
@@ -1591,8 +1867,8 @@
             "schedule": "0 19 * * 0",
             "var": "",
             "files": 0,
-            "sha": "efac3bc",
-            "updated": "2026-05-21",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon skill-update-check"
         },
         {
@@ -1603,9 +1879,21 @@
             "schedule": "0 6 1/7 * *",
             "var": "",
             "files": 0,
-            "sha": "50eec0e",
-            "updated": "2026-05-01",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon smithery-manifest"
+        },
+        {
+            "slug": "sparkleware-catalog",
+            "name": "sparkleware-catalog",
+            "description": "Weekly enriched export of skill-packs.json \u2014 joins the canonical community registry to live GitHub signals (stars, last-push, live manifest skill count) and writes a machine-readable skill-packs-catalog.json that external tools (e.g. Sparkleware) can consume without screen-scraping",
+            "category": "other",
+            "schedule": "0 9 * * 2",
+            "var": "",
+            "files": 0,
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
+            "install": "./add-skill aaronjmars/aeon sparkleware-catalog"
         },
         {
             "slug": "spawn-instance",
@@ -1615,9 +1903,21 @@
             "schedule": "workflow_dispatch",
             "var": "",
             "files": 0,
-            "sha": "73de769",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon spawn-instance"
+        },
+        {
+            "slug": "spend-monitor",
+            "name": "Spend Monitor",
+            "description": "Daily API spend watchdog \u2014 checks running weekly cost against a budget cap, alerts when approaching or exceeding it",
+            "category": "productivity",
+            "schedule": "0 12 * * *",
+            "var": "",
+            "files": 0,
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
+            "install": "./add-skill aaronjmars/aeon spend-monitor"
         },
         {
             "slug": "star-milestone",
@@ -1627,8 +1927,8 @@
             "schedule": "15 15 * * *",
             "var": "",
             "files": 0,
-            "sha": "04e6465",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon star-milestone"
         },
         {
@@ -1639,8 +1939,8 @@
             "schedule": "10 10 * * *",
             "var": "",
             "files": 0,
-            "sha": "1e167cf",
-            "updated": "2026-05-05",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon star-momentum-alert"
         },
         {
@@ -1651,8 +1951,8 @@
             "schedule": "0 18 * * *",
             "var": "",
             "files": 0,
-            "sha": "4438539",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon startup-idea"
         },
         {
@@ -1663,8 +1963,8 @@
             "schedule": "30 15 * * *",
             "var": "",
             "files": 0,
-            "sha": "70024a9",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon syndicate-article"
         },
         {
@@ -1675,8 +1975,8 @@
             "schedule": "30 14 * * *",
             "var": "",
             "files": 0,
-            "sha": "d92e895",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon technical-explainer"
         },
         {
@@ -1687,8 +1987,8 @@
             "schedule": "30 7 * * *",
             "var": "",
             "files": 1,
-            "sha": "61f52ef",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon telegram-digest"
         },
         {
@@ -1699,9 +1999,21 @@
             "schedule": "30 17 * * *",
             "var": "",
             "files": 0,
-            "sha": "f07d975",
-            "updated": "2026-04-30",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon thread-formatter"
+        },
+        {
+            "slug": "thread-writer",
+            "name": "Thread Writer",
+            "description": "Write a tweetstorm/thread (5\u201310 tweets) in the operator's voice on a given topic, grounded in memory and research",
+            "category": "social",
+            "schedule": "workflow_dispatch",
+            "var": "",
+            "files": 0,
+            "sha": "5386ace",
+            "updated": "2026-06-05",
+            "install": "./add-skill aaronjmars/aeon thread-writer"
         },
         {
             "slug": "token-alert",
@@ -1711,8 +2023,8 @@
             "schedule": "0 12 * * *",
             "var": "",
             "files": 0,
-            "sha": "ba0143d",
-            "updated": "2026-04-15",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon token-alert"
         },
         {
@@ -1723,8 +2035,8 @@
             "schedule": "0 12 * * *",
             "var": "",
             "files": 0,
-            "sha": "1c79aea",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon token-movers"
         },
         {
@@ -1735,8 +2047,8 @@
             "schedule": "0 12 * * *",
             "var": "",
             "files": 0,
-            "sha": "c22bfe3",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon token-pick"
         },
         {
@@ -1747,8 +2059,8 @@
             "schedule": "30 12 * * *",
             "var": "",
             "files": 0,
-            "sha": "1867c0e",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon token-report"
         },
         {
@@ -1759,8 +2071,8 @@
             "schedule": "reactive",
             "var": "",
             "files": 0,
-            "sha": "493ab77",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon tool-builder"
         },
         {
@@ -1768,11 +2080,11 @@
             "name": "topic-momentum",
             "description": "Weekly content-gap scanner \u2014 cross-references rising narrative signals (narrative-tracker, tweet-roundup, paper-pick, etc.) against recent article history and surfaces the top 3 uncovered angles to write next.",
             "category": "other",
-            "schedule": "",
+            "schedule": "30 6 * * 1",
             "var": "",
             "files": 0,
-            "sha": "ac068d2",
-            "updated": "2026-05-23",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon topic-momentum"
         },
         {
@@ -1783,8 +2095,8 @@
             "schedule": "0 12 * * *",
             "var": "",
             "files": 0,
-            "sha": "6f7959a",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon treasury-info"
         },
         {
@@ -1792,11 +2104,11 @@
             "name": "Tweet Digest",
             "description": "Account-based digest of recent tweets from tracked X/Twitter accounts. Sibling to fetch-tweets (keyword) and tweet-roundup (topic).",
             "category": "other",
-            "schedule": "",
+            "schedule": "0 17 * * *",
             "var": "",
             "files": 0,
-            "sha": "ac068d2",
-            "updated": "2026-05-23",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon tweet-digest"
         },
         {
@@ -1807,9 +2119,21 @@
             "schedule": "0 17 * * *",
             "var": "",
             "files": 0,
-            "sha": "3f85c67",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon tweet-roundup"
+        },
+        {
+            "slug": "tx-explain",
+            "name": "Tx Explain",
+            "description": "Decode any Base transaction into a plain-English story \u2014 method, token movements, swaps/approvals, counterparties, and suspicious-approval flags. Keyless via Base RPC + Etherscan v2.",
+            "category": "crypto",
+            "schedule": "workflow_dispatch",
+            "var": "",
+            "files": 0,
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
+            "install": "./add-skill aaronjmars/aeon tx-explain"
         },
         {
             "slug": "unlock-monitor",
@@ -1819,8 +2143,8 @@
             "schedule": "0 10 * * 1",
             "var": "",
             "files": 0,
-            "sha": "3c440e9",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon unlock-monitor"
         },
         {
@@ -1831,8 +2155,8 @@
             "schedule": "0 18 * * 0",
             "var": "",
             "files": 0,
-            "sha": "0a43b79",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon update-gallery"
         },
         {
@@ -1843,8 +2167,8 @@
             "schedule": "workflow_dispatch",
             "var": "",
             "files": 0,
-            "sha": "3450b31",
-            "updated": "2026-05-07",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon v4-readiness"
         },
         {
@@ -1855,8 +2179,8 @@
             "schedule": "0 18 * * 0",
             "var": "",
             "files": 0,
-            "sha": "594be2b",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon vercel-projects"
         },
         {
@@ -1867,9 +2191,21 @@
             "schedule": "30 17 * * *",
             "var": "",
             "files": 0,
-            "sha": "b3e8710",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon vibecoding-digest"
+        },
+        {
+            "slug": "vigil",
+            "name": "VIGIL Security Scanner",
+            "description": "Onchain security scanner on Base \u2014 scan token approvals, detect honeypots, analyze contracts for rugpull indicators, and score contract safety. Keyless read-only scanning via VIGIL API. Revoke actions require Bankr auth and are gated separately.",
+            "category": "other",
+            "schedule": "",
+            "var": "",
+            "files": 0,
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
+            "install": "./add-skill aaronjmars/aeon vigil"
         },
         {
             "slug": "vuln-scanner",
@@ -1879,8 +2215,8 @@
             "schedule": "0 16 * * 6",
             "var": "",
             "files": 0,
-            "sha": "88d688e",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon vuln-scanner"
         },
         {
@@ -1888,11 +2224,11 @@
             "name": "Vuln Tracker",
             "description": "Daily status check on every PR / advisory / queued draft produced by vuln-scanner \u2014 surfaces merges, stale opens, maintainer responses needing reply, and queued-too-long carve-outs",
             "category": "other",
-            "schedule": "",
+            "schedule": "30 16 * * *",
             "var": "",
             "files": 0,
-            "sha": "ac068d2",
-            "updated": "2026-05-23",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon vuln-tracker"
         },
         {
@@ -1900,12 +2236,36 @@
             "name": "Wallet Digest",
             "description": "Lightweight balance-and-activity summary across tracked wallets. Sibling to on-chain-monitor \u2014 balances-only, no per-transfer decode.",
             "category": "other",
-            "schedule": "",
+            "schedule": "30 12 * * *",
             "var": "",
             "files": 0,
-            "sha": "ac068d2",
-            "updated": "2026-05-23",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon wallet-digest"
+        },
+        {
+            "slug": "wallet-profile",
+            "name": "Wallet Profile",
+            "description": "Behavioral profile of any wallet on Base \u2014 age, activity class (bot/whale/sniper/trader), funding source, top counterparties, and risk flags. Keyless via Etherscan v2 + Base RPC.",
+            "category": "crypto",
+            "schedule": "workflow_dispatch",
+            "var": "",
+            "files": 0,
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
+            "install": "./add-skill aaronjmars/aeon wallet-profile"
+        },
+        {
+            "slug": "wallet-risk-weekly",
+            "name": "wallet-risk-weekly",
+            "description": "Weekly risk audit of this agent's own Base wallets \u2014 live ERC-20 approvals (unlimited flagged), honeypot simulation on every token with a live approval, severity-tiered findings. Keyless via Base RPC. First scheduled consumer of the HoundFlow security pack against `.x402books/wallets.json`.",
+            "category": "other",
+            "schedule": "15 11 * * 1",
+            "var": "",
+            "files": 0,
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
+            "install": "./add-skill aaronjmars/aeon wallet-risk-weekly"
         },
         {
             "slug": "weekly-review",
@@ -1915,8 +2275,8 @@
             "schedule": "0 19 * * 1",
             "var": "",
             "files": 0,
-            "sha": "e7896e1",
-            "updated": "2026-05-21",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon weekly-review"
         },
         {
@@ -1927,8 +2287,8 @@
             "schedule": "0 9 * * 1",
             "var": "",
             "files": 0,
-            "sha": "d188bcb",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon weekly-shiplog"
         },
         {
@@ -1939,8 +2299,8 @@
             "schedule": "0 16 * * 0",
             "var": "",
             "files": 0,
-            "sha": "132723c",
-            "updated": "2026-04-20",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon workflow-security-audit"
         },
         {
@@ -1951,8 +2311,8 @@
             "schedule": "0 17 * * *",
             "var": "",
             "files": 0,
-            "sha": "ba0143d",
-            "updated": "2026-04-15",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon write-tweet"
         },
         {
@@ -1960,252 +2320,12 @@
             "name": "Protocol Monitor (x402 default)",
             "description": "Weekly tracker for a configured protocol's ecosystem velocity \u2014 new GitHub integrations, npm adoption, notable announcements. Defaults to x402; operators swap in their own protocol via memory/topics/tracked-protocol.md.",
             "category": "other",
-            "schedule": "",
+            "schedule": "0 12 * * 2",
             "var": "",
             "files": 0,
-            "sha": "ac068d2",
-            "updated": "2026-05-23",
+            "sha": "9cb91a7",
+            "updated": "2026-06-05",
             "install": "./add-skill aaronjmars/aeon x402-monitor"
-        },
-        {
-            "slug": "contract-audit",
-            "name": "Contract Audit",
-            "description": "Audit any contract on Base \u2014 verification, proxy/upgradeability, ownership/admin roles, and mint/freeze/pause/drain powers as a live capability matrix. Keyless via Etherscan v2 + Base RPC.",
-            "category": "crypto",
-            "schedule": "workflow_dispatch",
-            "var": "",
-            "files": 0,
-            "sha": "",
-            "updated": "",
-            "install": "./add-skill aaronjmars/aeon contract-audit"
-        },
-        {
-            "slug": "deployer-trace",
-            "name": "Deployer Trace",
-            "description": "Map every contract deployed by an address on Base, link reused patterns, and surface serial-rug signals. Keyless via Etherscan v2 + Base RPC.",
-            "category": "crypto",
-            "schedule": "workflow_dispatch",
-            "var": "",
-            "files": 0,
-            "sha": "",
-            "updated": "",
-            "install": "./add-skill aaronjmars/aeon deployer-trace"
-        },
-        {
-            "slug": "holder-concentration",
-            "name": "Holder Concentration",
-            "description": "Analyze token holder distribution on Base \u2014 top-N share, HHI concentration, LP/lock/burn exclusions, and whale clusters. Keyless via Etherscan v2 + Base RPC.",
-            "category": "crypto",
-            "schedule": "workflow_dispatch",
-            "var": "",
-            "files": 0,
-            "sha": "",
-            "updated": "",
-            "install": "./add-skill aaronjmars/aeon holder-concentration"
-        },
-        {
-            "slug": "rug-scan",
-            "name": "Rug Scan",
-            "description": "Assess rug-pull risk for any token on Base \u2014 ownership, mint/freeze powers, LP lock, and holder concentration rolled into one risk verdict. Keyless via Etherscan v2 + Base RPC.",
-            "category": "crypto",
-            "schedule": "workflow_dispatch",
-            "var": "",
-            "files": 0,
-            "sha": "",
-            "updated": "",
-            "install": "./add-skill aaronjmars/aeon rug-scan"
-        },
-        {
-            "slug": "tx-explain",
-            "name": "Tx Explain",
-            "description": "Decode any Base transaction into a plain-English story \u2014 method, token movements, swaps/approvals, counterparties, and suspicious-approval flags. Keyless via Base RPC + Etherscan v2.",
-            "category": "crypto",
-            "schedule": "workflow_dispatch",
-            "var": "",
-            "files": 0,
-            "sha": "",
-            "updated": "",
-            "install": "./add-skill aaronjmars/aeon tx-explain"
-        },
-        {
-            "slug": "wallet-profile",
-            "name": "Wallet Profile",
-            "description": "Behavioral profile of any wallet on Base \u2014 age, activity class (bot/whale/sniper/trader), funding source, top counterparties, and risk flags. Keyless via Etherscan v2 + Base RPC.",
-            "category": "crypto",
-            "schedule": "workflow_dispatch",
-            "var": "",
-            "files": 0,
-            "sha": "",
-            "updated": "",
-            "install": "./add-skill aaronjmars/aeon wallet-profile"
-        },
-        {
-            "slug": "spend-monitor",
-            "name": "Spend Monitor",
-            "description": "Daily API spend watchdog \u2014 checks running weekly cost against a budget cap, alerts when approaching or exceeding it",
-            "category": "productivity",
-            "schedule": "0 12 * * *",
-            "var": "",
-            "files": 0,
-            "sha": "0000000",
-            "updated": "2026-05-29",
-            "install": "./add-skill aaronjmars/aeon spend-monitor"
-        },
-        {
-            "slug": "follow-up-patrol",
-            "name": "follow-up-patrol",
-            "description": "Weekly escalation audit \u2014 parses the follow-up / open-loop section of MEMORY.md plus the issue tracker, computes item ages, and alerts on items hitting urgency thresholds so nothing rots unattended",
-            "category": "productivity",
-            "schedule": "0 11 * * 2",
-            "var": "",
-            "files": 0,
-            "sha": "0000000",
-            "updated": "2026-05-29",
-            "install": "./add-skill aaronjmars/aeon follow-up-patrol"
-        },
-        {
-            "slug": "narrative-convergence",
-            "name": "narrative-convergence",
-            "description": "Daily cross-skill signal detector \u2014 finds entities or themes surfaced independently by 3+ different skill categories in the last 48h and surfaces them as high-confidence write opportunities",
-            "category": "research",
-            "schedule": "0 13 * * *",
-            "var": "",
-            "files": 0,
-            "sha": "0000000",
-            "updated": "2026-05-29",
-            "install": "./add-skill aaronjmars/aeon narrative-convergence"
-        },
-        {
-            "slug": "mcp-pulse",
-            "name": "mcp-pulse",
-            "description": "Weekly tracker for the Model Context Protocol (MCP) ecosystem \u2014 new server implementations, adoption velocity, npm/GitHub signals, and protocol evolution. Thesis check \u2014 is MCP becoming the default tool-call rail for agents?",
-            "category": "dev",
-            "schedule": "0 10 * * 5",
-            "var": "",
-            "files": 0,
-            "sha": "0000000",
-            "updated": "2026-05-29",
-            "install": "./add-skill aaronjmars/aeon mcp-pulse"
-        },
-        {
-            "slug": "fleet-scorecard",
-            "name": "Fleet Scorecard",
-            "description": "Daily fleet-wide scorecard across this instance and every managed instance in memory/instances.json \u2014 runs, tokens (OpenRouter shape), est. cost, skills, and reliability, with day-over-day deltas and alerts",
-            "category": "dev",
-            "schedule": "0 13 * * *",
-            "var": "",
-            "files": 0,
-            "sha": "0000000",
-            "updated": "2026-05-29",
-            "install": "./add-skill aaronjmars/aeon fleet-scorecard"
-        },
-        {
-            "slug": "approval-audit",
-            "name": "Approval Audit",
-            "description": "List a wallet's live ERC-20 token approvals on Base and flag unlimited / risky spender grants. Keyless via Base RPC (eth_getLogs + eth_call) \u2014 no explorer key needed.",
-            "category": "crypto",
-            "schedule": "workflow_dispatch",
-            "var": "",
-            "files": 0,
-            "sha": "",
-            "updated": "",
-            "install": "./add-skill aaronjmars/aeon approval-audit"
-        },
-        {
-            "slug": "honeypot-check",
-            "name": "Honeypot Check",
-            "description": "Detect un-sellable / restricted (honeypot) tokens on Base by simulating a real holder's sell via eth_call. Keyless \u2014 no explorer key needed.",
-            "category": "crypto",
-            "schedule": "workflow_dispatch",
-            "var": "",
-            "files": 0,
-            "sha": "",
-            "updated": "",
-            "install": "./add-skill aaronjmars/aeon honeypot-check"
-        },
-        {
-            "slug": "lp-lock-check",
-            "name": "LP Lock Check",
-            "description": "Resolve a token's main liquidity pool on Base and classify whether its LP is burned/locked or removable (rug-pull risk). Keyless \u2014 no explorer key needed.",
-            "category": "crypto",
-            "schedule": "workflow_dispatch",
-            "var": "",
-            "files": 0,
-            "sha": "",
-            "updated": "",
-            "install": "./add-skill aaronjmars/aeon lp-lock-check"
-        },
-        {
-            "slug": "linked-wallets",
-            "name": "Linked Wallets",
-            "description": "Cluster addresses likely controlled by the same entity on Base via shared-funder and co-spend heuristics. Keyless \u2014 no explorer key needed.",
-            "category": "crypto",
-            "schedule": "workflow_dispatch",
-            "var": "",
-            "files": 0,
-            "sha": "",
-            "updated": "",
-            "install": "./add-skill aaronjmars/aeon linked-wallets"
-        },
-        {
-            "slug": "fund-flow",
-            "name": "Fund Flow",
-            "description": "Trace where funds move to (or came from) across multiple hops from a Base address and render a Mermaid flow graph. Keyless \u2014 no explorer key needed.",
-            "category": "crypto",
-            "schedule": "workflow_dispatch",
-            "var": "",
-            "files": 0,
-            "sha": "",
-            "updated": "",
-            "install": "./add-skill aaronjmars/aeon fund-flow"
-        },
-        {
-            "slug": "investigation-report",
-            "name": "Investigation Report",
-            "description": "One-shot composite investigation of a Base token \u2014 runs rug-scan, contract-audit, deployer-trace and holder-concentration and merges them into a single report with an at-a-glance verdict. Keyless core; a Basescan key deepens it.",
-            "category": "crypto",
-            "schedule": "workflow_dispatch",
-            "var": "",
-            "files": 0,
-            "sha": "",
-            "updated": "",
-            "install": "./add-skill aaronjmars/aeon investigation-report"
-        },
-        {
-            "slug": "capabilities-map",
-            "name": "capabilities-map",
-            "description": "Weekly read-only audit of installed skills' capability coverage \u2014 maps every enabled/disabled skill against the locked 6-value taxonomy in docs/CAPABILITIES.md, flags any capability tier with zero enabled coverage as an actionable gap",
-            "category": "dev",
-            "schedule": "30 11 * * 1",
-            "var": "",
-            "files": 0,
-            "sha": "",
-            "updated": "2026-06-01",
-            "install": "./add-skill aaronjmars/aeon capabilities-map"
-        },
-        {
-            "slug": "liquidpad-launch",
-            "name": "LiquidPad Launch",
-            "description": "Emit a LiquidPad token deploy payload through the prefetch/postprocess shim pair. Routes 80% fees to deployer, 15% to LPAD burn, 5% to LIQ buyback, contract-enforced.",
-            "category": "crypto",
-            "schedule": "",
-            "var": "",
-            "files": 1,
-            "sha": "4f40f1c7",
-            "updated": "2026-05-28",
-            "install": "./add-skill aaronjmars/aeon liquidpad-launch"
-        },
-        {
-            "slug": "wallet-risk-weekly",
-            "name": "wallet-risk-weekly",
-            "description": "Weekly risk audit of this agent's own Base wallets (.x402books/wallets.json) — live ERC-20 approvals (unlimited flagged + known-safe-spender downgrade), per-token honeypot simulation. First scheduled consumer of the HoundFlow approval-audit + honeypot-check pair.",
-            "category": "crypto",
-            "schedule": "15 11 * * 1",
-            "var": "",
-            "files": 0,
-            "sha": "",
-            "updated": "2026-06-04",
-            "install": "./add-skill aaronjmars/aeon wallet-risk-weekly"
         }
     ],
     "install_all": "./add-skill aaronjmars/aeon --all",


### PR DESCRIPTION
Follow-up to #343.

## What

- **Category table refreshed** — adds all **37 skills** that had shipped since the table's last update: the Hound onchain pack (`rug-scan`, `contract-audit`, `honeypot-check`, `fund-flow`, `wallet-profile`, …), the fleet-analytics suite (`fleet-scorecard`, `fork-health-score`, `fleet-skill-adoption`, …), the PR-triage suite (`pr-merge-queue`, `pr-skill-triage`), catalog watchers (`atrium-catalog-watcher`, `sparkleware-catalog`, `capabilities-map`), and the 8 aeon-aaron ports from #343. Per-category counts corrected: 28 / 44 / 44 / 18 / 19 / 40 = **193**, verified programmatically against skills.json (no missing, no extinct slugs).
- **"New (June 2026)" showcase block** under the skills table for the 8 ported skills, one line each on what they add.
- **All six stale "156 skills" references → 193**: hero tagline, skills section intro, repo-structure tree (×2), FAQ category breakdown, skill-graph pointer.
- **`generate-skills-json`**: category-map entries for the 8 new skills (they were falling into `other`); `skills.json` regenerated (pretty-printed, matching committed format) — `total: 193`.

## Verification

```
Research & Content  declared 28 — OK     table total: 193
Dev & Code          declared 44 — OK     skills.json total: 193
Crypto & Markets    declared 44 — OK     missing from table: none
Social & Writing    declared 18 — OK     extinct in table: none
Productivity        declared 19 — OK     remaining "156" refs: 0
Meta / Agent        declared 40 — OK
```

Note: 73 pre-existing skills (the earlier derivative-instance ports) still map to `other` in generate-skills-json's category map — left untouched to keep this diff scoped; happy to categorize them in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)