### PR TITLE
fix(messages): name webhook-delivered runs 'msg (...)' + refresh instant-mode README

### DIFF
--- a/.github/workflows/messages.yml
+++ b/.github/workflows/messages.yml
@@ -1,5 +1,5 @@
 name: Messages & Scheduler
-run-name: "${{ inputs.message && format('msg ({0}): {1}', inputs.source || 'user', inputs.message) || 'tick: schedule + poll' }}"
+run-name: "${{ inputs.message && format('msg ({0}): {1}', inputs.source || 'user', inputs.message) || (github.event_name == 'repository_dispatch' && github.event.action != 'cron-tick' && format('msg ({0}): {1}', github.event.action, github.event.client_payload.message)) || 'tick: schedule + poll' }}"
 
 on:
   schedule:

--- a/README.md
+++ b/README.md
@@ -370,11 +370,13 @@ Aeon publishes articles to a GitHub Pages gallery and an RSS feed.
 
 ### Telegram instant mode
 
-Default polling has up to a 5-min delay. Deploy the self-contained Cloudflare Worker in [`apps/webhook/`](apps/webhook/) for ~1s response time — one click, into your own Cloudflare account (no shared infra, no credential custody):
+Replies aren't instant by default — Aeon runs on GitHub Actions and polls Telegram every 5 minutes. That's by design: it's built for autonomous background work, not real-time chat. For ~1-second replies, deploy the self-contained Cloudflare Worker in [`apps/webhook/`](apps/webhook/) into your own Cloudflare account (no shared infra, no credential custody) — a one-time setup of about 5 minutes:
 
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/aaronjmars/aeon/tree/main/apps/webhook)
 
-Setup details in [`apps/webhook/README.md`](apps/webhook/README.md). The poller skips Telegram automatically once a webhook is active, so the two never conflict.
+The deploy wizard prompts for the four variables (`TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`, `GITHUB_REPO`, `GITHUB_TOKEN`) and stores them as encrypted Worker secrets, so the Worker comes out configured — then point your bot at it with `setWebhook`. The dashboard walks through all three steps with one-click webhook registration: **Settings → Credentials → Telegram → ⚡ Instant replies**. The button needs a **public** source repo — on a private fork, mirror `apps/webhook/` to a small public repo and point the button URL there.
+
+Full guide: [`apps/webhook/README.md`](apps/webhook/README.md). The poller detects an active webhook (`getWebhookInfo`) and skips Telegram polling automatically, so the two never conflict.
 
 ### Remote dashboard access
 


### PR DESCRIPTION
## What

**Run-name fix** — webhook-delivered messages (`repository_dispatch`, e.g. from the instant-mode Worker) were titled `tick: schedule + poll` because the `run-name` expression only reads `inputs.message`, which doesn't exist for dispatch events. It now falls through to `client_payload.message` for non-`cron-tick` dispatches:

`msg (telegram-message): gm` instead of `tick: schedule + poll`

(Spotted live: the instant-path runs in a test fork executed the `run` job correctly but were indistinguishable from poller ticks in the Actions list.)

**README** — the instant-mode section now explains that replies aren't instant *by design* (GitHub Actions polls every 5 minutes; Aeon is built for autonomous background work), that the deploy wizard prompts for the four variables and produces a configured Worker, that the dashboard's ⚡ Instant replies row walks through the steps with one-click webhook registration, and that the deploy button needs a public source repo (mirror `apps/webhook/` if your fork is private).

## Verification

- `messages.yml` parses as valid YAML
- Expression logic: `workflow_dispatch` with message → unchanged; `repository_dispatch` telegram/discord/slack-message → `msg (<type>): <text>`; `cron-tick` and `schedule` → `tick: schedule + poll` as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)