### PR TITLE
Robustly parse skill-analysis JSON from gateway models

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -695,13 +695,15 @@ jobs:
           ANALYSIS_TEXT=$(echo "$RAW" | jq -r '.result // empty')
           [ -z "$ANALYSIS_TEXT" ] && { echo "::warning::Empty analysis result"; exit 0; }
 
-          # Parse score from response (try direct JSON, then extract embedded JSON)
+          # Parse score: accept raw JSON, else strip code fences, flatten newlines,
+          # and grab the outermost {…} object — handles fenced / multi-line output
+          # from gateways like Bankr that the old line-based grep missed.
           if echo "$ANALYSIS_TEXT" | jq empty 2>/dev/null; then
             PARSED="$ANALYSIS_TEXT"
           else
-            PARSED=$(echo "$ANALYSIS_TEXT" | grep -o '{[^{}]*}' | head -1 || true)
+            PARSED=$(printf '%s' "$ANALYSIS_TEXT" | sed 's/```[a-zA-Z]*//g' | tr '\n' ' ' | grep -o '{.*}' | head -1 || true)
             if [ -z "$PARSED" ] || ! echo "$PARSED" | jq empty 2>/dev/null; then
-              echo "::warning::Could not parse analysis JSON"
+              echo "::warning::Could not parse analysis JSON. Raw: $(printf '%s' "$ANALYSIS_TEXT" | head -c 300 | tr '\n' ' ')"
               exit 0
             fi
           fi


### PR DESCRIPTION
## Problem

Every Bankr run logged `Could not parse analysis JSON` in the post-run *Analyze skill output* step (non-fatal — runs still pass, but no quality score is recorded). The extractor used `grep -o '{[^{}]*}'`, which is **line-based and rejects nested or multi-line JSON**, and `jq empty` fails when the model wraps the object in markdown code fences. Gateway-routed models (e.g. Bankr) commonly return fenced and/or pretty-printed JSON, so extraction failed.

Verified: even the **succeeded** `digest` run on `aeonbankr` emitted this warning. The provider switch in the analyze step is correctly wired (`steps.run.outputs.GATEWAY == bankr` → exports Bankr base URL + token), so routing works — the gap was purely the brittle parse.

## Fix

- Strip code fences, flatten newlines, and grab the outermost `{…}` object, then validate with `jq`. Handles fenced / multi-line / nested output; the raw-JSON fast path is unchanged.
- Include a truncated raw snippet in the warning so any remaining parse failure shows the actual model output (distinguishes "fenced JSON" from an "API error string").

Demonstrated: the new extractor parses a fenced, multi-line payload that the old `grep` matched as nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)