### PR TITLE
fix(messages): stop Telegram messages being processed twice

### DIFF
--- a/.github/workflows/messages.yml
+++ b/.github/workflows/messages.yml
@@ -479,25 +479,44 @@ jobs:
 
           # --- Telegram (collect ALL pending updates) ---
           if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ]; then
-            RESPONSE=$(curl -s "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/getUpdates?timeout=0&allowed_updates=%5B%22message%22%5D")
-            COUNT=$(echo "$RESPONSE" | jq '.result | length')
-            MAX_UPDATE_ID=""
+            # A webhook and getUpdates are mutually exclusive: once a webhook is
+            # set (instant mode, see webhook/), getUpdates returns 409. Detect it
+            # and skip polling — the Worker delivers via repository_dispatch.
+            WEBHOOK_URL=$(curl -s "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/getWebhookInfo" | jq -r '.result.url // empty')
+            if [ -n "$WEBHOOK_URL" ]; then
+              echo "Telegram webhook active — skipping poll (instant mode delivers via repository_dispatch)"
+            else
+              RESPONSE=$(curl -s "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/getUpdates?timeout=0&allowed_updates=%5B%22message%22%5D")
+              COUNT=$(echo "$RESPONSE" | jq '.result | length')
+              MAX_UPDATE_ID=""
+              TG_MESSAGES='[]'
 
-            for ((i=0; i<COUNT; i++)); do
-              TEXT=$(echo "$RESPONSE" | jq -r ".result[$i].message.text // empty")
-              CHAT=$(echo "$RESPONSE" | jq -r ".result[$i].message.chat.id // empty")
-              UPDATE_ID=$(echo "$RESPONSE" | jq -r ".result[$i].update_id // empty")
+              for ((i=0; i<COUNT; i++)); do
+                TEXT=$(echo "$RESPONSE" | jq -r ".result[$i].message.text // empty")
+                CHAT=$(echo "$RESPONSE" | jq -r ".result[$i].message.chat.id // empty")
+                UPDATE_ID=$(echo "$RESPONSE" | jq -r ".result[$i].update_id // empty")
 
-              if [ -n "$TEXT" ] && [ "$CHAT" = "$TELEGRAM_CHAT_ID" ]; then
-                MESSAGES=$(echo "$MESSAGES" | jq --arg src "telegram" --arg txt "$TEXT" '. + [{source: $src, text: $txt}]')
-                echo "Telegram: $TEXT"
+                if [ -n "$TEXT" ] && [ "$CHAT" = "$TELEGRAM_CHAT_ID" ]; then
+                  TG_MESSAGES=$(echo "$TG_MESSAGES" | jq --arg src "telegram" --arg txt "$TEXT" '. + [{source: $src, text: $txt}]')
+                  echo "Telegram: $TEXT"
+                fi
+                MAX_UPDATE_ID="$UPDATE_ID"
+              done
+
+              # Acknowledge updates BEFORE queuing them for dispatch, and only
+              # enqueue once Telegram confirms the offset advanced (ok:true) — a
+              # re-poll then can't re-read them. If the ack fails, leave the
+              # messages pending for the next tick rather than dispatch updates
+              # that could be re-read and processed twice.
+              if [ -n "$MAX_UPDATE_ID" ]; then
+                ACK_OK=$(curl -s "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/getUpdates?offset=$((MAX_UPDATE_ID + 1))" | jq -r '.ok // false')
+                if [ "$ACK_OK" = "true" ]; then
+                  MESSAGES=$(echo "$MESSAGES" | jq --argjson tg "$TG_MESSAGES" '. + $tg')
+                else
+                  PENDING=$(echo "$TG_MESSAGES" | jq 'length')
+                  [ "$PENDING" -gt 0 ] && echo "::warning::Telegram offset ack failed — leaving $PENDING message(s) pending to avoid double-processing"
+                fi
               fi
-              MAX_UPDATE_ID="$UPDATE_ID"
-            done
-
-            # Acknowledge all updates at once
-            if [ -n "$MAX_UPDATE_ID" ]; then
-              curl -s "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/getUpdates?offset=$((MAX_UPDATE_ID + 1))" > /dev/null
             fi
           fi
 


### PR DESCRIPTION
## What

Roadmap item **#6 (dedupe + security verification)** — the dedupe half. Fixes the Telegram polling path in `messages.yml` so a message can't be processed twice, and makes the poller coexist with instant mode.

## The bug

The poll loop collected messages, then advanced the `getUpdates` offset with an **unverified** `curl … > /dev/null`, then dispatched. If that ack failed silently (the sandbox blocks outbound bash intermittently, or a transient error), the messages were **already dispatched** but the offset never moved — so the next 5-min tick re-read the same updates and re-dispatched them. Double processing.

The `aeon-tick` concurrency group already prevents *parallel* ticks (so that half of the spec's dedupe ask is already done), but it does nothing about a failed/lost ack.

## The fix

- **Acknowledge before enqueuing.** Collect Telegram messages into a temp array, advance the offset, and only merge them into the dispatch set once Telegram returns `ok:true`. If the ack fails, the messages stay **pending** for the next tick instead of being dispatched — at-most-once, which is the spec's stated goal ("stop messages being processed twice"). A `::warning::` records how many were held back.
- **Skip polling when a webhook is active.** Call `getWebhookInfo` first; if a webhook URL is set, skip the Telegram branch entirely. `getUpdates` returns `409` once instant mode (#8, `webhook/`) is enabled, so without this the poller and the Worker fight. If the `getWebhookInfo` call itself fails, it falls through to polling — the safe default.

Discord/Slack paths are untouched. Verified: YAML parses, the step passes `bash -n`, and the merge / leave-pending / acked-but-empty branches were exercised against `jq`.

## Security verification (the other half of #6)

Audited all five workflows: **every one already declares a least-privilege `permissions:` block**, and none use `set -x` or echo secret values. `messages.yml`'s `contents/pull-requests/actions: write` are each load-bearing (state commits, skill PRs, `gh workflow run` dispatch), so there's no safe reduction to make. No changes needed — recorded here for the audit trail. The deeper supply-chain surface (`add-skill`/`search-skill` executing external `SKILL.md`) is already gated by `skill-security-scan/scan.sh` + `trusted-sources.txt` and is out of scope for this quick win.

## Pairs with

PR #368 (instant webhook) — that PR adds `webhook/`; this PR adds the poller's `getWebhookInfo` skip so the two coexist. Independent files; merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)