### PR TITLE
feat: star-milestone auto-dispatch — wire 500⭐ → show-hn-draft

### DIFF
--- a/memory/topics/milestone-dispatch.json
+++ b/memory/topics/milestone-dispatch.json
@@ -1,0 +1,9 @@
+{
+  "_comment": "Auto-dispatch rules for star-milestone. Read by skills/star-milestone/SKILL.md step 8 on every announced milestone (gate 5f). `rules` is operator-editable: { owner/repo: { threshold (as string): skill_name } }. `dispatched` is managed automatically — one timestamp per (repo, threshold, skill) tuple, written only on successful dispatch. Step 5a in star-milestone (milestones.md already-recorded check) is the primary idempotency guard; `dispatched` here is a second guard for cases where milestones.md is hand-edited or reverted. Failures do NOT write to `dispatched` — the operator runs the dispatch manually if they want a retry.",
+  "rules": {
+    "aaronjmars/aeon": {
+      "500": "show-hn-draft"
+    }
+  },
+  "dispatched": {}
+}

--- a/skills/star-milestone/SKILL.md
+++ b/skills/star-milestone/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: star-milestone
-description: Announces when a watched repo crosses a star-count milestone (100, 150, 200, 250, 500, 1000, ...) with a velocity-shaped narrative — time-to-milestone, growth shape, projection, and a tight highlight reel
+description: Announces when a watched repo crosses a star-count milestone (100, 150, 200, 250, 500, 1000, ...) with a velocity-shaped narrative — time-to-milestone, growth shape, projection, and a tight highlight reel. Optionally auto-dispatches downstream skills (e.g. show-hn-draft at 500⭐) per the rule map in `memory/topics/milestone-dispatch.json`.
 var: ""
 tags: [dev]
 ---
@@ -123,9 +123,49 @@ Field rules:
 - `${eta_date}` — `today + (next_M - STARS) / max(v7/7, 0.5)` rounded to a date. If TRICKLE or pace < 0.5/day, write *"no projection — pace too slow"* instead of an inflated date.
 - **Highlights**: cap at 3. Source from `memory/logs/YYYY-MM-DD.md` last 14 days, sections like `## Push Recap`, `## Feature Built`, `## Repo Article`, `## Repo Actions`, `## Changelog`. Each highlight must include a verb, a concrete noun, and a delta or specificity (count, PR/issue number, name). Reject vague items like "improved docs" — rewrite as "Added 3 sections to README (PR #N)" or drop. If logs are empty, fall back to `gh api repos/$REPO/commits?since=<14d-ago> --jq '.[].commit.message'` and pick 3 commit subjects that ship value (skip chore/typo).
 - If velocity is `UNKNOWN`, replace the `Time to` and `Pace` lines with a single line: *"Velocity data unavailable this run — milestone confirmed by repo count."*
-- **`${status_footer}`** — single line, only printed in the log entry (step 9), NOT in the user-facing notification body. Format: `_status: shape=$SHAPE, v7=$N, fake_check=$ok|skip|defer, log_window=$days_d_`
+- **`${status_footer}`** — single line, only printed in the log entry (step 10), NOT in the user-facing notification body. Format: `_status: shape=$SHAPE, v7=$N, fake_check=$ok|skip|defer, log_window=$days_d_`
 
-### 8. Update `memory/topics/milestones.md`
+### 8. Auto-dispatch downstream skills
+
+Only reached when step 5 gate **f** passed (i.e. the milestone is being announced, not silently recorded as bootstrap/stale/deferred/skipped). A milestone crossed on dead momentum or a suspected fake-star burst is the wrong signal to fire a launch draft on — the silent-record path bypasses dispatch entirely.
+
+Read `memory/topics/milestone-dispatch.json`. If absent, write the seed `{"rules": {}, "dispatched": {}}` atomically (`.tmp` + `mv`) and skip — no dispatch happens until `rules` is populated. Format:
+
+```json
+{
+  "rules": {
+    "aaronjmars/aeon": {
+      "500": "show-hn-draft"
+    }
+  },
+  "dispatched": {
+    "aaronjmars/aeon:500:show-hn-draft": "2026-06-11T08:15:00Z"
+  }
+}
+```
+
+For the current repo + announced milestone `M`:
+
+a. Look up `rules["${REPO}"]["${M}"]` (key is the threshold integer as a string). If absent → skip (most milestones have no downstream skill).
+b. Check `dispatched["${REPO}:${M}:${SKILL}"]`. If present → already fired previously; do nothing. **Re-runs at higher star counts must NOT re-dispatch.** (Step 5a already prevents re-entry once `M` is recorded in `milestones.md`, but this is a second guard — milestones.md is hand-editable and git-revertable.)
+c. Otherwise fire-and-forget:
+   ```bash
+   gh workflow run aeon.yml -f skill="${SKILL}" -f var=""
+   ```
+   On success, set `dispatched["${REPO}:${M}:${SKILL}"]` to the current UTC timestamp (`YYYY-MM-DDTHH:MM:SSZ`) and write the file atomically (`.tmp` + `mv`) so a mid-write crash can't corrupt prior records. Do not wait or poll — the dispatched skill's own `./notify` delivers its outcome separately.
+d. On dispatch failure (gh non-zero, rate limit, permission denied), DO NOT write the dispatched flag. Send a single follow-up notification:
+   ```
+   star-milestone: ${REPO} crossed ${M} but auto-dispatch of ${SKILL} failed.
+   Run manually: gh workflow run aeon.yml -f skill=${SKILL}
+   ```
+   One attempt, one notification on failure. Step 5a will prevent auto-retry on the next run — operator dispatches manually if they want it.
+
+**Constraints:**
+- **Idempotent.** The `dispatched` map plus step 5a make this safe to re-run — a second pass at 502⭐ never fires `show-hn-draft` a second time.
+- **Operator-editable.** Rules are added/removed by hand; the skill only writes to `dispatched`. Adding `"aaronjmars/foo": {"1000": "celebrate"}` is a one-line edit.
+- **Silent on empty rules.** A repo with no rule for any threshold dispatches nothing — behaviour identical to the pre-feature skill.
+
+### 9. Update `memory/topics/milestones.md`
 
 Append the new entry under the repo's section. Create the file with `# Star Milestones` header if absent. Keep entries in ascending threshold order per repo. Format:
 
@@ -135,7 +175,7 @@ Append the new entry under the repo's section. Create the file with `# Star Mile
 
 For silent records (bootstrap/stale/deferred/skipped), use the corresponding suffix instead of the shape.
 
-### 9. Log to `memory/logs/${today}.md`
+### 10. Log to `memory/logs/${today}.md`
 
 ```
 ## Star Milestone
@@ -144,6 +184,7 @@ For silent records (bootstrap/stale/deferred/skipped), use the corresponding suf
 - **Δprior**: $N days from ${prev_M} (prior gap was $N days)
 - **Highlights used**: $N (source: logs|commits)
 - **Notification sent**: yes / no — ${reason}
+- **Dispatched**: ${SKILL} | none | FAILED — ${reason}
 - **Status**: STAR_MILESTONE_OK | STAR_MILESTONE_QUIET | STAR_MILESTONE_DEFERRED | STAR_MILESTONE_DEGRADED
 ```
 
@@ -159,7 +200,7 @@ For silent records (bootstrap/stale/deferred/skipped), use the corresponding suf
 
 ## Sandbox note
 
-`gh api` handles auth via the workflow's `GITHUB_TOKEN`, so no env-var curl workaround is needed. The stargazer pagination call is the only network-heavy step; if it fails, fall through to `UNKNOWN` shape rather than aborting. `./notify` fans out to every configured channel.
+`gh api` and `gh workflow run` handle auth via the workflow's `GITHUB_TOKEN`, so no env-var curl workaround is needed. The stargazer pagination call is the only network-heavy step; if it fails, fall through to `UNKNOWN` shape rather than aborting. `./notify` fans out to every configured channel. Auto-dispatch (step 8) uses the gh CLI's internal auth — no separate token plumbing required.
 
 ## Constraints
 


### PR DESCRIPTION
## What
New step 8 in `skills/star-milestone/SKILL.md` — when a milestone is announced (gate 5f path), the skill looks up `memory/topics/milestone-dispatch.json` for an auto-dispatch rule and fires the matching skill via `gh workflow run aeon.yml -f skill=<name>`. Silent records (bootstrap / stale / deferred / skipped) bypass dispatch entirely — a milestone crossed on dead momentum or a fake-star burst is the wrong signal to fire a launch draft on.

Seeded with the rule `aaronjmars/aeon:500 → show-hn-draft`.

## Why
PR #151 (show-hn-draft) has been open for 35 days. The skill is enabled-pending-500⭐ — the operator's own notes say "Enable at 500⭐." At the current trajectory (v7≈3.6⭐/day, currently 490⭐), 500 lands ~Jun 11 — three days from now. `star-milestone` detects threshold crossings but currently just notifies; it does not trigger downstream actions. Wiring it to dispatch `show-hn-draft` automatically removes the last manual gate: the operator no longer needs to notice the milestone, remember which PR to merge, and dispatch by hand. The skill fires itself.

This is idea #5 from `articles/repo-actions-2026-06-06.md`.

## Changes
- **`skills/star-milestone/SKILL.md`** (+50 / -5):
  - New step 8 *Auto-dispatch downstream skills* between the notification step and the milestones.md write — only reached on gate 5f announcements.
  - Reads `memory/topics/milestone-dispatch.json`, looks up `rules[REPO][M]`, checks `dispatched[REPO:M:SKILL]` as a second guard, fires `gh workflow run aeon.yml -f skill=<name> -f var=""` fire-and-forget on success, writes the dispatched timestamp atomically (`.tmp` + `mv`), notifies once with the manual recovery command on failure.
  - Renumbered: old step 8 (milestones.md) → 9, old step 9 (log) → 10. Log format extended with `**Dispatched**: ${SKILL} | none | FAILED — ${reason}`.
  - Frontmatter description updated to mention the rule map.
  - Sandbox note updated to note that `gh workflow run` uses the same auth as `gh api` — no extra plumbing.
- **`memory/topics/milestone-dispatch.json`** (new, +9): seed file with the `aaronjmars/aeon:500 → show-hn-draft` rule pre-populated and an empty `dispatched` map. Top-level `_comment` documents the format inline so operators can edit by hand without reading the SKILL.md.

## Design decisions
- **Configurable rule map, not a hard-coded 500-check.** A single hard-check was the simpler-looking option in the source idea, but a map lets the operator wire any (repo, threshold) → skill pairing later — e.g. a future `1000 → product-hunt-launch` — without another patch to star-milestone.
- **Defense-in-depth idempotency.** Step 5a (milestone-already-recorded in `milestones.md`) is the primary guard — once 500 is written to `milestones.md` for `aaronjmars/aeon`, the skill won't re-enter step 6+ on the next run. The `dispatched` map is a second guard for cases where `milestones.md` is hand-edited or git-reverted.
- **Silent-record bypass.** Bootstrap / stale / deferred / skipped milestones are recorded silently and do NOT auto-dispatch. A launch draft fired on a fake-star burst is worse than no draft.
- **Failure path mirrors `skill-of-the-day`'s dispatch convention** — one attempt, one recovery notification with the manual command, no retry. The dispatched flag is NOT written on failure, but step 5a still prevents auto-retry on the next run.
- **Seed file ships the aeon:500 rule populated** rather than empty — the wiring is live on merge, no second commit needed. Operators add more rules with a one-line edit.

## Test plan
- [ ] Manually invoke `star-milestone` with `var=aaronjmars/aeon` while stars < 500 — confirm no auto-dispatch path runs (no `gh workflow run` in the log).
- [ ] After 500⭐ crosses naturally (~Jun 11), confirm step 8 fires `show-hn-draft`, writes `dispatched["aaronjmars/aeon:500:show-hn-draft"]` to `memory/topics/milestone-dispatch.json`, and the dispatched run appears in Actions.
- [ ] Re-run `star-milestone` immediately after — confirm step 5a short-circuits (no second dispatch); the `dispatched` entry is unchanged.
- [ ] Manually delete `milestones.md`'s 500-stars line and re-run — confirm step 8b's dispatched-check is the second guard (still no re-dispatch).
- [ ] Force a dispatch failure (e.g. temporarily mis-name the skill in `rules`) — confirm the recovery notification fires and `dispatched` is NOT updated.

---
*Built autonomously by Aeon — from 2026-06-06's repo-actions idea #5.*
