### PR TITLE
feat: STRATEGY.md — a north-star every skill follows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,12 @@
 
 You are Aeon, an autonomous agent running on GitHub Actions via Claude Code.
 
+## Strategy
+
+`STRATEGY.md` (imported below) is the operator's north-star — their overarching goal, priorities, audience, and hard constraints. Read it at the start of every task and align your output to it; when a choice isn't otherwise determined, let the strategy break the tie. Absorb it, don't quote it verbatim. If it still holds the unconfigured defaults, use general best judgment.
+
+@STRATEGY.md
+
 ## Voice
 
 If `soul/` files exist, read them before writing any notification or output to match the operator's voice and style. Skip this section if the soul directory is empty or absent.

--- a/STRATEGY.md
+++ b/STRATEGY.md
@@ -1,0 +1,49 @@
+# Strategy
+
+Aeon's north-star. Every skill reads this — it's imported into `CLAUDE.md`, so it
+sits in context on **every** run. Skills should align their output to it: what to
+work on, what to prioritise, what to flag, what to skip.
+
+Keep it short (it costs tokens each run): one north-star, 3–5 priorities, the
+constraints. Replace the defaults below with your own.
+
+> **Status:** unconfigured defaults. Until you tailor this file, skills operate
+> with general best judgment and no specific bias. Remove this line once it's yours.
+
+## North-star metric
+
+The single outcome everything should move toward.
+*e.g. "weekly active users of my app", "MRR", "reach of my research".*
+
+**Default:** sustainable, compounding progress on the operator's active projects.
+
+## Priorities
+
+The few things that matter most right now, most important first.
+
+1. Correct, verifiable work over work that merely looks finished.
+2. Depth on the operator's core projects over broad, shallow coverage.
+3. Surface signal early — don't sit on something that needs a decision.
+
+*Replace with your own; cap at ~5.*
+
+## Audience
+
+Who the output is for, and their level.
+*e.g. "technical founders on X", "my internal team", "just me".*
+
+**Default:** the operator — assume technical and time-constrained.
+
+## Hard constraints
+
+Lines never to cross.
+
+- Never publish secrets, private data, or unverified claims as fact.
+- Stay within any configured spend and rate limits.
+
+*Add your own — budget caps, tone, topics to avoid, compliance limits.*
+
+## Optimize for / avoid
+
+- **Optimize for:** signal, correctness, and the priorities above.
+- **Avoid:** filler, hype, busywork, anything off-strategy.

--- a/onboard
+++ b/onboard
@@ -141,6 +141,20 @@ else
     "Restore from upstream: git checkout upstream/main -- aeon.yml"
 fi
 
+# --- STRATEGY.md (north-star imported into every run) ----------------------
+
+if [[ -f STRATEGY.md ]]; then
+  if grep -q '^> \*\*Status:\*\* unconfigured defaults' STRATEGY.md; then
+    emit warn "STRATEGY.md" "present but still using template defaults" \
+      "Edit STRATEGY.md — set your north-star metric, priorities, audience, and constraints. Every skill reads it (it's imported into CLAUDE.md), so tailoring it steers all output."
+  else
+    emit pass "STRATEGY.md" "customized" ""
+  fi
+else
+  emit warn "STRATEGY.md" "missing (skills run without a shared strategy)" \
+    "Restore the template: git checkout upstream/main -- STRATEGY.md  then edit it for your goal."
+fi
+
 # --- 3. memory writable ----------------------------------------------------
 
 if [[ ! -d memory ]]; then


### PR DESCRIPTION
## What

Roadmap item **#1 (Strategy.md)**. Adds a repo-root `Strategy.md` that captures the operator's overarching goal and wires it into every skill's context via a single `@Strategy.md` import in `CLAUDE.md`.

- **`Strategy.md`** — short template: north-star metric, priorities (max 5), audience, hard constraints, optimize/avoid.
- **`CLAUDE.md`** — new `## Strategy` section + `@Strategy.md` import. Claude Code auto-loads `CLAUDE.md` and resolves `@file` imports, so the strategy is in the base context of **every** skill run with zero per-skill change.
- **`onboard`** — validates it: `pass` when customized, `warn` when missing or still on template defaults.

## Why

Skills had no shared notion of what the operator is actually trying to achieve, so output couldn't align to a goal ("grow KPI X", "reach for my research"). One file, imported once, gives all 190+ skills the same north-star.

## Design choices

- **Safe when unfilled.** The template ships with neutral, real defaults and a `> **Status:** unconfigured defaults` line. Skills are told (in the `## Strategy` section) to fall back to general judgment while that line is present — so an un-customized fork isn't polluted with placeholder noise. `onboard` keys off the same line to nudge the operator to tailor it.
- **Short on purpose.** It's in context on every run, so it costs tokens each time. Capped structure (one north-star + ≤5 priorities + constraints) over prose.

## Acceptance criteria

- [x] A populated `Strategy.md` exists at repo root.
- [x] It's imported into every skill's context (`@Strategy.md` in `CLAUDE.md`).
- [x] `onboard` reflects whether it's been customized.
- [ ] *Dashboard view/edit panel* — deliberately a **fast-follow** (see below).

## Scope notes / decisions for the team

- **Dashboard editor deferred.** The spec's "view-and-edit panel" is a clean addition on the existing commit path (`github.ts` + `/api/sync`) but spans the typed `view` union + `LeftSidebar` + a new component + route against the custom design system — the one piece of #1 that isn't a quick win. Happy to do it as a focused follow-up.
- **Harness coupling (depends on #4).** `@`-import is Claude-Code-specific. A multi-harness runtime would need an equivalent injection (e.g. Codex `AGENTS.md`) or the strategy silently no-ops there. Flagged for the multi-harness spike.
- When #9 (update system) lands, `Strategy.md` belongs on the **never-touch / user-owned** list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)