### PR TITLE
feat(dashboard): edit STRATEGY.md + Telegram instant-mode guide

### DIFF
--- a/dashboard/app/api/strategy/route.ts
+++ b/dashboard/app/api/strategy/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server'
+import { getFileContent, updateFile, createFile } from '@/lib/github'
+
+const FILE = 'STRATEGY.md'
+
+export async function GET() {
+  try {
+    const { content, sha } = await getFileContent(FILE)
+    return NextResponse.json({ exists: true, content, sha })
+  } catch {
+    // Not created yet — the editor can bootstrap it on first save.
+    return NextResponse.json({ exists: false, content: '', sha: '' })
+  }
+}
+
+export async function PUT(request: Request) {
+  try {
+    const body = (await request.json()) as { content?: string }
+    if (typeof body.content !== 'string') {
+      return NextResponse.json({ error: 'content (string) required' }, { status: 400 })
+    }
+
+    // GitHub's API needs the current sha to update an existing file; when the
+    // file doesn't exist yet, create it instead. (Local mode ignores the sha.)
+    let sha = ''
+    try {
+      sha = (await getFileContent(FILE)).sha
+    } catch {
+      // new file
+    }
+    if (sha) {
+      await updateFile(FILE, body.content, sha, 'chore: update STRATEGY.md from dashboard')
+    } else {
+      await createFile(FILE, body.content, 'chore: add STRATEGY.md from dashboard')
+    }
+    return NextResponse.json({ ok: true })
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : 'Unknown error'
+    return NextResponse.json({ error: msg }, { status: 500 })
+  }
+}

--- a/dashboard/app/page.tsx
+++ b/dashboard/app/page.tsx
@@ -12,12 +12,13 @@ import { TopBar } from '../components/TopBar'
 import { HQOverview } from '../components/HQOverview'
 import { SkillDetail } from '../components/SkillDetail'
 import { SecretsPanel } from '../components/SecretsPanel'
+import { StrategyPanel } from '../components/StrategyPanel'
 import { RightPanel } from '../components/RightPanel'
 import { ImportModal } from '../components/ImportModal'
 import { AuthModal } from '../components/AuthModal'
 
 export default function Dashboard() {
-  const [view, setView] = useState<'hq' | 'secrets'>('hq')
+  const [view, setView] = useState<'hq' | 'secrets' | 'strategy'>('hq')
   const [selectedSkill, setSelectedSkill] = useState<string | null>(null)
 
   const [skills, setSkills] = useState<Skill[]>([])
@@ -46,6 +47,10 @@ export default function Dashboard() {
   const [authLoading, setAuthLoading] = useState(false)
   const [showAuthModal, setShowAuthModal] = useState(false)
 
+  const [strategy, setStrategy] = useState('')
+  const [strategyLoaded, setStrategyLoaded] = useState(false)
+  const [strategySaving, setStrategySaving] = useState(false)
+
   const flash = (msg: string) => { setToast(msg); setTimeout(() => setToast(''), 3000) }
 
   // --- API ---
@@ -58,6 +63,7 @@ export default function Dashboard() {
   useEffect(() => { fetchData() }, [fetchData])
   useEffect(() => { const id = setInterval(refreshRuns, 10_000); return () => clearInterval(id) }, [refreshRuns])
   useEffect(() => { setFeedLoading(true); fetch('/api/outputs').then(r => r.ok ? r.json() : { outputs: [] }).then(d => setOutputs(d.outputs || [])).finally(() => setFeedLoading(false)) }, [feedKey])
+  useEffect(() => { if (view === 'strategy' && !strategyLoaded) { fetch('/api/strategy').then(r => r.ok ? r.json() : null).then(d => { if (d) { setStrategy(d.content || ''); setStrategyLoaded(true) } }).catch(() => {}) } }, [view, strategyLoaded])
 
   const toggleSkill = async (n: string, en: boolean) => { setBusy(b => ({ ...b, [n]: true })); try { const r = await fetch('/api/skills', { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: n, enabled: en }) }); if (r.ok) { setSkills(s => s.map(sk => sk.name === n ? { ...sk, enabled: en } : sk)); flash(`${displayName(n)} ${en ? 'on duty' : 'off duty'}`); setHasChanges(true) } } finally { setBusy(b => ({ ...b, [n]: false })) } }
   const runSkill = async (n: string, v?: string, sm?: string) => { setBusy(b => ({ ...b, [`r-${n}`]: true })); try { const r = await fetch(`/api/skills/${n}/run`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ var: v || '', model: sm || model }) }); if (r.ok) { flash(`${displayName(n)} started`); for (const d of [2000, 5000, 10000]) setTimeout(refreshRuns, d) } else { const d = await r.json(); flash(d.error || 'Failed') } } finally { setBusy(b => ({ ...b, [`r-${n}`]: false })) } }
@@ -72,6 +78,7 @@ export default function Dashboard() {
   const saveSecret = async (n: string, value: string) => { setBusy(b => ({ ...b, [`sec-${n}`]: true })); try { const r = await fetch('/api/secrets', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: n, value }) }); if (r.ok) { setSecrets(s => { const e = s.some(x => x.name === n); if (e) return s.map(x => x.name === n ? { ...x, isSet: true } : x); return [...s, { name: n, group: 'Skill Keys', description: 'Custom', isSet: true }] }); flash(`${n} saved`) } } finally { setBusy(b => ({ ...b, [`sec-${n}`]: false })) } }
   const deleteSecret = async (n: string) => { setBusy(b => ({ ...b, [`sec-${n}`]: true })); try { const r = await fetch('/api/secrets', { method: 'DELETE', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: n }) }); if (r.ok) { setSecrets(s => s.map(x => x.name === n ? { ...x, isSet: false } : x)); flash(`${n} removed`) } } finally { setBusy(b => ({ ...b, [`sec-${n}`]: false })) } }
   const importSkill = async (files: UploadFile[], name?: string) => { const r = await fetch('/api/upload', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ files, name }) }); if (r.ok) { const d = await r.json(); flash(`${displayName(d.name)} hired`); fetchData() } }
+  const saveStrategy = async (content: string) => { setStrategySaving(true); try { const r = await fetch('/api/strategy', { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ content }) }); if (r.ok) { setStrategy(content); flash('Strategy saved'); setHasChanges(true) } else { flash('Save failed') } } finally { setStrategySaving(false) } }
 
   // --- Derived ---
   const skill = selectedSkill ? skills.find(s => s.name === selectedSkill) || null : null
@@ -105,7 +112,10 @@ export default function Dashboard() {
 
         <div className="flex-1 overflow-y-auto p-[var(--space-lg)]">
           {view === 'secrets' && !selectedSkill && (
-            <SecretsPanel secrets={secrets} busy={busy} onSave={saveSecret} onDelete={deleteSecret} />
+            <SecretsPanel secrets={secrets} busy={busy} repo={repo} onSave={saveSecret} onDelete={deleteSecret} />
+          )}
+          {view === 'strategy' && !selectedSkill && (
+            <StrategyPanel content={strategy} loading={!strategyLoaded} saving={strategySaving} onSave={saveStrategy} />
           )}
           {view === 'hq' && !selectedSkill && (
             <HQOverview skills={skills} runs={runs} enabledCount={enabledCount} workingCount={workingCount} onViewRun={() => {}} />

--- a/dashboard/components/InstantModeCard.tsx
+++ b/dashboard/components/InstantModeCard.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import { useState } from 'react'
+
+interface InstantModeCardProps {
+  repo: string
+}
+
+const SET_WEBHOOK_CMD =
+  'curl "https://api.telegram.org/bot<YOUR_BOT_TOKEN>/setWebhook?url=https://<your-worker>.workers.dev&secret_token=<YOUR_WEBHOOK_SECRET>"'
+
+export function InstantModeCard({ repo }: InstantModeCardProps) {
+  const [copied, setCopied] = useState(false)
+  const deployRepo = repo || 'aaronjmars/aeon'
+  const deployUrl = `https://deploy.workers.cloudflare.com/?url=https://github.com/${deployRepo}/tree/main/webhook`
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(SET_WEBHOOK_CMD)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch { /* clipboard blocked — the command is visible to copy manually */ }
+  }
+
+  return (
+    <section className="border-t border-[rgba(250,250,250,0.10)] pt-6">
+      <div className="flex items-center gap-3 mb-4">
+        <span className="font-display text-[13px] tracking-[0.18em] text-aeon-red">⚡ Telegram · Instant mode</span>
+        <span className="flex-1 h-px bg-[rgba(250,250,250,0.10)]" />
+        <span className="text-[10px] font-mono uppercase tracking-[0.18em] text-primary-35">optional · ~1s</span>
+      </div>
+
+      <div className="border border-[rgba(250,250,250,0.10)] p-[var(--space-md)] space-y-5">
+        <p className="text-[13px] text-primary-70 leading-relaxed">
+          By default Aeon polls Telegram every 5 minutes. Deploy a tiny Cloudflare Worker as a webhook and
+          replies arrive in <span className="text-primary-100">~1 second</span> — it relays each message to GitHub{' '}
+          <span className="font-mono text-primary-100">repository_dispatch</span>. It runs in your own Cloudflare
+          account; there&apos;s no shared infrastructure.
+        </p>
+
+        {/* 1 — deploy */}
+        <div>
+          <div className="text-[10px] font-mono uppercase tracking-[0.18em] text-primary-40 mb-2">1 · Deploy the Worker</div>
+          <a href={deployUrl} target="_blank" rel="noopener noreferrer" className="inline-block">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src="https://deploy.workers.cloudflare.com/button" alt="Deploy to Cloudflare" height={32} />
+          </a>
+          <p className="text-[11px] text-primary-35 font-mono mt-2">
+            Deploys <span className="text-primary-70">{deployRepo}/webhook</span> · requires a public repo.
+          </p>
+        </div>
+
+        {/* 2 — secrets */}
+        <div>
+          <div className="text-[10px] font-mono uppercase tracking-[0.18em] text-primary-40 mb-2">2 · Set the Worker&apos;s secrets (in Cloudflare)</div>
+          <ul className="text-[12px] font-mono text-primary-70 space-y-1">
+            <li><span className="text-primary-100">TELEGRAM_BOT_TOKEN</span> · <span className="text-primary-100">TELEGRAM_CHAT_ID</span></li>
+            <li><span className="text-primary-100">GITHUB_REPO</span> = {deployRepo} · <span className="text-primary-100">GITHUB_TOKEN</span> <span className="text-primary-35">(repo scope)</span></li>
+            <li><span className="text-primary-100">TELEGRAM_WEBHOOK_SECRET</span> <span className="text-primary-35">— optional, recommended</span></li>
+          </ul>
+          <p className="text-[11px] text-primary-35 mt-2 leading-relaxed">
+            These live in the Cloudflare dashboard (Workers &amp; Pages → your worker → Settings → Variables).
+            They&apos;re separate from the GitHub secrets above — the dashboard can&apos;t set them for you.
+          </p>
+        </div>
+
+        {/* 3 — register */}
+        <div>
+          <div className="text-[10px] font-mono uppercase tracking-[0.18em] text-primary-40 mb-2">3 · Point Telegram at the Worker</div>
+          <div className="flex items-start gap-2">
+            <code className="flex-1 bg-aeon-bg text-primary-70 text-[11px] px-3 py-2 border border-[rgba(250,250,250,0.10)] font-mono break-all">
+              {SET_WEBHOOK_CMD}
+            </code>
+            <button onClick={copy}
+              className="text-[11px] text-primary-40 font-mono hover:text-eva-orange transition-colors px-2 py-2 shrink-0">
+              {copied ? 'copied' : 'copy'}
+            </button>
+          </div>
+        </div>
+
+        <p className="text-[11px] text-primary-40 leading-relaxed">
+          Once the webhook is live, the poller detects it (<span className="font-mono">getWebhookInfo</span>) and
+          skips Telegram automatically — no double-processing. Full guide:{' '}
+          <span className="font-mono text-primary-70">webhook/README.md</span>.
+        </p>
+      </div>
+    </section>
+  )
+}

--- a/dashboard/components/LeftSidebar.tsx
+++ b/dashboard/components/LeftSidebar.tsx
@@ -6,8 +6,8 @@ import { DEPARTMENTS } from '../lib/constants'
 import { displayName, initials, getSkillStatus, statusDot } from '../lib/utils'
 
 interface LeftSidebarProps {
-  view: 'hq' | 'secrets'
-  setView: (v: 'hq' | 'secrets') => void
+  view: 'hq' | 'secrets' | 'strategy'
+  setView: (v: 'hq' | 'secrets' | 'strategy') => void
   selectedSkill: string | null
   setSelectedSkill: (s: string | null) => void
   skills: Skill[]
@@ -46,9 +46,10 @@ export function LeftSidebar({ view, setView, selectedSkill, skills, runs, repo, 
       <div className="px-2 py-2 border-b border-[rgba(250,250,250,0.10)] space-y-0.5">
         {[
           { id: 'hq', label: 'HQ', icon: 'M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6a2.25 2.25 0 01-2.25-2.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25a2.25 2.25 0 01-2.25-2.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25a2.25 2.25 0 01-2.25-2.25v-2.25z' },
+          { id: 'strategy', label: 'Strategy', icon: 'M3 3v1.5M3 21v-6m0 0l2.77-.693a9 9 0 016.208.682l.108.054a9 9 0 006.086.71l3.114-.732a48.524 48.524 0 01-.005-10.499l-3.11.732a9 9 0 01-6.085-.711l-.108-.054a9 9 0 00-6.208-.682L3 4.5M3 15V4.5' },
           { id: 'secrets', label: 'Settings', icon: 'M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.324.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.24-.438.613-.431.992a6.759 6.759 0 010 .255c-.007.378.138.75.43.99l1.005.828c.424.35.534.954.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.57 6.57 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.28c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.02-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.431l1.004-.827c.292-.24.437-.613.43-.992a6.932 6.932 0 010-.255c.007-.378-.138-.75-.43-.99l-1.004-.828a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.087.22-.128.332-.183.582-.495.644-.869l.214-1.281z' },
         ].map(item => (
-          <button key={item.id} onClick={() => { setView(item.id as 'hq' | 'secrets'); }}
+          <button key={item.id} onClick={() => { setView(item.id as 'hq' | 'secrets' | 'strategy'); }}
             className={`w-full flex items-center gap-2.5 px-3 py-2 text-xs font-mono uppercase tracking-[0.14em] transition-all ${view === item.id && !selectedSkill ? 'bg-aeon-bg text-aeon-fg border-l-2 border-aeon-red pl-[10px]' : 'text-primary-50 hover:text-primary-100 hover:bg-aeon-bg'}`}>
             <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}><path strokeLinecap="round" strokeLinejoin="round" d={item.icon} /></svg>
             {item.label}

--- a/dashboard/components/SecretsPanel.tsx
+++ b/dashboard/components/SecretsPanel.tsx
@@ -1,18 +1,20 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, Fragment } from 'react'
 import type { Secret } from '../lib/types'
 import { inputCls } from '../lib/utils'
 import { Scramble } from './ui/Animated'
+import { InstantModeCard } from './InstantModeCard'
 
 interface SecretsPanelProps {
   secrets: Secret[]
   busy: Record<string, boolean>
+  repo: string
   onSave: (name: string, value: string) => void
   onDelete: (name: string) => void
 }
 
-export function SecretsPanel({ secrets, busy, onSave, onDelete }: SecretsPanelProps) {
+export function SecretsPanel({ secrets, busy, repo, onSave, onDelete }: SecretsPanelProps) {
   const [editingSecret, setEditingSecret] = useState<string | null>(null)
   const [secretValue, setSecretValue] = useState('')
   const [addingSecret, setAddingSecret] = useState(false)
@@ -50,7 +52,8 @@ export function SecretsPanel({ secrets, busy, onSave, onDelete }: SecretsPanelPr
       {['Core', 'Telegram', 'Discord', 'Slack', 'Email', 'Skill Keys'].map((group, gi) => {
         const gs = secrets.filter(s => s.group === group); if (!gs.length) return null
         return (
-          <section key={group} className="border-t border-[rgba(250,250,250,0.10)] pt-6">
+          <Fragment key={group}>
+          <section className="border-t border-[rgba(250,250,250,0.10)] pt-6">
             <div className="flex items-center gap-3 mb-4">
               <span className="font-display text-[13px] tracking-[0.18em] text-aeon-red">
                 {String(gi + 1).padStart(2, '0')} / {group}
@@ -84,6 +87,8 @@ export function SecretsPanel({ secrets, busy, onSave, onDelete }: SecretsPanelPr
               ))}
             </div>
           </section>
+          {group === 'Telegram' && <InstantModeCard repo={repo} />}
+          </Fragment>
         )
       })}
       <div>{addingSecret ? (<div className="space-y-2"><input type="text" value={newSecretName} onChange={(e) => setNewSecretName(e.target.value.toUpperCase().replace(/[^A-Z0-9_]/g, ''))} placeholder="SECRET_NAME" autoFocus className={inputCls} />{newSecretName && <div className="flex gap-2"><input type="password" value={secretValue} onChange={(e) => setSecretValue(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && handleSave(newSecretName)} placeholder="value..." className={inputCls} /><button onClick={() => handleSave(newSecretName)} disabled={!secretValue.trim()} className="bg-eva-green text-white text-[11px] px-4 py-2 font-mono hover:opacity-90 disabled:opacity-50">Save</button></div>}<button onClick={() => { setAddingSecret(false); setNewSecretName(''); setSecretValue('') }} className="text-[11px] text-primary-40 font-mono hover:text-primary-70">Cancel</button></div>) : <button onClick={() => setAddingSecret(true)} className="text-[11px] text-primary-40 font-mono hover:text-eva-orange transition-colors">+ Add Credential</button>}</div>

--- a/dashboard/components/StrategyPanel.tsx
+++ b/dashboard/components/StrategyPanel.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { Scramble } from './ui/Animated'
+
+interface StrategyPanelProps {
+  content: string
+  loading: boolean
+  saving: boolean
+  onSave: (content: string) => void
+}
+
+// It's imported into CLAUDE.md and rides along in every skill run, so flag when
+// it's getting long enough to cost real tokens each time.
+const SOFT_LIMIT = 2500
+
+export function StrategyPanel({ content, loading, saving, onSave }: StrategyPanelProps) {
+  const [draft, setDraft] = useState(content)
+  useEffect(() => { setDraft(content) }, [content])
+
+  const dirty = draft !== content
+  const chars = draft.length
+  const overLimit = chars > SOFT_LIMIT
+  const unconfigured = /^> \*\*Status:\*\* unconfigured defaults/m.test(draft)
+
+  return (
+    <div className="max-w-5xl mx-auto pb-16 space-y-8">
+      <section className="relative overflow-hidden border border-[rgba(250,250,250,0.10)] bg-aeon-panel">
+        <div className="dither" aria-hidden="true" />
+        <div className="relative z-10 px-8 pt-10 pb-8">
+          <span className="text-[11px] font-mono uppercase tracking-[0.28em] text-aeon-red inline-flex items-center gap-3">
+            <span className="w-7 h-px bg-aeon-red" />
+            Direction · North Star
+          </span>
+          <h1 className="mt-4 font-display uppercase leading-[0.92] tracking-tight text-aeon-fg"
+              style={{ fontSize: 'clamp(40px, 6.5vw, 88px)' }}>
+            <Scramble text="STRA" />
+            <span className="text-aeon-red"><Scramble text="TEGY" delay={160} /></span>
+          </h1>
+          <p className="mt-4 max-w-xl text-sm text-primary-70 leading-relaxed">
+            One file every skill reads. It&apos;s imported into{' '}
+            <span className="font-mono text-primary-100">CLAUDE.md</span>, so it sits in the context of
+            every run — keep it tight: a north-star, a few priorities, the hard constraints.
+          </p>
+        </div>
+      </section>
+
+      <section className="border-t border-[rgba(250,250,250,0.10)] pt-6">
+        <div className="flex items-center gap-3 mb-4">
+          <span className="font-display text-[13px] tracking-[0.18em] text-aeon-red">01 / STRATEGY.md</span>
+          <span className="flex-1 h-px bg-[rgba(250,250,250,0.10)]" />
+          {unconfigured
+            ? <span className="text-[10px] font-mono uppercase tracking-[0.18em] text-eva-orange">template defaults</span>
+            : <span className="text-[10px] font-mono uppercase tracking-[0.18em] text-eva-green">customized</span>}
+        </div>
+
+        {loading ? (
+          <div className="text-xs font-mono text-primary-40 py-8">Loading…</div>
+        ) : (
+          <>
+            <textarea
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              spellCheck={false}
+              rows={24}
+              placeholder={'# Strategy\n\n## North-star metric\n…'}
+              className="w-full bg-aeon-bg text-aeon-fg text-[13px] leading-relaxed px-4 py-3 border border-[rgba(250,250,250,0.10)] outline-none font-mono focus:border-aeon-red transition-colors resize-y"
+            />
+            <div className="flex items-center justify-between mt-3">
+              <span className={`text-[11px] font-mono ${overLimit ? 'text-eva-orange' : 'text-primary-35'}`}>
+                {chars} chars{overLimit ? ` · over ~${SOFT_LIMIT}, trim it — this loads every run` : ''}
+              </span>
+              <div className="flex items-center gap-2">
+                {dirty && (
+                  <button onClick={() => setDraft(content)}
+                    className="text-[11px] text-primary-40 font-mono px-2 py-2 hover:text-primary-70 transition-colors">
+                    Revert
+                  </button>
+                )}
+                <button onClick={() => onSave(draft)} disabled={!dirty || saving}
+                  className="bg-eva-green text-white text-[11px] px-4 py-2 font-mono hover:opacity-90 transition-opacity disabled:opacity-40">
+                  {saving ? 'Saving…' : 'Save'}
+                </button>
+              </div>
+            </div>
+            <p className="mt-3 text-[11px] text-primary-35 font-mono">
+              Save writes STRATEGY.md — then hit <span className="text-primary-70">Push</span> in the top bar to commit it to GitHub.
+            </p>
+          </>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/dashboard/components/TopBar.tsx
+++ b/dashboard/components/TopBar.tsx
@@ -4,7 +4,7 @@ import { displayName } from '../lib/utils'
 
 interface TopBarProps {
   skill: Skill | null
-  view: 'hq' | 'secrets'
+  view: 'hq' | 'secrets' | 'strategy'
   repo: string
   model: string
   gateway: GatewayProvider
@@ -29,7 +29,7 @@ export function TopBar({ skill, view, repo, model, gateway, authStatus, authLoad
     <div className="h-14 border-b border-[rgba(250,250,250,0.10)] flex items-center justify-between px-5 shrink-0 bg-aeon-bg">
       <div className="flex items-center gap-3">
         <span className="font-display text-lg uppercase tracking-wide text-aeon-fg">
-          {skill ? displayName(skill.name) : view === 'secrets' ? 'Settings' : `${repo ? repo.split('/').pop() : 'Aeon'} HQ`}
+          {skill ? displayName(skill.name) : view === 'secrets' ? 'Settings' : view === 'strategy' ? 'Strategy' : `${repo ? repo.split('/').pop() : 'Aeon'} HQ`}
         </span>
         {skill && dept && (
           <span


### PR DESCRIPTION
## What

The frontend half of the two roadmap items — pairs with #370 (STRATEGY.md) and #368 (webhook). Adds two things to the dashboard, placed per the chosen IA: **Strategy as its own nav page**, and the **Cloudflare/instant-mode guide inside Settings, next to Telegram**.

### 1. Strategy editor (new "Strategy" nav item)
- `GET/PUT /api/strategy` reads/writes `STRATEGY.md` through the existing `github.ts` helpers (local FS or GitHub API). PUT uses the current sha to update, or creates the file if missing — so the editor **bootstraps `STRATEGY.md`** on first save.
- `StrategyPanel.tsx`: a textarea editor matching the EVA panel style, with a customized-vs-`template defaults` indicator and a **soft length warning** past ~2500 chars (it's imported into `CLAUDE.md` and rides in context on every run).
- Save writes the file and flips `hasChanges`, so the existing **Push** button commits it — no new commit path.

### 2. Telegram instant-mode guide (inside Settings → under Telegram)
- `InstantModeCard.tsx`: explains the ~1s webhook path and walks through it — a **Deploy to Cloudflare** button **prefilled with the fork's repo**, the list of Worker secrets to set *in Cloudflare*, and a copy-able `setWebhook` command.
- It's a **guided** setup by necessity: the dashboard can't set Cloudflare-side secrets (they're not GitHub secrets) and can't read the bot token back to fully pre-fill the command. That constraint is stated in the UI rather than hidden behind a fake one-click.
- Notes that the poller auto-skips Telegram via `getWebhookInfo` once the webhook is live (the behaviour added in #369), and points to `webhook/README.md`.

## Wiring

Extended the `view` union (`'hq' | 'secrets' | 'strategy'`) across `page.tsx`, `LeftSidebar`, `TopBar`; lazy-loads the strategy file only when the page is opened; passes `repo` into `SecretsPanel` for the deploy URL. `/api/strategy` is covered by the global `/api/*` middleware gate — no new auth surface.

## Verification

- `tsc --noEmit` clean
- `npm test` → **99/99 pass**
- `next build` green; `/api/strategy` route registered, middleware present

## Depends on / pairs with

- **#370** — adds `STRATEGY.md` + the `@STRATEGY.md` import. The editor works before it merges (it bootstraps the file), but the *"every skill reads it"* effect comes from #370.
- **#368** — the `webhook/` package the guide deploys. The card renders regardless; the deploy button needs `webhook/` on the public repo to actually deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)