### PR TITLE
Push gateway.provider change after Bankr auth (local mode)

### DIFF
--- a/apps/dashboard/app/api/auth/route.ts
+++ b/apps/dashboard/app/api/auth/route.ts
@@ -1,10 +1,22 @@
 import { NextResponse } from 'next/server'
 import { execFileSync, execSync } from 'child_process'
-import { ghAvailable, ghArgsRepo } from '@/lib/gh'
+import { ghAvailable, ghArgsRepo, REPO_ROOT } from '@/lib/gh'
 import { normalizeAuthConfig } from '@/lib/auth-provider.mjs'
-import { getFileContent, updateFile } from '@/lib/github'
+import { getFileContent, updateFile, isLocal } from '@/lib/github'
 import { updateGatewayInConfig } from '@/lib/config'
 import type { GatewayProvider } from '@/lib/types'
+
+// Commit a working-tree file and push it to the instance repo. In local mode
+// updateFile() only writes the working copy, so without this the GitHub Actions
+// workflow — which reads gateway.provider from aeon.yml on the remote default
+// branch — would never see the change.
+function commitAndPush(file: string, message: string) {
+  const git = (args: string[]) =>
+    execFileSync('git', ['-C', REPO_ROOT, ...args], { stdio: ['pipe', 'pipe', 'pipe'] })
+  git(['add', file])
+  git(['-c', 'user.name=Aeon Dashboard', '-c', 'user.email=dashboard@aeon.local', 'commit', '-m', message])
+  git(['push'])
+}
 
 // Keep aeon.yml's gateway.provider in sync with the authenticated key:
 // a Bankr (bk_) key flips it to `bankr`, anything else back to `direct`.
@@ -12,9 +24,13 @@ async function syncGatewayProvider(provider: string) {
   const next: GatewayProvider = provider === 'bankr' ? 'bankr' : 'direct'
   const { content, sha } = await getFileContent('aeon.yml')
   const updated = updateGatewayInConfig(content, next)
-  if (updated !== content) {
-    await updateFile('aeon.yml', updated, sha, `chore: set LLM gateway provider to ${next}`)
-  }
+  if (updated === content) return
+
+  const message = `chore: set LLM gateway provider to ${next}`
+  await updateFile('aeon.yml', updated, sha, message)
+  // Remote mode (GITHUB_TOKEN+GITHUB_REPO) already committed via the API;
+  // local mode wrote only the working copy, so commit & push it.
+  if (isLocal()) commitAndPush('aeon.yml', message)
 }
 
 export async function GET() {

--- a/apps/dashboard/lib/github.ts
+++ b/apps/dashboard/lib/github.ts
@@ -8,7 +8,7 @@ const GITHUB_API = 'https://api.github.com'
 interface GitHubContentFile { content: string; sha: string; encoding: string }
 interface GitHubContentEntry { name: string; type: 'file' | 'dir' | 'symlink' | 'submodule'; path: string }
 
-function isLocal() {
+export function isLocal() {
   return !process.env.GITHUB_TOKEN || !process.env.GITHUB_REPO
 }
 


### PR DESCRIPTION
## Problem

A `bk_` key pasted into the auth modal saved `BANKR_LLM_KEY` on the repo but left `gateway.provider: direct`, so the workflow never routed to `https://llm.bankr.bot` (`Not logged in`). Root cause: secrets are set via the `gh` CLI (always remote), but `syncGatewayProvider()` wrote `aeon.yml` via `updateFile()`, which in **local mode** (no `GITHUB_TOKEN`/`GITHUB_REPO`) only touches the working copy — it never commits or pushes. The remote default branch kept `direct`.

## Fix

After writing `aeon.yml`, local mode now commits and pushes the change so the workflow sees the new provider. Remote mode is unchanged (the contents-API PUT already commits).

- `lib/github.ts` — export `isLocal()`.
- `app/api/auth/route.ts` — `commitAndPush()` helper; push `aeon.yml` when `isLocal()`.

## Verification

`tsc --noEmit` clean · auth-provider tests pass · config tests 34/34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)