### PR TITLE
Cleanup 1/7: dead imports, latent tsc error, knip config

### DIFF
--- a/dashboard/components/ImportModal.tsx
+++ b/dashboard/components/ImportModal.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useRef } from 'react'
 import type { UploadFile } from '../lib/types'
-import { displayName } from '../lib/utils'
 import { inputCls } from '../lib/utils'
 
 interface ImportModalProps {

--- a/dashboard/knip.json
+++ b/dashboard/knip.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://unpkg.com/knip@5/schema.json",
+  "entry": ["lib/catalog.ts!"]
+}

--- a/dashboard/lib/config.ts
+++ b/dashboard/lib/config.ts
@@ -1,4 +1,4 @@
-import { parseDocument, isMap, isSeq, isPair, isScalar, type Document } from 'yaml'
+import { parseDocument, isMap, isPair, isScalar } from 'yaml'
 import type { GatewayProvider } from './types'
 
 export interface SkillConfig {

--- a/dashboard/lib/utils.test.ts
+++ b/dashboard/lib/utils.test.ts
@@ -151,7 +151,7 @@ describe("buildCron", () => {
   });
 
   it("builds a daily cron with specific days", () => {
-    const cron = buildCron("time", 9, 0, 9, 0, "AM", [1, 3, 5]);
+    const cron = buildCron("time", 9, "m", 9, 0, "AM", [1, 3, 5]);
     // 9 AM local — we just verify the cron structure
     assert.ok(cron.includes("*"));
     assert.ok(cron.includes("1,3,5"));


### PR DESCRIPTION
**Part 1 of a 7-PR stacked code-quality cleanup.** Stack base: \`main\`.

From the dead-code audit (knip + \`tsc --noEmit --noUnusedLocals\` + repo-wide reference verification). The codebase had **zero unused files and zero unused deps**; this PR is the small real residue.

### Changes
- **`utils.test.ts`** — `buildCron("time", 9, 0, …)` passed `0` where the 3rd arg is `'m' | 'h'`. Fixed to `'m'` (ignored in `"time"` mode, so assertions are unchanged). This was the **only** `tsc --noEmit` error in the dashboard.
- **`ImportModal.tsx`** — removed unused `displayName` import.
- **`config.ts`** — removed unused `isSeq` and `type Document` from the `yaml` import.
- **`knip.json`** — marks `lib/catalog.ts` as an entry. Default `npx knip` falsely flagged `catalog.ts` + all three `@json-render/*` deps as unused because they're reached only via the external `npx @json-render/mcp --catalog dashboard/lib/catalog.ts` invocation, invisible to static analysis. **Do not delete those** — this config documents the real entry.

### Verification
- `tsc --noEmit` — clean (was 1 error).
- `npm test` — 99/99 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)