### PR TITLE
Fix parseCron crash on non-cron schedules (workflow_dispatch)

### DIFF
--- a/apps/dashboard/lib/utils.test.ts
+++ b/apps/dashboard/lib/utils.test.ts
@@ -114,6 +114,16 @@ describe("parseCron", () => {
       assert.equal(parsed.unit, "h");
     }
   });
+
+  it("does not crash on non-cron schedules like workflow_dispatch", () => {
+    assert.doesNotThrow(() => parseCron("workflow_dispatch"));
+    const parsed = parseCron("workflow_dispatch");
+    assert.equal(parsed.mode, "time");
+  });
+
+  it("does not crash on an empty schedule", () => {
+    assert.doesNotThrow(() => parseCron(""));
+  });
 });
 
 // ── cronLabel ─────────────────────────────────────────────────────────

--- a/apps/dashboard/lib/utils.ts
+++ b/apps/dashboard/lib/utils.ts
@@ -16,7 +16,13 @@ function utcToLocal24(utcH: number): number { return ((utcH + getUtcOffsetHours(
 export function localToUtc24(localH: number): number { return ((localH - getUtcOffsetHours()) % 24 + 24) % 24 }
 
 export function parseCron(cron: string) {
-  const [m, h, , , dow] = cron.split(' ')
+  const [m, h, , , dow] = (cron ?? '').split(' ')
+  // Schedules that aren't 5-field crons (e.g. "workflow_dispatch") have no
+  // minute/hour fields — fall back to a daily 9 AM default so the editor renders
+  // instead of crashing on undefined.includes().
+  if (m === undefined || h === undefined) {
+    return { mode: 'time' as const, hour12: 9, minute: 0, ampm: 'AM' as 'AM' | 'PM', days: [-1] }
+  }
   if (m.includes('/')) return { mode: 'interval' as const, value: parseInt(m.split('/')[1]) || 5, unit: 'm' as const }
   if (h === '*' || h.includes('/')) return { mode: 'interval' as const, value: h === '*' ? 1 : parseInt(h.split('/')[1]) || 1, unit: 'h' as const }
   const localH = utcToLocal24(parseInt(h))


### PR DESCRIPTION
## Problem

`parseCron("workflow_dispatch")` (and `""`) threw `Cannot read properties of undefined (reading 'includes')` at `lib/utils.ts:21` — `cron.split(' ')` yields a single element, so `h` is `undefined` and `h.includes('/')` blows up. `cronLabel` special-cases `workflow_dispatch`, but `ScheduleEditor` calls `parseCron` directly, so the dashboard crashed.

## Fix

Guard at the single chokepoint (`parseCron`): when the minute/hour fields are missing, return a daily 9 AM default so the schedule editor renders instead of crashing. Covers every caller.

## Verification

`tsc --noEmit` clean · utils tests pass (added cases for `workflow_dispatch` and empty schedule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)