### PR TITLE
Cleanup 7/7: drop decorative box-drawing section banners

### DIFF
--- a/dashboard/components/HQOverview.tsx
+++ b/dashboard/components/HQOverview.tsx
@@ -49,7 +49,6 @@ export function HQOverview({ skills, runs, enabledCount, workingCount, onViewRun
 
   return (
     <div className="max-w-5xl mx-auto pb-16 space-y-10">
-      {/* ───── HERO ───── */}
       <section className="relative overflow-hidden border border-[rgba(250,250,250,0.10)] bg-aeon-panel">
         <div className="dither" aria-hidden="true" />
         <div className="relative z-10 px-8 pt-10 pb-8">
@@ -84,7 +83,6 @@ export function HQOverview({ skills, runs, enabledCount, workingCount, onViewRun
         </dl>
       </section>
 
-      {/* ───── 01 / DEPARTMENTS ───── */}
       <Section index="01" label="Departments">
         <ul
           ref={spotRef}
@@ -116,7 +114,6 @@ export function HQOverview({ skills, runs, enabledCount, workingCount, onViewRun
         </ul>
       </Section>
 
-      {/* ───── 02 / ACTIVITY ───── */}
       <Section index="02" label="Recent activity">
         <div className="border border-[rgba(250,250,250,0.10)] divide-y divide-[rgba(250,250,250,0.08)]">
           {runs.slice(0, 8).map(run => (
@@ -141,7 +138,6 @@ export function HQOverview({ skills, runs, enabledCount, workingCount, onViewRun
         </div>
       </Section>
 
-      {/* ───── MARQUEE BAND ───── */}
       <VelocityMarquee
         className="overflow-hidden border-y border-aeon-fg/30 whitespace-nowrap py-3 font-display uppercase tracking-wide text-base text-aeon-fg/85"
         trackClassName="inline-block will-change-transform"

--- a/dashboard/components/SecretsPanel.tsx
+++ b/dashboard/components/SecretsPanel.tsx
@@ -29,7 +29,6 @@ export function SecretsPanel({ secrets, busy, onSave, onDelete }: SecretsPanelPr
 
   return (
     <div className="max-w-5xl mx-auto pb-16 space-y-10">
-      {/* ───── HERO ───── */}
       <section className="relative overflow-hidden border border-[rgba(250,250,250,0.10)] bg-aeon-panel">
         <div className="dither" aria-hidden="true" />
         <div className="relative z-10 px-8 pt-10 pb-8">

--- a/dashboard/components/SkillDetail.tsx
+++ b/dashboard/components/SkillDetail.tsx
@@ -48,7 +48,6 @@ export function SkillDetail({ skill, runs, model, gateway, busy, onToggle, onRun
 
   return (
     <div className="max-w-5xl mx-auto pb-16 space-y-10">
-      {/* ───── HERO ───── */}
       <section className="relative overflow-hidden border border-[rgba(250,250,250,0.10)] bg-aeon-panel">
         <div className="dither" aria-hidden="true" />
         <div className="relative z-10 px-8 pt-10 pb-8">
@@ -96,7 +95,6 @@ export function SkillDetail({ skill, runs, model, gateway, busy, onToggle, onRun
         </div>
       </section>
 
-      {/* ───── 01 / SHIFT ───── */}
       <Section
         index="01"
         label="Shift schedule"
@@ -120,7 +118,6 @@ export function SkillDetail({ skill, runs, model, gateway, busy, onToggle, onRun
         )}
       </Section>
 
-      {/* ───── 02 / BRIEF ───── */}
       <Section
         index="02"
         label="Assignment brief"
@@ -154,7 +151,6 @@ export function SkillDetail({ skill, runs, model, gateway, busy, onToggle, onRun
         )}
       </Section>
 
-      {/* ───── 03 / MODEL ───── */}
       <Section index="03" label="Capability level">
         <select
           value={skill.model}
@@ -166,7 +162,6 @@ export function SkillDetail({ skill, runs, model, gateway, busy, onToggle, onRun
         </select>
       </Section>
 
-      {/* ───── 04 / ACTIVITY ───── */}
       <Section index="04" label="Activity log">
         <div className="border border-[rgba(250,250,250,0.10)] divide-y divide-[rgba(250,250,250,0.08)]">
           {skillRuns.slice(0, 10).map(run => (


### PR DESCRIPTION
**Part 7 of 7 (stacked on #364).** Base: \`cleanup/06-errors\`.

AI-slop / comment audit. The codebase is **notably clean** — no `TODO`/`FIXME`/`HACK`, no stubs, no larp, no signature-echoing JSDoc. The single actionable finding:

### Decorative section banners
Removed 10 `{/* ───── LABEL ───── */}` box-drawing divider comments across `HQOverview`, `SkillDetail`, `SecretsPanel`. The numbered ones sat directly above `<Section index="01" label="Departments">`, which already renders the index + label — pure redundant decoration. JSX comments don't render, so zero runtime effect (`tsc` + tests confirm).

### Deliberately left untouched
- The `# ──` section labels in `a2a-server` and the shell installers — an established house-style that genuinely aids navigation in 200–550-line single files; only the dash-fill is noise, and that's a style call for you.
- `Animated.tsx`'s multi-line comment blocks (not decorative dividers — they hold descriptive text).
- `SKILL.md` instructional prose — runtime-load-bearing (the agent reads it).

### Verification
- `tsc --noEmit` clean · `npm test` 99/99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)