### PR TITLE
feat(dashboard): fold instant replies into the Telegram group as a compact row

### DIFF
--- a/apps/dashboard/components/InstantModeCard.tsx
+++ b/apps/dashboard/components/InstantModeCard.tsx
@@ -10,6 +10,8 @@ interface InstantModeCardProps {
   sessionBotToken?: string
 }
 
+// Rendered as a row inside the Telegram credentials list: a one-liner with a
+// Yes/No choice when collapsed, the full Cloudflare Worker walkthrough when on.
 export function InstantModeCard({ repo, sessionBotToken }: InstantModeCardProps) {
   const [enabled, setEnabled] = useState(false)
   const [copied, setCopied] = useState<string | null>(null)
@@ -63,127 +65,128 @@ export function InstantModeCard({ repo, sessionBotToken }: InstantModeCardProps)
   }
 
   return (
-    <section className="border-t border-[rgba(250,250,250,0.10)] pt-6">
-      <div className="flex items-center gap-3 mb-4">
-        <span className="font-display text-[13px] tracking-[0.18em] text-aeon-red">⚡ Telegram · Instant replies</span>
-        <span className="flex-1 h-px bg-[rgba(250,250,250,0.10)]" />
-        <span className="text-[10px] font-mono uppercase tracking-[0.18em] text-primary-35">optional</span>
-      </div>
-
-      <div className="border border-[rgba(250,250,250,0.10)] p-[var(--space-md)] space-y-5">
-        <p className="text-[13px] text-primary-70 leading-relaxed">
-          Replies aren&apos;t instant — by design. Aeon runs on GitHub Actions and polls Telegram every{' '}
-          <span className="text-primary-100">5 minutes</span>; it&apos;s built for autonomous background work,
-          not real-time chat. If you want <span className="text-primary-100">~1-second</span> replies anyway,
-          you can deploy a tiny Cloudflare Worker webhook into your own account — a one-time setup of about 5 minutes.
-        </p>
-
-        <div className="flex flex-wrap items-center gap-3">
-          <span className="text-[10px] font-mono uppercase tracking-[0.18em] text-primary-40">Enable instant reply mode?</span>
+    <div className="px-[var(--space-md)] py-[var(--space-sm)]">
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="font-mono text-xs">⚡ Instant replies</span>
+            <span className="text-[10px] font-mono uppercase tracking-[0.14em] text-primary-35">optional</span>
+          </div>
+          <div className="text-[11px] text-primary-40 font-mono">
+            {enabled
+              ? 'One-time setup, about 5 minutes — three steps below.'
+              : 'Aeon polls every 5 min — flip to Yes for ~1s replies via your own Cloudflare Worker.'}
+          </div>
+        </div>
+        <div className="flex items-center gap-1.5 shrink-0">
           <button
             onClick={() => setEnabled(true)}
-            className={`text-[11px] font-mono px-4 py-1.5 border transition-colors ${enabled ? 'border-eva-green text-eva-green' : 'border-[rgba(250,250,250,0.16)] text-primary-40 hover:text-eva-green hover:border-eva-green/40'}`}
+            className={`text-[11px] font-mono px-3 py-1 border transition-colors ${enabled ? 'border-eva-green text-eva-green' : 'border-[rgba(250,250,250,0.16)] text-primary-40 hover:text-eva-green hover:border-eva-green/40'}`}
           >
             Yes
           </button>
           <button
             onClick={() => setEnabled(false)}
-            className={`text-[11px] font-mono px-4 py-1.5 border transition-colors ${!enabled ? 'border-[rgba(250,250,250,0.35)] text-primary-70' : 'border-[rgba(250,250,250,0.16)] text-primary-40 hover:text-primary-70'}`}
+            className={`text-[11px] font-mono px-3 py-1 border transition-colors ${!enabled ? 'border-[rgba(250,250,250,0.35)] text-primary-70' : 'border-[rgba(250,250,250,0.16)] text-primary-40 hover:text-primary-70'}`}
           >
             No
           </button>
-          {!enabled && (
-            <span className="text-[10px] font-mono text-primary-35">keeping the 5-minute poll — flip this anytime</span>
-          )}
         </div>
-
-        {enabled && (
-          <>
-            {/* 1 — deploy */}
-            <div>
-              <div className="text-[10px] font-mono uppercase tracking-[0.18em] text-primary-40 mb-2">1 · Deploy the Worker</div>
-              <a href={deployUrl} target="_blank" rel="noopener noreferrer" className="inline-block">
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img src="https://deploy.workers.cloudflare.com/button" alt="Deploy to Cloudflare" height={32} />
-              </a>
-              <p className="text-[11px] text-primary-35 font-mono mt-2">
-                Deploys <span className="text-primary-70">{deployRepo}/webhook</span> · requires a public repo.
-              </p>
-            </div>
-
-            {/* 2 — variables */}
-            <div>
-              <div className="text-[10px] font-mono uppercase tracking-[0.18em] text-primary-40 mb-2">2 · Fill the variables in the deploy wizard</div>
-              <ul className="text-[12px] font-mono text-primary-70 space-y-1.5">
-                <li>
-                  <span className="text-primary-100">TELEGRAM_BOT_TOKEN</span>{' '}
-                  <a href="https://t.me/BotFather" target="_blank" rel="noopener noreferrer"
-                    title="Open BotFather in Telegram, send /newbot (or /token for an existing bot), copy the token it replies with"
-                    className="text-[10px] text-eva-orange/80 hover:text-eva-orange transition-colors">@BotFather ↗</a>
-                </li>
-                <li>
-                  <span className="text-primary-100">TELEGRAM_CHAT_ID</span>{' '}
-                  <span className="text-[10px] text-primary-35">— use the &quot;Find my chat ID&quot; helper in the Telegram section above, before registering the webhook (it stops getUpdates)</span>
-                </li>
-                <li>
-                  <span className="text-primary-100">GITHUB_REPO</span> = {deployRepo}{' '}
-                  <button onClick={() => copy('repo', deployRepo)}
-                    className="text-[10px] text-primary-40 hover:text-eva-orange transition-colors">
-                    {copied === 'repo' ? 'copied' : 'copy'}
-                  </button>
-                </li>
-                <li>
-                  <span className="text-primary-100">GITHUB_TOKEN</span>{' '}
-                  <a href={patUrl} target="_blank" rel="noopener noreferrer"
-                    title="Opens GitHub's token page with the repo scope and a name prefilled — generate and copy"
-                    className="text-[10px] text-eva-orange/80 hover:text-eva-orange transition-colors">create token ↗</a>
-                </li>
-              </ul>
-              <p className="text-[11px] text-primary-35 mt-2 leading-relaxed">
-                The wizard prompts for these during deploy and stores them as encrypted Worker secrets in your
-                Cloudflare account. Edit later: Workers &amp; Pages → your worker → Settings → Variables.
-              </p>
-            </div>
-
-            {/* 3 — register */}
-            <div>
-              <div className="text-[10px] font-mono uppercase tracking-[0.18em] text-primary-40 mb-2">3 · Point Telegram at the Worker</div>
-              <div className="flex flex-col sm:flex-row gap-2">
-                <input type="password" value={botToken} onChange={(e) => setBotToken(e.target.value)}
-                  placeholder="bot token..." className={inputCls} />
-                <input type="text" value={workerUrl} onChange={(e) => setWorkerUrl(e.target.value)}
-                  onKeyDown={(e) => e.key === 'Enter' && registerWebhook()}
-                  placeholder="aeon-telegram-webhook.<subdomain>.workers.dev" className={inputCls} />
-                <button onClick={registerWebhook} disabled={!botToken.trim() || !fullWorkerUrl || whBusy}
-                  className="bg-eva-green text-white text-[11px] px-4 py-2 font-mono hover:opacity-90 transition-opacity disabled:opacity-50 shrink-0">
-                  {whBusy ? 'Registering…' : 'Register'}
-                </button>
-              </div>
-              <p className="text-[11px] text-primary-35 mt-2">
-                The Worker URL is on its Overview tab in Cloudflare. The token only goes to api.telegram.org; nothing is stored.
-              </p>
-              {whStatus && (
-                <p className={`text-[11px] font-mono mt-2 ${whStatus.ok ? 'text-eva-green' : 'text-eva-red/80'}`}>{whStatus.msg}</p>
-              )}
-              <div className="flex items-start gap-2 mt-3">
-                <code className="flex-1 bg-aeon-bg text-primary-70 text-[11px] px-3 py-2 border border-[rgba(250,250,250,0.10)] font-mono break-all">
-                  {setWebhookCmd}
-                </code>
-                <button onClick={() => copy('cmd', setWebhookCmd)}
-                  className="text-[11px] text-primary-40 font-mono hover:text-eva-orange transition-colors px-2 py-2 shrink-0">
-                  {copied === 'cmd' ? 'copied' : 'copy'}
-                </button>
-              </div>
-            </div>
-
-            <p className="text-[11px] text-primary-40 leading-relaxed">
-              Once the webhook is live, the poller detects it (<span className="font-mono">getWebhookInfo</span>) and
-              skips Telegram automatically — no double-processing. Full guide:{' '}
-              <span className="font-mono text-primary-70">apps/webhook/README.md</span>.
-            </p>
-          </>
-        )}
       </div>
-    </section>
+
+      {enabled && (
+        <div className="mt-3 pt-4 border-t border-[rgba(250,250,250,0.08)] space-y-5">
+          <p className="text-[13px] text-primary-70 leading-relaxed">
+            Replies aren&apos;t instant — by design. Aeon runs on GitHub Actions and polls Telegram every{' '}
+            <span className="text-primary-100">5 minutes</span>; it&apos;s built for autonomous background work,
+            not real-time chat. For <span className="text-primary-100">~1-second</span> replies, deploy a tiny
+            Cloudflare Worker webhook into your own account — no shared infrastructure.
+          </p>
+
+          {/* 1 — deploy */}
+          <div>
+            <div className="text-[10px] font-mono uppercase tracking-[0.18em] text-primary-40 mb-2">1 · Deploy the Worker</div>
+            <a href={deployUrl} target="_blank" rel="noopener noreferrer" className="inline-block">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src="https://deploy.workers.cloudflare.com/button" alt="Deploy to Cloudflare" height={32} />
+            </a>
+            <p className="text-[11px] text-primary-35 font-mono mt-2">
+              Deploys <span className="text-primary-70">{deployRepo}/webhook</span> · requires a public repo.
+            </p>
+          </div>
+
+          {/* 2 — variables */}
+          <div>
+            <div className="text-[10px] font-mono uppercase tracking-[0.18em] text-primary-40 mb-2">2 · Fill the variables in the deploy wizard</div>
+            <ul className="text-[12px] font-mono text-primary-70 space-y-1.5">
+              <li>
+                <span className="text-primary-100">TELEGRAM_BOT_TOKEN</span>{' '}
+                <a href="https://t.me/BotFather" target="_blank" rel="noopener noreferrer"
+                  title="Open BotFather in Telegram, send /newbot (or /token for an existing bot), copy the token it replies with"
+                  className="text-[10px] text-eva-orange/80 hover:text-eva-orange transition-colors">@BotFather ↗</a>
+              </li>
+              <li>
+                <span className="text-primary-100">TELEGRAM_CHAT_ID</span>{' '}
+                <span className="text-[10px] text-primary-35">— use the &quot;Find my chat ID&quot; helper above, before registering the webhook (it stops getUpdates)</span>
+              </li>
+              <li>
+                <span className="text-primary-100">GITHUB_REPO</span> = {deployRepo}{' '}
+                <button onClick={() => copy('repo', deployRepo)}
+                  className="text-[10px] text-primary-40 hover:text-eva-orange transition-colors">
+                  {copied === 'repo' ? 'copied' : 'copy'}
+                </button>
+              </li>
+              <li>
+                <span className="text-primary-100">GITHUB_TOKEN</span>{' '}
+                <a href={patUrl} target="_blank" rel="noopener noreferrer"
+                  title="Opens GitHub's token page with the repo scope and a name prefilled — generate and copy"
+                  className="text-[10px] text-eva-orange/80 hover:text-eva-orange transition-colors">create token ↗</a>
+              </li>
+            </ul>
+            <p className="text-[11px] text-primary-35 mt-2 leading-relaxed">
+              The wizard prompts for these during deploy and stores them as encrypted Worker secrets in your
+              Cloudflare account. Edit later: Workers &amp; Pages → your worker → Settings → Variables.
+            </p>
+          </div>
+
+          {/* 3 — register */}
+          <div>
+            <div className="text-[10px] font-mono uppercase tracking-[0.18em] text-primary-40 mb-2">3 · Point Telegram at the Worker</div>
+            <div className="flex flex-col sm:flex-row gap-2">
+              <input type="password" value={botToken} onChange={(e) => setBotToken(e.target.value)}
+                placeholder="bot token..." className={inputCls} />
+              <input type="text" value={workerUrl} onChange={(e) => setWorkerUrl(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && registerWebhook()}
+                placeholder="aeon-telegram-webhook.<subdomain>.workers.dev" className={inputCls} />
+              <button onClick={registerWebhook} disabled={!botToken.trim() || !fullWorkerUrl || whBusy}
+                className="bg-eva-green text-white text-[11px] px-4 py-2 font-mono hover:opacity-90 transition-opacity disabled:opacity-50 shrink-0">
+                {whBusy ? 'Registering…' : 'Register'}
+              </button>
+            </div>
+            <p className="text-[11px] text-primary-35 mt-2">
+              The Worker URL is on its Overview tab in Cloudflare. The token only goes to api.telegram.org; nothing is stored.
+            </p>
+            {whStatus && (
+              <p className={`text-[11px] font-mono mt-2 ${whStatus.ok ? 'text-eva-green' : 'text-eva-red/80'}`}>{whStatus.msg}</p>
+            )}
+            <div className="flex items-start gap-2 mt-3">
+              <code className="flex-1 bg-aeon-bg text-primary-70 text-[11px] px-3 py-2 border border-[rgba(250,250,250,0.10)] font-mono break-all">
+                {setWebhookCmd}
+              </code>
+              <button onClick={() => copy('cmd', setWebhookCmd)}
+                className="text-[11px] text-primary-40 font-mono hover:text-eva-orange transition-colors px-2 py-2 shrink-0">
+                {copied === 'cmd' ? 'copied' : 'copy'}
+              </button>
+            </div>
+          </div>
+
+          <p className="text-[11px] text-primary-40 leading-relaxed">
+            Once the webhook is live, the poller detects it (<span className="font-mono">getWebhookInfo</span>) and
+            skips Telegram automatically — no double-processing. Full guide:{' '}
+            <span className="font-mono text-primary-70">apps/webhook/README.md</span>.
+          </p>
+        </div>
+      )}
+    </div>
   )
 }

--- a/apps/dashboard/components/SecretsPanel.tsx
+++ b/apps/dashboard/components/SecretsPanel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, Fragment } from 'react'
+import { useState, useEffect } from 'react'
 import type { Secret, Skill } from '../lib/types'
 import { inputCls, displayName } from '../lib/utils'
 import { Scramble } from './ui/Animated'
@@ -86,8 +86,7 @@ export function SecretsPanel({ secrets, skills, busy, repo, focusKey, onFocusHan
       {['Core', 'Telegram', 'Discord', 'Slack', 'Email', 'Skill Keys'].map((group, gi) => {
         const gs = secrets.filter(s => s.group === group); if (!gs.length) return null
         return (
-          <Fragment key={group}>
-          <section className="border-t border-[rgba(250,250,250,0.10)] pt-6">
+          <section key={group} className="border-t border-[rgba(250,250,250,0.10)] pt-6">
             <div className="flex items-center gap-3 mb-4">
               <span className="font-display text-[13px] tracking-[0.18em] text-aeon-red">
                 {String(gi + 1).padStart(2, '0')} / {group}
@@ -153,10 +152,9 @@ export function SecretsPanel({ secrets, skills, busy, repo, focusKey, onFocusHan
                   )}
                 </div>
               ))}
+              {group === 'Telegram' && <InstantModeCard repo={repo} sessionBotToken={sessionBotToken} />}
             </div>
           </section>
-          {group === 'Telegram' && <InstantModeCard repo={repo} sessionBotToken={sessionBotToken} />}
-          </Fragment>
         )
       })}
       <div>{addingSecret ? (<div className="space-y-2"><input type="text" value={newSecretName} onChange={(e) => setNewSecretName(e.target.value.toUpperCase().replace(/[^A-Z0-9_]/g, ''))} placeholder="SECRET_NAME" autoFocus className={inputCls} />{newSecretName && <div className="flex gap-2"><input type="password" value={secretValue} onChange={(e) => setSecretValue(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && handleSave(newSecretName)} placeholder="value..." className={inputCls} /><button onClick={() => handleSave(newSecretName)} disabled={!secretValue.trim()} className="bg-eva-green text-white text-[11px] px-4 py-2 font-mono hover:opacity-90 disabled:opacity-50">Save</button></div>}<button onClick={() => { setAddingSecret(false); setNewSecretName(''); setSecretValue('') }} className="text-[11px] text-primary-40 font-mono hover:text-primary-70">Cancel</button></div>) : <button onClick={() => setAddingSecret(true)} className="w-full text-sm font-mono uppercase tracking-[0.14em] text-primary-60 border border-dashed border-[rgba(250,250,250,0.16)] py-3.5 hover:text-eva-orange hover:border-eva-orange/40 transition-colors">+ Add Credential</button>}</div>


### PR DESCRIPTION
## What

Moves the instant-replies card from its own standalone section into the **02 / Telegram** credentials list, as a third row under `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID`:

- **Collapsed (default, No):** a single small row — "⚡ Instant replies · optional — Aeon polls every 5 min, flip to Yes for ~1s replies via your own Cloudflare Worker" with Yes/No buttons.
- **Expanded (Yes):** the why-it's-not-instant explanation (Aeon is built for autonomous background work, not real-time chat) plus the three setup steps: deploy button, wizard variables (BotFather link, chat-ID helper pointer, GITHUB_REPO copy, prefilled PAT link), and the one-click setWebhook registration with curl fallback.

No content changes to the steps themselves — this is a layout/IA change so the Telegram section is one coherent block.

## Verification

- `tsc --noEmit` — clean
- `next build` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)