### PR TITLE
Restrict model picker to Anthropic models only

### DIFF
--- a/apps/dashboard/app/page.tsx
+++ b/apps/dashboard/app/page.tsx
@@ -132,7 +132,7 @@ export default function Dashboard() {
           )}
           {skill && (
             <SkillDetail
-              skill={skill} runs={runs} model={model} gateway={gateway} busy={busy}
+              skill={skill} runs={runs} model={model} busy={busy}
               onToggle={toggleSkill} onRun={runSkill} onDelete={deleteSkill}
               onUpdateSchedule={updateSchedule} onUpdateVar={updateVar} onUpdateModel={updateSkillModel}
               onViewRun={() => {}}

--- a/apps/dashboard/components/SkillDetail.tsx
+++ b/apps/dashboard/components/SkillDetail.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { useState } from 'react'
-import type { Skill, Run, GatewayProvider } from '../lib/types'
-import { MODELS, BANKR_EXTRA_MODELS, CATEGORY_BY_KEY } from '../lib/constants'
+import type { Skill, Run } from '../lib/types'
+import { MODELS, CATEGORY_BY_KEY } from '../lib/constants'
 import { displayName, getSkillStatus, cronLabel, statusDot, inputCls } from '../lib/utils'
 import { ScheduleEditor } from './ScheduleEditor'
 import { timeAgo } from '../lib/utils'
@@ -12,7 +12,6 @@ interface SkillDetailProps {
   skill: Skill
   runs: Run[]
   model: string
-  gateway: GatewayProvider
   busy: Record<string, boolean>
   onToggle: (name: string, enabled: boolean) => void
   onRun: (name: string, v?: string, m?: string) => void
@@ -36,8 +35,8 @@ function Section({ index, label, action, children }: { index: string; label: str
   )
 }
 
-export function SkillDetail({ skill, runs, model, gateway, busy, onToggle, onRun, onDelete, onUpdateSchedule, onUpdateVar, onUpdateModel, onViewRun }: SkillDetailProps) {
-  const modelOptions = gateway === 'bankr' ? [...MODELS, ...BANKR_EXTRA_MODELS] : MODELS
+export function SkillDetail({ skill, runs, model, busy, onToggle, onRun, onDelete, onUpdateSchedule, onUpdateVar, onUpdateModel, onViewRun }: SkillDetailProps) {
+  const modelOptions = MODELS
   const [editingSchedule, setEditingSchedule] = useState(false)
   const [editingVar, setEditingVar] = useState(false)
   const [varDraft, setVarDraft] = useState('')

--- a/apps/dashboard/components/TopBar.tsx
+++ b/apps/dashboard/components/TopBar.tsx
@@ -1,5 +1,5 @@
 import type { Skill, GatewayProvider } from '../lib/types'
-import { MODELS, BANKR_EXTRA_MODELS, CATEGORY_BY_KEY } from '../lib/constants'
+import { MODELS, CATEGORY_BY_KEY } from '../lib/constants'
 import { displayName } from '../lib/utils'
 
 interface TopBarProps {
@@ -22,7 +22,7 @@ interface TopBarProps {
 
 export function TopBar({ skill, view, repo, model, gateway, authStatus, authLoading, pulling, syncing, hasChanges, behind, onSetupAuth, onUpdateModel, onPull, onSync }: TopBarProps) {
   const dept = skill ? (CATEGORY_BY_KEY[skill.category || 'meta'] || null) : null
-  const modelOptions = gateway === 'bankr' ? [...MODELS, ...BANKR_EXTRA_MODELS] : MODELS
+  const modelOptions = MODELS
 
   return (
     <div className="h-14 border-b border-[rgba(250,250,250,0.10)] flex items-center justify-between px-5 shrink-0 bg-aeon-bg">

--- a/apps/dashboard/lib/constants.ts
+++ b/apps/dashboard/lib/constants.ts
@@ -5,14 +5,6 @@ export const MODELS = [
   { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5' },
 ]
 
-export const BANKR_EXTRA_MODELS = [
-  { id: 'gemini-3-pro', label: 'Gemini 3 Pro' },
-  { id: 'gemini-3-flash', label: 'Gemini 3 Flash' },
-  { id: 'gpt-5.2', label: 'GPT-5.2' },
-  { id: 'kimi-k2.5', label: 'Kimi K2.5' },
-  { id: 'qwen3-coder', label: 'Qwen3 Coder' },
-]
-
 export const DAYS = [
   { label: 'All', value: -1 }, { label: 'Mon', value: 1 }, { label: 'Tue', value: 2 },
   { label: 'Wed', value: 3 }, { label: 'Thu', value: 4 }, { label: 'Fri', value: 5 },


### PR DESCRIPTION
## What

The Capability-level model dropdown appended `BANKR_EXTRA_MODELS` (Gemini 3 Pro/Flash, GPT-5.2, Kimi K2.5, Qwen3 Coder) whenever `gateway === 'bankr'`. This removes them so only Claude models — Opus 4.8/4.7, Sonnet 4.6, Haiku 4.5 — are selectable, regardless of gateway.

## Changes

- `lib/constants.ts` — remove `BANKR_EXTRA_MODELS`.
- `TopBar.tsx` / `SkillDetail.tsx` — `modelOptions = MODELS` (drop the gateway ternary).
- `SkillDetail.tsx` — remove the now-unused `gateway` prop (interface, destructure, `GatewayProvider` import); drop its pass-through in `page.tsx`. (`TopBar` keeps `gateway` — still used for the "Bankr" badge.)

## Verification

`tsc --noEmit` clean; no remaining references to the extra models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)