### PR TITLE
fix(dashboard): MCP credential cleanup, enabled filter, 28 display

### DIFF
--- a/apps/dashboard/app/page.tsx
+++ b/apps/dashboard/app/page.tsx
@@ -125,7 +125,7 @@ export default function Dashboard() {
             <StrategyPanel content={strategy} loading={!strategyLoaded} saving={strategySaving} onSave={saveStrategy} />
           )}
           {view === 'mcp' && !selectedSkill && (
-            <McpPanel servers={mcpServers} loading={!mcpLoaded} saving={mcpSaving} secrets={secrets} busy={busy} onSave={saveMcp} onSetSecret={saveSecret} />
+            <McpPanel servers={mcpServers} loading={!mcpLoaded} saving={mcpSaving} secrets={secrets} busy={busy} onSave={saveMcp} onSetSecret={saveSecret} onDeleteSecret={deleteSecret} />
           )}
           {view === 'hq' && !selectedSkill && (
             <HQOverview skills={skills} runs={runs} enabledCount={enabledCount} workingCount={workingCount} onViewRun={() => {}} />

--- a/apps/dashboard/components/HQOverview.tsx
+++ b/apps/dashboard/components/HQOverview.tsx
@@ -97,7 +97,7 @@ export function HQOverview({ skills, runs, enabledCount, workingCount, onViewRun
                 key={cat.key}
                 className="spotlight relative overflow-hidden bg-aeon-bg px-6 py-5 flex items-center gap-5 transition-colors hover:bg-aeon-panel-2"
               >
-                <span className="font-display leading-none text-aeon-red" style={{ fontSize: 'clamp(28px, 3vw, 44px)' }}>
+                <span className="font-display leading-none text-aeon-red shrink-0 whitespace-nowrap" style={{ fontSize: 'clamp(28px, 3vw, 44px)' }}>
                   <Flip value={cat.skills.length} />
                 </span>
                 <div className="min-w-0">

--- a/apps/dashboard/components/LeftSidebar.tsx
+++ b/apps/dashboard/components/LeftSidebar.tsx
@@ -22,6 +22,7 @@ interface LeftSidebarProps {
 export function LeftSidebar({ view, setView, selectedSkill, skills, runs, repo, enabledCount, workingCount, onSkillSelect, onShowImport }: LeftSidebarProps) {
   const [skillSearch, setSkillSearch] = useState('')
   const [categoryFilter, setCategoryFilter] = useState<string | null>(null)
+  const [enabledOnly, setEnabledOnly] = useState(false)
 
   return (
     <div className="w-[240px] border-r border-[rgba(250,250,250,0.10)] flex flex-col shrink-0 bg-aeon-panel">
@@ -75,6 +76,14 @@ export function LeftSidebar({ view, setView, selectedSkill, skills, runs, repo, 
           >
             All
           </button>
+          <button
+            onClick={() => setEnabledOnly(v => !v)}
+            title="Show only skills on duty"
+            className={`text-[10px] font-mono uppercase tracking-[0.1em] px-2 py-1 border flex items-center gap-1.5 transition-colors ${enabledOnly ? 'text-eva-green border-eva-green/50 bg-eva-green/10' : 'text-primary-40 border-[rgba(250,250,250,0.12)] hover:text-primary-70 hover:border-[rgba(250,250,250,0.22)]'}`}
+          >
+            <span className="w-1.5 h-1.5 rounded-full shrink-0 bg-eva-green" />
+            Enabled
+          </button>
           {CATEGORIES.map(cat => {
             const active = categoryFilter === cat.key
             return (
@@ -96,8 +105,9 @@ export function LeftSidebar({ view, setView, selectedSkill, skills, runs, repo, 
           if (categoryFilter && cat.key !== categoryFilter) return null
           const catSkills = skills.filter(s => (s.category || 'meta') === cat.key)
           if (!catSkills.length) return null
-          const filtered = skillSearch ? catSkills.filter(s => displayName(s.name).toLowerCase().includes(skillSearch.toLowerCase()) || s.name.includes(skillSearch.toLowerCase())) : catSkills
-          if (skillSearch && !filtered.length) return null
+          const searched = skillSearch ? catSkills.filter(s => displayName(s.name).toLowerCase().includes(skillSearch.toLowerCase()) || s.name.includes(skillSearch.toLowerCase())) : catSkills
+          const filtered = enabledOnly ? searched.filter(s => s.enabled) : searched
+          if (!filtered.length) return null
           const en = filtered.filter(s => s.enabled).length
           return (
             <div key={cat.key} className="mb-1">

--- a/apps/dashboard/components/McpPanel.tsx
+++ b/apps/dashboard/components/McpPanel.tsx
@@ -16,6 +16,7 @@ interface McpPanelProps {
   busy: Record<string, boolean>
   onSave: (servers: McpServers) => void
   onSetSecret: (name: string, value: string) => void
+  onDeleteSecret: (name: string) => void
 }
 
 // The ${VAR} secret references a server needs at runtime.
@@ -41,7 +42,7 @@ function transportOf(server: McpServer): string {
   return typeof server.command === 'string' ? 'stdio' : 'http'
 }
 
-export function McpPanel({ servers, loading, saving, secrets, busy, onSave, onSetSecret }: McpPanelProps) {
+export function McpPanel({ servers, loading, saving, secrets, busy, onSave, onSetSecret, onDeleteSecret }: McpPanelProps) {
   const [draft, setDraft] = useState<McpServers>(servers)
   useEffect(() => { setDraft(servers) }, [servers])
 
@@ -100,8 +101,19 @@ export function McpPanel({ servers, loading, saving, secrets, busy, onSave, onSe
     resetForm()
   }
 
+  // A credential this panel minted for a server is stored as MCP_<SLUG>_TOKEN.
+  const isMcpToken = (r: string) => /^MCP_[A-Z0-9_]+_TOKEN$/.test(r)
+
   const removeServer = (n: string) => {
-    const next = { ...draft }; delete next[n]; setDraft(next)
+    const next = { ...draft }; delete next[n]
+    // Any MCP token this server owned that nothing else references is now orphaned
+    // on GitHub — delete it so removing a server actually removes its credentials.
+    // Only touch panel-minted MCP_*_TOKEN secrets, never shared/builtin ones.
+    const stillUsed = new Set(Object.values(next).flatMap(refsOf))
+    const orphans = refsOf(draft[n]).filter(r => isMcpToken(r) && !stillUsed.has(r) && isSecretSet(r))
+    if (orphans.length && !confirm(`Remove server "${n}" and delete its credential${orphans.length === 1 ? '' : 's'} (${orphans.join(', ')}) from GitHub?`)) return
+    orphans.forEach(onDeleteSecret)
+    setDraft(next)
   }
 
   return (


### PR DESCRIPTION
Three small dashboard fixes:

### 1. Category count no longer wraps into stacked digits
`HQOverview` rendered each digit of a count as a separate `inline-block` reel. When a long two-word label like **Research & Content** wrapped to two lines, flexbox squeezed the number column until "28" broke into a stacked "2" / "8". Added `shrink-0 whitespace-nowrap` to the number span so the digits stay on one line and the label wraps instead.

### 2. Removing an MCP server now deletes its credential from GitHub
`removeServer` previously only dropped the entry from the local `.mcp.json` draft — the bearer token it had stored on GitHub (`MCP_<SLUG>_TOKEN`) lingered forever. It now deletes that credential via the existing `DELETE /api/secrets` (`gh secret delete`), but only:
- panel-minted `MCP_*_TOKEN` secrets (never shared/builtin secrets like `ANTHROPIC_API_KEY`), and
- tokens **no other remaining server still references**.

A `confirm()` is shown first (matching `SkillDetail`'s convention) since the GitHub deletion is immediate.

### 3. "Enabled" filter in the Team section
Added a green **ENABLED** toggle next to **ALL** in the sidebar Team filters that shows only on-duty skills. Composes with the category filter and search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)