### PR TITLE
Auto-route Bankr (bk_) keys through the Bankr gateway

### DIFF
--- a/apps/dashboard/app/api/auth/route.ts
+++ b/apps/dashboard/app/api/auth/route.ts
@@ -2,6 +2,20 @@ import { NextResponse } from 'next/server'
 import { execFileSync, execSync } from 'child_process'
 import { ghAvailable, ghArgsRepo } from '@/lib/gh'
 import { normalizeAuthConfig } from '@/lib/auth-provider.mjs'
+import { getFileContent, updateFile } from '@/lib/github'
+import { updateGatewayInConfig } from '@/lib/config'
+import type { GatewayProvider } from '@/lib/types'
+
+// Keep aeon.yml's gateway.provider in sync with the authenticated key:
+// a Bankr (bk_) key flips it to `bankr`, anything else back to `direct`.
+async function syncGatewayProvider(provider: string) {
+  const next: GatewayProvider = provider === 'bankr' ? 'bankr' : 'direct'
+  const { content, sha } = await getFileContent('aeon.yml')
+  const updated = updateGatewayInConfig(content, next)
+  if (updated !== content) {
+    await updateFile('aeon.yml', updated, sha, `chore: set LLM gateway provider to ${next}`)
+  }
+}
 
 export async function GET() {
   try {
@@ -15,6 +29,7 @@ export async function GET() {
     const secrets = out ? out.split('\n').filter(Boolean) : []
     const hasApiKey = secrets.includes('ANTHROPIC_API_KEY')
     const hasOauth = secrets.includes('CLAUDE_CODE_OAUTH_TOKEN')
+    const hasBankr = secrets.includes('BANKR_LLM_KEY')
     let hasBaseUrl = false
 
     try {
@@ -24,7 +39,7 @@ export async function GET() {
       hasBaseUrl = vars ? vars.split('\n').includes('ANTHROPIC_BASE_URL') : false
     } catch {}
 
-    return NextResponse.json({ authenticated: hasApiKey || hasOauth, hasApiKey, hasOauth, hasBaseUrl })
+    return NextResponse.json({ authenticated: hasApiKey || hasOauth || hasBankr, hasApiKey, hasOauth, hasBankr, hasBaseUrl })
   } catch {
     return NextResponse.json({ authenticated: false })
   }
@@ -50,7 +65,8 @@ export async function POST(request: Request) {
         input: config.key,
         stdio: ['pipe', 'pipe', 'pipe'],
       })
-      return NextResponse.json({ ok: true, method: config.method, secret: config.secretName, baseUrl: Boolean(config.baseUrl) })
+      await syncGatewayProvider(config.gateway)
+      return NextResponse.json({ ok: true, method: config.method, secret: config.secretName, baseUrl: Boolean(config.baseUrl), gateway: config.gateway })
     }
 
     const output = execSync('claude setup-token', {
@@ -84,10 +100,11 @@ export async function POST(request: Request) {
       stdio: ['pipe', 'pipe', 'pipe'],
     })
 
+    await syncGatewayProvider(config.gateway)
     return NextResponse.json({ ok: true, method: 'oauth' })
   } catch (error: unknown) {
     const msg = error instanceof Error ? error.message : 'Failed to setup auth'
-    const status = msg.includes('Base URL') || msg.includes('OAuth tokens') ? 400 : 500
+    const status = msg.includes('Base URL') || msg.includes('OAuth tokens') || msg.includes('Bankr') ? 400 : 500
     return NextResponse.json({ error: msg }, { status })
   }
 }

--- a/apps/dashboard/components/AuthModal.tsx
+++ b/apps/dashboard/components/AuthModal.tsx
@@ -21,7 +21,7 @@ export function AuthModal({ loading, onClose, onAuth }: AuthModalProps) {
           <h2 className="font-display text-xl">Authenticate</h2>
           <button onClick={onClose} className="text-primary-35 hover:text-primary-100 text-lg">&times;</button>
         </div>
-        <p className="text-xs text-primary-50 font-mono mb-[var(--space-md)]">Connect a Claude subscription token, or paste an Anthropic or Anthropic-compatible API key.</p>
+        <p className="text-xs text-primary-50 font-mono mb-[var(--space-md)]">Connect a Claude subscription token, or paste an Anthropic or Anthropic-compatible API key. A Bankr key (bk_…) routes through the Bankr gateway automatically.</p>
         <button onClick={() => onAuth()} disabled={loading} className="w-full bg-aeon-fg text-aeon-bg text-sm py-3 font-mono uppercase tracking-[2px] hover:opacity-90 transition-opacity disabled:opacity-50">
           {loading ? '...' : 'Use Claude Subscription'}
         </button>

--- a/apps/dashboard/lib/auth-provider.mjs
+++ b/apps/dashboard/lib/auth-provider.mjs
@@ -3,7 +3,18 @@ export function normalizeAuthConfig(body = {}) {
   const baseUrl = String(body.baseUrl || '').trim()
 
   if (!key) {
-    return { key: '', baseUrl: normalizeBaseUrl(baseUrl), method: 'oauth', secretName: 'CLAUDE_CODE_OAUTH_TOKEN' }
+    return { key: '', baseUrl: normalizeBaseUrl(baseUrl), method: 'oauth', secretName: 'CLAUDE_CODE_OAUTH_TOKEN', gateway: 'direct' }
+  }
+
+  // Bankr LLM Gateway keys (bk_…) are stored as BANKR_LLM_KEY and flip
+  // gateway.provider to `bankr`. The workflow then sets ANTHROPIC_BASE_URL to
+  // https://llm.bankr.bot itself, so a custom base URL is rejected here.
+  const isBankr = key.startsWith('bk_')
+  if (isBankr) {
+    if (baseUrl) {
+      throw new Error('Bankr gateway keys cannot be used with a custom base URL')
+    }
+    return { key, baseUrl: '', method: 'bankr', secretName: 'BANKR_LLM_KEY', gateway: 'bankr' }
   }
 
   const isOauth = key.startsWith('sk-ant-oat')
@@ -16,6 +27,7 @@ export function normalizeAuthConfig(body = {}) {
     baseUrl: isOauth ? '' : normalizeBaseUrl(baseUrl),
     method: isOauth ? 'oauth' : 'api-key',
     secretName: isOauth ? 'CLAUDE_CODE_OAUTH_TOKEN' : 'ANTHROPIC_API_KEY',
+    gateway: 'direct',
   }
 }
 

--- a/apps/dashboard/lib/auth-provider.test.mjs
+++ b/apps/dashboard/lib/auth-provider.test.mjs
@@ -14,6 +14,28 @@ test('stores Anthropic-compatible API keys in ANTHROPIC_API_KEY', () => {
   assert.equal(config.baseUrl, 'https://api.deepseek.com/anthropic')
 })
 
+test('routes Bankr gateway keys to BANKR_LLM_KEY and flips gateway to bankr', () => {
+  const config = normalizeAuthConfig({ key: 'bk_live_abc123' })
+
+  assert.equal(config.secretName, 'BANKR_LLM_KEY')
+  assert.equal(config.method, 'bankr')
+  assert.equal(config.gateway, 'bankr')
+  assert.equal(config.baseUrl, '')
+})
+
+test('rejects Bankr keys with a custom base URL', () => {
+  assert.throws(
+    () => normalizeAuthConfig({ key: 'bk_live_abc123', baseUrl: 'https://llm.bankr.bot' }),
+    /Bankr gateway keys cannot be used with a custom base URL/,
+  )
+})
+
+test('keeps the direct gateway for non-Bankr keys', () => {
+  assert.equal(normalizeAuthConfig({ key: 'sk-ant-api03-xyz' }).gateway, 'direct')
+  assert.equal(normalizeAuthConfig({ key: 'sk-ant-oat-abc123' }).gateway, 'direct')
+  assert.equal(normalizeAuthConfig({}).gateway, 'direct')
+})
+
 test('stores Claude OAuth tokens separately', () => {
   const config = normalizeAuthConfig({ key: 'sk-ant-oat-abc123' })
 

--- a/apps/dashboard/lib/config.test.ts
+++ b/apps/dashboard/lib/config.test.ts
@@ -13,6 +13,7 @@ import {
   parseConfig,
   updateSkillInConfig,
   updateModelInConfig,
+  updateGatewayInConfig,
   updateJsonrenderInConfig,
   removeSkillFromConfig,
   addSkillToConfig,
@@ -164,6 +165,26 @@ describe("updateModelInConfig", () => {
     const updated = updateModelInConfig(FULL_YAML, "claude-haiku-4-5-20251001");
     const config = parseConfig(updated);
     assert.equal(config.model, "claude-haiku-4-5-20251001");
+  });
+});
+
+// ── updateGatewayInConfig ────────────────────────────────────────────
+
+describe("updateGatewayInConfig", () => {
+  it("flips an existing provider to bankr", () => {
+    const updated = updateGatewayInConfig(FULL_YAML, "bankr");
+    assert.equal(parseConfig(updated).gateway.provider, "bankr");
+  });
+
+  it("flips back to direct", () => {
+    const bankr = updateGatewayInConfig(FULL_YAML, "bankr");
+    const updated = updateGatewayInConfig(bankr, "direct");
+    assert.equal(parseConfig(updated).gateway.provider, "direct");
+  });
+
+  it("creates the gateway block when absent", () => {
+    const updated = updateGatewayInConfig(MINIMAL_YAML, "bankr");
+    assert.equal(parseConfig(updated).gateway.provider, "bankr");
   });
 });
 

--- a/apps/dashboard/lib/config.ts
+++ b/apps/dashboard/lib/config.ts
@@ -113,6 +113,15 @@ export function updateModelInConfig(raw: string, model: string): string {
 }
 
 /**
+ * Update the LLM gateway provider. Creates the gateway block if absent.
+ */
+export function updateGatewayInConfig(raw: string, provider: GatewayProvider): string {
+  const doc = parseDocument(raw)
+  doc.setIn(['gateway', 'provider'], provider)
+  return doc.toString()
+}
+
+/**
  * Update jsonrender enabled flag.
  */
 export function updateJsonrenderInConfig(raw: string, enabled: boolean): string {


### PR DESCRIPTION
## What

When a key pasted into the dashboard auth modal starts with `bk_` (a Bankr LLM Gateway key), it's now:
1. saved as the **`BANKR_LLM_KEY`** secret (not `ANTHROPIC_API_KEY`), and
2. `aeon.yml` `gateway.provider` is flipped to **`bankr`**.

Any other key (Anthropic `sk-ant-…`, OAuth, or a base-URL-compatible key) keeps/restores `provider: direct`. So the auth popup is now the single source of truth for gateway routing.

## Why

Before this, a `bk_` key got stored as `ANTHROPIC_API_KEY` while the gateway stayed `direct`. The workflow only routes to `https://llm.bankr.bot` when `gateway.provider: bankr`, so the key was ignored and runs failed auth ("Invalid API key" / "Not logged in"). This is exactly the misconfiguration that had to be fixed by hand on an instance repo.

## Changes

- **`lib/auth-provider.mjs`** — detect `bk_` prefix → `method: 'bankr'`, `secretName: 'BANKR_LLM_KEY'`, `gateway: 'bankr'`; reject a custom base URL (the gateway sets `ANTHROPIC_BASE_URL` itself). All configs now carry a `gateway` field.
- **`lib/config.ts`** — new `updateGatewayInConfig(raw, provider)` (creates the `gateway` block if absent).
- **`app/api/auth/route.ts`** — after saving any key, sync `gateway.provider` to match; `GET` now treats `BANKR_LLM_KEY` as authenticated; Bankr validation errors return 400.
- **`components/AuthModal.tsx`** — note that `bk_` keys route through Bankr.
- **Tests** — added cases to `auth-provider.test.mjs` and `config.test.ts`.

## Verification

- `tsc --noEmit`: clean
- `auth-provider.test.mjs`: pass
- `config.test.ts`: 34/34 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)