### PR TITLE
feat(dashboard): Available filter, clickable category cards, spinning brand mark, No|Yes flip

### DIFF
--- a/apps/dashboard/app/globals.css
+++ b/apps/dashboard/app/globals.css
@@ -163,21 +163,33 @@ body::before {
 }
 
 /* ──────────────────────────────────────────────────────────
-   BRAND DOT — the pulsing red bullet from the site's nav
+   BRAND MARK — the spinning Aeon star (replaces the pulsing dot).
+   Slow constant spin; hover runs a second, faster rotation on the
+   inner image. Pausing an animation preserves its phase, so the
+   speed-up and slow-down are seamless — no angle jump.
    ────────────────────────────────────────────────────────── */
-.brand-dot {
-  width: 10px;
-  height: 10px;
+.brand-mark {
   border-radius: 50%;
-  background: var(--aeon-red);
-  box-shadow: 0 0 0 2px var(--aeon-bg), 0 0 14px var(--aeon-red);
-  animation: brandPulse 2.4s ease-in-out infinite;
-  display: inline-block;
+  display: inline-flex;
   flex: none;
+  overflow: hidden;
+  box-shadow: 0 0 0 2px var(--aeon-bg), 0 0 14px rgba(210, 75, 64, 0.55);
+  animation: brandSpin 6s linear infinite;
 }
-@keyframes brandPulse {
-  0%, 100% { opacity: 1; transform: scale(1); }
-  50% { opacity: 0.5; transform: scale(0.82); }
+.brand-mark img {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  object-fit: cover;
+  animation: brandSpin 1.1s linear infinite;
+  animation-play-state: paused;
+}
+.brand-mark:hover img { animation-play-state: running; }
+@keyframes brandSpin {
+  to { transform: rotate(360deg); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .brand-mark, .brand-mark img { animation: none; }
 }
 
 /* Background grid — kept for the dashboard's surface texture but recolored to coral */

--- a/apps/dashboard/app/page.tsx
+++ b/apps/dashboard/app/page.tsx
@@ -22,6 +22,8 @@ export default function Dashboard() {
   const [view, setView] = useState<'hq' | 'secrets' | 'strategy' | 'mcp'>('hq')
   const [selectedSkill, setSelectedSkill] = useState<string | null>(null)
   const [secretFocus, setSecretFocus] = useState<string | null>(null)
+  // Shared with the sidebar's category chips — HQ category cards toggle it too.
+  const [categoryFilter, setCategoryFilter] = useState<string | null>(null)
 
   const [skills, setSkills] = useState<Skill[]>([])
   const [runs, setRuns] = useState<Run[]>([])
@@ -112,6 +114,7 @@ export default function Dashboard() {
         selectedSkill={selectedSkill} setSelectedSkill={setSelectedSkill}
         skills={skills} runs={runs} secrets={secrets} repo={repo}
         enabledCount={enabledCount} workingCount={workingCount}
+        categoryFilter={categoryFilter} setCategoryFilter={setCategoryFilter}
         onSkillSelect={(name) => { setSelectedSkill(name); setView('hq') }}
         onShowImport={() => setShowImport(true)}
       />
@@ -136,7 +139,7 @@ export default function Dashboard() {
             <McpPanel servers={mcpServers} loading={!mcpLoaded} saving={mcpSaving} secrets={secrets} busy={busy} onSave={saveMcp} onSetSecret={saveSecret} onDeleteSecret={deleteSecret} />
           )}
           {view === 'hq' && !selectedSkill && (
-            <HQOverview skills={skills} runs={runs} enabledCount={enabledCount} workingCount={workingCount} onViewRun={() => {}} />
+            <HQOverview skills={skills} runs={runs} enabledCount={enabledCount} workingCount={workingCount} categoryFilter={categoryFilter} onCategoryClick={(key) => setCategoryFilter(categoryFilter === key ? null : key)} onViewRun={() => {}} />
           )}
           {skill && (
             <SkillDetail

--- a/apps/dashboard/components/HQOverview.tsx
+++ b/apps/dashboard/components/HQOverview.tsx
@@ -11,6 +11,8 @@ interface HQOverviewProps {
   runs: Run[]
   enabledCount: number
   workingCount: number
+  categoryFilter: string | null
+  onCategoryClick: (key: string) => void
   onViewRun: (run: Run) => void
 }
 
@@ -26,7 +28,7 @@ function Section({ index, label, children }: { index: string; label: string; chi
   )
 }
 
-export function HQOverview({ skills, runs, enabledCount, workingCount, onViewRun }: HQOverviewProps) {
+export function HQOverview({ skills, runs, enabledCount, workingCount, categoryFilter, onCategoryClick, onViewRun }: HQOverviewProps) {
   const spotRef = useRef<HTMLUListElement>(null)
 
   const onMove = (e: React.MouseEvent<HTMLUListElement>) => {
@@ -92,22 +94,30 @@ export function HQOverview({ skills, runs, enabledCount, workingCount, onViewRun
         >
           {cats.map(cat => {
             const en = cat.skills.filter(s => s.enabled).length
+            const active = categoryFilter === cat.key
+            // li is flex so the button stretches to the grid row's full height —
+            // otherwise the active ring stops short when the row neighbor is taller
             return (
-              <li
-                key={cat.key}
-                className="spotlight relative overflow-hidden bg-aeon-bg px-6 py-5 flex items-center gap-5 transition-colors hover:bg-aeon-panel-2"
-              >
-                <span className="font-display leading-none text-aeon-red shrink-0 whitespace-nowrap" style={{ fontSize: 'clamp(28px, 3vw, 44px)' }}>
-                  <Flip value={cat.skills.length} />
-                </span>
-                <div className="min-w-0">
-                  <div className="font-display uppercase tracking-wide text-aeon-fg text-base leading-tight">{cat.label}</div>
-                  <div className="text-[11px] text-primary-40 font-mono mt-1 uppercase tracking-[0.14em]">{en} active · {cat.skills.length - en} idle</div>
-                </div>
-                <span
-                  className="ml-auto w-2 h-2 rounded-full shrink-0"
-                  style={{ backgroundColor: en > 0 ? cat.color : 'rgba(250,250,250,0.15)' }}
-                />
+              <li key={cat.key} className="spotlight relative overflow-hidden bg-aeon-bg transition-colors hover:bg-aeon-panel-2 flex">
+                <button
+                  onClick={() => onCategoryClick(cat.key)}
+                  title={active ? 'Clear the team filter' : `Filter the team to ${cat.label}`}
+                  aria-pressed={active}
+                  className="w-full px-6 py-5 flex items-center gap-5 text-left cursor-pointer"
+                  style={active ? { boxShadow: `inset 0 0 0 1px ${cat.color}`, backgroundColor: cat.color + '14' } : undefined}
+                >
+                  <span className="font-display leading-none text-aeon-red shrink-0 whitespace-nowrap" style={{ fontSize: 'clamp(28px, 3vw, 44px)' }}>
+                    <Flip value={cat.skills.length} />
+                  </span>
+                  <div className="min-w-0">
+                    <div className="font-display uppercase tracking-wide text-aeon-fg text-base leading-tight">{cat.label}</div>
+                    <div className="text-[11px] text-primary-40 font-mono mt-1 uppercase tracking-[0.14em]">{en} active · {cat.skills.length - en} idle</div>
+                  </div>
+                  <span
+                    className="ml-auto w-2 h-2 rounded-full shrink-0"
+                    style={{ backgroundColor: active || en > 0 ? cat.color : 'rgba(250,250,250,0.15)' }}
+                  />
+                </button>
               </li>
             )
           })}

--- a/apps/dashboard/components/InstantModeCard.tsx
+++ b/apps/dashboard/components/InstantModeCard.tsx
@@ -80,16 +80,16 @@ export function InstantModeCard({ repo, sessionBotToken }: InstantModeCardProps)
         </div>
         <div className="flex items-center gap-1.5 shrink-0">
           <button
-            onClick={() => setEnabled(true)}
-            className={`text-[11px] font-mono px-3 py-1 border transition-colors ${enabled ? 'border-eva-green text-eva-green' : 'border-[rgba(250,250,250,0.16)] text-primary-40 hover:text-eva-green hover:border-eva-green/40'}`}
-          >
-            Yes
-          </button>
-          <button
             onClick={() => setEnabled(false)}
             className={`text-[11px] font-mono px-3 py-1 border transition-colors ${!enabled ? 'border-[rgba(250,250,250,0.35)] text-primary-70' : 'border-[rgba(250,250,250,0.16)] text-primary-40 hover:text-primary-70'}`}
           >
             No
+          </button>
+          <button
+            onClick={() => setEnabled(true)}
+            className={`text-[11px] font-mono px-3 py-1 border transition-colors ${enabled ? 'border-eva-green text-eva-green' : 'border-[rgba(250,250,250,0.16)] text-primary-40 hover:text-eva-green hover:border-eva-green/40'}`}
+          >
+            Yes
           </button>
         </div>
       </div>

--- a/apps/dashboard/components/LeftSidebar.tsx
+++ b/apps/dashboard/components/LeftSidebar.tsx
@@ -16,14 +16,16 @@ interface LeftSidebarProps {
   repo: string
   enabledCount: number
   workingCount: number
+  categoryFilter: string | null
+  setCategoryFilter: (c: string | null) => void
   onSkillSelect: (name: string) => void
   onShowImport: () => void
 }
 
-export function LeftSidebar({ view, setView, selectedSkill, skills, runs, secrets, repo, enabledCount, workingCount, onSkillSelect, onShowImport }: LeftSidebarProps) {
+export function LeftSidebar({ view, setView, selectedSkill, skills, runs, secrets, repo, enabledCount, workingCount, categoryFilter, setCategoryFilter, onSkillSelect, onShowImport }: LeftSidebarProps) {
   const [skillSearch, setSkillSearch] = useState('')
-  const [categoryFilter, setCategoryFilter] = useState<string | null>(null)
   const [enabledOnly, setEnabledOnly] = useState(false)
+  const [availableOnly, setAvailableOnly] = useState(false)
 
   // A skill is "key-blocked" when it's enabled but a required (non-optional)
   // credential it declares isn't set — flagged inline so the operator sees it
@@ -32,12 +34,18 @@ export function LeftSidebar({ view, setView, selectedSkill, skills, runs, secret
   const missingRequiredKeys = (s: Skill) =>
     (s.requires ?? []).filter(r => !r.optional && !setSecretNames.has(r.key))
 
+  // "Available" = runnable out of the box: every declared key is optional.
+  const needsNoKey = (s: Skill) => (s.requires ?? []).every(r => r.optional)
+
   return (
     <div className="w-[240px] border-r border-[rgba(250,250,250,0.10)] flex flex-col shrink-0 bg-aeon-panel">
       {/* Brand */}
       <div className="px-4 py-4 border-b border-[rgba(250,250,250,0.10)]">
         <div className="flex items-center gap-3">
-          <span className="brand-dot" aria-hidden="true" />
+          <span className="brand-mark w-[22px] h-[22px]" aria-hidden="true">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src="/android-chrome-192x192.png" alt="" />
+          </span>
           <div className="min-w-0">
             <div className="font-display text-lg leading-tight uppercase tracking-tight text-aeon-fg truncate">
               {repo ? repo.split('/').pop() : 'Aeon'} HQ
@@ -92,6 +100,14 @@ export function LeftSidebar({ view, setView, selectedSkill, skills, runs, secret
             <span className="w-1.5 h-1.5 rounded-full shrink-0 bg-eva-green" />
             Enabled
           </button>
+          <button
+            onClick={() => setAvailableOnly(v => !v)}
+            title="Show only skills that need no API key"
+            className={`text-[10px] font-mono uppercase tracking-[0.1em] px-2 py-1 border flex items-center gap-1.5 transition-colors ${availableOnly ? 'text-eva-amber border-eva-amber/50 bg-eva-amber/10' : 'text-primary-40 border-[rgba(250,250,250,0.12)] hover:text-primary-70 hover:border-[rgba(250,250,250,0.22)]'}`}
+          >
+            <span className="w-1.5 h-1.5 rounded-full shrink-0 bg-eva-amber" />
+            Available
+          </button>
           {CATEGORIES.map(cat => {
             const active = categoryFilter === cat.key
             return (
@@ -114,7 +130,8 @@ export function LeftSidebar({ view, setView, selectedSkill, skills, runs, secret
           const catSkills = skills.filter(s => (s.category || 'meta') === cat.key)
           if (!catSkills.length) return null
           const searched = skillSearch ? catSkills.filter(s => displayName(s.name).toLowerCase().includes(skillSearch.toLowerCase()) || s.name.includes(skillSearch.toLowerCase())) : catSkills
-          const filtered = enabledOnly ? searched.filter(s => s.enabled) : searched
+          const enabledFiltered = enabledOnly ? searched.filter(s => s.enabled) : searched
+          const filtered = availableOnly ? enabledFiltered.filter(needsNoKey) : enabledFiltered
           if (!filtered.length) return null
           const en = filtered.filter(s => s.enabled).length
           return (

--- a/apps/dashboard/components/LoadingScreen.tsx
+++ b/apps/dashboard/components/LoadingScreen.tsx
@@ -3,9 +3,12 @@ export function LoadingScreen() {
     <div className="min-h-screen flex flex-col items-center justify-center bg-aeon-bg relative overflow-hidden">
       <div className="dither" aria-hidden="true" />
       <div className="relative z-10 flex flex-col items-center gap-6">
-        <div className="relative w-20 h-20 flex items-center justify-center">
+        <div className="relative w-28 h-28 flex items-center justify-center">
           <span className="absolute inset-0 rounded-full border border-dashed border-aeon-rule animate-aeon-spin" aria-hidden="true" />
-          <span className="brand-dot" style={{ width: 14, height: 14 }} aria-hidden="true" />
+          <span className="brand-mark" style={{ width: 72, height: 72 }} aria-hidden="true">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src="/android-chrome-192x192.png" alt="" />
+          </span>
         </div>
         <div className="text-center space-y-1">
           <p className="font-display text-2xl uppercase tracking-wide text-aeon-fg">AEON HQ</p>

--- a/memory/logs/2026-06-09.md
+++ b/memory/logs/2026-06-09.md
@@ -36,3 +36,11 @@
 - Added legacy fallbacks: retrospective reads `articles/weekly-review-*.md` when no `retrospective-*` exists; shiplog momentum check accepts legacy `weekly-shiplog-*` articles.
 - Left untouched: memory/logs history, SHOWCASE fleet observations (forks still run old slugs), external `morning-briefing` pack in skill-packs.json, self-contained dashboard test fixtures.
 - Regenerated skills.json (196 skills, all new slugs verified; aeon.yml parses clean).
+
+## Dashboard UI polish (PR pending)
+
+- Added an amber "Available" filter chip to the sidebar team roster — shows only skills whose declared keys are all optional (no required API key).
+- Flipped the Instant replies toggle order in Settings to No | Yes.
+- Replaced the pulsing red brand dot (sidebar + loading screen) with the spinning Aeon star mark; hover runs a second paused rotation so the speed-up is seamless. Loading-screen mark enlarged to 72px inside a 112px ring.
+- Made the HQ "01 / Categories" cards clickable — they toggle the same category filter as the sidebar chips, with an active ring in the category color (li made flex so the ring spans the full grid row height).
+- Verified live: typecheck, production build, and browser walkthrough (filter on/off, category switch, Available count math, No|Yes order).


### PR DESCRIPTION
## What

Four visual/UX updates to the dashboard:

1. **Available filter** — new amber chip in the sidebar team filters; shows only skills that need no API key (every declared key optional). Sits next to Enabled with the same chip pattern.
2. **Clickable category cards** — the HQ "01 / Categories" cards now toggle the same category filter as the sidebar chips (state lifted to `page.tsx`). Active card gets an inset ring + tint in the category color; `aria-pressed` + title hints included. The `li` is flexed so the ring spans the full grid-row height even when the row neighbor wraps to two lines.
3. **Spinning brand mark** — the pulsing red dot (sidebar brand + loading screen) is replaced with the Aeon star mark that rotates continuously and **speeds up on hover**. The hover boost is a second, normally-paused rotation on the inner image — pausing preserves animation phase, so speed-up/slow-down has no angle jump. Loading-screen mark sized up to 72px inside a 112px dashed ring. `prefers-reduced-motion` disables the spin.
4. **Instant replies toggle** — Settings now reads **No | Yes** instead of Yes | No.

## Verified

- `tsc --noEmit` and `next build` pass.
- Live browser walkthrough: category card click filters the sidebar roster + highlights the matching chip, second click clears, Available chip drops key-gated skills (Core: 15 → 12), No|Yes order renders, active-ring full-height fix confirmed against the two-line neighbor row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)