### PR TITLE
Revert gateway to direct when the Bankr key is removed

### DIFF
--- a/apps/dashboard/app/api/auth/route.ts
+++ b/apps/dashboard/app/api/auth/route.ts
@@ -1,37 +1,8 @@
 import { NextResponse } from 'next/server'
 import { execFileSync, execSync } from 'child_process'
-import { ghAvailable, ghArgsRepo, REPO_ROOT } from '@/lib/gh'
+import { ghAvailable, ghArgsRepo } from '@/lib/gh'
 import { normalizeAuthConfig } from '@/lib/auth-provider.mjs'
-import { getFileContent, updateFile, isLocal } from '@/lib/github'
-import { updateGatewayInConfig } from '@/lib/config'
-import type { GatewayProvider } from '@/lib/types'
-
-// Commit a working-tree file and push it to the instance repo. In local mode
-// updateFile() only writes the working copy, so without this the GitHub Actions
-// workflow — which reads gateway.provider from aeon.yml on the remote default
-// branch — would never see the change.
-function commitAndPush(file: string, message: string) {
-  const git = (args: string[]) =>
-    execFileSync('git', ['-C', REPO_ROOT, ...args], { stdio: ['pipe', 'pipe', 'pipe'] })
-  git(['add', file])
-  git(['-c', 'user.name=Aeon Dashboard', '-c', 'user.email=dashboard@aeon.local', 'commit', '-m', message])
-  git(['push'])
-}
-
-// Keep aeon.yml's gateway.provider in sync with the authenticated key:
-// a Bankr (bk_) key flips it to `bankr`, anything else back to `direct`.
-async function syncGatewayProvider(provider: string) {
-  const next: GatewayProvider = provider === 'bankr' ? 'bankr' : 'direct'
-  const { content, sha } = await getFileContent('aeon.yml')
-  const updated = updateGatewayInConfig(content, next)
-  if (updated === content) return
-
-  const message = `chore: set LLM gateway provider to ${next}`
-  await updateFile('aeon.yml', updated, sha, message)
-  // Remote mode (GITHUB_TOKEN+GITHUB_REPO) already committed via the API;
-  // local mode wrote only the working copy, so commit & push it.
-  if (isLocal()) commitAndPush('aeon.yml', message)
-}
+import { syncGatewayProvider } from '@/lib/gateway'
 
 export async function GET() {
   try {

--- a/apps/dashboard/app/api/secrets/route.ts
+++ b/apps/dashboard/app/api/secrets/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { execFileSync } from 'child_process'
 import { ghAvailable, ghArgsRepo } from '@/lib/gh'
+import { syncGatewayProvider } from '@/lib/gateway'
 import type { Secret } from '@/lib/types'
 
 const BUILTIN_SECRETS: Omit<Secret, 'isSet'>[] = [
@@ -103,6 +104,8 @@ export async function POST(request: Request) {
       stdio: 'pipe',
       cwd: process.cwd(),
     })
+    // Setting the Bankr key here (not just via the auth modal) routes through Bankr.
+    if (name === 'BANKR_LLM_KEY') await syncGatewayProvider('bankr')
     return NextResponse.json({ ok: true })
   } catch (error: unknown) {
     const msg = error instanceof Error ? error.message : 'Failed to set secret'
@@ -123,6 +126,8 @@ export async function DELETE(request: Request) {
 
   try {
     execFileSync('gh', ['secret', 'delete', name, ...ghArgsRepo()], { stdio: 'pipe', cwd: process.cwd() })
+    // Deleting the Bankr key reverts the gateway to the classic (direct) provider.
+    if (name === 'BANKR_LLM_KEY') await syncGatewayProvider('direct')
     return NextResponse.json({ ok: true })
   } catch (error: unknown) {
     const msg = error instanceof Error ? error.message : 'Failed to delete secret'

--- a/apps/dashboard/lib/gateway.ts
+++ b/apps/dashboard/lib/gateway.ts
@@ -1,0 +1,33 @@
+import { execFileSync } from 'child_process'
+import { REPO_ROOT } from './gh'
+import { getFileContent, updateFile, isLocal } from './github'
+import { updateGatewayInConfig } from './config'
+import type { GatewayProvider } from './types'
+
+// Commit a working-tree file and push it to the instance repo. In local mode
+// updateFile() only writes the working copy, so without this the GitHub Actions
+// workflow — which reads gateway.provider from aeon.yml on the remote default
+// branch — would never see the change.
+function commitAndPush(file: string, message: string) {
+  const git = (args: string[]) =>
+    execFileSync('git', ['-C', REPO_ROOT, ...args], { stdio: ['pipe', 'pipe', 'pipe'] })
+  git(['add', file])
+  git(['-c', 'user.name=Aeon Dashboard', '-c', 'user.email=dashboard@aeon.local', 'commit', '-m', message])
+  git(['push'])
+}
+
+// Set aeon.yml's gateway.provider and make the change land on the repo the
+// workflow reads. A Bankr (bk_) key uses `bankr`; removing it — or any other
+// key — reverts to `direct`. No-ops when the provider is already correct.
+export async function syncGatewayProvider(provider: string) {
+  const next: GatewayProvider = provider === 'bankr' ? 'bankr' : 'direct'
+  const { content, sha } = await getFileContent('aeon.yml')
+  const updated = updateGatewayInConfig(content, next)
+  if (updated === content) return
+
+  const message = `chore: set LLM gateway provider to ${next}`
+  await updateFile('aeon.yml', updated, sha, message)
+  // Remote mode (GITHUB_TOKEN+GITHUB_REPO) already committed via the API;
+  // local mode wrote only the working copy, so commit & push it.
+  if (isLocal()) commitAndPush('aeon.yml', message)
+}


### PR DESCRIPTION
## What

Keeps `aeon.yml` `gateway.provider` tracking the `BANKR_LLM_KEY` secret from **every** entry point, not just the auth modal:

- Deleting `BANKR_LLM_KEY` (secrets panel) → provider reverts to **`direct`** (classic).
- Setting `BANKR_LLM_KEY` (secrets panel) → provider set to **`bankr`**.
- Auth modal already did `bk_` → bankr / else → direct.

## Why

Previously, deleting the Bankr key left `provider: bankr` pointing at a now-missing secret, so the workflow failed (`BANKR_LLM_KEY not set`). Now removal cleanly falls back to the classic provider.

## How

Extracted `syncGatewayProvider` (and its local-mode commit+push) from the auth route into shared **`lib/gateway.ts`**, now used by both the auth route and the secrets route.

## Verification

`tsc --noEmit` clean · all dashboard tests pass (76).

🤖 Generated with [Claude Code](https://claude.com/claude-code)