### PR TITLE
ci: pin Claude Code CLI install to a known version

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -129,7 +129,10 @@ jobs:
 
       - name: Install Claude Code
         if: steps.work.outputs.mode != ''
-        run: npm install -g @anthropic-ai/claude-code
+        # Pinned for supply-chain safety — a freshly-published (or compromised)
+        # version is never pulled automatically. Bump deliberately after reviewing
+        # the release notes: https://github.com/anthropics/claude-code/releases
+        run: npm install -g @anthropic-ai/claude-code@2.1.168
 
       - name: Validate skill secrets
         if: steps.work.outputs.mode != ''

--- a/.github/workflows/messages.yml
+++ b/.github/workflows/messages.yml
@@ -614,7 +614,8 @@ jobs:
 
       - name: Install Claude Code
         if: steps.msg.outputs.source != ''
-        run: npm install -g @anthropic-ai/claude-code
+        # Pinned for supply-chain safety — keep in sync with aeon.yml's pin.
+        run: npm install -g @anthropic-ai/claude-code@2.1.168
 
       - name: Run
         id: run


### PR DESCRIPTION
## What

Pins the Claude Code CLI install in both runner workflows to `@anthropic-ai/claude-code@2.1.168` instead of pulling `latest` on every run.

- `.github/workflows/aeon.yml` (skill runner)
- `.github/workflows/messages.yml` (message runner)

## Why

This is roadmap item **#7 (supply-chain hardening)**. Both workflows ran `npm install -g @anthropic-ai/claude-code` with no version, so each run installed whatever `latest` resolved to at that moment. A freshly-published — or compromised — release would be pulled into the runner with zero review window.

`2.1.168` is the current `latest`, so there is **no behaviour change today**; the pin just freezes the version until someone bumps it deliberately.

## Notes

- Bump procedure is documented in a comment above the install step (review the release notes, then bump both files in lockstep).
- The broader half of #7 (pnpm + `minimumReleaseAge` on the `dashboard/` package) is intentionally **deferred** — it changes Vercel's package-manager detection and is not a quick win. The spec itself flags version-pinning the CLI as "the highest-value action right now."

🤖 Generated with [Claude Code](https://claude.com/claude-code)