### PR TITLE
fix(gateway): normalize sidecar requests to plain OpenAI shape

### DIFF
--- a/memory/logs/2026-06-09.md
+++ b/memory/logs/2026-06-09.md
@@ -66,3 +66,9 @@
 - Added scripts/ccr-sanitize.js (custom ccr transformer, fail-soft if unloadable): strips whitespace-only text blocks from system + message content, drops emptied messages, nulls content on tool_calls messages. Registered via config transformers[].path; runs first in the provider use chain (covers Venice too). 6 unit tests.
 - Added "Sidecar logs (on failure)" steps to aeon.yml + messages.yml — tails ~/.claude-code-router logs into the job log (config.json with embedded key deliberately not printed; runner masks secrets).
 - Verified: stubbed sidecar source run produces valid config.json whose plugin path loads; 14/14 gateway smoke checks; shellcheck clean.
+
+## Surplus 400 round two: normalize to plain OpenAI (PR pending)
+
+- aeonsa retest failed with the same "system: text content blocks" 400 *with* the sanitizer active. Local repro (real ccr 2.0.0 + pinned CC 2.1.168 + recording mock upstream) proved our requests were already clean — the empty block is manufactured inside Surplus: ccr 2.0.0 serializes a hybrid shape (OpenAI envelope, Anthropic content-part arrays + cache_control), naive bridges read `content` expecting a string, extract nothing, and forward empty system blocks to their Anthropic upstream.
+- Extended scripts/ccr-sanitize.js: flatten all-text content arrays to plain strings (join "\n\n"), strip cache_control from parts and tool defs, keep mixed arrays (tool_use/tool_result) intact. 8 unit tests.
+- E2E verified locally: CC 2.1.168 → ccr (sanitize+anthropic chain) → mock upstream now receives system:string/user:string, zero cache_control, zero whitespace text. Sidecar prompt caching is lost by design — irrelevant, bridges don't honor Anthropic cache_control anyway.

--- a/scripts/ccr-sanitize.js
+++ b/scripts/ccr-sanitize.js
@@ -1,22 +1,50 @@
-// Custom claude-code-router transformer: strip whitespace-only text content
-// blocks before the request reaches the upstream provider.
+// Custom claude-code-router transformer: sanitize + normalize requests before
+// they reach an OpenAI-compatible upstream.
 //
-// Claude Code (>= 2.1.104) sometimes emits empty text blocks in the system
-// prompt or message content. The Anthropic API itself tolerates the shapes CC
-// sends directly, but strict Anthropic-validating upstreams behind OpenAI
-// bridges (Surplus, Bedrock proxies, …) reject the round-tripped request with
-// "text content blocks must contain non-whitespace text".
-// See musistudio/claude-code-router#1328.
+// Two distinct problems, one pass:
+//
+// 1. Claude Code (>= 2.1.104) sometimes emits whitespace-only text blocks.
+//    Strict Anthropic-validating upstreams reject these with "text content
+//    blocks must contain non-whitespace text" (musistudio/claude-code-router#1328).
+//
+// 2. ccr 2.0.0 serializes messages in a hybrid shape: OpenAI envelope, but
+//    content as Anthropic-style part arrays carrying `cache_control`. Naive
+//    OpenAI bridges (observed with Surplus) read `content` expecting a string,
+//    extract nothing, and forward EMPTY system blocks to their Anthropic
+//    upstream — same 400, manufactured downstream of a perfectly clean request.
+//    Flattening all-text part arrays to plain strings (and dropping
+//    cache_control, which is non-standard OpenAI) gives bridges the shape they
+//    actually parse.
 //
 // Registered by scripts/llm-gateway.sh via config.json:
 //   "transformers": [{ "path": ".../scripts/ccr-sanitize.js" }]
-// and used first in the provider chain. ccr instantiates `new (require(path))()`
-// and skips the transformer gracefully if it fails to load.
+// ccr instantiates `new (require(path))()` and skips the transformer
+// gracefully if it fails to load.
 
+const isTextPart = (part) => part && part.type === 'text'
 const isEmptyTextPart = (part) =>
-  part && part.type === 'text' && (typeof part.text !== 'string' || part.text.trim() === '')
+  isTextPart(part) && (typeof part.text !== 'string' || part.text.trim() === '')
 
 const hasToolCalls = (msg) => Array.isArray(msg.tool_calls) && msg.tool_calls.length > 0
+
+// Drop empty text parts, drop cache_control, and flatten to a plain string
+// when everything left is text. Mixed content (tool_use, images, …) stays an
+// array, minus the junk.
+const normalizeContent = (content) => {
+  if (!Array.isArray(content)) return content
+  const parts = content
+    .filter((p) => !isEmptyTextPart(p))
+    .map((p) => {
+      if (p && typeof p === 'object' && 'cache_control' in p) {
+        const { cache_control, ...rest } = p
+        return rest
+      }
+      return p
+    })
+  if (parts.length === 0) return []
+  if (parts.every(isTextPart)) return parts.map((p) => p.text).join('\n\n')
+  return parts
+}
 
 module.exports = class SanitizeEmptyText {
   name = 'sanitize-empty-text'
@@ -28,15 +56,16 @@ module.exports = class SanitizeEmptyText {
     if (typeof request.system === 'string' && request.system.trim() === '') {
       delete request.system
     } else if (Array.isArray(request.system)) {
-      request.system = request.system.filter((p) => !isEmptyTextPart(p))
-      if (request.system.length === 0) delete request.system
+      const system = normalizeContent(request.system)
+      if (system.length === 0) delete request.system
+      else request.system = system
     }
 
     if (Array.isArray(request.messages)) {
       request.messages = request.messages
         .map((msg) => {
           if (!msg || !Array.isArray(msg.content)) return msg
-          const content = msg.content.filter((p) => !isEmptyTextPart(p))
+          const content = normalizeContent(msg.content)
           // OpenAI-shape assistant messages carry tool_calls outside content;
           // null content is valid there, an empty array often is not.
           if (content.length === 0 && hasToolCalls(msg)) return { ...msg, content: null }
@@ -48,6 +77,18 @@ module.exports = class SanitizeEmptyText {
           if (Array.isArray(msg.content)) return msg.content.length > 0 || hasToolCalls(msg)
           return true // null/undefined content (e.g. tool_calls-only) — leave as-is
         })
+    }
+
+    // Anthropic marks tool definitions with cache_control too — non-standard
+    // for OpenAI endpoints, so scrub it there as well.
+    if (Array.isArray(request.tools)) {
+      request.tools = request.tools.map((t) => {
+        if (t && typeof t === 'object' && 'cache_control' in t) {
+          const { cache_control, ...rest } = t
+          return rest
+        }
+        return t
+      })
     }
 
     return request


### PR DESCRIPTION
## Problem

The Surplus retest ([aeonsa/27240877212](https://github.com/aaronjmars/aeonsa/actions/runs/27240877212)) failed with the identical `system: text content blocks must contain non-whitespace text` 400 — **with the #411 sanitizer active**.

## Diagnosis (full local repro)

Ran the real pipeline locally: pinned Claude Code 2.1.168 → real ccr 2.0.0 with our exact generated config → a mock upstream that records request bodies.

- The sanitizer works: no whitespace-only blocks survive in any captured request.
- The real culprit: ccr 2.0.0 serializes a **hybrid shape** — OpenAI envelope, but `content` as Anthropic-style part arrays carrying `cache_control` (with or without the `anthropic` provider transformer). A naive OpenAI bridge reads `content` expecting a string, extracts nothing, and forwards **empty** system blocks to its Anthropic upstream — manufacturing the 400 from a perfectly clean request.

## Fix

`scripts/ccr-sanitize.js` now also normalizes to standard OpenAI:
- all-text content arrays flatten to plain strings (joined with a blank line)
- `cache_control` stripped from content parts and tool definitions (non-standard OpenAI; bridges don't honor Anthropic caching anyway)
- mixed arrays (tool_use / tool_result / images) stay arrays, minus the junk

## Verification

- E2E local: CC 2.1.168 → ccr (production `["sanitize-empty-text", "anthropic"]` chain) → upstream receives `system: string` / `user: string`, zero `cache_control`, zero whitespace-only text; CC completes normally
- 8 transformer unit tests; 14/14 gateway smoke checks under `bash -e`

🤖 Generated with [Claude Code](https://claude.com/claude-code)