### PR TITLE
docs: add Mneme to ecosystem + aeon-skill-pack-mneme registry

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -51,6 +51,7 @@ These are the projects we know of that run Aeon, extend it, or integrate with th
 | <img src="https://pbs.twimg.com/profile_images/2059995800902537220/IngKmW55_400x400.jpg" width="36" height="36" alt="MANAGR logo"> | MANAGR | [@USICAI](https://x.com/USICAI) |
 | <img src="https://pbs.twimg.com/profile_images/2030743130421751808/w4Yi3fC7_400x400.jpg" width="36" height="36" alt="Mei logo"> | Mei | [@MeiMighty1](https://x.com/MeiMighty1) |
 | <img src="https://pbs.twimg.com/profile_images/2060426975718592517/Jdj2fOzg_400x400.jpg" width="36" height="36" alt="MiroShark logo"> | MiroShark | [@miroshark_](https://x.com/miroshark_) |
+| <img src="https://mnemedb.dev/mnemelogo.png" width="36" height="36" alt="Mneme logo"> | Mneme | [mnemedb.dev](https://mnemedb.dev) · [skill pack](https://github.com/mnemedb/aeon-skill-pack-mneme) |
 | <img src="https://pbs.twimg.com/profile_images/2022853922847887363/7hiICjWl_400x400.jpg" width="36" height="36" alt="MythosForge logo"> | MythosForge | [@mythosforgebot](https://x.com/mythosforgebot) |
 | <img src="https://pbs.twimg.com/profile_images/2059382579107659778/pkh1HmwK_400x400.jpg" width="36" height="36" alt="Noctel logo"> | Noctel | [@noctelxbt](https://x.com/noctelxbt) · [noctel.xyz](https://www.noctel.xyz) |
 | <img src="https://pbs.twimg.com/profile_images/2050098727512322048/bS61Qs6N_400x400.jpg" width="36" height="36" alt="NoelClaw logo"> | NoelClaw | [@noelclawfun](https://x.com/noelclawfun) |

--- a/README.md
+++ b/README.md
@@ -485,6 +485,7 @@ To browse known packs without installing, run `./install-skill-pack --list` — 
 | [morning-briefing](https://github.com/sparkleware/morning-briefing) | 1 | Daily morning briefing — date, day-of-week, current weather, and a sparkly closer |
 | [aeon-skill-pack-noelclaw](https://github.com/noelclaw/aeon-skill-pack-noelclaw) | 2 | Persistent versioned memory and multi-agent swarm coordination — save typed artifacts to Noel Vault and manage shared agent session state across runs |
 | [signa](https://github.com/codexvritra/signa) (`--path aeon-skills`) | 10 | Full SIGNA suite — wallet-signed cross-platform agent messaging, multi-agent broadcast and delegate, plus Bankr resolver / launches, gitlawb activity, MiroShark sim stats and wallet-signed sim fire |
+| [aeon-skill-pack-mneme](https://github.com/mnemedb/aeon-skill-pack-mneme) | 8 | Mneme as Aeon's persistent memory layer — vector recall across runs, entity/relation graph, live Base chain streams, async LLM "dream" reflections, and schema-aware /chat. One `MNEME_API_KEY`, zero infra. |
 
 **To list a pack here**, open a PR adding a row. Guidelines:
 

--- a/skill-packs.json
+++ b/skill-packs.json
@@ -229,6 +229,17 @@
       "category": "crypto",
       "trust_level": "community",
       "skills": ["atrium-publish", "atrium-scout", "atrium-earnings"]
+    },
+    {
+      "repo": "mnemedb/aeon-skill-pack-mneme",
+      "name": "aeon-skill-pack-mneme",
+      "description": "Mneme as Aeon's persistent memory layer — vector recall across runs, entity/relation graph, live Base chain streams, async LLM 'dream' reflections, and schema-aware /chat. One MNEME_API_KEY (scope *), zero infra. Drops into any Aeon agent and replaces the markdown+JSON memory dir with a real Postgres schema that's searchable, traversable, and stream-aware.",
+      "author": "mnemedb",
+      "license": "MIT",
+      "homepage": "https://mnemedb.dev",
+      "category": "memory",
+      "trust_level": "community",
+      "skills": ["mneme-remember", "mneme-recall", "mneme-entity", "mneme-relate", "mneme-find", "mneme-dream", "mneme-watch", "mneme-ask"]
     }
   ]
 }


### PR DESCRIPTION
Hey Aaron — small additive PR adding [Mneme](https://mnemedb.dev) and our skill pack to the right places. Three files, 13 lines, alphabetical:

### What's added

**1. `ECOSYSTEM.md`** — Mneme row (alphabetical, between MiroShark and MythosForge).

**2. `README.md` → Community skill packs** — entry for [`aeon-skill-pack-mneme`](https://github.com/mnemedb/aeon-skill-pack-mneme).

**3. `skill-packs.json`** — matching registry row so `./install-skill-pack --list` picks it up. `category: "memory"`, `trust_level: "community"`, MIT.

### What Mneme actually is

An agent-native database (real Postgres + pgvector + an entities/relations graph + live Base chain event streams + an async LLM \"dream\" reflection layer). The skill pack drops 8 `SKILL.md` files into any Aeon agent that wrap Mneme's REST API behind one `MNEME_API_KEY`:

| Skill | Wraps |
|---|---|
| `mneme-remember` / `mneme-recall` | `memories` table — vector + keyword search |
| `mneme-entity` / `mneme-relate` / `mneme-find` | graph (with hybrid `semanticNeighbors`) |
| `mneme-dream` | trigger an LLM reflection pass on the schema |
| `mneme-watch` | subscribe to any Base contract event → auto-INSERT |
| `mneme-ask` | schema-aware, stream-aware, dream-aware `/chat` |

The vibe: Aeon decides when to think, Mneme remembers what it learned. Pack and Mneme are both MIT, no Aeon-internal patches, schema is `skills-pack.json`-compliant.

### Quick sanity check

- Repo: https://github.com/mnemedb/aeon-skill-pack-mneme (public, MIT, README with full install + auth steps)
- 8 skills, each in `skills/<name>/SKILL.md`
- Defaults to `https://gateway.mnemedb.dev` (override via `MNEME_GATEWAY` env var)
- Requires `MNEME_API_KEY` from any Mneme project's API Keys tab (free signup, email/google/x/apple/wallet)

Happy to adjust naming, ordering, the description, or split the PR if you'd like only a subset merged. No rush from our side.

🟡