### PR TITLE
Cleanup 3/7: consolidate triplicated REPO_ROOT

### DIFF
--- a/dashboard/lib/github.ts
+++ b/dashboard/lib/github.ts
@@ -1,10 +1,8 @@
 import { readFile, writeFile, readdir, mkdir, rm } from 'fs/promises'
-import { join, resolve } from 'path'
+import { join } from 'path'
+import { REPO_ROOT } from './gh'
 
 const GITHUB_API = 'https://api.github.com'
-
-// Resolve the repo root (one level up from dashboard/)
-const REPO_ROOT = resolve(process.cwd(), '..')
 
 // Minimal shapes for the GitHub "Get repository content" REST responses.
 interface GitHubContentFile { content: string; sha: string; encoding: string }

--- a/dashboard/lib/memory.ts
+++ b/dashboard/lib/memory.ts
@@ -1,7 +1,7 @@
 import { readdir, readFile, stat } from 'fs/promises'
-import { resolve, join, sep, normalize } from 'path'
+import { join, sep, normalize } from 'path'
+import { REPO_ROOT } from './gh'
 
-const REPO_ROOT = resolve(process.cwd(), '..')
 const MEMORY_ROOT = join(REPO_ROOT, 'memory')
 
 const TOPICS_DIR = join(MEMORY_ROOT, 'topics')


### PR DESCRIPTION
**Part 3 of 7 (stacked on #360).** Base: \`cleanup/02-legacy\`.

Dedup / DRY audit. The dashboard TS was already clean (jscpd: 0.23% duplication) and **`gh.ts` vs `github.ts` are NOT duplicates** (gh CLI vs REST API — 4 auditors confirmed). The one genuine, safe TS duplication:

### `REPO_ROOT` triplication
`github.ts` and `memory.ts` each redefined `const REPO_ROOT = resolve(process.cwd(), '..')`, identical to the export `gh.ts` already provides. Now imported from `./gh`. `gh.ts` is a leaf module (only `child_process` + `path`), so importing the const triggers no gh-CLI side effects and **no dependency cycle** (`madge --circular` confirms clean).

### Deferred (assessed, not applied)
Extracting the duplicated `is_trusted`/`is_trusted_source` and `err/info/ok/warn` shell helpers into `scripts/lib/`. They would convert self-contained installers into files with a sourced runtime dependency, the duplicated bodies **diverge** (add-a2a colorizes `err()`; the trust funcs differ in guard structure) so it's not a mechanical dedup, and the installers fetch repos + mutate `aeon.yml` so they can't be end-to-end tested in this pass. `is_trusted` gates security scanning — not worth refactoring without integration tests. Flagged as follow-up.

### Verification
- `tsc --noEmit` clean · `madge --circular` clean · `npm test` 99/99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)