### PR TITLE
chore: declare MIT license in package manifests, update copyright name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Aaron Mars
+Copyright (c) 2026 Aaron Elijah Mars
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/apps/a2a-server/package.json
+++ b/apps/a2a-server/package.json
@@ -1,6 +1,7 @@
 {
   "name": "aeon-a2a-server",
   "version": "1.0.0",
+  "license": "MIT",
   "description": "A2A Protocol Gateway — expose all Aeon skills to any AI agent framework",
   "type": "module",
   "main": "dist/index.js",

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,6 +1,7 @@
 {
   "name": "aeon-dashboard",
   "version": "0.1.0",
+  "license": "MIT",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -1,6 +1,7 @@
 {
   "name": "aeon-mcp",
   "version": "1.0.0",
+  "license": "MIT",
   "description": "MCP server that exposes all Aeon skills as Claude tools",
   "type": "module",
   "main": "dist/index.js",

--- a/apps/webhook/package.json
+++ b/apps/webhook/package.json
@@ -1,6 +1,7 @@
 {
   "name": "aeon-telegram-webhook",
   "version": "1.0.0",
+  "license": "MIT",
   "private": true,
   "description": "Cloudflare Worker that relays Telegram messages to an Aeon fork via GitHub repository_dispatch for ~1s response time.",
   "scripts": {


### PR DESCRIPTION
Two small license-hygiene fixes.

- **Add `"license": "MIT"`** to all four `apps/*` package.json files (`aeon-a2a-server`, `aeon-dashboard`, `aeon-mcp`, `aeon-telegram-webhook`). Previously they had no license field, so npm and GitHub's per-package license detection couldn't see that they're MIT — they relied solely on the root `LICENSE`.
- **Update copyright holder** in `LICENSE`: `Aaron Mars` → `Aaron Elijah Mars`.

No functional change. JSON validated on all four manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)