### PR TITLE
fix(dashboard): migrate middleware→proxy, hide upstream-sync from feed

### DIFF
--- a/dashboard/app/api/runs/route.ts
+++ b/dashboard/app/api/runs/route.ts
@@ -9,18 +9,22 @@ export async function GET() {
   try {
     const out = execFileSync(
       'gh',
-      ['run', 'list', ...ghArgsRepo(), '--json', 'databaseId,name,status,conclusion,createdAt,url,displayTitle', '--limit', '20'],
+      ['run', 'list', ...ghArgsRepo(), '--json', 'databaseId,name,status,conclusion,createdAt,url,displayTitle', '--limit', '30'],
       { stdio: 'pipe', cwd: REPO_ROOT },
     ).toString()
     const raw: GhRunListItem[] = JSON.parse(out)
-    const runs = raw.map((r) => ({
-      id: r.databaseId,
-      workflow: r.displayTitle || r.name,
-      status: r.status,
-      conclusion: r.conclusion,
-      created_at: r.createdAt,
-      url: r.url,
-    }))
+    const runs = raw
+      // Fork-maintenance runs (upstream sync) are noise, not Aeon skill
+      // activity — keep them out of the feed and runs list.
+      .filter((r) => r.name !== 'Sync from upstream')
+      .map((r) => ({
+        id: r.databaseId,
+        workflow: r.displayTitle || r.name,
+        status: r.status,
+        conclusion: r.conclusion,
+        created_at: r.createdAt,
+        url: r.url,
+      }))
     return NextResponse.json({ runs })
   } catch (error: unknown) {
     const msg = error instanceof Error ? error.message : 'Failed to list runs'

--- a/dashboard/lib/security/api-gate.ts
+++ b/dashboard/lib/security/api-gate.ts
@@ -148,7 +148,7 @@ export function isSameOriginWrite(
 }
 
 /**
- * Top-level gate used by `dashboard/middleware.ts`. Reads the two env
+ * Top-level gate used by `dashboard/proxy.ts`. Reads the two env
  * vars once and applies both checks. Returns `null` on success or a
  * `Response` with a 403 + JSON body explaining the rejection.
  */

--- a/dashboard/proxy.ts
+++ b/dashboard/proxy.ts
@@ -18,7 +18,7 @@ import { gateRequest } from "@/lib/security/api-gate";
  * entirely via `AEON_DASHBOARD_ALLOW_ANY_HOST=1` (intended only for
  * trusted-reverse-proxy setups).
  */
-export function middleware(req: NextRequest) {
+export function proxy(req: NextRequest) {
   const rejected = gateRequest(req);
   if (rejected) return rejected;
   return NextResponse.next();


### PR DESCRIPTION
## What

Two dashboard fixes:

1. **Next.js 16 `middleware` → `proxy` migration.** Next 16 deprecated the `middleware` file convention (`⚠ The "middleware" file convention is deprecated. Please use "proxy" instead.`). Renamed `dashboard/middleware.ts` → `dashboard/proxy.ts` and the exported `middleware()` → `proxy()`; the `config`/`matcher` export is unchanged. The gate only inspects the request (loopback Host allowlist + same-origin check), so the `proxy` nodejs-only runtime (no edge) is fine here.

2. **Hide "Sync from upstream" from the feed.** Those entries are runs of the `Sync from upstream` workflow — fork-maintenance noise, not Aeon skill activity. Filtered them out at the source in `/api/runs` so they no longer appear in the **Feed** or **Runs** tabs. Bumped `--limit` 20→30 to keep ~20 meaningful runs visible after filtering.

## Files
- `dashboard/proxy.ts` (renamed from `middleware.ts`, function renamed)
- `dashboard/lib/security/api-gate.ts` (doc comment reference)
- `dashboard/app/api/runs/route.ts` (filter + limit)

`npx tsc --noEmit` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)