### PR TITLE
fix(analyze): retry empty scoring result on the run's main model

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -698,14 +698,25 @@ jobs:
 
           JSON format: {\"score\": N, \"assessment\": \"one line\", \"flags\": []}"
 
+          SCORE_MODEL="${ANTHROPIC_DEFAULT_HAIKU_MODEL:-claude-haiku-4-5-20251001}"
           if ! RAW=$(echo "$ANALYSIS_PROMPT" | claude -p - \
-            --model "${ANTHROPIC_DEFAULT_HAIKU_MODEL:-claude-haiku-4-5-20251001}" --output-format json 2>&1); then
-            echo "::warning::Skill analysis failed (non-fatal). Raw: $(printf '%s' "$RAW" | head -c 300 | tr '\n' ' ')"
+            --model "$SCORE_MODEL" --output-format json 2>&1); then
+            echo "::warning::Skill analysis failed (non-fatal). Raw: $(printf '%s' "$RAW" | head -c 800 | tr '\n' ' ')"
             exit 0
           fi
 
           ANALYSIS_TEXT=$(echo "$RAW" | jq -r '.result // empty')
-          [ -z "$ANALYSIS_TEXT" ] && { echo "::warning::Empty analysis result. Raw: $(printf '%s' "$RAW" | head -c 300 | tr '\n' ' ')"; exit 0; }
+          # Some gateway model slots return a successful-but-empty result for
+          # this call (seen twice on OpenRouter's haiku slug, while its opus
+          # slug always returns text). Retry once on the run's main model —
+          # llm-gateway.sh only sets MODEL here when the gateway remaps it.
+          if [ -z "$ANALYSIS_TEXT" ] && [ -n "${MODEL:-}" ] && [ "$MODEL" != "$SCORE_MODEL" ]; then
+            echo "::warning::Empty analysis result from ${SCORE_MODEL} — retrying with ${MODEL}. Raw: $(printf '%s' "$RAW" | head -c 800 | tr '\n' ' ')"
+            if RAW=$(echo "$ANALYSIS_PROMPT" | claude -p - --model "$MODEL" --output-format json 2>&1); then
+              ANALYSIS_TEXT=$(echo "$RAW" | jq -r '.result // empty')
+            fi
+          fi
+          if [ -z "$ANALYSIS_TEXT" ]; then echo "::warning::Empty analysis result. Raw: $(printf '%s' "$RAW" | head -c 800 | tr '\n' ' ')"; exit 0; fi
 
           # Parse score: accept raw JSON, else strip code fences, flatten newlines,
           # and grab the outermost {…} object — handles fenced / multi-line output

--- a/memory/logs/2026-06-09.md
+++ b/memory/logs/2026-06-09.md
@@ -72,3 +72,8 @@
 - aeonsa retest failed with the same "system: text content blocks" 400 *with* the sanitizer active. Local repro (real ccr 2.0.0 + pinned CC 2.1.168 + recording mock upstream) proved our requests were already clean — the empty block is manufactured inside Surplus: ccr 2.0.0 serializes a hybrid shape (OpenAI envelope, Anthropic content-part arrays + cache_control), naive bridges read `content` expecting a string, extract nothing, and forward empty system blocks to their Anthropic upstream.
 - Extended scripts/ccr-sanitize.js: flatten all-text content arrays to plain strings (join "\n\n"), strip cache_control from parts and tool defs, keep mixed arrays (tool_use/tool_result) intact. 8 unit tests.
 - E2E verified locally: CC 2.1.168 → ccr (sanitize+anthropic chain) → mock upstream now receives system:string/user:string, zero cache_control, zero whitespace text. Sidecar prompt caching is lost by design — irrelevant, bridges don't honor Anthropic cache_control anyway.
+
+## Venice validated (7/7) + analyze empty-result retry (PR pending)
+
+- Venice run passed after the key's USD spend cap was lifted: sidecar routing x3 steps, skill completed, score 3/3 — all seven auth/gateway configurations now live-validated (direct, oauth, bankr, openrouter, usepod, venice, surplus).
+- OpenRouter's empty-analysis niggle recurred and the new debug capture nailed the shape: scoring call on the haiku slug succeeds (is_error:false, ~9s, end_turn) but returns result:"" — opus slug always returns text. Analyze step now retries once with the run's main model when the scoring result is empty and the gateway remapped MODEL (fires on OpenRouter only; all other paths unchanged), raw dumps widened 300->800 chars.


### PR DESCRIPTION
## Problem

OpenRouter's haiku slug twice returned a successful-but-empty quality-scoring result ([aeonllm run](https://github.com/aaronjmars/aeonllm/actions/runs/27239935132), [aeon-open run](https://github.com/aaronjmars/aeon-open/actions/runs/27241789323)): `is_error: false`, ~9s generation, `stop_reason: end_turn`, `result: ""` — while the opus slug on the same gateway always returns text. Those runs silently get no quality score.

## Fix (blast radius: one fail-soft step)

In the Analyze step only: when the scoring result is empty **and** the gateway remapped `MODEL` (llm-gateway.sh sets it in this step only for remapping gateways — in practice OpenRouter), retry once with the run's main model. All other paths (direct, oauth, bankr, usepod, venice, surplus) have `MODEL` unset there, so the new branch is dead code for them. Every path still ends `::warning::` + `exit 0` — this step cannot fail a workflow, before or after. Raw debug dumps widened 300 → 800 chars to include usage/model details.

## Verification

- actionlint findings identical to main
- Retry call wrapped in `if` — an outright retry failure still warns and exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)