### PR TITLE
feat(dashboard): explicit provider list in auth picker + analyze raw-output debug

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -700,12 +700,12 @@ jobs:
 
           if ! RAW=$(echo "$ANALYSIS_PROMPT" | claude -p - \
             --model "${ANTHROPIC_DEFAULT_HAIKU_MODEL:-claude-haiku-4-5-20251001}" --output-format json 2>&1); then
-            echo "::warning::Skill analysis failed (non-fatal)"
+            echo "::warning::Skill analysis failed (non-fatal). Raw: $(printf '%s' "$RAW" | head -c 300 | tr '\n' ' ')"
             exit 0
           fi
 
           ANALYSIS_TEXT=$(echo "$RAW" | jq -r '.result // empty')
-          [ -z "$ANALYSIS_TEXT" ] && { echo "::warning::Empty analysis result"; exit 0; }
+          [ -z "$ANALYSIS_TEXT" ] && { echo "::warning::Empty analysis result. Raw: $(printf '%s' "$RAW" | head -c 300 | tr '\n' ' ')"; exit 0; }
 
           # Parse score: accept raw JSON, else strip code fences, flatten newlines,
           # and grab the outermost {…} object — handles fenced / multi-line output

--- a/apps/dashboard/components/AuthModal.tsx
+++ b/apps/dashboard/components/AuthModal.tsx
@@ -3,11 +3,12 @@
 import { useState } from 'react'
 import { inputCls } from '../lib/utils'
 
-// Gateway providers selectable in the picker. Auto-detect covers keys with a
-// distinctive prefix (Anthropic, Bankr bk_, OpenRouter sk-or-, Surplus inf_);
-// Venice and UsePod have no prefix so they must be selected explicitly.
+// Key providers selectable in the picker. Anthropic submits no provider, so
+// the backend still prefix-detects (Anthropic-compatible keys, OAuth tokens);
+// every gateway is selected explicitly.
 const PROVIDER_OPTIONS = [
-  { value: '', label: 'Auto-detect (Anthropic / Bankr / OpenRouter / Surplus)' },
+  { value: '', label: 'Anthropic (or compatible)' },
+  { value: 'bankr', label: 'Bankr' },
   { value: 'openrouter', label: 'OpenRouter' },
   { value: 'usepod', label: 'UsePod' },
   { value: 'venice', label: 'Venice' },
@@ -32,7 +33,7 @@ export function AuthModal({ loading, onClose, onAuth }: AuthModalProps) {
           <h2 className="font-display text-xl">Authenticate</h2>
           <button onClick={onClose} className="text-primary-35 hover:text-primary-100 text-lg">&times;</button>
         </div>
-        <p className="text-xs text-primary-50 font-mono mb-[var(--space-md)]">Connect a Claude subscription token, or paste an Anthropic or Anthropic-compatible API key. Gateway keys with a prefix (Bankr bk_…, OpenRouter sk-or-…, Surplus inf_…) route automatically — pick Venice or UsePod explicitly.</p>
+        <p className="text-xs text-primary-50 font-mono mb-[var(--space-md)]">Connect a Claude subscription token, or pick your key&apos;s provider and paste it below. Gateway keys route Claude through that provider automatically.</p>
         <button onClick={() => onAuth()} disabled={loading} className="w-full bg-aeon-fg text-aeon-bg text-sm py-3 font-mono uppercase tracking-[2px] hover:opacity-90 transition-opacity disabled:opacity-50">
           {loading ? '...' : 'Use Claude Subscription'}
         </button>

--- a/memory/logs/2026-06-09.md
+++ b/memory/logs/2026-06-09.md
@@ -54,3 +54,8 @@
 - Dashboard: GatewayProvider union + shared GATEWAY_PROVIDERS allowlist (types/config/gateway.ts), auth-provider.mjs recognizes all four (prefix auto-detect for sk-or-/inf_, explicit picker for Venice/UsePod), AuthModal provider dropdown, auth GET counts gateway secrets as authenticated, secrets route syncs gateway.provider for any gateway secret set/delete, TopBar badge shows any non-direct gateway.
 - Tests 9→15 auth-provider cases (118 total pass); tsc clean.
 - README: "Bankr Gateway" section generalized to "LLM Gateways" with a 5-provider table + model-override vars.
+
+## Auth picker: explicit provider list + analyze debug (PR pending)
+
+- AuthModal dropdown now lists all six providers explicitly (Anthropic default, Bankr, OpenRouter, UsePod, Venice, Surplus) — removed Auto-detect; Anthropic submits no provider so backend prefix-detection still applies.
+- First live OpenRouter run on the aeonllm fork verified: all 3 steps routed (::notice:: lines), rss-digest completed, output captured. Analyze step warned "Empty analysis result" — both analyze warning paths now include the first 300 chars of raw CLI output for diagnosis.


### PR DESCRIPTION
## Summary

- **Auth picker**: replaces the Auto-detect option with an explicit list of all six providers — Anthropic (default), Bankr, OpenRouter, UsePod, Venice, Surplus. Selecting Anthropic submits no provider, so backend prefix detection still handles Anthropic-compatible keys and OAuth tokens; every gateway is now an explicit choice.
- **Analyze debug**: the first live OpenRouter run (aeonllm fork) warned `Empty analysis result` with nothing in the log to diagnose it. Both warning paths in the Analyze step now include the first 300 chars of the raw claude CLI output.

## Verification

- 118/118 dashboard tests, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)