### PR TITLE
feat(webhook): one-click Telegram instant-mode Worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,11 @@ Set the secret → channel activates. No code changes needed.
 
 ### Telegram instant mode (optional)
 
-Default polling has up to 5-min delay. Deploy a ~20-line Cloudflare Worker as a webhook for ~1s response time. See [`docs/telegram-instant.md`](docs/telegram-instant.md) for the Worker code and setup.
+Default polling has up to a 5-min delay. Deploy the self-contained Cloudflare Worker in [`webhook/`](webhook/) for ~1s response time — one click, into your own Cloudflare account (no shared infra, no credential custody):
+
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/aaronjmars/aeon/tree/main/webhook)
+
+Setup, required secrets, and how it coexists with polling are in [`webhook/README.md`](webhook/README.md). The poller calls `getWebhookInfo` and skips Telegram automatically once a webhook is active, so the two never conflict.
 
 ---
 

--- a/docs/telegram-instant.md
+++ b/docs/telegram-instant.md
@@ -1,42 +1,22 @@
 # Telegram Instant Mode
 
-Default polling checks for messages every 5 minutes. For ~1s response time, deploy this Cloudflare Worker as a Telegram webhook.
+Default polling checks for messages every 5 minutes. For ~1s response time, deploy
+the Cloudflare Worker in [`../webhook/`](../webhook/) as a Telegram webhook.
 
-## Worker code
+The Worker is now a self-contained, one-click-deployable package — source,
+`wrangler.toml`, and full setup instructions live in
+**[`webhook/README.md`](../webhook/README.md)**, including the "Deploy to
+Cloudflare" button.
 
-```js
-export default {
-  async fetch(request, env) {
-    const { message } = await request.json();
-    if (!message?.text || String(message.chat.id) !== env.TELEGRAM_CHAT_ID)
-      return new Response("ignored");
+In short:
 
-    // Advance offset so polling doesn't reprocess
-    await fetch(`https://api.telegram.org/bot${env.TELEGRAM_BOT_TOKEN}/getUpdates?offset=${message.update_id + 1}`);
-
-    // Trigger GitHub Actions immediately
-    await fetch(`https://api.github.com/repos/${env.GITHUB_REPO}/dispatches`, {
-      method: "POST",
-      headers: { Authorization: `token ${env.GITHUB_TOKEN}`, Accept: "application/vnd.github.v3+json" },
-      body: JSON.stringify({ event_type: "telegram-message", client_payload: { message: message.text } }),
-    });
-
-    return new Response("ok");
-  },
-};
-```
-
-## Setup
-
-1. Create a Cloudflare Worker and paste the code above
-2. Set environment variables in the Cloudflare dashboard:
-   - `TELEGRAM_BOT_TOKEN` — your bot token from @BotFather
-   - `TELEGRAM_CHAT_ID` — your chat ID
-   - `GITHUB_REPO` — `owner/repo` format (e.g. `aaronjmars/aeon`)
-   - `GITHUB_TOKEN` — a GitHub PAT with `repo` scope
-3. Point your bot's webhook at the Worker URL:
+1. Deploy `webhook/` to your own Cloudflare account (button or `npx wrangler deploy`).
+2. Set the `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`, `GITHUB_REPO`, and `GITHUB_TOKEN`
+   secrets (plus the optional `TELEGRAM_WEBHOOK_SECRET`).
+3. Point your bot at the Worker:
    ```bash
-   curl "https://api.telegram.org/bot<YOUR_TOKEN>/setWebhook?url=https://your-worker.workers.dev"
+   curl "https://api.telegram.org/bot<YOUR_TOKEN>/setWebhook?url=https://your-worker.workers.dev&secret_token=<YOUR_WEBHOOK_SECRET>"
    ```
 
-Messages now arrive in ~1 second instead of up to 5 minutes.
+Once a webhook is active the poller detects it via `getWebhookInfo` and skips the
+Telegram branch, so polling and the webhook never conflict.

--- a/webhook/.gitignore
+++ b/webhook/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.wrangler/
+.dev.vars

--- a/webhook/README.md
+++ b/webhook/README.md
@@ -1,0 +1,94 @@
+# Aeon Telegram webhook — instant mode
+
+Default polling checks Telegram every 5 minutes. Deploy this Cloudflare Worker as
+a Telegram webhook to drop that to **~1 second**: the Worker relays each message
+to your Aeon fork via a GitHub `repository_dispatch`, which fires the
+**Messages & Scheduler** workflow immediately.
+
+Each user deploys it into **their own** Cloudflare account. There's no shared
+relay and no credential custody — your bot token and GitHub PAT live only in your
+Worker's secrets.
+
+## Deploy
+
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/aaronjmars/aeon/tree/main/webhook)
+
+> Forked Aeon? Change `aaronjmars/aeon` in the button URL above to
+> `your-username/your-fork` so it deploys from your repo. (The button requires a
+> **public** source repo.)
+
+Or from a clone:
+
+```bash
+cd webhook
+npm install
+npx wrangler deploy
+```
+
+## Configure
+
+After the first deploy the Worker exists but has no config. Set these as
+**secrets** (Cloudflare dashboard → Workers & Pages → your worker → Settings →
+Variables → *Add variable* → *Encrypt*), or via the CLI:
+
+```bash
+npx wrangler secret put TELEGRAM_BOT_TOKEN        # bot token from @BotFather
+npx wrangler secret put TELEGRAM_CHAT_ID          # your chat id (only this chat is allowed)
+npx wrangler secret put GITHUB_REPO               # owner/repo of your Aeon fork
+npx wrangler secret put GITHUB_TOKEN              # GitHub PAT (see scopes below)
+npx wrangler secret put TELEGRAM_WEBHOOK_SECRET   # optional but recommended — any random string
+```
+
+| Secret | Required | Notes |
+|--------|----------|-------|
+| `TELEGRAM_BOT_TOKEN` | yes | From [@BotFather](https://t.me/BotFather). |
+| `TELEGRAM_CHAT_ID` | yes | Only messages from this chat are relayed; everything else is dropped. |
+| `GITHUB_REPO` | yes | `owner/repo`, e.g. `aaronjmars/aeon`. |
+| `GITHUB_TOKEN` | yes | Fine-grained PAT scoped to your fork with **Contents: read/write** and **Actions: read/write**, or a classic token with `repo`. |
+| `TELEGRAM_WEBHOOK_SECRET` | recommended | Shared secret that lets the Worker reject forged calls. Use the same value when registering the webhook (below). |
+
+## Point Telegram at the Worker
+
+Register your Worker URL as the bot's webhook. Include the optional secret so
+Telegram signs every call (the Worker verifies it):
+
+```bash
+curl "https://api.telegram.org/bot<YOUR_BOT_TOKEN>/setWebhook?url=https://aeon-telegram-webhook.<your-subdomain>.workers.dev&secret_token=<YOUR_WEBHOOK_SECRET>"
+```
+
+Verify it took:
+
+```bash
+curl "https://api.telegram.org/bot<YOUR_BOT_TOKEN>/getWebhookInfo"
+```
+
+Messages now arrive in ~1s. To go back to polling, clear the webhook:
+
+```bash
+curl "https://api.telegram.org/bot<YOUR_BOT_TOKEN>/deleteWebhook"
+```
+
+## How it coexists with polling
+
+A webhook and `getUpdates` polling are **mutually exclusive** — once a webhook is
+set, `getUpdates` returns `409 Conflict`. The Messages & Scheduler workflow's
+poller calls `getWebhookInfo` first and **skips the Telegram branch when a webhook
+is active**, so the two never fight. Delivery then runs entirely through this
+Worker → `repository_dispatch`.
+
+Dedupe in webhook mode is by the `update_id` carried in the dispatch payload:
+the Worker returns `200` once GitHub accepts the dispatch (so Telegram never
+redelivers) and a non-2xx only when the dispatch genuinely failed (so Telegram
+retries).
+
+## What it does
+
+```
+Telegram → POST update → Worker
+  ├─ verify method + secret_token
+  ├─ ignore (200) anything not a text message from TELEGRAM_CHAT_ID
+  └─ POST repository_dispatch {event_type: telegram-message, client_payload:{message,…}}
+       → GitHub Actions: Messages & Scheduler `run` job acts on it (~1s)
+```
+
+The Worker source is [`src/worker.js`](src/worker.js) — ~30 lines, no build step.

--- a/webhook/package.json
+++ b/webhook/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "aeon-telegram-webhook",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Cloudflare Worker that relays Telegram messages to an Aeon fork via GitHub repository_dispatch for ~1s response time.",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy"
+  },
+  "devDependencies": {
+    "wrangler": "4.98.0"
+  }
+}

--- a/webhook/src/worker.js
+++ b/webhook/src/worker.js
@@ -1,0 +1,79 @@
+/**
+ * Aeon — Telegram instant-delivery webhook.
+ *
+ * A Cloudflare Worker that receives Telegram webhook updates and relays them to
+ * your Aeon fork via a GitHub `repository_dispatch` (event_type: telegram-message).
+ * The "Messages & Scheduler" workflow's `run` job picks it up immediately, so a
+ * message is acted on in ~1s instead of waiting up to 5 minutes for the next poll.
+ *
+ * Each user deploys this into their OWN Cloudflare account — there is no shared
+ * infrastructure and no credential custody. See README.md for deployment.
+ *
+ * Required vars/secrets (set after deploy):
+ *   TELEGRAM_BOT_TOKEN        bot token from @BotFather
+ *   TELEGRAM_CHAT_ID          the only chat allowed to command the agent
+ *   GITHUB_REPO               "owner/repo" of your Aeon fork
+ *   GITHUB_TOKEN              GitHub PAT — fine-grained with Contents: read/write
+ *                             and Actions: read/write on your fork (or classic `repo`)
+ *   TELEGRAM_WEBHOOK_SECRET   (optional, recommended) shared secret; set the same
+ *                             value as setWebhook's `secret_token` so forged
+ *                             requests are rejected
+ */
+export default {
+  async fetch(request, env) {
+    // Telegram only ever POSTs updates. Treat anything else as a health probe.
+    if (request.method !== "POST") {
+      return new Response("aeon telegram webhook: ok", { status: 200 });
+    }
+
+    // Reject forged requests when a shared secret is configured. Telegram echoes
+    // the secret passed to setWebhook(secret_token) in this header on every call.
+    if (
+      env.TELEGRAM_WEBHOOK_SECRET &&
+      request.headers.get("x-telegram-bot-api-secret-token") !== env.TELEGRAM_WEBHOOK_SECRET
+    ) {
+      return new Response("forbidden", { status: 403 });
+    }
+
+    let update;
+    try {
+      update = await request.json();
+    } catch {
+      return new Response("bad request", { status: 400 });
+    }
+
+    const message = update?.message;
+    // Return 200 for anything we intentionally ignore so Telegram marks the
+    // update delivered and never redelivers it. Only commands from the configured
+    // chat are relayed — every other chat is dropped.
+    if (!message?.text || String(message.chat?.id) !== String(env.TELEGRAM_CHAT_ID)) {
+      return new Response("ignored", { status: 200 });
+    }
+
+    const res = await fetch(`https://api.github.com/repos/${env.GITHUB_REPO}/dispatches`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${env.GITHUB_TOKEN}`,
+        Accept: "application/vnd.github+json",
+        "Content-Type": "application/json",
+        "User-Agent": "aeon-telegram-webhook",
+      },
+      body: JSON.stringify({
+        event_type: "telegram-message",
+        client_payload: {
+          message: message.text,
+          update_id: update.update_id,
+          chat_id: message.chat.id,
+        },
+      }),
+    });
+
+    // On failure return non-2xx so Telegram retries the update later — dedupe is
+    // by the update_id carried in client_payload. On success return 200 so the
+    // update is never redelivered.
+    if (!res.ok) {
+      return new Response(`dispatch failed: ${res.status}`, { status: 502 });
+    }
+    return new Response("ok", { status: 200 });
+  },
+};

--- a/webhook/wrangler.toml
+++ b/webhook/wrangler.toml
@@ -1,0 +1,13 @@
+name = "aeon-telegram-webhook"
+main = "src/worker.js"
+compatibility_date = "2025-01-01"
+
+# This Worker reads its config from environment variables / secrets, not from
+# this file. After deploying, set them in the Cloudflare dashboard
+# (Workers & Pages → your worker → Settings → Variables) or via the CLI:
+#
+#   wrangler secret put TELEGRAM_BOT_TOKEN
+#   wrangler secret put TELEGRAM_CHAT_ID
+#   wrangler secret put GITHUB_REPO
+#   wrangler secret put GITHUB_TOKEN
+#   wrangler secret put TELEGRAM_WEBHOOK_SECRET   # optional but recommended


### PR DESCRIPTION
## What

Roadmap item **#8 (instant GitHub notifications)** — the part the spec listed as "remaining wiring." It turns the hand-rolled snippet in `docs/telegram-instant.md` into a self-contained, one-click-deployable Cloudflare Worker under `webhook/`.

```
webhook/
├── src/worker.js     # the relay (~30 lines, no build step)
├── wrangler.toml     # name + entry; config comes from secrets
├── package.json      # wrangler pinned to 4.98.0
├── .gitignore
└── README.md         # Deploy button + secrets + setWebhook + coexistence
```

## Why

The spec claims this was "built — see the `webhook/` directory," but **no such directory existed in this repo** — only a 1.5 KB doc snippet with manual `setWebhook` curl and no deploy button. This builds it for real.

Instant mode drops Telegram response time from *up to 5 min* (polling) to *~1s* (webhook → `repository_dispatch` → the `run` job). Each user deploys into their **own** Cloudflare account, so there's no shared relay and no credential custody.

## Hardening over the old snippet

- Verifies request method and Telegram's `secret_token` header (rejects forged calls).
- Guards against malformed JSON; allowlists `TELEGRAM_CHAT_ID`.
- Returns **200 on ignore** so Telegram marks the update delivered (no redelivery storms), **502 only on a real dispatch failure** so it retries.
- Carries `update_id` in `client_payload` for webhook-mode dedupe.
- Drops the old snippet's `getUpdates?offset=…` line, which would `409` in webhook mode anyway.

Payload shape matches what `messages.yml`'s `run` job already reads (`client_payload.message`, source derived from the `telegram-message` action — `messages.yml:577-584`).

## Docs

- Main `README.md` now shows the **Deploy to Cloudflare** button and links to `webhook/README.md`.
- `docs/telegram-instant.md` is slimmed to a pointer — single source of truth for the Worker code.

## Depends on / pairs with

The **poller-side** coexistence (calling `getWebhookInfo` and skipping the Telegram branch when a webhook is active) lands in the **#6 dedupe PR**. Without it, the 5-min poller would `409` once a webhook is set. Merge both; order doesn't matter (they touch different files).

> Note for maintainers: the deploy-button URL hard-codes `aaronjmars/aeon`. Forks change it to their own repo (documented in `webhook/README.md`). The button needs a **public** source repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)