### PR TITLE
Cleanup 4/7: bind API producers to central types, unify gh-run shapes

### DIFF
--- a/dashboard/app/api/analytics/route.ts
+++ b/dashboard/app/api/analytics/route.ts
@@ -3,15 +3,9 @@ import { execFileSync } from 'child_process'
 import { resolve } from 'path'
 import { readFileSync } from 'fs'
 import { REPO_ROOT, ghArgsRepo } from '@/lib/gh'
-import type { SkillMetrics, Insight } from '@/lib/types'
+import type { SkillMetrics, Insight, GhRunJson } from '@/lib/types'
 
-interface RunRecord {
-  name: string
-  status: string
-  conclusion: string | null
-  createdAt: string
-  updatedAt: string
-}
+type RunRecord = Pick<GhRunJson, 'name' | 'status' | 'conclusion' | 'createdAt' | 'updatedAt'>
 
 export async function GET() {
   try {

--- a/dashboard/app/api/runs/[id]/logs/route.ts
+++ b/dashboard/app/api/runs/[id]/logs/route.ts
@@ -1,13 +1,9 @@
 import { NextResponse } from 'next/server'
 import { execFileSync } from 'child_process'
 import { REPO_ROOT, ghArgsRepo } from '@/lib/gh'
+import type { GhRunJson } from '@/lib/types'
 
-interface GhRunView {
-  status: string
-  conclusion: string | null
-  displayTitle: string
-  jobs: Array<{ name: string; status: string; conclusion: string | null }>
-}
+type GhRunView = Pick<GhRunJson, 'status' | 'conclusion' | 'displayTitle' | 'jobs'>
 
 export async function GET(
   _request: Request,

--- a/dashboard/app/api/runs/route.ts
+++ b/dashboard/app/api/runs/route.ts
@@ -1,16 +1,9 @@
 import { NextResponse } from 'next/server'
 import { execFileSync } from 'child_process'
 import { REPO_ROOT, ghArgsRepo } from '@/lib/gh'
+import type { GhRunJson } from '@/lib/types'
 
-interface GhRunListItem {
-  databaseId: number
-  name: string
-  status: string
-  conclusion: string | null
-  createdAt: string
-  url: string
-  displayTitle: string
-}
+type GhRunListItem = Pick<GhRunJson, 'databaseId' | 'name' | 'status' | 'conclusion' | 'createdAt' | 'url' | 'displayTitle'>
 
 export async function GET() {
   try {

--- a/dashboard/app/api/secrets/route.ts
+++ b/dashboard/app/api/secrets/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from 'next/server'
 import { execFileSync } from 'child_process'
 import { ghAvailable, ghArgsRepo } from '@/lib/gh'
+import type { Secret } from '@/lib/types'
 
-const BUILTIN_SECRETS = [
+const BUILTIN_SECRETS: Omit<Secret, 'isSet'>[] = [
   { name: 'CLAUDE_CODE_OAUTH_TOKEN', group: 'Core', description: 'Claude Code OAuth token (set via Authenticate button)', either: 'auth' },
   { name: 'ANTHROPIC_API_KEY', group: 'Core', description: 'Anthropic or Anthropic-compatible API key for Claude Code', either: 'auth' },
   { name: 'BANKR_LLM_KEY', group: 'Core', description: 'Bankr Gateway API key (bk_...) — enable at bankr.bot/api' },
@@ -53,7 +54,7 @@ export async function GET() {
   const setSecrets = new Set(listSecrets())
 
   // Start with builtin secrets
-  const secrets = BUILTIN_SECRETS.map(s => ({
+  const secrets: Secret[] = BUILTIN_SECRETS.map(s => ({
     ...s,
     isSet: setSecrets.has(s.name),
   }))

--- a/dashboard/app/api/skills/route.ts
+++ b/dashboard/app/api/skills/route.ts
@@ -11,6 +11,7 @@ import {
 } from '@/lib/config'
 import { deleteDirectory } from '@/lib/github'
 import { parseFrontmatter } from '@/lib/frontmatter'
+import type { Skill } from '@/lib/types'
 
 function getRepoSlug(): string {
   if (process.env.GITHUB_REPO) return process.env.GITHUB_REPO
@@ -44,7 +45,7 @@ export async function GET() {
       }),
     )
 
-    const skills = dirNames.map(name => {
+    const skills: Skill[] = dirNames.map(name => {
       const m = meta.find(d => d.name === name)
       return {
         name,

--- a/dashboard/lib/types.ts
+++ b/dashboard/lib/types.ts
@@ -4,6 +4,19 @@ export interface Secret { name: string; group: string; description: string; isSe
 export interface SkillOutput { filename: string; skill: string; timestamp: string; spec: { root: string; state?: Record<string, unknown>; elements: Record<string, SpecElement> } }
 export interface SpecElement { type: string; props?: Record<string, unknown>; children?: string[] }
 
+// Shape of `gh run list`/`gh run view --json` output. Routes Pick<> the columns they request.
+export interface GhRunJson {
+  databaseId: number
+  name: string
+  status: string
+  conclusion: string | null
+  createdAt: string
+  updatedAt: string
+  url: string
+  displayTitle: string
+  jobs: Array<{ name: string; status: string; conclusion: string | null }>
+}
+
 export type GatewayProvider = 'direct' | 'bankr'
 
 export interface UploadFile { path: string; content: string }


### PR DESCRIPTION
**Part 4 of 7 (stacked on #361).** Base: \`cleanup/03-dedup\`.

Type consolidation — all changes are type-level, zero runtime change.

### Bind producers to central types
- **`/api/skills` GET** — the mapped array is annotated `Skill[]` (from `@/lib/types`). The client (`page.tsx`) already imports `Skill`; now both ends are bound, so field drift is a compile error.
- **`/api/secrets`** — `BUILTIN_SECRETS: Omit<Secret,'isSet'>[]` and the response `Secret[]`.

### One source of truth for `gh run --json`
Three routes (`runs`, `analytics`, `runs/[id]/logs`) each redefined an overlapping shape for the same gh output. Added `GhRunJson` in `lib/types.ts`; each route now `Pick<>`s exactly the columns its `--json` flag requests — so the column list and the TS shape can't drift apart per-route.

That `tsc --noEmit` stays clean **proves** the producers already matched these types; the annotations just enforce it.

### Deferred
Shared `SkillManifestEntry`/`SkillsManifest` for mcp/a2a servers — needs a tsconfig `rootDir` change that would shift their `dist` layout (breaking `bin`/`main`). Flagged by the auditor as "not a blind auto-apply"; left for a deliberate workspace decision.

### Verification
- `tsc --noEmit` clean · `npm test` 99/99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)