### PR TITLE
feat(mcp): auto-resolve any .mcp.json secret — no workflow editing

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -246,6 +246,10 @@ jobs:
         id: run
         if: steps.work.outputs.mode != ''
         env:
+          # Full secrets context — lets .mcp.json reference ANY repo secret as
+          # ${NAME} with no per-name env wiring. Consumed by the MCP preflight
+          # below, then unset before Claude runs so it never reaches skill code.
+          ALL_SECRETS: ${{ toJSON(secrets) }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
@@ -463,17 +467,21 @@ jobs:
 
           # MCP (opt-in): when a project .mcp.json exists, load it for this run
           # and allow each server's tools. No-op when the file is absent, so
-          # existing forks are unaffected. If the config references an env var
-          # that is unset and has no ":-" default, skip MCP with a warning rather
+          # existing forks are unaffected. Any ${VAR} the config references is
+          # auto-resolved from this repo's secrets (ALL_SECRETS) — set the secret
+          # in the dashboard and it just works, no per-name workflow wiring. If a
+          # referenced secret genuinely isn't set, skip MCP with a warning rather
           # than let Claude's config parse-failure break the whole skill run.
           MCP_FLAGS=()
           if [ -f .mcp.json ] && jq -e '.mcpServers' .mcp.json >/dev/null 2>&1; then
             MCP_MISSING=""
             for v in $(grep -oE '\$\{[A-Z_][A-Z0-9_]*\}' .mcp.json | sed -E 's/[${}]//g' | sort -u); do
-              [ -z "${!v:-}" ] && MCP_MISSING="$MCP_MISSING $v"
+              [ -n "${!v:-}" ] && continue                                  # already in env (built-in)
+              val="$(jq -r --arg k "$v" '.[$k] // empty' <<<"${ALL_SECRETS:-{}}")"
+              if [ -n "$val" ]; then export "$v=$val"; else MCP_MISSING="$MCP_MISSING $v"; fi
             done
             if [ -n "$MCP_MISSING" ]; then
-              echo "::warning::.mcp.json references unset env:${MCP_MISSING} — skipping MCP this run (set the secret(s) and map them into this workflow's env)"
+              echo "::warning::.mcp.json references secret(s) not set:${MCP_MISSING} — add them in the dashboard (Settings or the MCP tab); the next run picks them up. Skipping MCP this run."
             else
               for srv in $(jq -r '.mcpServers | keys[]' .mcp.json); do
                 ALLOWED="$ALLOWED,mcp__${srv}"
@@ -482,6 +490,7 @@ jobs:
               echo "MCP enabled: $(jq -r '.mcpServers | keys | join(", ")' .mcp.json)"
             fi
           fi
+          unset ALL_SECRETS   # drop the secrets blob before any skill/Claude code runs
 
           SKILL_NAME="${{ steps.skill.outputs.name }}"
           VAR="$SKILL_VAR"

--- a/.github/workflows/messages.yml
+++ b/.github/workflows/messages.yml
@@ -640,6 +640,10 @@ jobs:
         id: run
         if: steps.msg.outputs.source != ''
         env:
+          # Full secrets context — lets .mcp.json reference ANY repo secret as
+          # ${NAME} with no per-name env wiring. Consumed by the MCP preflight
+          # below, then unset before Claude runs so it never reaches skill code.
+          ALL_SECRETS: ${{ toJSON(secrets) }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
@@ -693,17 +697,21 @@ jobs:
           ALLOWED="$ALLOWED,Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(sort:*),Bash(grep:*)"
 
           # MCP (opt-in): when a project .mcp.json exists, load it for this run
-          # and allow each server's tools. No-op when the file is absent. If the
-          # config references an env var that is unset and has no ":-" default,
+          # and allow each server's tools. No-op when the file is absent. Any
+          # ${VAR} the config references is auto-resolved from this repo's secrets
+          # (ALL_SECRETS) — set the secret in the dashboard and it just works, no
+          # per-name workflow wiring. If a referenced secret genuinely isn't set,
           # skip MCP with a warning rather than break the run on a parse failure.
           MCP_FLAGS=()
           if [ -f .mcp.json ] && jq -e '.mcpServers' .mcp.json >/dev/null 2>&1; then
             MCP_MISSING=""
             for v in $(grep -oE '\$\{[A-Z_][A-Z0-9_]*\}' .mcp.json | sed -E 's/[${}]//g' | sort -u); do
-              [ -z "${!v:-}" ] && MCP_MISSING="$MCP_MISSING $v"
+              [ -n "${!v:-}" ] && continue                                  # already in env (built-in)
+              val="$(jq -r --arg k "$v" '.[$k] // empty' <<<"${ALL_SECRETS:-{}}")"
+              if [ -n "$val" ]; then export "$v=$val"; else MCP_MISSING="$MCP_MISSING $v"; fi
             done
             if [ -n "$MCP_MISSING" ]; then
-              echo "::warning::.mcp.json references unset env:${MCP_MISSING} — skipping MCP this run"
+              echo "::warning::.mcp.json references secret(s) not set:${MCP_MISSING} — add them in the dashboard; the next run picks them up. Skipping MCP this run."
             else
               for srv in $(jq -r '.mcpServers | keys[]' .mcp.json); do
                 ALLOWED="$ALLOWED,mcp__${srv}"
@@ -712,6 +720,7 @@ jobs:
               echo "MCP enabled: $(jq -r '.mcpServers | keys | join(", ")' .mcp.json)"
             fi
           fi
+          unset ALL_SECRETS   # drop the secrets blob before any skill/Claude code runs
 
           SOURCE="$_MSG_SOURCE"
           MESSAGE="$_MSG_MESSAGE"

--- a/README.md
+++ b/README.md
@@ -604,16 +604,14 @@ Reference secrets with `${VAR}` — **never commit the value**:
 }
 ```
 
-Then make `ACME_API_KEY` reachable in the run:
+Then make `ACME_API_KEY` reachable in the run — just **set the secret**, no workflow editing:
 
-1. Add it as a repo **secret** (dashboard → Settings → Add Credential, or `gh secret set ACME_API_KEY`).
-2. **Map it into the workflow env** so the runner can expand it — add one line under the `Run` step's `env:` in `.github/workflows/aeon.yml` (and `messages.yml` if you use it from chat):
-   ```yaml
-   ACME_API_KEY: ${{ secrets.ACME_API_KEY }}
-   ```
-   (Secrets already mapped — `GITHUB_TOKEN`, `XAI_API_KEY`, `ALCHEMY_API_KEY`, `COINGECKO_API_KEY`, `NEYNAR_*`, … — need no extra wiring.)
+- Dashboard → **MCP** tab: type the value inline when you add the server, **or**
+- Dashboard → **Settings** → Add Credential, **or** `gh secret set ACME_API_KEY`.
 
-**Safety valve:** if a `.mcp.json` references a `${VAR}` that is unset (and has no `${VAR:-default}` fallback), the runner **skips MCP for that run and logs a warning** instead of letting the config parse-failure break the skill. Set the secret, and the next run picks it up.
+That's it. The runner auto-resolves any `${VAR}` your `.mcp.json` references from the repo's secrets (via `toJSON(secrets)`, consumed and discarded before any skill code runs) — so **any** secret name works with zero per-name wiring. Built-ins like `XAI_API_KEY`, `ALCHEMY_API_KEY`, `COINGECKO_API_KEY`, `NEYNAR_*`, … are always available too.
+
+**Safety valve:** if a `.mcp.json` references a `${VAR}` whose secret isn't set (and has no `${VAR:-default}` fallback), the runner **skips MCP for that run and logs a warning** instead of letting the config parse-failure break the skill. Set the secret, and the next run picks it up.
 
 ### Notes
 

--- a/apps/dashboard/.gitignore
+++ b/apps/dashboard/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 .next/
 .env
 .env.local
+*.tsbuildinfo

--- a/apps/dashboard/app/page.tsx
+++ b/apps/dashboard/app/page.tsx
@@ -124,7 +124,7 @@ export default function Dashboard() {
             <StrategyPanel content={strategy} loading={!strategyLoaded} saving={strategySaving} onSave={saveStrategy} />
           )}
           {view === 'mcp' && !selectedSkill && (
-            <McpPanel servers={mcpServers} loading={!mcpLoaded} saving={mcpSaving} onSave={saveMcp} />
+            <McpPanel servers={mcpServers} loading={!mcpLoaded} saving={mcpSaving} onSave={saveMcp} onSetSecret={saveSecret} />
           )}
           {view === 'hq' && !selectedSkill && (
             <HQOverview skills={skills} runs={runs} enabledCount={enabledCount} workingCount={workingCount} onViewRun={() => {}} />

--- a/apps/dashboard/components/McpPanel.tsx
+++ b/apps/dashboard/components/McpPanel.tsx
@@ -12,6 +12,7 @@ interface McpPanelProps {
   loading: boolean
   saving: boolean
   onSave: (servers: McpServers) => void
+  onSetSecret: (name: string, value: string) => void
 }
 
 // The ${VAR} secret references a server needs at runtime.
@@ -37,7 +38,7 @@ function transportOf(server: McpServer): string {
   return typeof server.command === 'string' ? 'stdio' : 'http'
 }
 
-export function McpPanel({ servers, loading, saving, onSave }: McpPanelProps) {
+export function McpPanel({ servers, loading, saving, onSave, onSetSecret }: McpPanelProps) {
   const [draft, setDraft] = useState<McpServers>(servers)
   useEffect(() => { setDraft(servers) }, [servers])
 
@@ -46,15 +47,19 @@ export function McpPanel({ servers, loading, saving, onSave }: McpPanelProps) {
   const [transport, setTransport] = useState<'http' | 'stdio'>('http')
   const [url, setUrl] = useState('')
   const [secretVar, setSecretVar] = useState('')
+  const [secretValue, setSecretValue] = useState('')
   const [command, setCommand] = useState('npx')
   const [args, setArgs] = useState('')
+
+  // The secret name a typed bearer-token ref resolves to (UPPER_SNAKE_CASE).
+  const envName = (s: string) => s.trim().toUpperCase().replace(/[^A-Z0-9_]/g, '_')
 
   const dirty = JSON.stringify(draft) !== JSON.stringify(servers)
   const names = Object.keys(draft)
   const allRefs = [...new Set(names.flatMap(n => refsOf(draft[n])))]
 
   const resetForm = () => {
-    setAdding(false); setName(''); setUrl(''); setSecretVar(''); setCommand('npx'); setArgs(''); setTransport('http')
+    setAdding(false); setName(''); setUrl(''); setSecretVar(''); setSecretValue(''); setCommand('npx'); setArgs(''); setTransport('http')
   }
 
   const addServer = () => {
@@ -64,7 +69,13 @@ export function McpPanel({ servers, loading, saving, onSave }: McpPanelProps) {
     if (transport === 'http') {
       if (!url.trim()) return
       server = { type: 'http', url: url.trim() }
-      if (secretVar.trim()) server.headers = { Authorization: `Bearer \${${secretVar.trim().toUpperCase().replace(/[^A-Z0-9_]/g, '_')}}` }
+      if (secretVar.trim()) {
+        const ref = envName(secretVar)
+        server.headers = { Authorization: `Bearer \${${ref}}` }
+        // Save the token straight to repo secrets so the run can resolve it —
+        // no Settings detour, no workflow editing.
+        if (secretValue.trim()) onSetSecret(ref, secretValue.trim())
+      }
     } else {
       if (!command.trim()) return
       server = { type: 'stdio', command: command.trim() }
@@ -157,6 +168,9 @@ export function McpPanel({ servers, loading, saving, onSave }: McpPanelProps) {
                     <>
                       <input value={url} onChange={e => setUrl(e.target.value)} placeholder="https://mcp.example.com/v1" className={inputCls} />
                       <input value={secretVar} onChange={e => setSecretVar(e.target.value)} placeholder="bearer-token secret name (optional, e.g. ACME_API_KEY)" className={inputCls} />
+                      {secretVar.trim() && (
+                        <input type="password" value={secretValue} onChange={e => setSecretValue(e.target.value)} placeholder={`value for ${envName(secretVar)} — saved as a repo secret, wired into every run`} className={inputCls} />
+                      )}
                     </>
                   ) : (
                     <>
@@ -170,16 +184,16 @@ export function McpPanel({ servers, loading, saving, onSave }: McpPanelProps) {
                   </div>
                 </div>
               ) : (
-                <button onClick={() => setAdding(true)} className="text-[11px] text-primary-40 font-mono hover:text-eva-orange transition-colors">+ Add server</button>
+                <button onClick={() => setAdding(true)} className="w-full text-sm font-mono uppercase tracking-[0.14em] text-primary-60 border border-dashed border-[rgba(250,250,250,0.16)] py-3.5 hover:text-eva-orange hover:border-eva-orange/40 transition-colors">+ Add server</button>
               )}
             </div>
 
             {/* Footer: secrets reminder + save */}
             {allRefs.length > 0 && (
               <p className="mt-5 text-[11px] text-primary-40 leading-relaxed">
-                <span className="text-eva-orange">Secrets:</span> set {allRefs.map(r => <span key={r} className="font-mono text-primary-70">{r} </span>)}
-                in <span className="text-primary-70">Settings</span>, and map each into the workflow&apos;s <span className="font-mono">env:</span> block
-                (see README → MCP). Until then, runs skip MCP rather than fail.
+                <span className="text-eva-orange">Secrets:</span> {allRefs.map(r => <span key={r} className="font-mono text-primary-70">{r} </span>)}
+                — set the value{allRefs.length > 1 ? 's' : ''} above when adding a server, or in <span className="text-primary-70">Settings</span>.
+                The runner wires {allRefs.length > 1 ? 'them' : 'it'} into every run automatically; until set, runs skip MCP rather than fail.
               </p>
             )}
             <div className="flex items-center justify-between mt-4">


### PR DESCRIPTION
## What

Makes MCP setup fully hands-off from the dashboard. Set a secret → it's wired into every run automatically. No more editing `aeon.yml` to map `${VAR}` into the step `env:` block.

### The engine
The MCP preflight in `aeon.yml` + `messages.yml` now resolves **every `${VAR}`** a project's `.mcp.json` references straight from the repo's secrets:

- The run step gets `ALL_SECRETS: ${{ toJSON(secrets) }}`.
- For each referenced var not already in env, it pulls the value from that context via `jq` and `export`s it for the run.
- It then `unset`s the blob **before any skill/Claude code runs**, so the broad context never reaches untrusted code — only the specific MCP secrets do (same exposure as the old manual wiring).
- Truly-missing secrets still **skip MCP with a warning** rather than break the skill (safety valve unchanged; message now points at the dashboard).

Works for **any** secret name, however the server was added (MCP tab, hand-edited `.mcp.json`, or `gh` CLI). Avoids the alternative of having the dashboard rewrite workflow YAML (which would need a `workflow`-scoped PAT + brittle string-surgery).

### Dashboard
- MCP tab: inline **token-value field** when adding an HTTP server — stores the secret on add (`gh secret set`), so server + credential is one step.
- Footer text + README updated to drop the obsolete "map into the workflow's `env:`" instruction.
- Enlarged the **+ Add server** button; ignore `*.tsbuildinfo`.

## Test
- `tsc --noEmit` clean, dashboard tests 99/99 pass.
- Both workflows parse (`yaml.safe_load`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)