### PR TITLE
feat(skill): beamr-route — pay-per-call inference over x402 with onchain receipt

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -292,6 +292,10 @@ jobs:
           DEVTO_API_KEY: ${{ secrets.DEVTO_API_KEY }}
           NEYNAR_API_KEY: ${{ secrets.NEYNAR_API_KEY }}
           NEYNAR_SIGNER_UUID: ${{ secrets.NEYNAR_SIGNER_UUID }}
+          BEAMR_GATEWAY_URL: ${{ secrets.BEAMR_GATEWAY_URL }}
+          BEAMR_PAYER_KEY: ${{ secrets.BEAMR_PAYER_KEY }}
+          BEAMR_NETWORK: ${{ vars.BEAMR_NETWORK }}
+          BEAMR_MAX_PAY_USDC: ${{ vars.BEAMR_MAX_PAY_USDC }}
           JSONRENDER_ENABLED: ${{ vars.JSONRENDER_ENABLED || 'true' }}
           SKILL_VAR: ${{ inputs.var }}
           SKILL_NAME: ${{ steps.skill.outputs.name }}

--- a/apps/dashboard/app/api/secrets/route.ts
+++ b/apps/dashboard/app/api/secrets/route.ts
@@ -43,6 +43,8 @@ const BUILTIN_SECRETS: Omit<Secret, 'isSet'>[] = [
   { name: 'NEYNAR_SIGNER_UUID', group: 'Skill Keys', description: 'Neynar managed signer UUID — required to publish Farcaster casts' },
   { name: 'GH_GLOBAL', group: 'Skill Keys', description: 'GitHub PAT with cross-repo access — cross-repo skills & deploys' },
   { name: 'BASE_RPC_URL', group: 'Skill Keys', description: 'Custom Base RPC endpoint — onchain Base skills (fund-flow, honeypot-check, vigil-revoke). Optional: a public RPC is used by default; set a paid endpoint to lift rate limits.' },
+  { name: 'BEAMR_GATEWAY_URL', group: 'Skill Keys', description: 'BEAMR inference-gateway URL — the beamr-route skill pays per call over x402 (USDC on Base) and returns the answer + onchain receipt.' },
+  { name: 'BEAMR_PAYER_KEY', group: 'Skill Keys', description: 'Payer wallet private key (0x...) for the beamr-route skill — fund a DEDICATED low-balance wallet with USDC on Base; per-call spend is capped by the BEAMR_MAX_PAY_USDC variable.' },
 ]
 
 const BUILTIN_NAMES = new Set(BUILTIN_SECRETS.map(s => s.name))

--- a/skills/beamr-route/SKILL.md
+++ b/skills/beamr-route/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: BEAMR Route
+description: Route a prompt through a BEAMR x402 gateway and report the answer + onchain receipt
+var: ""
+tags: [crypto, dev]
+requires: [BEAMR_GATEWAY_URL, BEAMR_PAYER_KEY]
+---
+> **${var}** — The prompt to send through BEAMR (e.g. `"Summarize the latest x402 spec changes"`). **Required.** If empty, abort cleanly with a notify.
+
+Today is ${today}. Send `${var}` to a BEAMR inference gateway, pay for that single call over x402 (USDC on Base), and report the answer alongside the onchain settlement receipt.
+
+BEAMR is an OpenAI-compatible **inference router**: it classifies the request, routes it to the cheapest capable provider, runs the completion, and settles the exact cost per call in USDC on Base via the x402 `exact` scheme. This skill is the buyer side — it pays a fraction of a cent and gets back both the model output and the settlement tx hash, so a run produces a verifiable onchain artifact, not just text.
+
+Read `memory/MEMORY.md` for context before starting.
+
+## Steps
+
+1. **Guard the input.** If `${var}` is empty, do not proceed:
+   ```bash
+   if [ -z "$SKILL_VAR" ]; then ./notify "beamr-route skipped: no prompt — pass var=\"your question\""; exit 0; fi
+   ```
+   (`SKILL_VAR` carries `${var}` through the environment so embedded `$`/quotes in the prompt aren't mangled by the shell.)
+
+2. **Skip gracefully if unconfigured.** This skill needs a BEAMR deployment and a funded payer wallet. If either secret is not set, skip rather than fail:
+   ```bash
+   if [ -z "$BEAMR_GATEWAY_URL" ] || [ -z "$BEAMR_PAYER_KEY" ]; then
+     ./notify "beamr-route skipped: set BEAMR_GATEWAY_URL and BEAMR_PAYER_KEY (a low-balance USDC-on-Base wallet) to enable"; exit 0
+   fi
+   ```
+
+3. **Ensure the x402 client is available.** The payment client depends on `x402-fetch` (which pulls `viem`). Install on demand if missing:
+   ```bash
+   node -e "require.resolve('x402-fetch')" 2>/dev/null || npm install --no-save x402-fetch >/dev/null 2>&1
+   ```
+
+4. **Pay and infer.** Run the client with the prompt. It handles the full `402 → sign X-PAYMENT → retry → receipt` handshake and prints one JSON line. The per-call spend is capped by `BEAMR_MAX_PAY_USDC` (default `0.05`) — an offer above the cap throws rather than overpaying.
+   ```bash
+   RESULT=$(node skills/beamr-route/scripts/beamr-pay.mjs "$SKILL_VAR")
+   echo "$RESULT"
+   ```
+
+5. **Handle the result.** Parse the JSON.
+   - If `.ok` is `false`, notify the error and stop: `./notify "beamr-route failed: <error>"`.
+   - If `.ok` is `true`, extract `.answer`, `.model`, `.usage`, and `.settlement` (`.txHash`, `.network`, `.payer`). When a settlement is present, build a block-explorer link: `https://basescan.org/tx/<txHash>` for `base`, or `https://sepolia.basescan.org/tx/<txHash>` for `base-sepolia`. A `null` settlement means the answer came free (cache hit or paywall off) — say so.
+
+6. **Notify.** Send a concise message: the question, the answer, then a one-line footer with the model BEAMR chose, token usage, and the settlement link (or "free — served from cache"). Keep the answer readable; don't dump raw JSON.
+   ```bash
+   ./notify -f .pending-notify-temp/beamr-route-${today}.md
+   ```
+
+7. **Log.** Append a one-line entry to today's `memory/logs/${today}.md`: the prompt, the chosen model, the cost, and the tx hash — so repeat questions and spend are auditable over time.
+
+## Notes
+
+- **Use a dedicated, low-balance wallet** for `BEAMR_PAYER_KEY` and keep `BEAMR_MAX_PAY_USDC` small — like every skill secret, it is exposed to the run environment.
+- `BEAMR_NETWORK` (default `base-sepolia`) must match the gateway's network; set it to `base` for mainnet.
+- `BEAMR_MODEL` defaults to `auto`, letting BEAMR's router pick the model. Set a specific id to pin one.
+- BEAMR's paywall meters the non-streaming path only, so the client always sends `stream:false`.

--- a/skills/beamr-route/scripts/beamr-pay.mjs
+++ b/skills/beamr-route/scripts/beamr-pay.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * beamr-pay — send one prompt to a BEAMR gateway and pay for it over x402.
+ *
+ * BEAMR is an OpenAI-compatible inference router: it classifies the request,
+ * routes it to the cheapest capable provider, and (with its seller paywall on)
+ * charges the caller per call in USDC on Base via the x402 `exact` scheme.
+ * This script does the buyer side — `wrapFetchWithPayment` catches BEAMR's 402
+ * offer, signs an `X-PAYMENT` header within BEAMR_MAX_PAY_USDC, and retries —
+ * then prints a single JSON object the skill can parse.
+ *
+ * The paywall meters the non-streaming path only, so this sends stream:false.
+ *
+ * Output (stdout): one line of JSON —
+ *   { "ok": true, "answer": "...", "model": "...", "usage": {...},
+ *     "settlement": { "txHash": "0x..", "network": "base", "payer": "0x.." } | null }
+ * On failure: { "ok": false, "error": "..." } and a non-zero exit.
+ *
+ * Env:
+ *   BEAMR_GATEWAY_URL   (required) base URL of the BEAMR deployment
+ *   BEAMR_PAYER_KEY     (required) 0x-hex key of a funded wallet (USDC on Base)
+ *   BEAMR_NETWORK       base | base-sepolia (default base-sepolia)
+ *   BEAMR_MODEL         model id or "auto" (default auto)
+ *   BEAMR_MAX_PAY_USDC  per-call ceiling in USDC (default 0.05)
+ */
+
+import { createSigner, wrapFetchWithPayment, decodeXPaymentResponse } from "x402-fetch";
+
+const out = (obj, code = 0) => {
+  process.stdout.write(JSON.stringify(obj) + "\n");
+  process.exit(code);
+};
+
+async function main() {
+  const baseUrl = process.env.BEAMR_GATEWAY_URL;
+  const key = process.env.BEAMR_PAYER_KEY;
+  if (!baseUrl) out({ ok: false, error: "BEAMR_GATEWAY_URL not set" }, 2);
+  if (!key) out({ ok: false, error: "BEAMR_PAYER_KEY not set" }, 2);
+
+  const network = process.env.BEAMR_NETWORK || "base-sepolia";
+  const model = process.env.BEAMR_MODEL || "auto";
+  const maxUsd = Number(process.env.BEAMR_MAX_PAY_USDC || "0.05");
+
+  const prompt = process.argv.slice(2).join(" ").trim();
+  if (!prompt) out({ ok: false, error: "no prompt argument" }, 2);
+
+  // USDC is 6-decimal; the cap is a hard ceiling — an offer above it throws.
+  const maxAtomic = BigInt(Math.round(maxUsd * 1e6));
+  const signer = await createSigner(network, key);
+  const fetchWithPay = wrapFetchWithPayment(fetch, signer, maxAtomic);
+
+  const url = new URL("/api/v1/chat/completions", baseUrl).toString();
+  const res = await fetchWithPay(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      model,
+      stream: false,
+      messages: [{ role: "user", content: prompt }],
+    }),
+  });
+
+  const text = await res.text();
+  if (!res.ok) out({ ok: false, error: `HTTP ${res.status}: ${text.slice(0, 300)}` }, 1);
+
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    out({ ok: false, error: `non-JSON response: ${text.slice(0, 200)}` }, 1);
+  }
+
+  const receiptHeader = res.headers.get("x-payment-response");
+  const receipt = receiptHeader ? decodeXPaymentResponse(receiptHeader) : null;
+
+  out({
+    ok: true,
+    answer: body?.choices?.[0]?.message?.content ?? "",
+    model: body?.model ?? model,
+    usage: body?.usage ?? null,
+    trace: res.headers.get("x-beamr-trace") || null,
+    settlement: receipt
+      ? { txHash: receipt.transaction, network: receipt.network, payer: receipt.payer }
+      : null,
+  });
+}
+
+main().catch((e) => out({ ok: false, error: e?.message ?? String(e) }, 1));


### PR DESCRIPTION
## What

Adds a new skill, **`beamr-route`**, that sends a prompt through a [BEAMR](https://askbeamr.com) inference gateway, pays for that single call in **USDC on Base over x402**, and reports the answer **plus the onchain settlement receipt** (tx hash + basescan link).

BEAMR is an OpenAI-compatible **router**: it classifies the request, routes it to the cheapest capable provider, runs the completion, and settles the exact cost per call via the x402 `exact` scheme. Where the [companion gateway PR](https://github.com/aaronjmars/aeon/pull/414) routes *all* of Aeon's traffic through BEAMR silently, this skill is an on-demand task whose output is a **verifiable onchain artifact** — a natural fit alongside `x402-monitor` and Aeon's x402 tracking.

## Files

- **`skills/beamr-route/SKILL.md`** — standard skill flow: input guard → graceful skip when unconfigured → on-demand `x402-fetch` install → pay+infer → notify (answer + model + basescan link) → log spend to memory.
- **`skills/beamr-route/scripts/beamr-pay.mjs`** — buyer-side x402 client (`createSigner` → `wrapFetchWithPayment`), emits one JSON line. Per-call spend is capped by `BEAMR_MAX_PAY_USDC` (default `0.05`) — an offer above the cap throws rather than overpaying.
- **`.github/workflows/aeon.yml`** — inject `BEAMR_GATEWAY_URL` / `BEAMR_PAYER_KEY` (+ `BEAMR_NETWORK` / `BEAMR_MAX_PAY_USDC` vars) into the run step, matching how every other skill key is wired.
- **dashboard** — surface the two secrets under **Skill Keys**.

## Safety / opt-in

The skill is **inert until configured**: with `BEAMR_GATEWAY_URL` / `BEAMR_PAYER_KEY` unset it skips cleanly (`exit 0`), so it never fails a run or moves funds by default. The payer key is a wallet secret — the SKILL.md and the dashboard descriptor both tell operators to **fund a dedicated, low-balance wallet** and keep `BEAMR_MAX_PAY_USDC` small. This mirrors the existing pattern for fund-moving secrets (e.g. `BANKR_API_KEY`).

## Relationship to #414

Independent and complementary — #414 adds BEAMR as a *gateway* (route everything), this adds a *skill* (ask once, get a receipt). Either can merge alone; neither depends on the other.

## Validation

- `node --check skills/beamr-route/scripts/beamr-pay.mjs` ✅
- YAML parse of `aeon.yml` ✅
- Frontmatter matches the `create-skill` schema (`name`/`description`/`var`/`tags`/`requires`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)