### PR TITLE
docs(readme): cross-platform quick start, fork walkthrough, run-without-push

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,21 +26,21 @@
 
 You need three things:
 
-1. **Node.js 20+**
-2. **[GitHub CLI](https://cli.github.com/) (`gh`), authenticated** — `brew install gh`, then `gh auth login`. The dashboard uses it for everything (secrets, workflows), and `./aeon` checks it before starting.
-3. **Your own copy of this repo** — fork it (or `gh repo create <you>/aeon --public --clone --source=.`), then `gh repo set-default <you>/<repo>`.
+1. **Node.js 20+** — check with `node -v`. Missing or too old? Grab the LTS installer from [nodejs.org](https://nodejs.org/en/download), or use a package manager: `brew install node` (macOS), `winget install OpenJS.NodeJS.LTS` (Windows), [nvm](https://github.com/nvm-sh/nvm) or your distro's package manager (Linux).
+2. **[GitHub CLI](https://cli.github.com/) (`gh`), authenticated** — the dashboard uses it for everything (secrets, workflows), and `./aeon` checks it before starting. Install: `brew install gh` (macOS), `winget install --id GitHub.cli` (Windows), [per-distro instructions](https://github.com/cli/cli/blob/trunk/docs/install_linux.md) (Linux). Then run `gh auth login` and follow the prompts.
+3. **Your own fork of this repo** — click the **Fork** button at the top of [the repo page](https://github.com/aaronjmars/aeon) (keep it public — Actions minutes are free on public repos), or run `gh repo fork aaronjmars/aeon --clone`. Then point `gh` at it once: `gh repo set-default <you>/aeon`.
 
 ```bash
-git clone https://github.com/<you>/aeon
+git clone https://github.com/<you>/aeon   # skip if you used `gh repo fork --clone`
 cd aeon && ./aeon
 ```
 
 Open [http://localhost:5555](http://localhost:5555) and follow the four steps:
 
-1. **Authenticate** — connect your Claude Pro/Max subscription, or paste an API key (Anthropic, Anthropic-compatible, or a Bankr `bk_…` key — routed automatically).
+1. **Authenticate** — connect your Claude Pro/Max subscription, or paste an API key (Anthropic, Anthropic-compatible, or a Bankr `bk_…` key from [bankr.bot/api-keys](https://bankr.bot/api-keys) — routed automatically).
 2. **Add a channel** — [Telegram, Discord, or Slack](#notifications) so Aeon can talk to you.
 3. **Pick skills** — toggle what you want, set schedules. Each skill shows the API keys and MCP servers it needs, with one-click setup.
-4. **Push** — one click commits your config to GitHub. Actions takes it from there.
+4. **Run** — hit **Run now** on any skill to try it immediately; API keys and `var`s apply directly, no push needed. When you change config (schedules, toggles), **Push** commits it to GitHub in one click so Actions runs it on cron.
 
 That's it — Aeon now runs unattended. On a public repo, GitHub Actions minutes are **free**. Run `./onboard` anytime to verify your setup.
 
@@ -61,7 +61,7 @@ Grab the `gh_*_macOS_arm64.zip` (or your platform's binary) from [github.com/cli
 
 | Category | Count | Examples |
 |----------|-------|----------|
-| 🧬 **Core** | 15 | self-healing, self-evolution, fleet control, vuln scanning |
+| 🧬 **Core** | 15 | `skill-repair`, `autoresearch`, `spawn-instance`, `vuln-scanner` |
 | 📚 **Research & Content** | 28 | `deep-research`, `paper-digest`, `hacker-news-digest` |
 | 💻 **Dev & Code** | 37 | `pr-review`, `github-monitor`, `auto-merge` |
 | 📈 **Crypto & Markets** | 29 | `token-alert`, `defi-monitor`, `polymarket`, `base-mcp` |
@@ -347,7 +347,7 @@ The built-in `GITHUB_TOKEN` is scoped to this repo only. For `github-monitor`, `
 
 Route requests through [Bankr LLM Gateway](https://docs.bankr.bot/llm-gateway/overview) for ~67% cheaper Opus (via Vertex AI), plus gateway access to Gemini, GPT, Kimi, and Qwen models (set the model id manually in `aeon.yml`).
 
-Get a key at [bankr.bot/api](https://bankr.bot/api), top up credits, and paste it in the dashboard's Authenticate modal — `bk_…` keys are saved as `BANKR_LLM_KEY` and `gateway: { provider: bankr }` is set automatically. Removing the key reverts the gateway to `direct`.
+Get a key at [bankr.bot/api-keys](https://bankr.bot/api-keys), top up credits, and paste it in the dashboard's Authenticate modal — `bk_…` keys are saved as `BANKR_LLM_KEY` and `gateway: { provider: bankr }` is set automatically. Removing the key reverts the gateway to `direct`.
 
 ### Soul
 

--- a/memory/logs/2026-06-09.md
+++ b/memory/logs/2026-06-09.md
@@ -6,4 +6,9 @@
 - Fixed stale facts: skill count 195 → **196** (Crypto & Markets 28 → 29 with `base-mcp` from #395), model options now include `claude-fable-5` (#394) and `claude-opus-4-7` (#379), Bankr auto-routing/revert behavior (#386/#391) reflected in Authentication + Bankr Gateway sections.
 - Restructured the README for time-to-first-launch (791 → ~540 lines): Quick start first and trimmed, capabilities showcase second (compact category table + full catalog in a `<details>` block, self-healing / fleet / real-world-action highlights), everyday config under **Configure**, and everything else (chaining, reactive triggers, MCP-in-runs, MCP/A2A, cross-repo, Bankr, soul, publishing, instant mode, remote dashboard access, Fleet Watcher, community packs, two-repo, Actions cost, project structure) under a single **Advanced** section. FAQ deduplicated.
 - Preserved externally-linked anchors: `#quick-start`, `#community-skill-packs`, `#mcp-servers-in-skill-runs`, `#notifications`.
-- Opened PR from branch `docs/readme-simplify`.
+- Opened PR from branch `docs/readme-simplify` (merged as #396).
+
+## Dashboard cleanup + Quick start polish (later same day)
+
+- PR #397 (merged): hid the empty "01 / API keys" section on SkillDetail (dynamic numbering, like the MCP section) and removed the "* = required" legend + asterisks from Settings → Access Keys.
+- Quick start polish: cross-platform install steps for Node.js 20+ and `gh` (macOS/Windows/Linux), fork-button walkthrough, Bankr key link (bankr.bot/api-keys), reworded step 4 — **Run now** works without pushing (keys/`var`s apply directly; Push is for config changes). Fixed the Core row in the category table to use backticked skill names like the other rows.


### PR DESCRIPTION
Follow-up polish on the Quick start after #396, per operator feedback:

- **Node.js 20+ explained** — `node -v` check, then install paths for all three OSes (brew / winget / nvm-or-distro-pm) plus the nodejs.org LTS download.
- **GitHub CLI works for Windows / macOS / Linux** — `brew install gh`, `winget install --id GitHub.cli`, and the per-distro Linux install doc, with `gh auth login` spelled out as its own step.
- **Forking explained** — points at the **Fork** button at the top of the repo page (or `gh repo fork aaronjmars/aeon --clone`), with a note to keep the fork public for free Actions minutes. Clone line marked skippable when `--clone` was used.
- **No push needed to run** — step 4 reworded: **Run now** triggers any skill immediately (API keys and `var`s apply directly); **Push** is only for config changes (schedules, toggles) that the cron scheduler needs on GitHub.
- **Bankr links** — `bk_` key references now link to [bankr.bot/api-keys](https://bankr.bot/api-keys) in both the quick start and the Bankr Gateway section.
- **Core row formatting fixed** — the category table's Core examples were plain prose while every other row used backticked skill names; now `skill-repair`, `autoresearch`, `spawn-instance`, `vuln-scanner`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)