### PR TITLE
feat: let skills use MCP servers during runs (#3)

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -458,6 +458,28 @@ jobs:
           ALLOWED="$ALLOWED,Bash(date:*),Bash(echo:*),Bash(node:*),Bash(npm:*),Bash(npx:*)"
           ALLOWED="$ALLOWED,Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(sort:*),Bash(grep:*)"
 
+          # MCP (opt-in): when a project .mcp.json exists, load it for this run
+          # and allow each server's tools. No-op when the file is absent, so
+          # existing forks are unaffected. If the config references an env var
+          # that is unset and has no ":-" default, skip MCP with a warning rather
+          # than let Claude's config parse-failure break the whole skill run.
+          MCP_FLAGS=()
+          if [ -f .mcp.json ] && jq -e '.mcpServers' .mcp.json >/dev/null 2>&1; then
+            MCP_MISSING=""
+            for v in $(grep -oE '\$\{[A-Z_][A-Z0-9_]*\}' .mcp.json | sed -E 's/[${}]//g' | sort -u); do
+              [ -z "${!v:-}" ] && MCP_MISSING="$MCP_MISSING $v"
+            done
+            if [ -n "$MCP_MISSING" ]; then
+              echo "::warning::.mcp.json references unset env:${MCP_MISSING} — skipping MCP this run (set the secret(s) and map them into this workflow's env)"
+            else
+              for srv in $(jq -r '.mcpServers | keys[]' .mcp.json); do
+                ALLOWED="$ALLOWED,mcp__${srv}"
+              done
+              MCP_FLAGS=(--mcp-config .mcp.json --strict-mcp-config)
+              echo "MCP enabled: $(jq -r '.mcpServers | keys | join(", ")' .mcp.json)"
+            fi
+          fi
+
           SKILL_NAME="${{ steps.skill.outputs.name }}"
           VAR="$SKILL_VAR"
 
@@ -483,7 +505,7 @@ jobs:
           fi
           if ! CLAUDE_OUTPUT=$(echo "$PROMPT" | claude -p - \
             --model "$MODEL" --allowedTools "$ALLOWED" \
-            --output-format json 2>&1); then
+            "${MCP_FLAGS[@]}" --output-format json 2>&1); then
             echo "::error::Claude CLI failed. Output: $CLAUDE_OUTPUT"
             # Save error signature for quality tracking (cron-state step reads this)
             echo "$CLAUDE_OUTPUT" | tail -c 500 | tr '\n' ' ' | cut -c1-200 > /tmp/skill-error.txt

--- a/.github/workflows/messages.yml
+++ b/.github/workflows/messages.yml
@@ -672,6 +672,27 @@ jobs:
           ALLOWED="$ALLOWED,Bash(date:*),Bash(echo:*),Bash(node:*),Bash(npm:*),Bash(npx:*)"
           ALLOWED="$ALLOWED,Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(sort:*),Bash(grep:*)"
 
+          # MCP (opt-in): when a project .mcp.json exists, load it for this run
+          # and allow each server's tools. No-op when the file is absent. If the
+          # config references an env var that is unset and has no ":-" default,
+          # skip MCP with a warning rather than break the run on a parse failure.
+          MCP_FLAGS=()
+          if [ -f .mcp.json ] && jq -e '.mcpServers' .mcp.json >/dev/null 2>&1; then
+            MCP_MISSING=""
+            for v in $(grep -oE '\$\{[A-Z_][A-Z0-9_]*\}' .mcp.json | sed -E 's/[${}]//g' | sort -u); do
+              [ -z "${!v:-}" ] && MCP_MISSING="$MCP_MISSING $v"
+            done
+            if [ -n "$MCP_MISSING" ]; then
+              echo "::warning::.mcp.json references unset env:${MCP_MISSING} — skipping MCP this run"
+            else
+              for srv in $(jq -r '.mcpServers | keys[]' .mcp.json); do
+                ALLOWED="$ALLOWED,mcp__${srv}"
+              done
+              MCP_FLAGS=(--mcp-config .mcp.json --strict-mcp-config)
+              echo "MCP enabled: $(jq -r '.mcpServers | keys | join(", ")' .mcp.json)"
+            fi
+          fi
+
           SOURCE="$_MSG_SOURCE"
           MESSAGE="$_MSG_MESSAGE"
           PROMPT="Today is $TODAY. You received this message from the user on ${SOURCE}:
@@ -689,7 +710,7 @@ jobs:
           Always send your response back via ./notify so the user sees it."
           if ! CLAUDE_OUTPUT=$(echo "$PROMPT" | claude -p - \
             --model "$MODEL" --allowedTools "$ALLOWED" \
-            --output-format json 2>&1); then
+            "${MCP_FLAGS[@]}" --output-format json 2>&1); then
             echo "::error::Claude CLI failed. Output: $CLAUDE_OUTPUT"
             exit 1
           fi

--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "headers": {
+        "Authorization": "Bearer ${GITHUB_TOKEN}"
+      }
+    },
+    "sequential-thinking": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -548,6 +548,75 @@ Start with [`examples/README.md`](examples/README.md) for the full setup walk-th
 
 ---
 
+## MCP servers in skill runs
+
+The section above exposes Aeon skills *as* MCP tools. This is the other direction: letting your skills **call** MCP servers (GitHub, a database, a paid API, your own) while they run in GitHub Actions.
+
+It's **opt-in and safe** — nothing changes until you add a `.mcp.json` at the repo root. With no file, runs are byte-identical to before.
+
+### Quick start
+
+```bash
+cp .mcp.json.example .mcp.json   # then edit, commit, push
+```
+
+The example ships two working servers:
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "headers": { "Authorization": "Bearer ${GITHUB_TOKEN}" }
+    },
+    "sequential-thinking": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+    }
+  }
+}
+```
+
+- **`github`** works out of the box — `GITHUB_TOKEN` is already in the runner's environment.
+- **`sequential-thinking`** is a no-auth stdio server — nothing to configure.
+
+On the next run, the runner loads `.mcp.json` (`--mcp-config .mcp.json --strict-mcp-config`) and auto-allows every server's tools (`mcp__github`, `mcp__sequential-thinking`, …). A skill can then just say *"use the github MCP server to …"*.
+
+Or add servers from the dashboard: the **MCP** tab writes `.mcp.json` for you and tells you which secret each server needs.
+
+### Servers that need a secret
+
+Reference secrets with `${VAR}` — **never commit the value**:
+
+```json
+"acme": {
+  "type": "http",
+  "url": "https://mcp.acme.dev/v1",
+  "headers": { "Authorization": "Bearer ${ACME_API_KEY}" }
+}
+```
+
+Then make `ACME_API_KEY` reachable in the run:
+
+1. Add it as a repo **secret** (dashboard → Settings → Add Credential, or `gh secret set ACME_API_KEY`).
+2. **Map it into the workflow env** so the runner can expand it — add one line under the `Run` step's `env:` in `.github/workflows/aeon.yml` (and `messages.yml` if you use it from chat):
+   ```yaml
+   ACME_API_KEY: ${{ secrets.ACME_API_KEY }}
+   ```
+   (Secrets already mapped — `GITHUB_TOKEN`, `XAI_API_KEY`, `ALCHEMY_API_KEY`, `COINGECKO_API_KEY`, `NEYNAR_*`, … — need no extra wiring.)
+
+**Safety valve:** if a `.mcp.json` references a `${VAR}` that is unset (and has no `${VAR:-default}` fallback), the runner **skips MCP for that run and logs a warning** instead of letting the config parse-failure break the skill. Set the secret, and the next run picks it up.
+
+### Notes
+
+- **Scope is global** — `.mcp.json` applies to every skill. Per-skill scoping isn't supported yet.
+- **Tool visibility:** add `"alwaysLoad": true` to a server entry to force its tools into context every run (otherwise they load on demand via tool search).
+- **Sandbox:** stdio servers run as local processes in the runner (`npx`/`node`/`python` are available); HTTP/SSE servers are reached over the network. No prefetch/postprocess pattern is needed — Claude Code manages the MCP connection itself.
+
+---
+
 ## Fleet Watcher (optional authorization layer)
 
 Add inline ALLOW/BLOCK authorization in front of every skill run. Each skill workflow asks your self-hosted [Fleet Watcher](https://github.com/yourorg/fleet-watcher) control plane *"is this allowed?"* before Claude starts, and reports the outcome after Claude finishes. BLOCK = workflow exits non-zero, Claude never runs, no side-effects, audit ref recorded.

--- a/dashboard/app/api/mcp/route.ts
+++ b/dashboard/app/api/mcp/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from 'next/server'
+import { getFileContent, updateFile, createFile } from '@/lib/github'
+
+const FILE = '.mcp.json'
+
+type McpServers = Record<string, unknown>
+
+export async function GET() {
+  try {
+    const { content, sha } = await getFileContent(FILE)
+    let servers: McpServers = {}
+    try {
+      const parsed = JSON.parse(content) as { mcpServers?: McpServers }
+      servers = parsed.mcpServers ?? {}
+    } catch {
+      // Malformed JSON — return raw so the operator can see/fix it.
+    }
+    return NextResponse.json({ exists: true, servers, sha, raw: content })
+  } catch {
+    return NextResponse.json({ exists: false, servers: {}, sha: '', raw: '' })
+  }
+}
+
+export async function PUT(request: Request) {
+  try {
+    const body = (await request.json()) as { servers?: McpServers }
+    if (!body.servers || typeof body.servers !== 'object' || Array.isArray(body.servers)) {
+      return NextResponse.json({ error: 'servers (object) required' }, { status: 400 })
+    }
+    const content = JSON.stringify({ mcpServers: body.servers }, null, 2) + '\n'
+    let sha = ''
+    try {
+      sha = (await getFileContent(FILE)).sha
+    } catch {
+      // new file
+    }
+    if (sha) {
+      await updateFile(FILE, content, sha, 'chore: update .mcp.json from dashboard')
+    } else {
+      await createFile(FILE, content, 'chore: add .mcp.json from dashboard')
+    }
+    return NextResponse.json({ ok: true })
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : 'Unknown error'
+    return NextResponse.json({ error: msg }, { status: 500 })
+  }
+}

--- a/dashboard/app/page.tsx
+++ b/dashboard/app/page.tsx
@@ -12,12 +12,13 @@ import { TopBar } from '../components/TopBar'
 import { HQOverview } from '../components/HQOverview'
 import { SkillDetail } from '../components/SkillDetail'
 import { SecretsPanel } from '../components/SecretsPanel'
+import { McpPanel } from '../components/McpPanel'
 import { RightPanel } from '../components/RightPanel'
 import { ImportModal } from '../components/ImportModal'
 import { AuthModal } from '../components/AuthModal'
 
 export default function Dashboard() {
-  const [view, setView] = useState<'hq' | 'secrets'>('hq')
+  const [view, setView] = useState<'hq' | 'secrets' | 'mcp'>('hq')
   const [selectedSkill, setSelectedSkill] = useState<string | null>(null)
 
   const [skills, setSkills] = useState<Skill[]>([])
@@ -46,6 +47,10 @@ export default function Dashboard() {
   const [authLoading, setAuthLoading] = useState(false)
   const [showAuthModal, setShowAuthModal] = useState(false)
 
+  const [mcpServers, setMcpServers] = useState<Record<string, Record<string, unknown>>>({})
+  const [mcpLoaded, setMcpLoaded] = useState(false)
+  const [mcpSaving, setMcpSaving] = useState(false)
+
   const flash = (msg: string) => { setToast(msg); setTimeout(() => setToast(''), 3000) }
 
   // --- API ---
@@ -58,6 +63,7 @@ export default function Dashboard() {
   useEffect(() => { fetchData() }, [fetchData])
   useEffect(() => { const id = setInterval(refreshRuns, 10_000); return () => clearInterval(id) }, [refreshRuns])
   useEffect(() => { setFeedLoading(true); fetch('/api/outputs').then(r => r.ok ? r.json() : { outputs: [] }).then(d => setOutputs(d.outputs || [])).finally(() => setFeedLoading(false)) }, [feedKey])
+  useEffect(() => { if (view === 'mcp' && !mcpLoaded) { fetch('/api/mcp').then(r => r.ok ? r.json() : null).then(d => { if (d) { setMcpServers(d.servers || {}); setMcpLoaded(true) } }).catch(() => {}) } }, [view, mcpLoaded])
 
   const toggleSkill = async (n: string, en: boolean) => { setBusy(b => ({ ...b, [n]: true })); try { const r = await fetch('/api/skills', { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: n, enabled: en }) }); if (r.ok) { setSkills(s => s.map(sk => sk.name === n ? { ...sk, enabled: en } : sk)); flash(`${displayName(n)} ${en ? 'on duty' : 'off duty'}`); setHasChanges(true) } } finally { setBusy(b => ({ ...b, [n]: false })) } }
   const runSkill = async (n: string, v?: string, sm?: string) => { setBusy(b => ({ ...b, [`r-${n}`]: true })); try { const r = await fetch(`/api/skills/${n}/run`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ var: v || '', model: sm || model }) }); if (r.ok) { flash(`${displayName(n)} started`); for (const d of [2000, 5000, 10000]) setTimeout(refreshRuns, d) } else { const d = await r.json(); flash(d.error || 'Failed') } } finally { setBusy(b => ({ ...b, [`r-${n}`]: false })) } }
@@ -72,6 +78,7 @@ export default function Dashboard() {
   const saveSecret = async (n: string, value: string) => { setBusy(b => ({ ...b, [`sec-${n}`]: true })); try { const r = await fetch('/api/secrets', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: n, value }) }); if (r.ok) { setSecrets(s => { const e = s.some(x => x.name === n); if (e) return s.map(x => x.name === n ? { ...x, isSet: true } : x); return [...s, { name: n, group: 'Skill Keys', description: 'Custom', isSet: true }] }); flash(`${n} saved`) } } finally { setBusy(b => ({ ...b, [`sec-${n}`]: false })) } }
   const deleteSecret = async (n: string) => { setBusy(b => ({ ...b, [`sec-${n}`]: true })); try { const r = await fetch('/api/secrets', { method: 'DELETE', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: n }) }); if (r.ok) { setSecrets(s => s.map(x => x.name === n ? { ...x, isSet: false } : x)); flash(`${n} removed`) } } finally { setBusy(b => ({ ...b, [`sec-${n}`]: false })) } }
   const importSkill = async (files: UploadFile[], name?: string) => { const r = await fetch('/api/upload', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ files, name }) }); if (r.ok) { const d = await r.json(); flash(`${displayName(d.name)} hired`); fetchData() } }
+  const saveMcp = async (servers: Record<string, Record<string, unknown>>) => { setMcpSaving(true); try { const r = await fetch('/api/mcp', { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ servers }) }); if (r.ok) { setMcpServers(servers); flash('MCP servers saved'); setHasChanges(true) } else { flash('Save failed') } } finally { setMcpSaving(false) } }
 
   // --- Derived ---
   const skill = selectedSkill ? skills.find(s => s.name === selectedSkill) || null : null
@@ -106,6 +113,9 @@ export default function Dashboard() {
         <div className="flex-1 overflow-y-auto p-[var(--space-lg)]">
           {view === 'secrets' && !selectedSkill && (
             <SecretsPanel secrets={secrets} busy={busy} onSave={saveSecret} onDelete={deleteSecret} />
+          )}
+          {view === 'mcp' && !selectedSkill && (
+            <McpPanel servers={mcpServers} loading={!mcpLoaded} saving={mcpSaving} onSave={saveMcp} />
           )}
           {view === 'hq' && !selectedSkill && (
             <HQOverview skills={skills} runs={runs} enabledCount={enabledCount} workingCount={workingCount} onViewRun={() => {}} />

--- a/dashboard/components/LeftSidebar.tsx
+++ b/dashboard/components/LeftSidebar.tsx
@@ -6,8 +6,8 @@ import { DEPARTMENTS } from '../lib/constants'
 import { displayName, initials, getSkillStatus, statusDot } from '../lib/utils'
 
 interface LeftSidebarProps {
-  view: 'hq' | 'secrets'
-  setView: (v: 'hq' | 'secrets') => void
+  view: 'hq' | 'secrets' | 'mcp'
+  setView: (v: 'hq' | 'secrets' | 'mcp') => void
   selectedSkill: string | null
   setSelectedSkill: (s: string | null) => void
   skills: Skill[]
@@ -47,8 +47,9 @@ export function LeftSidebar({ view, setView, selectedSkill, skills, runs, repo, 
         {[
           { id: 'hq', label: 'HQ', icon: 'M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6a2.25 2.25 0 01-2.25-2.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25a2.25 2.25 0 01-2.25-2.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25a2.25 2.25 0 01-2.25-2.25v-2.25z' },
           { id: 'secrets', label: 'Settings', icon: 'M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.324.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.24-.438.613-.431.992a6.759 6.759 0 010 .255c-.007.378.138.75.43.99l1.005.828c.424.35.534.954.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.57 6.57 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.28c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.02-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.431l1.004-.827c.292-.24.437-.613.43-.992a6.932 6.932 0 010-.255c.007-.378-.138-.75-.43-.99l-1.004-.828a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.087.22-.128.332-.183.582-.495.644-.869l.214-1.281z' },
+          { id: 'mcp', label: 'MCP', icon: 'M5.25 14.25h13.5m-13.5 0a3 3 0 01-3-3m3 3a3 3 0 100 6h13.5a3 3 0 100-6m-16.5-3a3 3 0 013-3h13.5a3 3 0 013 3m-19.5 0a4.5 4.5 0 01.9-2.7L5.737 5.1a3.375 3.375 0 012.7-1.35h7.126c1.062 0 2.062.5 2.7 1.35l2.587 3.45a4.5 4.5 0 01.9 2.7m0 0a3 3 0 01-3 3m0 3h.008v.008h-.008v-.008zm0-6h.008v.008h-.008v-.008zm-3 6h.008v.008h-.008v-.008zm0-6h.008v.008h-.008v-.008z' },
         ].map(item => (
-          <button key={item.id} onClick={() => { setView(item.id as 'hq' | 'secrets'); }}
+          <button key={item.id} onClick={() => { setView(item.id as 'hq' | 'secrets' | 'mcp'); }}
             className={`w-full flex items-center gap-2.5 px-3 py-2 text-xs font-mono uppercase tracking-[0.14em] transition-all ${view === item.id && !selectedSkill ? 'bg-aeon-bg text-aeon-fg border-l-2 border-aeon-red pl-[10px]' : 'text-primary-50 hover:text-primary-100 hover:bg-aeon-bg'}`}>
             <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}><path strokeLinecap="round" strokeLinejoin="round" d={item.icon} /></svg>
             {item.label}

--- a/dashboard/components/McpPanel.tsx
+++ b/dashboard/components/McpPanel.tsx
@@ -1,0 +1,200 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { Scramble } from './ui/Animated'
+import { inputCls } from '../lib/utils'
+
+type McpServer = Record<string, unknown>
+type McpServers = Record<string, McpServer>
+
+interface McpPanelProps {
+  servers: McpServers
+  loading: boolean
+  saving: boolean
+  onSave: (servers: McpServers) => void
+}
+
+// The ${VAR} secret references a server needs at runtime.
+function refsOf(server: McpServer): string[] {
+  const out = new Set<string>()
+  const re = /\$\{([A-Z_][A-Z0-9_]*)\}/g
+  let m: RegExpExecArray | null
+  while ((m = re.exec(JSON.stringify(server)))) out.add(m[1])
+  return [...out]
+}
+
+function describe(server: McpServer): string {
+  if (typeof server.url === 'string') return server.url
+  if (typeof server.command === 'string') {
+    const args = Array.isArray(server.args) ? ' ' + (server.args as string[]).join(' ') : ''
+    return server.command + args
+  }
+  return '—'
+}
+
+function transportOf(server: McpServer): string {
+  if (typeof server.type === 'string') return server.type
+  return typeof server.command === 'string' ? 'stdio' : 'http'
+}
+
+export function McpPanel({ servers, loading, saving, onSave }: McpPanelProps) {
+  const [draft, setDraft] = useState<McpServers>(servers)
+  useEffect(() => { setDraft(servers) }, [servers])
+
+  const [adding, setAdding] = useState(false)
+  const [name, setName] = useState('')
+  const [transport, setTransport] = useState<'http' | 'stdio'>('http')
+  const [url, setUrl] = useState('')
+  const [secretVar, setSecretVar] = useState('')
+  const [command, setCommand] = useState('npx')
+  const [args, setArgs] = useState('')
+
+  const dirty = JSON.stringify(draft) !== JSON.stringify(servers)
+  const names = Object.keys(draft)
+  const allRefs = [...new Set(names.flatMap(n => refsOf(draft[n])))]
+
+  const resetForm = () => {
+    setAdding(false); setName(''); setUrl(''); setSecretVar(''); setCommand('npx'); setArgs(''); setTransport('http')
+  }
+
+  const addServer = () => {
+    const slug = name.trim().toLowerCase().replace(/[^a-z0-9_-]/g, '-').replace(/^-+|-+$/g, '')
+    if (!slug) return
+    let server: McpServer
+    if (transport === 'http') {
+      if (!url.trim()) return
+      server = { type: 'http', url: url.trim() }
+      if (secretVar.trim()) server.headers = { Authorization: `Bearer \${${secretVar.trim().toUpperCase().replace(/[^A-Z0-9_]/g, '_')}}` }
+    } else {
+      if (!command.trim()) return
+      server = { type: 'stdio', command: command.trim() }
+      if (args.trim()) server.args = args.trim().split(/\s+/)
+    }
+    setDraft({ ...draft, [slug]: server })
+    resetForm()
+  }
+
+  const removeServer = (n: string) => {
+    const next = { ...draft }; delete next[n]; setDraft(next)
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto pb-16 space-y-8">
+      <section className="relative overflow-hidden border border-[rgba(250,250,250,0.10)] bg-aeon-panel">
+        <div className="dither" aria-hidden="true" />
+        <div className="relative z-10 px-8 pt-10 pb-8">
+          <span className="text-[11px] font-mono uppercase tracking-[0.28em] text-aeon-red inline-flex items-center gap-3">
+            <span className="w-7 h-px bg-aeon-red" />
+            Tools · Model Context Protocol
+          </span>
+          <h1 className="mt-4 font-display uppercase leading-[0.92] tracking-tight text-aeon-fg"
+              style={{ fontSize: 'clamp(40px, 6.5vw, 88px)' }}>
+            <Scramble text="MCP" />{' '}
+            <span className="text-aeon-red"><Scramble text="SERVERS" delay={160} /></span>
+          </h1>
+          <p className="mt-4 max-w-xl text-sm text-primary-70 leading-relaxed">
+            Servers your skills can <span className="text-primary-100">call</span> during a run — GitHub, a database,
+            a paid API. Saved to <span className="font-mono text-primary-100">.mcp.json</span> and loaded on every run.
+          </p>
+        </div>
+      </section>
+
+      <section className="border-t border-[rgba(250,250,250,0.10)] pt-6">
+        <div className="flex items-center gap-3 mb-4">
+          <span className="font-display text-[13px] tracking-[0.18em] text-aeon-red">01 / .mcp.json</span>
+          <span className="flex-1 h-px bg-[rgba(250,250,250,0.10)]" />
+          <span className="text-[10px] font-mono uppercase tracking-[0.18em] text-primary-35">{names.length} server{names.length === 1 ? '' : 's'}</span>
+        </div>
+
+        {loading ? (
+          <div className="text-xs font-mono text-primary-40 py-8">Loading…</div>
+        ) : (
+          <>
+            {names.length > 0 ? (
+              <div className="border border-[rgba(250,250,250,0.10)] divide-y divide-[rgba(250,250,250,0.08)]">
+                {names.map(n => {
+                  const s = draft[n]
+                  const refs = refsOf(s)
+                  return (
+                    <div key={n} className="px-[var(--space-md)] py-[var(--space-sm)] flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-2">
+                          <span className="font-mono text-xs text-primary-100">{n}</span>
+                          <span className="text-[9px] font-mono uppercase tracking-[0.14em] text-primary-40 border border-[rgba(250,250,250,0.12)] px-1.5 py-0.5">{transportOf(s)}</span>
+                        </div>
+                        <div className="text-[11px] text-primary-40 font-mono truncate mt-0.5">{describe(s)}</div>
+                        {refs.length > 0 && (
+                          <div className="flex flex-wrap gap-1.5 mt-1.5">
+                            {refs.map(r => (
+                              <span key={r} className="text-[10px] font-mono text-eva-orange border border-eva-orange/30 px-1.5 py-0.5">${'{'}{r}{'}'}</span>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                      <button onClick={() => removeServer(n)} className="text-[11px] text-eva-red/50 hover:text-eva-red font-mono px-2 py-1 transition-colors shrink-0">Remove</button>
+                    </div>
+                  )
+                })}
+              </div>
+            ) : (
+              <div className="text-xs font-mono text-primary-40 py-6 border border-dashed border-[rgba(250,250,250,0.10)] text-center">No servers yet. Add one below.</div>
+            )}
+
+            {/* Add form */}
+            <div className="mt-4">
+              {adding ? (
+                <div className="border border-[rgba(250,250,250,0.10)] p-[var(--space-md)] space-y-3">
+                  <div className="flex gap-2">
+                    <input value={name} onChange={e => setName(e.target.value)} placeholder="server name (e.g. github)" autoFocus className={inputCls} />
+                    <div className="flex shrink-0 border border-[rgba(250,250,250,0.10)]">
+                      {(['http', 'stdio'] as const).map(t => (
+                        <button key={t} onClick={() => setTransport(t)}
+                          className={`text-[11px] font-mono uppercase tracking-[0.14em] px-3 py-2 transition-colors ${transport === t ? 'bg-aeon-red text-white' : 'text-primary-40 hover:text-primary-70'}`}>{t}</button>
+                      ))}
+                    </div>
+                  </div>
+                  {transport === 'http' ? (
+                    <>
+                      <input value={url} onChange={e => setUrl(e.target.value)} placeholder="https://mcp.example.com/v1" className={inputCls} />
+                      <input value={secretVar} onChange={e => setSecretVar(e.target.value)} placeholder="bearer-token secret name (optional, e.g. ACME_API_KEY)" className={inputCls} />
+                    </>
+                  ) : (
+                    <>
+                      <input value={command} onChange={e => setCommand(e.target.value)} placeholder="command (e.g. npx)" className={inputCls} />
+                      <input value={args} onChange={e => setArgs(e.target.value)} placeholder="args, space-separated (e.g. -y @modelcontextprotocol/server-sequential-thinking)" className={inputCls} />
+                    </>
+                  )}
+                  <div className="flex gap-2">
+                    <button onClick={addServer} className="bg-eva-green text-white text-[11px] px-4 py-2 font-mono hover:opacity-90 transition-opacity">Add server</button>
+                    <button onClick={resetForm} className="text-[11px] text-primary-40 font-mono px-2 py-2 hover:text-primary-70">Cancel</button>
+                  </div>
+                </div>
+              ) : (
+                <button onClick={() => setAdding(true)} className="text-[11px] text-primary-40 font-mono hover:text-eva-orange transition-colors">+ Add server</button>
+              )}
+            </div>
+
+            {/* Footer: secrets reminder + save */}
+            {allRefs.length > 0 && (
+              <p className="mt-5 text-[11px] text-primary-40 leading-relaxed">
+                <span className="text-eva-orange">Secrets:</span> set {allRefs.map(r => <span key={r} className="font-mono text-primary-70">{r} </span>)}
+                in <span className="text-primary-70">Settings</span>, and map each into the workflow&apos;s <span className="font-mono">env:</span> block
+                (see README → MCP). Until then, runs skip MCP rather than fail.
+              </p>
+            )}
+            <div className="flex items-center justify-between mt-4">
+              <span className="text-[11px] font-mono text-primary-35">writes .mcp.json — then Push to commit</span>
+              <div className="flex items-center gap-2">
+                {dirty && <button onClick={() => setDraft(servers)} className="text-[11px] text-primary-40 font-mono px-2 py-2 hover:text-primary-70 transition-colors">Revert</button>}
+                <button onClick={() => onSave(draft)} disabled={!dirty || saving}
+                  className="bg-eva-green text-white text-[11px] px-4 py-2 font-mono hover:opacity-90 transition-opacity disabled:opacity-40">
+                  {saving ? 'Saving…' : 'Save'}
+                </button>
+              </div>
+            </div>
+          </>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/dashboard/components/TopBar.tsx
+++ b/dashboard/components/TopBar.tsx
@@ -4,7 +4,7 @@ import { displayName } from '../lib/utils'
 
 interface TopBarProps {
   skill: Skill | null
-  view: 'hq' | 'secrets'
+  view: 'hq' | 'secrets' | 'mcp'
   repo: string
   model: string
   gateway: GatewayProvider
@@ -29,7 +29,7 @@ export function TopBar({ skill, view, repo, model, gateway, authStatus, authLoad
     <div className="h-14 border-b border-[rgba(250,250,250,0.10)] flex items-center justify-between px-5 shrink-0 bg-aeon-bg">
       <div className="flex items-center gap-3">
         <span className="font-display text-lg uppercase tracking-wide text-aeon-fg">
-          {skill ? displayName(skill.name) : view === 'secrets' ? 'Settings' : `${repo ? repo.split('/').pop() : 'Aeon'} HQ`}
+          {skill ? displayName(skill.name) : view === 'secrets' ? 'Settings' : view === 'mcp' ? 'MCP' : `${repo ? repo.split('/').pop() : 'Aeon'} HQ`}
         </span>
         {skill && dept && (
           <span


### PR DESCRIPTION
## What

Roadmap item **#3 — MCP during runs.** Skills can now **call** MCP servers (GitHub, a database, a paid API, your own) while they run in GitHub Actions. This is the *inbound* direction — distinct from the existing `## Integrations` section, which *exposes* skills as MCP tools.

## Safe by construction

**Entirely opt-in.** The runner only changes behaviour when a repo-root `.mcp.json` exists. With no file, runs are **byte-identical** to today — zero risk to existing forks.

## Runner (`aeon.yml` + `messages.yml`)

When `.mcp.json` is present, the `claude -p` call gains `--mcp-config .mcp.json --strict-mcp-config` and each server is auto-allowed via `mcp__<server>` in `--allowedTools`.

Two design decisions grounded in the current CLI (2.1.168) + docs:
- **Explicit `--mcp-config`** (not relying on auto-load) — project-scope `.mcp.json` servers otherwise sit in *"pending approval"* and would hang a headless run. Passing the config explicitly trusts it.
- **`--strict-mcp-config`** so only the repo's config loads (ignores any user/global MCP config on the runner).
- Deliberately **not** `--bare` — that flag skips CLAUDE.md auto-discovery, which would break the whole Aeon model (and the STRATEGY.md import).

**Safety valve:** if `.mcp.json` references a `${VAR}` that is unset *and* has no `${VAR:-default}` fallback, the runner **skips MCP for that run with a `::warning::`** instead of letting Claude's config parse-failure break the skill. Verified across no-file / no-secret / secret-present / secret-missing / defaulted-var cases.

## Config + docs

- **`.mcp.json.example`** — two working servers: `github` (HTTP, uses the already-present `GITHUB_TOKEN`) and `sequential-thinking` (no-auth stdio).
- **README `## MCP servers in skill runs`** — quickstart, the secret-bearing path (set the secret **and** map it into the workflow `env:` block), the safety valve, and scoping/`alwaysLoad` notes.

## Dashboard

New **MCP** tab (its own nav page): list servers, add via a form (name · transport · url+bearer-secret / command+args), remove, and a per-server view of the `${VAR}` secrets it references with a reminder to set them. Writes `.mcp.json` through `/api/mcp` and flags **Push** — same commit flow as Strategy/skills. `/api/mcp` is covered by the global `/api/*` middleware gate.

## Acceptance criteria

- [x] A configured MCP server is usable by a skill during a run (runner loads it + allows its tools).
- [x] Dashboard adds a **no-secret** server end-to-end (form → `.mcp.json` → Push → usable).
- [x] The secret-bearing path is documented and works (`${VAR}` + secret + env mapping).

## Decisions made (from the spec's open list)

- **Secrets-write scope:** the dashboard already sets GitHub secrets (`gh secret set`), so it *instructs + can set* — no new scope needed. The remaining manual step (mapping a custom secret into the workflow `env:`) is GHA-inherent and documented.
- **Scope:** **global** (`.mcp.json` applies to all skills) — matches `.mcp.json` semantics. Per-skill is a future note.
- **Example servers:** `github` + `sequential-thinking`.

## Verification

yaml ✓ · `bash -n` ✓ · MCP detect/skip logic exercised across 5 scenarios ✓ · `tsc` clean ✓ · **99/99 tests** ✓ · `next build` green, `/api/mcp` registered ✓

## Merge note

The dashboard nav (the `view` union in `page.tsx` / `LeftSidebar` / `TopBar`) is also extended by **#371** (Strategy tab). Both add a member to the same union lines → a **trivial conflict** if both land: resolve by unioning both (`'hq' | 'secrets' | 'strategy' | 'mcp'`). The nav-array inserts don't overlap (MCP appended after Settings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)