### PR TITLE
Cleanup 2/7: collapse dead watched-repos path, drop unused exports

### DIFF
--- a/dashboard/components/ui/TargetCursor.tsx
+++ b/dashboard/components/ui/TargetCursor.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useRef, useCallback, useMemo } from 'react';
 import { gsap } from 'gsap';
 import './TargetCursor.css';
 
-export interface TargetCursorProps {
+interface TargetCursorProps {
   targetSelector?: string;
   spinDuration?: number;
   hideDefaultCursor?: boolean;

--- a/dashboard/lib/config.ts
+++ b/dashboard/lib/config.ts
@@ -8,7 +8,7 @@ export interface SkillConfig {
   model: string
 }
 
-export interface GatewayConfig {
+interface GatewayConfig {
   provider: GatewayProvider
 }
 

--- a/dashboard/lib/memory.ts
+++ b/dashboard/lib/memory.ts
@@ -2,7 +2,7 @@ import { readdir, readFile, stat } from 'fs/promises'
 import { resolve, join, sep, normalize } from 'path'
 
 const REPO_ROOT = resolve(process.cwd(), '..')
-export const MEMORY_ROOT = join(REPO_ROOT, 'memory')
+const MEMORY_ROOT = join(REPO_ROOT, 'memory')
 
 const TOPICS_DIR = join(MEMORY_ROOT, 'topics')
 const LOGS_DIR = join(MEMORY_ROOT, 'logs')

--- a/skills/builder-map/SKILL.md
+++ b/skills/builder-map/SKILL.md
@@ -15,7 +15,7 @@ When a repo, framework, or stack attracts builders — forks, third-party apps, 
 
 ## Config
 
-This skill reads watched repos from `memory/topics/watched-repos.md`. Each row should declare a primary repo and optional search keywords. Example format:
+This skill reads watched repos from `memory/watched-repos.md`. Each row should declare a primary repo and optional search keywords. Example format:
 
 ```markdown
 # Watched Repos
@@ -26,7 +26,7 @@ This skill reads watched repos from `memory/topics/watched-repos.md`. Each row s
 | acme/dataengine | dataengine, acmedata | trading / quant ecosystem |
 ```
 
-If `memory/topics/watched-repos.md` doesn't exist, fall back to `memory/watched-repos.md` (legacy single-line OWNER format). If neither exists, log `BUILDER_MAP_SKIP: no watched repos configured` and stop — there's nothing to map.
+If `memory/watched-repos.md` doesn't exist or lists no repos, log `BUILDER_MAP_SKIP: no watched repos configured` and stop — there's nothing to map.
 
 ## Steps
 
@@ -62,7 +62,7 @@ Extract:
 
 ### 2. Scan forks for each watched repo
 
-For each repo from `memory/topics/watched-repos.md`:
+For each repo from `memory/watched-repos.md`:
 
 ```bash
 gh api "repos/${OWNER}/${REPO}/forks" --paginate \
@@ -97,7 +97,7 @@ gh api "search/repositories?q=${KEYWORD}+in:readme+in:description&sort=updated&p
 ```
 
 Filter:
-- Exclude the owners listed in `memory/topics/watched-repos.md` (their own repos)
+- Exclude the owners listed in `memory/watched-repos.md` (their own repos)
 - Exclude repos that are clearly forks already captured in step 2
 - Focus on repos updated in last 30 days
 

--- a/skills/feature/SKILL.md
+++ b/skills/feature/SKILL.md
@@ -11,7 +11,7 @@ This skill is the **multi-repo** sibling of `external-feature`:
 | | `feature` (this skill) | `external-feature` |
 |---|---|---|
 | Per run | Iterates **every** watched repo, ships one PR per repo | **Single** repo per run |
-| Repo source | `memory/topics/watched-repos.md` | `memory/topics/watched-repos.md` (or `${var}` override) |
+| Repo source | `memory/watched-repos.md` | `memory/watched-repos.md` (or `${var}` override) |
 | Use it for | Weekly broad sweep — keep every repo moving | Targeted enhancement on one repo |
 | Notification | One per successfully-built feature (per repo) | One per run |
 
@@ -23,7 +23,7 @@ If `soul/SOUL.md` and `soul/STYLE.md` are populated, read both and match the ope
 
 ## Config
 
-This skill reads the candidate repo list from `memory/topics/watched-repos.md`. If the file is missing or empty, log `FEATURE_NO_CONFIG` and exit cleanly (no notification — empty config is not an error).
+This skill reads the candidate repo list from `memory/watched-repos.md`. If the file is missing or empty, log `FEATURE_NO_CONFIG` and exit cleanly (no notification — empty config is not an error).
 
 Format: one `owner/repo` per line. Markdown bullets like `- owner/repo` are fine; comment lines starting with `#` are ignored.
 
@@ -31,7 +31,7 @@ Format: one `owner/repo` per line. Markdown bullets like `- owner/repo` are fine
 
 ### 1. Load the target list
 
-Parse `memory/topics/watched-repos.md` into a list of `owner/repo` entries.
+Parse `memory/watched-repos.md` into a list of `owner/repo` entries.
 
 If `${var}` is set, restrict the list to **the first repo only** and use `${var}` as the feature spec for it.
 

--- a/skills/repo-revive/SKILL.md
+++ b/skills/repo-revive/SKILL.md
@@ -11,7 +11,7 @@ tags: [dev, growth]
 
 If `${var}` is set, skip selection and work on that repo directly.
 
-Read `memory/MEMORY.md`, `memory/topics/watched-repos.md`, and the last 7 days of `memory/logs/` before starting.
+Read `memory/MEMORY.md`, `memory/watched-repos.md`, and the last 7 days of `memory/logs/` before starting.
 
 ## Voice
 
@@ -21,7 +21,7 @@ If `soul/SOUL.md` and `soul/STYLE.md` are populated, read both and match the ope
 
 This skill reads two operator-controlled files:
 
-- **`memory/topics/watched-repos.md`** — the candidate repo pool. One `owner/repo` per line (markdown bullets like `- owner/repo` are fine; comment lines starting with `#` are ignored). If the file is missing or empty, log `REPO_REVIVE_NO_CONFIG` and exit cleanly (no notification — empty config is not an error).
+- **`memory/watched-repos.md`** — the candidate repo pool. One `owner/repo` per line (markdown bullets like `- owner/repo` are fine; comment lines starting with `#` are ignored). If the file is missing or empty, log `REPO_REVIVE_NO_CONFIG` and exit cleanly (no notification — empty config is not an error).
 - **`memory/topics/stale-models.md`** — list of AI model names the operator considers stale and the current model names they want to see referenced instead. Used only when scoring stale-model fixes. Example shape:
 
   ```markdown
@@ -49,7 +49,7 @@ This skill reads two operator-controlled files:
 
 If `${var}` is set, use that repo. Otherwise:
 
-- Parse `memory/topics/watched-repos.md` into a list of `owner/repo` candidates
+- Parse `memory/watched-repos.md` into a list of `owner/repo` candidates
 - For each candidate, fetch metadata via `gh api`:
   ```bash
   gh api "repos/$REPO" --jq '{stars: .stargazers_count, pushed_at, archived, default_branch}'


### PR DESCRIPTION
**Part 2 of 7 (stacked on #359).** Base: \`cleanup/01-dead-code\`.

Legacy / fallback audit — collapse every code path to one clean current path.

### watched-repos split-brain (the real find)
`builder-map`, `feature`, and `repo-revive` read **`memory/topics/watched-repos.md`**, which **does not exist on disk**. 25+ other skills read **`memory/watched-repos.md`**, which does. `builder-map:29` even called the only-extant file the *"legacy"* fallback — inverting reality. Per the chosen direction (converge on the file that exists):
- Repointed all 3 skills to `memory/watched-repos.md`.
- Rewrote `builder-map`'s self-referential fallback into a single clean existence check.
- `feature`/`repo-revive` already document the `- owner/repo` bullet format the root file uses, so no format change.

### Dead `export` modifiers (knip)
De-exported 3 symbols with zero external importers (each used only inside its own file): `MEMORY_ROOT` (`memory.ts`), `GatewayConfig` (`config.ts`), `TargetCursorProps` (`TargetCursor.tsx`).

### Verification
- `tsc --noEmit` clean · `npm test` 99/99 · `knip` reports no unused exports · zero remaining `topics/watched-repos` references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)