### PR TITLE
fix(gateway): sanitize empty text blocks for sidecar providers + failure logs

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -790,6 +790,22 @@ jobs:
             ./notify-jsonrender "$SKILL" "$(cat "$pending")" && rm -f "$pending" || echo "json-render: $SKILL conversion failed (non-fatal)"
           done
 
+      # Sidecar gateway logs die with the VM — surface them in the job log on
+      # failure (set the CCR_LOG=true repo variable for request-level detail).
+      # Secrets in the output are auto-masked by the Actions runner. The ccr
+      # config.json is deliberately NOT printed (it embeds the provider key).
+      - name: Sidecar logs (on failure)
+        if: failure()
+        run: |
+          found=0
+          for f in "$HOME"/.claude-code-router/logs/*.log "$HOME"/.claude-code-router/*.log; do
+            [ -f "$f" ] || continue
+            found=1
+            echo "===== ${f} (last 200 lines) ====="
+            tail -n 200 "$f"
+          done
+          if [ "$found" -eq 0 ]; then echo "No claude-code-router logs found (gateway was not a sidecar provider, or it never started)."; fi
+
       - name: Send pending notifications
         if: steps.work.outputs.mode != '' && steps.run.outcome == 'success'
         env:

--- a/.github/workflows/messages.yml
+++ b/.github/workflows/messages.yml
@@ -785,6 +785,21 @@ jobs:
 
           echo "::notice::Token usage — input: $INPUT_TOKENS, output: $OUTPUT_TOKENS, cache_read: $CACHE_READ, cache_creation: $CACHE_CREATION, total: $TOTAL_TOKENS"
 
+      # Sidecar gateway logs die with the VM — surface them in the job log on
+      # failure (set the CCR_LOG=true repo variable for request-level detail).
+      # The ccr config.json is deliberately NOT printed (it embeds the provider key).
+      - name: Sidecar logs (on failure)
+        if: failure()
+        run: |
+          found=0
+          for f in "$HOME"/.claude-code-router/logs/*.log "$HOME"/.claude-code-router/*.log; do
+            [ -f "$f" ] || continue
+            found=1
+            echo "===== ${f} (last 200 lines) ====="
+            tail -n 200 "$f"
+          done
+          if [ "$found" -eq 0 ]; then echo "No claude-code-router logs found (gateway was not a sidecar provider, or it never started)."; fi
+
       - name: Log token usage
         if: steps.msg.outputs.source != ''
         env:

--- a/memory/logs/2026-06-09.md
+++ b/memory/logs/2026-06-09.md
@@ -59,3 +59,10 @@
 
 - AuthModal dropdown now lists all six providers explicitly (Anthropic default, Bankr, OpenRouter, UsePod, Venice, Surplus) — removed Auto-detect; Anthropic submits no provider so backend prefix-detection still applies.
 - First live OpenRouter run on the aeonllm fork verified: all 3 steps routed (::notice:: lines), rss-digest completed, output captured. Analyze step warned "Empty analysis result" — both analyze warning paths now include the first 300 chars of raw CLI output for diagnosis.
+
+## Surplus sidecar 400 fix: ccr-sanitize transformer (PR pending)
+
+- First Surplus run on aeontm fork failed instantly: upstream rejected "system: text content blocks must contain non-whitespace text" — known ccr 2.0.0 gap (musistudio/claude-code-router#1328): Claude Code >=2.1.104 emits empty text blocks, ccr forwards verbatim, strict Anthropic-validating upstreams 400. No newer ccr release exists; sidecar start/route machinery itself worked.
+- Added scripts/ccr-sanitize.js (custom ccr transformer, fail-soft if unloadable): strips whitespace-only text blocks from system + message content, drops emptied messages, nulls content on tool_calls messages. Registered via config transformers[].path; runs first in the provider use chain (covers Venice too). 6 unit tests.
+- Added "Sidecar logs (on failure)" steps to aeon.yml + messages.yml — tails ~/.claude-code-router logs into the job log (config.json with embedded key deliberately not printed; runner masks secrets).
+- Verified: stubbed sidecar source run produces valid config.json whose plugin path loads; 14/14 gateway smoke checks; shellcheck clean.

--- a/scripts/ccr-sanitize.js
+++ b/scripts/ccr-sanitize.js
@@ -1,0 +1,55 @@
+// Custom claude-code-router transformer: strip whitespace-only text content
+// blocks before the request reaches the upstream provider.
+//
+// Claude Code (>= 2.1.104) sometimes emits empty text blocks in the system
+// prompt or message content. The Anthropic API itself tolerates the shapes CC
+// sends directly, but strict Anthropic-validating upstreams behind OpenAI
+// bridges (Surplus, Bedrock proxies, …) reject the round-tripped request with
+// "text content blocks must contain non-whitespace text".
+// See musistudio/claude-code-router#1328.
+//
+// Registered by scripts/llm-gateway.sh via config.json:
+//   "transformers": [{ "path": ".../scripts/ccr-sanitize.js" }]
+// and used first in the provider chain. ccr instantiates `new (require(path))()`
+// and skips the transformer gracefully if it fails to load.
+
+const isEmptyTextPart = (part) =>
+  part && part.type === 'text' && (typeof part.text !== 'string' || part.text.trim() === '')
+
+const hasToolCalls = (msg) => Array.isArray(msg.tool_calls) && msg.tool_calls.length > 0
+
+module.exports = class SanitizeEmptyText {
+  name = 'sanitize-empty-text'
+
+  async transformRequestIn(request) {
+    if (!request || typeof request !== 'object') return request
+
+    // System prompt: Anthropic shape is a string or an array of text blocks.
+    if (typeof request.system === 'string' && request.system.trim() === '') {
+      delete request.system
+    } else if (Array.isArray(request.system)) {
+      request.system = request.system.filter((p) => !isEmptyTextPart(p))
+      if (request.system.length === 0) delete request.system
+    }
+
+    if (Array.isArray(request.messages)) {
+      request.messages = request.messages
+        .map((msg) => {
+          if (!msg || !Array.isArray(msg.content)) return msg
+          const content = msg.content.filter((p) => !isEmptyTextPart(p))
+          // OpenAI-shape assistant messages carry tool_calls outside content;
+          // null content is valid there, an empty array often is not.
+          if (content.length === 0 && hasToolCalls(msg)) return { ...msg, content: null }
+          return { ...msg, content }
+        })
+        .filter((msg) => {
+          if (!msg) return false
+          if (typeof msg.content === 'string') return msg.content.trim() !== '' || hasToolCalls(msg)
+          if (Array.isArray(msg.content)) return msg.content.length > 0 || hasToolCalls(msg)
+          return true // null/undefined content (e.g. tool_calls-only) — leave as-is
+        })
+    }
+
+    return request
+  }
+}

--- a/scripts/llm-gateway.sh
+++ b/scripts/llm-gateway.sh
@@ -42,8 +42,15 @@ start_ccr_sidecar() {
   # NOTE: the host step runs under `bash -e` (Actions default), so conditionals
   # in this file must use `if` — a bare `[ … ] && …` list that evaluates false
   # would kill the step.
-  local transformers='"anthropic"'
-  if [ -n "$extra_tf" ]; then transformers="\"anthropic\", \"${extra_tf}\""; fi
+  #
+  # sanitize-empty-text (scripts/ccr-sanitize.js) runs first: Claude Code can
+  # emit whitespace-only text blocks that strict upstreams reject with a 400
+  # ("text content blocks must contain non-whitespace text"). ccr skips the
+  # transformer gracefully if the plugin fails to load.
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  local transformers='"sanitize-empty-text", "anthropic"'
+  if [ -n "$extra_tf" ]; then transformers="\"sanitize-empty-text\", \"anthropic\", \"${extra_tf}\""; fi
 
   if ! command -v ccr >/dev/null 2>&1; then
     if ! npm install -g @musistudio/claude-code-router@2.0.0 >/dev/null 2>&1; then
@@ -61,6 +68,9 @@ start_ccr_sidecar() {
   "PORT": ${CCR_PORT},
   "LOG": ${CCR_LOG:-false},
   "API_TIMEOUT_MS": 600000,
+  "transformers": [
+    { "path": "${script_dir}/ccr-sanitize.js" }
+  ],
   "Providers": [
     {
       "name": "${name}",


### PR DESCRIPTION
## Problem

First live Surplus run ([aeontm/27240379494](https://github.com/aaronjmars/aeontm/actions/runs/27240379494)) failed on the very first API call:

> `400 … system: text content blocks must contain non-whitespace text`

The sidecar machinery itself worked (ccr installed, started, routed). The failure is a known claude-code-router 2.0.0 gap ([musistudio/claude-code-router#1328](https://github.com/musistudio/claude-code-router/issues/1328)): Claude Code ≥ 2.1.104 (Aeon pins 2.1.168) emits whitespace-only text blocks, ccr forwards them verbatim, and strict Anthropic-validating upstreams reject the request. 2.0.0 is the latest ccr — no upstream fix to bump to.

## Fix

- **`scripts/ccr-sanitize.js`** — custom ccr transformer (interface verified against the 2.0.0 bundle): strips whitespace-only text blocks from `system` and message content, drops messages reduced to nothing, nulls content on `tool_calls`-bearing messages. Registered via `transformers[].path` in the generated config and run **first** in the provider chain for both Surplus and Venice. ccr skips it gracefully if it ever fails to load.
- **Sidecar failure logs** — new `Sidecar logs (on failure)` step in `aeon.yml` + `messages.yml` tails `~/.claude-code-router` logs into the job log (they die with the VM otherwise). The ccr `config.json` — which embeds the provider key — is deliberately never printed; the runner auto-masks secrets in step output.

## Verification

- 6 unit tests on the transformer (system-block strip, all-empty system removal, tool_use/tool_result preservation, tool_calls null-content, passthrough)
- Stubbed-sidecar source run: generated `config.json` is valid JSON, plugin loads from the exact path the config carries, `use` chain = `["sanitize-empty-text", "anthropic"]`
- 14/14 gateway smoke checks under `bash -e`; shellcheck clean; actionlint findings identical to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)