### PR TITLE
Cleanup 5/7: strengthen weak types at parse + JSON-RPC boundaries

### DIFF
--- a/a2a-server/src/index.ts
+++ b/a2a-server/src/index.ts
@@ -309,11 +309,25 @@ function buildAgentCard(): Record<string, unknown> {
 
 type RpcResult<T> = T | { error: { code: number; message: string } };
 
+// Narrowing guards for untrusted JSON-RPC params (params is Record<string, unknown>).
+function asString(v: unknown): string | undefined {
+  return typeof v === "string" ? v : undefined;
+}
+function asNumber(v: unknown): number | undefined {
+  return typeof v === "number" ? v : undefined;
+}
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+function isA2AMessage(v: unknown): v is A2AMessage {
+  return isRecord(v) && Array.isArray((v as { parts?: unknown }).parts);
+}
+
 function handleTasksSend(params: Record<string, unknown>): RpcResult<Task> {
-  const id = (params.id as string | undefined) ?? randomUUID();
-  const message = params.message as A2AMessage | undefined;
-  const skillId = params.skillId as string | undefined;
-  const varOverride = params.var as string | undefined;
+  const id = asString(params.id) ?? randomUUID();
+  const message = isA2AMessage(params.message) ? params.message : undefined;
+  const skillId = asString(params.skillId);
+  const varOverride = asString(params.var);
 
   let slug: string | undefined;
   let varValue = varOverride ?? "";
@@ -348,7 +362,7 @@ function handleTasksSend(params: Record<string, unknown>): RpcResult<Task> {
     status: { state: "submitted", timestamp: new Date().toISOString() },
     artifacts: [],
     history: message ? [message] : [],
-    metadata: params.metadata as Record<string, unknown> | undefined,
+    metadata: isRecord(params.metadata) ? params.metadata : undefined,
     skillSlug: slug,
     _subscribers: [],
   };
@@ -362,19 +376,19 @@ function handleTasksSend(params: Record<string, unknown>): RpcResult<Task> {
 }
 
 function handleTasksGet(params: Record<string, unknown>): RpcResult<Record<string, unknown>> {
-  const id = params.id as string;
+  const id = asString(params.id) ?? "";
   const task = tasks.get(id);
   if (!task) {
     return { error: { code: -32602, message: `Task not found: ${id}` } };
   }
-  const historyLength = (params.historyLength as number | undefined) ?? task.history.length;
+  const historyLength = asNumber(params.historyLength) ?? task.history.length;
   // Omit internal _subscribers from response
   const { _subscribers: _, ...safe } = task;
   return { ...safe, history: task.history.slice(-historyLength) };
 }
 
 function handleTasksCancel(params: Record<string, unknown>): RpcResult<Record<string, unknown>> {
-  const id = params.id as string;
+  const id = asString(params.id) ?? "";
   const task = tasks.get(id);
   if (!task) {
     return { error: { code: -32602, message: `Task not found: ${id}` } };

--- a/dashboard/app/api/import/route.ts
+++ b/dashboard/app/api/import/route.ts
@@ -12,7 +12,11 @@ import { parseFrontmatter } from '@/lib/frontmatter'
 
 export async function POST(request: Request) {
   try {
-    const { action, repo, skills: skillNames } = await request.json()
+    const { action, repo, skills: skillNames } = await request.json() as { action?: string; repo?: string; skills?: string[] }
+
+    if (!repo) {
+      return NextResponse.json({ error: 'repo required' }, { status: 400 })
+    }
 
     if (action === 'list') {
       // Check both root and skills/ subdirectory
@@ -55,10 +59,13 @@ export async function POST(request: Request) {
     }
 
     if (action === 'install') {
+      if (!skillNames) {
+        return NextResponse.json({ error: 'skills required' }, { status: 400 })
+      }
       const installed: string[] = []
       const failed: string[] = []
 
-      for (const name of skillNames as string[]) {
+      for (const name of skillNames) {
         const content =
           (await getRemoteFileContent(repo, `${name}/SKILL.md`)) ||
           (await getRemoteFileContent(repo, `skills/${name}/SKILL.md`))

--- a/dashboard/app/api/secrets/route.ts
+++ b/dashboard/app/api/secrets/route.ts
@@ -74,7 +74,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'GitHub CLI not authenticated' }, { status: 503 })
   }
 
-  const { name, value } = await request.json()
+  const { name, value } = await request.json() as { name?: string; value?: string }
 
   if (!name || !value) {
     return NextResponse.json({ error: 'name and value required' }, { status: 400 })
@@ -102,7 +102,7 @@ export async function DELETE(request: Request) {
     return NextResponse.json({ error: 'GitHub CLI not authenticated' }, { status: 503 })
   }
 
-  const { name } = await request.json()
+  const { name } = await request.json() as { name?: string }
 
   if (!name || !VALID_SECRET_NAME.test(name)) {
     return NextResponse.json({ error: 'Invalid secret name' }, { status: 400 })

--- a/dashboard/app/api/skills/[name]/run/route.ts
+++ b/dashboard/app/api/skills/[name]/run/route.ts
@@ -20,7 +20,7 @@ export async function POST(
     let skillVar = ''
     let model = ''
     try {
-      const body = await request.json()
+      const body = await request.json() as { var?: string; model?: string }
       if (body.var && typeof body.var === 'string') {
         skillVar = body.var.replace(/[^a-zA-Z0-9_ .\-/#@]/g, '')
       }

--- a/dashboard/app/api/skills/route.ts
+++ b/dashboard/app/api/skills/route.ts
@@ -68,7 +68,7 @@ export async function GET() {
 
 export async function PATCH(request: Request) {
   try {
-    const { name, enabled, schedule, var: skillVar, model, skillModel, jsonrenderEnabled } = await request.json()
+    const { name, enabled, schedule, var: skillVar, model, skillModel, jsonrenderEnabled } = await request.json() as { name?: string; enabled?: boolean; schedule?: string; var?: string; model?: string; skillModel?: string; jsonrenderEnabled?: boolean }
     const { content, sha } = await getFileContent('aeon.yml')
     let updated = content
 
@@ -107,7 +107,7 @@ export async function PATCH(request: Request) {
 
 export async function DELETE(request: Request) {
   try {
-    const { name } = await request.json()
+    const { name } = await request.json() as { name?: string }
     if (!name || !/^[a-z][a-z0-9-]*$/.test(name)) {
       return NextResponse.json({ error: 'Invalid skill name' }, { status: 400 })
     }

--- a/dashboard/app/api/upload/route.ts
+++ b/dashboard/app/api/upload/route.ts
@@ -84,9 +84,9 @@ function deriveSkillName(files: UploadFile[]): { name: string; prefix: string } 
 
 export async function POST(request: Request) {
   try {
-    const body = await request.json()
-    const files = body.files as UploadFile[]
-    const overrideName = body.name as string | undefined
+    const body = await request.json() as { files?: UploadFile[]; name?: string }
+    const files = body.files
+    const overrideName = body.name
 
     if (!files || files.length === 0) {
       return NextResponse.json({ error: 'No files provided' }, { status: 400 })

--- a/dashboard/lib/github.ts
+++ b/dashboard/lib/github.ts
@@ -13,8 +13,9 @@ function isLocal() {
 }
 
 function getConfig() {
-  const token = process.env.GITHUB_TOKEN!
-  const repo = process.env.GITHUB_REPO!
+  const token = process.env.GITHUB_TOKEN
+  const repo = process.env.GITHUB_REPO
+  if (!token || !repo) throw new Error('github.ts: getConfig() requires GITHUB_TOKEN and GITHUB_REPO (non-local mode)')
   return { token, repo }
 }
 
@@ -46,7 +47,7 @@ export async function getFileContent(path: string): Promise<{ content: string; s
   }
 }
 
-export async function updateFile(path: string, content: string, sha: string, _message: string) {
+export async function updateFile(path: string, content: string, sha: string, _message: string): Promise<unknown> {
   if (isLocal()) {
     await writeFile(join(REPO_ROOT, path), content, 'utf-8')
     return { ok: true }
@@ -66,7 +67,7 @@ export async function updateFile(path: string, content: string, sha: string, _me
   return res.json()
 }
 
-export async function createFile(path: string, content: string, message: string) {
+export async function createFile(path: string, content: string, message: string): Promise<unknown> {
   if (isLocal()) {
     const fullPath = join(REPO_ROOT, path)
     await mkdir(join(fullPath, '..'), { recursive: true })

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -210,7 +210,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     };
   }
 
-  const varValue = (request.params.arguments?.var as string) ?? "";
+  const varArg = request.params.arguments?.var;
+  const varValue = typeof varArg === "string" ? varArg : "";
   const output = await runSkill(slug, varValue);
 
   return {


### PR DESCRIPTION
**Part 5 of 7 (stacked on #362).** Base: \`cleanup/04-types\`.

The codebase has **zero `any`/`as any`/`@ts-ignore`** — the only weak typing is at deserialization boundaries TS types loosely.

### Dashboard (HC)
- Typed every untyped `await request.json()` (the DOM types it `Promise<any>`) with a per-route body shape. **No new `.catch` fallbacks** — malformed JSON still surfaces through existing handlers (consistent with PR6's error-handling cleanup).
- `import/route.ts`: typing `repo`/`skills` **surfaced a real gap** — both were used unvalidated. Added explicit `400` guards (proper boundary validation) and dropped the `as string[]` cast.
- `upload/route.ts`: typed the body, dropped two `as` casts.
- `github.ts`: `process.env.X!` → explicit throw in `getConfig()`; `updateFile`/`createFile` now return `Promise<unknown>` instead of leaking `res.json()`'s `any`.

### Servers — input hardening (opted-in mediums)
- `a2a-server`: added `asString`/`asNumber`/`isRecord`/`isA2AMessage` guards and replaced **8** unvalidated `as` casts on attacker-controllable JSON-RPC params. `params.message` was cast to `A2AMessage` then dereferenced as `.parts` with no check — malformed input now rejects cleanly (`-32602`) instead of throwing.
- `mcp-server`: narrowed `arguments?.var` via `typeof` instead of `as string`.

Justified `unknown` at trust boundaries is **kept** and narrowed via guards, not replaced with `any`.

### Verification
- `tsc --noEmit` clean in **all three** packages · `npm test` 99/99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)