### PR TITLE
feat(webhook): deploy-wizard variable prompts + guided instant-mode card

### DIFF
--- a/apps/dashboard/components/InstantModeCard.tsx
+++ b/apps/dashboard/components/InstantModeCard.tsx
@@ -1,88 +1,188 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
+import { inputCls } from '../lib/utils'
 
 interface InstantModeCardProps {
   repo: string
+  // Bot token saved earlier in this session — secrets are write-only on GitHub,
+  // so this is the only chance to pre-fill it for the setWebhook step.
+  sessionBotToken?: string
 }
 
-const SET_WEBHOOK_CMD =
-  'curl "https://api.telegram.org/bot<YOUR_BOT_TOKEN>/setWebhook?url=https://<your-worker>.workers.dev&secret_token=<YOUR_WEBHOOK_SECRET>"'
+export function InstantModeCard({ repo, sessionBotToken }: InstantModeCardProps) {
+  const [enabled, setEnabled] = useState(false)
+  const [copied, setCopied] = useState<string | null>(null)
+  const [botToken, setBotToken] = useState('')
+  const [workerUrl, setWorkerUrl] = useState('')
+  const [whBusy, setWhBusy] = useState(false)
+  const [whStatus, setWhStatus] = useState<{ ok: boolean; msg: string } | null>(null)
 
-export function InstantModeCard({ repo }: InstantModeCardProps) {
-  const [copied, setCopied] = useState(false)
+  useEffect(() => { if (sessionBotToken) setBotToken(sessionBotToken) }, [sessionBotToken])
+
   const deployRepo = repo || 'aaronjmars/aeon'
   const deployUrl = `https://deploy.workers.cloudflare.com/?url=https://github.com/${deployRepo}/tree/main/apps/webhook`
+  // Classic-token page supports prefilling scope + description; fine-grained doesn't.
+  const patUrl = 'https://github.com/settings/tokens/new?scopes=repo&description=aeon-telegram-webhook'
 
-  const copy = async () => {
+  // Accept a bare subdomain, a host, or a full URL — normalize to https://host.
+  const trimmedWorker = workerUrl.trim().replace(/\/+$/, '')
+  const fullWorkerUrl = trimmedWorker
+    ? trimmedWorker.startsWith('http') ? trimmedWorker
+      : `https://${trimmedWorker.includes('.') ? trimmedWorker : `aeon-telegram-webhook.${trimmedWorker}.workers.dev`}`
+    : ''
+  const setWebhookCmd =
+    `curl "https://api.telegram.org/bot${botToken.trim() || '<YOUR_BOT_TOKEN>'}/setWebhook?url=${fullWorkerUrl || 'https://<your-worker>.workers.dev'}"`
+
+  const copy = async (key: string, text: string) => {
     try {
-      await navigator.clipboard.writeText(SET_WEBHOOK_CMD)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 1500)
-    } catch { /* clipboard blocked — the command is visible to copy manually */ }
+      await navigator.clipboard.writeText(text)
+      setCopied(key)
+      setTimeout(() => setCopied(null), 1500)
+    } catch { /* clipboard blocked — the value is visible to copy manually */ }
+  }
+
+  // Telegram's API allows CORS, so the webhook can be registered straight from
+  // the browser — same trick as the chat-ID helper. The token never leaves the
+  // page except to api.telegram.org.
+  const registerWebhook = async () => {
+    if (!botToken.trim() || !fullWorkerUrl) return
+    setWhBusy(true)
+    setWhStatus(null)
+    try {
+      const res = await fetch(`https://api.telegram.org/bot${botToken.trim()}/setWebhook?url=${encodeURIComponent(fullWorkerUrl)}`)
+      const data = await res.json() as { ok: boolean; description?: string }
+      setWhStatus(data.ok
+        ? { ok: true, msg: 'Webhook set — replies now arrive in ~1s. The poller backs off automatically.' }
+        : { ok: false, msg: data.description ?? 'Telegram rejected the request — double-check the token.' })
+    } catch {
+      setWhStatus({ ok: false, msg: 'Could not reach api.telegram.org from the browser — copy the curl command below instead.' })
+    } finally {
+      setWhBusy(false)
+    }
   }
 
   return (
     <section className="border-t border-[rgba(250,250,250,0.10)] pt-6">
       <div className="flex items-center gap-3 mb-4">
-        <span className="font-display text-[13px] tracking-[0.18em] text-aeon-red">⚡ Telegram · Instant mode</span>
+        <span className="font-display text-[13px] tracking-[0.18em] text-aeon-red">⚡ Telegram · Instant replies</span>
         <span className="flex-1 h-px bg-[rgba(250,250,250,0.10)]" />
-        <span className="text-[10px] font-mono uppercase tracking-[0.18em] text-primary-35">optional · ~1s</span>
+        <span className="text-[10px] font-mono uppercase tracking-[0.18em] text-primary-35">optional</span>
       </div>
 
       <div className="border border-[rgba(250,250,250,0.10)] p-[var(--space-md)] space-y-5">
         <p className="text-[13px] text-primary-70 leading-relaxed">
-          By default Aeon polls Telegram every 5 minutes. Deploy a tiny Cloudflare Worker as a webhook and
-          replies arrive in <span className="text-primary-100">~1 second</span> — it relays each message to GitHub{' '}
-          <span className="font-mono text-primary-100">repository_dispatch</span>. It runs in your own Cloudflare
-          account; there&apos;s no shared infrastructure.
+          Replies aren&apos;t instant — by design. Aeon runs on GitHub Actions and polls Telegram every{' '}
+          <span className="text-primary-100">5 minutes</span>; it&apos;s built for autonomous background work,
+          not real-time chat. If you want <span className="text-primary-100">~1-second</span> replies anyway,
+          you can deploy a tiny Cloudflare Worker webhook into your own account — a one-time setup of about 5 minutes.
         </p>
 
-        {/* 1 — deploy */}
-        <div>
-          <div className="text-[10px] font-mono uppercase tracking-[0.18em] text-primary-40 mb-2">1 · Deploy the Worker</div>
-          <a href={deployUrl} target="_blank" rel="noopener noreferrer" className="inline-block">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img src="https://deploy.workers.cloudflare.com/button" alt="Deploy to Cloudflare" height={32} />
-          </a>
-          <p className="text-[11px] text-primary-35 font-mono mt-2">
-            Deploys <span className="text-primary-70">{deployRepo}/webhook</span> · requires a public repo.
-          </p>
+        <div className="flex flex-wrap items-center gap-3">
+          <span className="text-[10px] font-mono uppercase tracking-[0.18em] text-primary-40">Enable instant reply mode?</span>
+          <button
+            onClick={() => setEnabled(true)}
+            className={`text-[11px] font-mono px-4 py-1.5 border transition-colors ${enabled ? 'border-eva-green text-eva-green' : 'border-[rgba(250,250,250,0.16)] text-primary-40 hover:text-eva-green hover:border-eva-green/40'}`}
+          >
+            Yes
+          </button>
+          <button
+            onClick={() => setEnabled(false)}
+            className={`text-[11px] font-mono px-4 py-1.5 border transition-colors ${!enabled ? 'border-[rgba(250,250,250,0.35)] text-primary-70' : 'border-[rgba(250,250,250,0.16)] text-primary-40 hover:text-primary-70'}`}
+          >
+            No
+          </button>
+          {!enabled && (
+            <span className="text-[10px] font-mono text-primary-35">keeping the 5-minute poll — flip this anytime</span>
+          )}
         </div>
 
-        {/* 2 — secrets */}
-        <div>
-          <div className="text-[10px] font-mono uppercase tracking-[0.18em] text-primary-40 mb-2">2 · Set the Worker&apos;s secrets (in Cloudflare)</div>
-          <ul className="text-[12px] font-mono text-primary-70 space-y-1">
-            <li><span className="text-primary-100">TELEGRAM_BOT_TOKEN</span> · <span className="text-primary-100">TELEGRAM_CHAT_ID</span></li>
-            <li><span className="text-primary-100">GITHUB_REPO</span> = {deployRepo} · <span className="text-primary-100">GITHUB_TOKEN</span> <span className="text-primary-35">(repo scope)</span></li>
-            <li><span className="text-primary-100">TELEGRAM_WEBHOOK_SECRET</span> <span className="text-primary-35">— optional, recommended</span></li>
-          </ul>
-          <p className="text-[11px] text-primary-35 mt-2 leading-relaxed">
-            These live in the Cloudflare dashboard (Workers &amp; Pages → your worker → Settings → Variables).
-            They&apos;re separate from the GitHub secrets above — the dashboard can&apos;t set them for you.
-          </p>
-        </div>
+        {enabled && (
+          <>
+            {/* 1 — deploy */}
+            <div>
+              <div className="text-[10px] font-mono uppercase tracking-[0.18em] text-primary-40 mb-2">1 · Deploy the Worker</div>
+              <a href={deployUrl} target="_blank" rel="noopener noreferrer" className="inline-block">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img src="https://deploy.workers.cloudflare.com/button" alt="Deploy to Cloudflare" height={32} />
+              </a>
+              <p className="text-[11px] text-primary-35 font-mono mt-2">
+                Deploys <span className="text-primary-70">{deployRepo}/webhook</span> · requires a public repo.
+              </p>
+            </div>
 
-        {/* 3 — register */}
-        <div>
-          <div className="text-[10px] font-mono uppercase tracking-[0.18em] text-primary-40 mb-2">3 · Point Telegram at the Worker</div>
-          <div className="flex items-start gap-2">
-            <code className="flex-1 bg-aeon-bg text-primary-70 text-[11px] px-3 py-2 border border-[rgba(250,250,250,0.10)] font-mono break-all">
-              {SET_WEBHOOK_CMD}
-            </code>
-            <button onClick={copy}
-              className="text-[11px] text-primary-40 font-mono hover:text-eva-orange transition-colors px-2 py-2 shrink-0">
-              {copied ? 'copied' : 'copy'}
-            </button>
-          </div>
-        </div>
+            {/* 2 — variables */}
+            <div>
+              <div className="text-[10px] font-mono uppercase tracking-[0.18em] text-primary-40 mb-2">2 · Fill the variables in the deploy wizard</div>
+              <ul className="text-[12px] font-mono text-primary-70 space-y-1.5">
+                <li>
+                  <span className="text-primary-100">TELEGRAM_BOT_TOKEN</span>{' '}
+                  <a href="https://t.me/BotFather" target="_blank" rel="noopener noreferrer"
+                    title="Open BotFather in Telegram, send /newbot (or /token for an existing bot), copy the token it replies with"
+                    className="text-[10px] text-eva-orange/80 hover:text-eva-orange transition-colors">@BotFather ↗</a>
+                </li>
+                <li>
+                  <span className="text-primary-100">TELEGRAM_CHAT_ID</span>{' '}
+                  <span className="text-[10px] text-primary-35">— use the &quot;Find my chat ID&quot; helper in the Telegram section above, before registering the webhook (it stops getUpdates)</span>
+                </li>
+                <li>
+                  <span className="text-primary-100">GITHUB_REPO</span> = {deployRepo}{' '}
+                  <button onClick={() => copy('repo', deployRepo)}
+                    className="text-[10px] text-primary-40 hover:text-eva-orange transition-colors">
+                    {copied === 'repo' ? 'copied' : 'copy'}
+                  </button>
+                </li>
+                <li>
+                  <span className="text-primary-100">GITHUB_TOKEN</span>{' '}
+                  <a href={patUrl} target="_blank" rel="noopener noreferrer"
+                    title="Opens GitHub's token page with the repo scope and a name prefilled — generate and copy"
+                    className="text-[10px] text-eva-orange/80 hover:text-eva-orange transition-colors">create token ↗</a>
+                </li>
+              </ul>
+              <p className="text-[11px] text-primary-35 mt-2 leading-relaxed">
+                The wizard prompts for these during deploy and stores them as encrypted Worker secrets in your
+                Cloudflare account. Edit later: Workers &amp; Pages → your worker → Settings → Variables.
+              </p>
+            </div>
 
-        <p className="text-[11px] text-primary-40 leading-relaxed">
-          Once the webhook is live, the poller detects it (<span className="font-mono">getWebhookInfo</span>) and
-          skips Telegram automatically — no double-processing. Full guide:{' '}
-          <span className="font-mono text-primary-70">apps/webhook/README.md</span>.
-        </p>
+            {/* 3 — register */}
+            <div>
+              <div className="text-[10px] font-mono uppercase tracking-[0.18em] text-primary-40 mb-2">3 · Point Telegram at the Worker</div>
+              <div className="flex flex-col sm:flex-row gap-2">
+                <input type="password" value={botToken} onChange={(e) => setBotToken(e.target.value)}
+                  placeholder="bot token..." className={inputCls} />
+                <input type="text" value={workerUrl} onChange={(e) => setWorkerUrl(e.target.value)}
+                  onKeyDown={(e) => e.key === 'Enter' && registerWebhook()}
+                  placeholder="aeon-telegram-webhook.<subdomain>.workers.dev" className={inputCls} />
+                <button onClick={registerWebhook} disabled={!botToken.trim() || !fullWorkerUrl || whBusy}
+                  className="bg-eva-green text-white text-[11px] px-4 py-2 font-mono hover:opacity-90 transition-opacity disabled:opacity-50 shrink-0">
+                  {whBusy ? 'Registering…' : 'Register'}
+                </button>
+              </div>
+              <p className="text-[11px] text-primary-35 mt-2">
+                The Worker URL is on its Overview tab in Cloudflare. The token only goes to api.telegram.org; nothing is stored.
+              </p>
+              {whStatus && (
+                <p className={`text-[11px] font-mono mt-2 ${whStatus.ok ? 'text-eva-green' : 'text-eva-red/80'}`}>{whStatus.msg}</p>
+              )}
+              <div className="flex items-start gap-2 mt-3">
+                <code className="flex-1 bg-aeon-bg text-primary-70 text-[11px] px-3 py-2 border border-[rgba(250,250,250,0.10)] font-mono break-all">
+                  {setWebhookCmd}
+                </code>
+                <button onClick={() => copy('cmd', setWebhookCmd)}
+                  className="text-[11px] text-primary-40 font-mono hover:text-eva-orange transition-colors px-2 py-2 shrink-0">
+                  {copied === 'cmd' ? 'copied' : 'copy'}
+                </button>
+              </div>
+            </div>
+
+            <p className="text-[11px] text-primary-40 leading-relaxed">
+              Once the webhook is live, the poller detects it (<span className="font-mono">getWebhookInfo</span>) and
+              skips Telegram automatically — no double-processing. Full guide:{' '}
+              <span className="font-mono text-primary-70">apps/webhook/README.md</span>.
+            </p>
+          </>
+        )}
       </div>
     </section>
   )

--- a/apps/dashboard/components/SecretsPanel.tsx
+++ b/apps/dashboard/components/SecretsPanel.tsx
@@ -155,7 +155,7 @@ export function SecretsPanel({ secrets, skills, busy, repo, focusKey, onFocusHan
               ))}
             </div>
           </section>
-          {group === 'Telegram' && <InstantModeCard repo={repo} />}
+          {group === 'Telegram' && <InstantModeCard repo={repo} sessionBotToken={sessionBotToken} />}
           </Fragment>
         )
       })}

--- a/apps/dashboard/components/SecretsPanel.tsx
+++ b/apps/dashboard/components/SecretsPanel.tsx
@@ -5,6 +5,7 @@ import type { Secret, Skill } from '../lib/types'
 import { inputCls, displayName } from '../lib/utils'
 import { Scramble } from './ui/Animated'
 import { InstantModeCard } from './InstantModeCard'
+import { TelegramChatIdHelper } from './TelegramChatIdHelper'
 
 interface SecretsPanelProps {
   secrets: Secret[]
@@ -23,6 +24,9 @@ export function SecretsPanel({ secrets, skills, busy, repo, focusKey, onFocusHan
   const [secretValue, setSecretValue] = useState('')
   const [addingSecret, setAddingSecret] = useState(false)
   const [newSecretName, setNewSecretName] = useState('')
+  // Bot token saved this session, kept to pre-fill the chat-ID helper —
+  // GitHub secrets are write-only, so it can't be read back later.
+  const [sessionBotToken, setSessionBotToken] = useState('')
 
   // Deep-link from a skill's API-keys panel: open the requested key's editor,
   // scroll it into view, and clear the request so re-navigating works.
@@ -51,6 +55,7 @@ export function SecretsPanel({ secrets, skills, busy, repo, focusKey, onFocusHan
 
   const handleSave = (name: string) => {
     if (!secretValue.trim()) return
+    if (name === 'TELEGRAM_BOT_TOKEN') setSessionBotToken(secretValue.trim())
     onSave(name, secretValue.trim())
     setEditingSecret(null)
     setSecretValue('')
@@ -99,6 +104,23 @@ export function SecretsPanel({ secrets, skills, busy, repo, focusKey, onFocusHan
                     <div className="min-w-0">
                       <div className="flex items-center gap-2"><span className="font-mono text-xs">{secret.name}</span><span className={`w-2 h-2 rounded-full ${secret.isSet ? 'bg-eva-green' : 'bg-[rgba(250,250,250,0.15)]'}`} /></div>
                       <div className="text-[11px] text-primary-40 font-mono">{secret.description}</div>
+                      {secret.name === 'TELEGRAM_BOT_TOKEN' && (
+                        <a
+                          href="https://t.me/BotFather"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          title="Opens BotFather in Telegram. Send /newbot and follow the prompts (or /token for an existing bot) — it replies with the bot token, e.g. 123456789:AAxx... Paste that here."
+                          className="inline-block text-[10px] font-mono text-eva-orange/80 hover:text-eva-orange transition-colors mt-1"
+                        >
+                          Get one from @BotFather ↗
+                        </a>
+                      )}
+                      {secret.name === 'TELEGRAM_CHAT_ID' && (
+                        <TelegramChatIdHelper
+                          defaultToken={sessionBotToken}
+                          onFound={(chatId) => { setEditingSecret('TELEGRAM_CHAT_ID'); setSecretValue(chatId) }}
+                        />
+                      )}
                       {(usedBy.get(secret.name)?.length ?? 0) > 0 && (
                         <div className="text-[10px] text-primary-35 font-mono mt-1 flex flex-wrap items-center gap-x-1.5 gap-y-1">
                           <span className="uppercase tracking-[0.14em] text-primary-30">Used by</span>

--- a/apps/dashboard/components/TelegramChatIdHelper.tsx
+++ b/apps/dashboard/components/TelegramChatIdHelper.tsx
@@ -1,0 +1,122 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { inputCls } from '../lib/utils'
+
+interface TelegramChatIdHelperProps {
+  // Bot token saved earlier in this session — secrets are write-only on GitHub,
+  // so this is the only chance to pre-fill and save the operator a second paste.
+  defaultToken?: string
+  onFound: (chatId: string) => void
+}
+
+// Minimal slice of the getUpdates payload — any update type carrying a chat id works.
+interface TgUpdate {
+  message?: { chat?: { id?: number } }
+  edited_message?: { chat?: { id?: number } }
+  channel_post?: { chat?: { id?: number } }
+  my_chat_member?: { chat?: { id?: number } }
+}
+
+export function TelegramChatIdHelper({ defaultToken, onFound }: TelegramChatIdHelperProps) {
+  const [open, setOpen] = useState(false)
+  const [token, setToken] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [status, setStatus] = useState<{ ok: boolean; msg: string } | null>(null)
+
+  useEffect(() => { if (defaultToken) setToken(defaultToken) }, [defaultToken])
+
+  const trimmed = token.trim()
+  const getUpdatesUrl = trimmed ? `https://api.telegram.org/bot${trimmed}/getUpdates` : null
+
+  const chatIdFrom = (u: TgUpdate) =>
+    u.message?.chat?.id ?? u.edited_message?.chat?.id ?? u.channel_post?.chat?.id ?? u.my_chat_member?.chat?.id
+
+  const findChatId = async () => {
+    if (!getUpdatesUrl) return
+    setBusy(true)
+    setStatus(null)
+    try {
+      const res = await fetch(getUpdatesUrl)
+      const data = await res.json() as { ok: boolean; description?: string; result?: TgUpdate[] }
+      if (!data.ok) {
+        setStatus({ ok: false, msg: data.description ?? 'Telegram rejected the token — double-check it.' })
+        return
+      }
+      // Latest update wins — scan backwards for anything with a chat id.
+      const updates = data.result ?? []
+      for (let i = updates.length - 1; i >= 0; i--) {
+        const id = chatIdFrom(updates[i])
+        if (id !== undefined) {
+          onFound(String(id))
+          setStatus({ ok: true, msg: `Found chat ID ${id} — filled in above, hit Save.` })
+          return
+        }
+      }
+      setStatus({ ok: false, msg: 'No messages yet — open your bot in Telegram, send it anything, then fetch again.' })
+    } catch {
+      setStatus({ ok: false, msg: 'Could not reach api.telegram.org from the browser — use the open link instead.' })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        title="Paste your bot token and Aeon reads your chat ID from Telegram's getUpdates API"
+        className="text-[10px] font-mono text-eva-orange/80 hover:text-eva-orange transition-colors mt-1"
+      >
+        Find my chat ID →
+      </button>
+    )
+  }
+
+  return (
+    <div className="mt-2 border border-[rgba(250,250,250,0.10)] bg-aeon-bg/40 p-3 space-y-2">
+      <p className="text-[11px] text-primary-40 leading-relaxed">
+        Send your bot any message in Telegram first (it can&apos;t see you until you do), then paste
+        its token — the chat ID is read from <span className="font-mono text-primary-70">getUpdates</span>.
+        The token stays in your browser; nothing is stored.
+      </p>
+      <div className="flex gap-2">
+        <input
+          type="password"
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && findChatId()}
+          placeholder="paste bot token..."
+          className={inputCls}
+        />
+        <button
+          onClick={findChatId}
+          disabled={!trimmed || busy}
+          className="bg-eva-green text-white text-[11px] px-4 py-2 font-mono hover:opacity-90 transition-opacity disabled:opacity-50 shrink-0"
+        >
+          {busy ? 'Fetching…' : 'Fetch'}
+        </button>
+        <button
+          onClick={() => { setOpen(false); setStatus(null) }}
+          className="text-[11px] text-primary-40 font-mono px-2 py-2 hover:text-primary-70 shrink-0"
+        >
+          Cancel
+        </button>
+      </div>
+      {status && (
+        <p className={`text-[11px] font-mono ${status.ok ? 'text-eva-green' : 'text-eva-red/80'}`}>{status.msg}</p>
+      )}
+      {getUpdatesUrl && (
+        <a
+          href={getUpdatesUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          title={'Opens getUpdates for your bot in a new tab — look for "chat":{"id":...} in the JSON. Empty result? Message your bot first.'}
+          className="inline-block text-[10px] font-mono text-primary-40 hover:text-eva-orange transition-colors"
+        >
+          or open getUpdates in a new tab ↗
+        </a>
+      )}
+    </div>
+  )
+}

--- a/apps/webhook/.dev.vars.example
+++ b/apps/webhook/.dev.vars.example
@@ -1,0 +1,8 @@
+# Declared here so the "Deploy to Cloudflare" wizard prompts for each value
+# during deploy and stores it as an encrypted Worker secret. This file holds
+# names only — never put real values in it. For local dev, copy to .dev.vars
+# (gitignored) and fill in.
+TELEGRAM_BOT_TOKEN=        # paste from @BotFather
+TELEGRAM_CHAT_ID=
+GITHUB_REPO=owner/your-aeon-fork
+GITHUB_TOKEN=

--- a/apps/webhook/README.md
+++ b/apps/webhook/README.md
@@ -27,33 +27,34 @@ npx wrangler deploy
 
 ## Configure
 
-After the first deploy the Worker exists but has no config. Set these as
-**secrets** (Cloudflare dashboard → Workers & Pages → your worker → Settings →
-Variables → *Add variable* → *Encrypt*), or via the CLI:
+The deploy button prompts for all four values during the wizard (declared in
+[`.dev.vars.example`](.dev.vars.example)) and stores them as encrypted Worker
+secrets — the Worker comes out configured. Deploying from a clone instead? Set
+them via the CLI:
 
 ```bash
 npx wrangler secret put TELEGRAM_BOT_TOKEN        # bot token from @BotFather
 npx wrangler secret put TELEGRAM_CHAT_ID          # your chat id (only this chat is allowed)
 npx wrangler secret put GITHUB_REPO               # owner/repo of your Aeon fork
 npx wrangler secret put GITHUB_TOKEN              # GitHub PAT (see scopes below)
-npx wrangler secret put TELEGRAM_WEBHOOK_SECRET   # optional but recommended — any random string
 ```
 
 | Secret | Required | Notes |
 |--------|----------|-------|
 | `TELEGRAM_BOT_TOKEN` | yes | From [@BotFather](https://t.me/BotFather). |
 | `TELEGRAM_CHAT_ID` | yes | Only messages from this chat are relayed; everything else is dropped. |
-| `GITHUB_REPO` | yes | `owner/repo`, e.g. `aaronjmars/aeon`. |
+| `GITHUB_REPO` | yes | `owner/repo` of your Aeon fork, e.g. `aaronjmars/aeon` — not the worker repo the deploy button creates. |
 | `GITHUB_TOKEN` | yes | Fine-grained PAT scoped to your fork with **Contents: read/write** and **Actions: read/write**, or a classic token with `repo`. |
-| `TELEGRAM_WEBHOOK_SECRET` | recommended | Shared secret that lets the Worker reject forged calls. Use the same value when registering the webhook (below). |
+
+To edit values later: Cloudflare dashboard → Workers & Pages → your worker →
+Settings → Variables and secrets.
 
 ## Point Telegram at the Worker
 
-Register your Worker URL as the bot's webhook. Include the optional secret so
-Telegram signs every call (the Worker verifies it):
+Register your Worker URL as the bot's webhook:
 
 ```bash
-curl "https://api.telegram.org/bot<YOUR_BOT_TOKEN>/setWebhook?url=https://aeon-telegram-webhook.<your-subdomain>.workers.dev&secret_token=<YOUR_WEBHOOK_SECRET>"
+curl "https://api.telegram.org/bot<YOUR_BOT_TOKEN>/setWebhook?url=https://aeon-telegram-webhook.<your-subdomain>.workers.dev"
 ```
 
 Verify it took:
@@ -85,7 +86,7 @@ retries).
 
 ```
 Telegram → POST update → Worker
-  ├─ verify method + secret_token
+  ├─ verify method
   ├─ ignore (200) anything not a text message from TELEGRAM_CHAT_ID
   └─ POST repository_dispatch {event_type: telegram-message, client_payload:{message,…}}
        → GitHub Actions: Messages & Scheduler `run` job acts on it (~1s)

--- a/apps/webhook/package.json
+++ b/apps/webhook/package.json
@@ -8,6 +8,22 @@
     "dev": "wrangler dev",
     "deploy": "wrangler deploy"
   },
+  "cloudflare": {
+    "bindings": {
+      "TELEGRAM_BOT_TOKEN": {
+        "description": "Bot token from @BotFather — open t.me/BotFather, send /newbot (or /token for an existing bot), and paste the token it replies with."
+      },
+      "TELEGRAM_CHAT_ID": {
+        "description": "Your Telegram chat ID — only this chat can command the agent. Message your bot, then open api.telegram.org/bot<TOKEN>/getUpdates and copy chat.id."
+      },
+      "GITHUB_REPO": {
+        "description": "owner/repo of YOUR Aeon fork (where the GitHub Actions run) — not this worker repo."
+      },
+      "GITHUB_TOKEN": {
+        "description": "GitHub PAT — fine-grained with Contents: read/write + Actions: read/write on your fork, or a classic token with repo scope."
+      }
+    }
+  },
   "devDependencies": {
     "wrangler": "4.98.0"
   }

--- a/apps/webhook/src/worker.js
+++ b/apps/webhook/src/worker.js
@@ -9,15 +9,12 @@
  * Each user deploys this into their OWN Cloudflare account — there is no shared
  * infrastructure and no credential custody. See README.md for deployment.
  *
- * Required vars/secrets (set after deploy):
+ * Required vars/secrets (the deploy wizard prompts for them; see .dev.vars.example):
  *   TELEGRAM_BOT_TOKEN        bot token from @BotFather
  *   TELEGRAM_CHAT_ID          the only chat allowed to command the agent
  *   GITHUB_REPO               "owner/repo" of your Aeon fork
  *   GITHUB_TOKEN              GitHub PAT — fine-grained with Contents: read/write
  *                             and Actions: read/write on your fork (or classic `repo`)
- *   TELEGRAM_WEBHOOK_SECRET   (optional, recommended) shared secret; set the same
- *                             value as setWebhook's `secret_token` so forged
- *                             requests are rejected
  */
 export default {
   async fetch(request, env) {

--- a/apps/webhook/wrangler.toml
+++ b/apps/webhook/wrangler.toml
@@ -3,11 +3,10 @@ main = "src/worker.js"
 compatibility_date = "2025-01-01"
 
 # This Worker reads its config from environment variables / secrets, not from
-# this file. After deploying, set them in the Cloudflare dashboard
-# (Workers & Pages → your worker → Settings → Variables) or via the CLI:
+# this file. The "Deploy to Cloudflare" wizard prompts for them (declared in
+# .dev.vars.example); when deploying from a clone, set them via the CLI:
 #
 #   wrangler secret put TELEGRAM_BOT_TOKEN
 #   wrangler secret put TELEGRAM_CHAT_ID
 #   wrangler secret put GITHUB_REPO
 #   wrangler secret put GITHUB_TOKEN
-#   wrangler secret put TELEGRAM_WEBHOOK_SECRET   # optional but recommended

--- a/docs/telegram-instant.md
+++ b/docs/telegram-instant.md
@@ -11,11 +11,12 @@ Cloudflare" button.
 In short:
 
 1. Deploy `webhook/` to your own Cloudflare account (button or `npx wrangler deploy`).
-2. Set the `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`, `GITHUB_REPO`, and `GITHUB_TOKEN`
-   secrets (plus the optional `TELEGRAM_WEBHOOK_SECRET`).
+2. Fill in `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`, `GITHUB_REPO`, and `GITHUB_TOKEN`
+   when the deploy wizard prompts for them (or set them as Worker secrets via
+   `wrangler secret put` when deploying from a clone).
 3. Point your bot at the Worker:
    ```bash
-   curl "https://api.telegram.org/bot<YOUR_TOKEN>/setWebhook?url=https://your-worker.workers.dev&secret_token=<YOUR_WEBHOOK_SECRET>"
+   curl "https://api.telegram.org/bot<YOUR_TOKEN>/setWebhook?url=https://your-worker.workers.dev"
    ```
 
 Once a webhook is active the poller detects it via `getWebhookInfo` and skips the


### PR DESCRIPTION
## What

**Deploy-wizard prefill** — `apps/webhook/.dev.vars.example` declares the four required vars (`TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`, `GITHUB_REPO`, `GITHUB_TOKEN`) so the Deploy to Cloudflare wizard prompts for them **during** deploy and stores them as encrypted Worker secrets. `package.json` gains `cloudflare.bindings` descriptions shown under each field. No real values ever live in the repo — names and hints only (`.dev.vars` itself is gitignored).

**TELEGRAM_WEBHOOK_SECRET dropped** from all user-facing surfaces (webhook README, `docs/telegram-instant.md`, `wrangler.toml` comment, `worker.js` header, dashboard card, setWebhook commands). The Worker still honors it if someone sets it.

**Instant-mode card reworked** — collapsed by default behind an `Enable instant reply mode? Yes/No` choice. The copy explains replies aren't instant *by design* (Aeon runs on GitHub Actions and polls every 5 minutes; it's built for autonomous background work, not real-time chat) and that instant mode is an optional one-time ~5-minute Cloudflare Worker setup. Choosing **Yes** reveals the three steps.

**Autofill / ease-of-use in the steps:**
- `TELEGRAM_BOT_TOKEN` → @BotFather link with how-to tooltip
- `TELEGRAM_CHAT_ID` → points at the Find-my-chat-ID helper (with the do-it-before-webhook caveat, since a webhook disables `getUpdates`)
- `GITHUB_REPO` → value grabbed from the dashboard, copy button
- `GITHUB_TOKEN` → GitHub new-token link with `repo` scope + name prefilled
- Step 3 → bot token carried over from the session if it was just saved, Worker URL input (accepts bare subdomain, host, or URL), **one-click Register** that calls `setWebhook` straight from the browser (Telegram's API allows CORS), and a curl fallback that interpolates whatever values are entered

Built on top of #403 (now merged).

## Verification

- `tsc --noEmit` — clean
- `next build` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)