### PR TITLE
Cleanup 6/7: surface gh failures instead of masking them as empty 200s

### DIFF
--- a/dashboard/app/api/analytics/route.ts
+++ b/dashboard/app/api/analytics/route.ts
@@ -164,7 +164,8 @@ export async function GET() {
           : 0,
       },
     })
-  } catch {
-    return NextResponse.json({ skills: [], insights: [], summary: { totalRuns: 0, totalSuccess: 0, totalFailure: 0, overallSuccessRate: 0, uniqueSkills: 0, periodDays: 0 } })
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : 'Failed to load analytics'
+    return NextResponse.json({ error: msg }, { status: 500 })
   }
 }

--- a/dashboard/app/api/runs/route.ts
+++ b/dashboard/app/api/runs/route.ts
@@ -22,7 +22,8 @@ export async function GET() {
       url: r.url,
     }))
     return NextResponse.json({ runs })
-  } catch {
-    return NextResponse.json({ runs: [] })
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : 'Failed to list runs'
+    return NextResponse.json({ error: msg }, { status: 500 })
   }
 }


### PR DESCRIPTION
**Part 6 of 7 (stacked on #363).** Base: \`cleanup/05-weaktypes\`.

Error-handling audit — remove error-hiding catches; keep legitimate boundary guards.

`GET /api/analytics` and `GET /api/runs` each wrapped their gh-CLI call + `JSON.parse` in a `try` whose `catch` returned **HTTP 200 with zeroed/empty data**. A broken `gh` auth or a gh-output schema change therefore rendered as a *healthy-but-idle* dashboard — indistinguishable from "nothing has run yet."

- Both empty `catch {}` → the codebase's standard `catch (error: unknown)` returning `{ error: msg }` at **status 500**.
- The **inner** best-effort `aeon.yml` catch in analytics (optional file, enabled-skill insights) is legitimate and **kept**.

**Safe** because both clients already branch on `r.ok` (`page.tsx:53/57/128`): a 500 degrades to "list not updated" / "panel not populated" — honest — instead of fake zeros.

Left as-is (per audit): the `page.tsx` mutation handlers' silent `catch {}` — surfacing those is a UX change (error toasts) needing copy/placement sign-off. The shell `|| echo '{}'` curl fallbacks are load-bearing boundary guards (checked downstream) and stay.

### Verification
- `tsc --noEmit` clean · `npm test` 99/99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)