### PR TITLE
feat(gateway): add BEAMR as an LLM gateway

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -151,7 +151,7 @@ jobs:
           SECRETS=$(grep -oE '\$\{?[A-Z][A-Z0-9_]{2,}\}?' "$SKILL_FILE" 2>/dev/null | \
             sed 's/[${}]//g' | \
             grep -E '_(API_KEY|KEY|TOKEN|SECRET|WEBHOOK_URL)$' | \
-            grep -vE '^(GITHUB_TOKEN|GH_TOKEN|ANTHROPIC_API_KEY|CLAUDE_CODE_OAUTH_TOKEN|BANKR_LLM_KEY|OPENROUTER_API_KEY|USEPOD_TOKEN|VENICE_API_KEY|SURPLUS_API_KEY|TELEGRAM_|DISCORD_|SLACK_)' | \
+            grep -vE '^(GITHUB_TOKEN|GH_TOKEN|ANTHROPIC_API_KEY|CLAUDE_CODE_OAUTH_TOKEN|BANKR_LLM_KEY|OPENROUTER_API_KEY|USEPOD_TOKEN|VENICE_API_KEY|SURPLUS_API_KEY|BEAMR_API_KEY|BEAMR_BASE_URL|TELEGRAM_|DISCORD_|SLACK_)' | \
             sort -u) || true
 
           [ -z "$SECRETS" ] && exit 0
@@ -259,6 +259,8 @@ jobs:
           USEPOD_TOKEN: ${{ secrets.USEPOD_TOKEN }}
           VENICE_API_KEY: ${{ secrets.VENICE_API_KEY }}
           SURPLUS_API_KEY: ${{ secrets.SURPLUS_API_KEY }}
+          BEAMR_BASE_URL: ${{ secrets.BEAMR_BASE_URL }}
+          BEAMR_API_KEY: ${{ secrets.BEAMR_API_KEY }}
           # Optional gateway model overrides + sidecar debug (defaults live in scripts/llm-gateway.sh)
           OPENROUTER_MODEL: ${{ vars.OPENROUTER_MODEL }}
           OPENROUTER_MODEL_SONNET: ${{ vars.OPENROUTER_MODEL_SONNET }}
@@ -269,6 +271,7 @@ jobs:
           VENICE_MODEL: ${{ vars.VENICE_MODEL }}
           VENICE_CLEANCACHE: ${{ vars.VENICE_CLEANCACHE }}
           SURPLUS_MODEL: ${{ vars.SURPLUS_MODEL }}
+          BEAMR_MODEL: ${{ vars.BEAMR_MODEL }}
           CCR_LOG: ${{ vars.CCR_LOG }}
           GITHUB_TOKEN: ${{ secrets.GH_GLOBAL || secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GH_GLOBAL || secrets.GITHUB_TOKEN }}
@@ -654,6 +657,8 @@ jobs:
           USEPOD_TOKEN: ${{ secrets.USEPOD_TOKEN }}
           VENICE_API_KEY: ${{ secrets.VENICE_API_KEY }}
           SURPLUS_API_KEY: ${{ secrets.SURPLUS_API_KEY }}
+          BEAMR_BASE_URL: ${{ secrets.BEAMR_BASE_URL }}
+          BEAMR_API_KEY: ${{ secrets.BEAMR_API_KEY }}
           OPENROUTER_MODEL: ${{ vars.OPENROUTER_MODEL }}
           OPENROUTER_MODEL_SONNET: ${{ vars.OPENROUTER_MODEL_SONNET }}
           OPENROUTER_MODEL_HAIKU: ${{ vars.OPENROUTER_MODEL_HAIKU }}
@@ -663,6 +668,7 @@ jobs:
           VENICE_MODEL: ${{ vars.VENICE_MODEL }}
           VENICE_CLEANCACHE: ${{ vars.VENICE_CLEANCACHE }}
           SURPLUS_MODEL: ${{ vars.SURPLUS_MODEL }}
+          BEAMR_MODEL: ${{ vars.BEAMR_MODEL }}
           CCR_LOG: ${{ vars.CCR_LOG }}
         run: |
           SKILL="${{ steps.skill.outputs.name }}"
@@ -779,6 +785,8 @@ jobs:
           USEPOD_TOKEN: ${{ secrets.USEPOD_TOKEN }}
           VENICE_API_KEY: ${{ secrets.VENICE_API_KEY }}
           SURPLUS_API_KEY: ${{ secrets.SURPLUS_API_KEY }}
+          BEAMR_BASE_URL: ${{ secrets.BEAMR_BASE_URL }}
+          BEAMR_API_KEY: ${{ secrets.BEAMR_API_KEY }}
           OPENROUTER_MODEL: ${{ vars.OPENROUTER_MODEL }}
           OPENROUTER_MODEL_SONNET: ${{ vars.OPENROUTER_MODEL_SONNET }}
           OPENROUTER_MODEL_HAIKU: ${{ vars.OPENROUTER_MODEL_HAIKU }}
@@ -788,6 +796,7 @@ jobs:
           VENICE_MODEL: ${{ vars.VENICE_MODEL }}
           VENICE_CLEANCACHE: ${{ vars.VENICE_CLEANCACHE }}
           SURPLUS_MODEL: ${{ vars.SURPLUS_MODEL }}
+          BEAMR_MODEL: ${{ vars.BEAMR_MODEL }}
           CCR_LOG: ${{ vars.CCR_LOG }}
         run: |
           # GATEWAY may be empty when the Run step failed early — the script

--- a/.github/workflows/messages.yml
+++ b/.github/workflows/messages.yml
@@ -652,6 +652,8 @@ jobs:
           USEPOD_TOKEN: ${{ secrets.USEPOD_TOKEN }}
           VENICE_API_KEY: ${{ secrets.VENICE_API_KEY }}
           SURPLUS_API_KEY: ${{ secrets.SURPLUS_API_KEY }}
+          BEAMR_BASE_URL: ${{ secrets.BEAMR_BASE_URL }}
+          BEAMR_API_KEY: ${{ secrets.BEAMR_API_KEY }}
           OPENROUTER_MODEL: ${{ vars.OPENROUTER_MODEL }}
           OPENROUTER_MODEL_SONNET: ${{ vars.OPENROUTER_MODEL_SONNET }}
           OPENROUTER_MODEL_HAIKU: ${{ vars.OPENROUTER_MODEL_HAIKU }}
@@ -661,6 +663,7 @@ jobs:
           VENICE_MODEL: ${{ vars.VENICE_MODEL }}
           VENICE_CLEANCACHE: ${{ vars.VENICE_CLEANCACHE }}
           SURPLUS_MODEL: ${{ vars.SURPLUS_MODEL }}
+          BEAMR_MODEL: ${{ vars.BEAMR_MODEL }}
           CCR_LOG: ${{ vars.CCR_LOG }}
           GITHUB_TOKEN: ${{ secrets.GH_GLOBAL || secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GH_GLOBAL || secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ Route Claude Code through an alternative gateway instead of the direct Anthropic
 | [UsePod](https://usepod.ai) | `USEPOD_TOKEN` | dropdown | passthrough | Solana marketplace; token is embedded in the base URL, keep it secret |
 | [Venice](https://venice.ai) | `VENICE_API_KEY` | dropdown | up to Opus 4.6 | Privacy-first; OpenAI-compatible, bridged via a per-run [claude-code-router](https://github.com/musistudio/claude-code-router) sidecar |
 | [Surplus](https://surplusintelligence.ai) | `SURPLUS_API_KEY` | `inf_…` prefix | Opus 4.8 | Settles in USDC on Base — fund the wallet + `approve()` once before use; sidecar-bridged |
-| BEAMR ([x402](https://github.com/coinbase/x402)) | `BEAMR_BASE_URL` | dropdown | router (`auto`) | Self-hostable router — classifies each call and routes to the cheapest capable provider, settling per call in USDC on Base over x402. Point at your own deployment; sidecar-bridged |
+| [BEAMR](https://askbeamr.com) ([x402](https://github.com/coinbase/x402)) | `BEAMR_BASE_URL` | dropdown | router (`auto`) | Self-hostable router — classifies each call and routes to the cheapest capable provider, settling per call in USDC on Base over x402. Point at your own deployment; sidecar-bridged |
 
 Optional model overrides (repo **variables**, consumed by `scripts/llm-gateway.sh`): `OPENROUTER_MODEL` / `_SONNET` / `_HAIKU` (defaults `anthropic/claude-opus-4.8` etc.), `USEPOD_MODEL` / `_SONNET` / `_HAIKU`, `VENICE_MODEL` (default `claude-opus-4-6`), `SURPLUS_MODEL` (default `claude-opus-4.8`), `BEAMR_MODEL` (default `auto` — lets BEAMR's router pick) + optional `BEAMR_API_KEY` if your deployment is auth-gated. Sidecar debugging: set `CCR_LOG=true`; `VENICE_CLEANCACHE=1` works around Venice's prompt-cache block limit.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ cd aeon && ./aeon
 
 Open [http://localhost:5555](http://localhost:5555) and follow the four steps:
 
-1. **Authenticate** — connect your Claude Pro/Max subscription, or paste an API key: Anthropic, Anthropic-compatible, or a [gateway key](#llm-gateways) (Bankr, OpenRouter, UsePod, Venice, Surplus) — routed automatically.
+1. **Authenticate** — connect your Claude Pro/Max subscription, or paste an API key: Anthropic, Anthropic-compatible, or a [gateway key](#llm-gateways) (Bankr, OpenRouter, UsePod, Venice, Surplus, BEAMR) — routed automatically.
 2. **Add a channel** — [Telegram, Discord, or Slack](#notifications) so Aeon can talk to you.
 3. **Pick skills** — toggle what you want, set schedules. Each skill shows the API keys and MCP servers it needs, with one-click setup.
 4. **Run** — hit **Run now** on any skill to try it immediately; API keys and `var` values apply directly, no push needed. When you change config (schedules, toggles), **Push** commits it to GitHub in one click so Actions runs it on cron.
@@ -217,7 +217,7 @@ Set **one** of these — not both:
 claude setup-token   # opens browser → prints sk-ant-oat01-... (valid 1 year)
 ```
 
-The dashboard's Authenticate modal handles both — and routes gateway keys (Bankr `bk_…`, OpenRouter `sk-or-…`, Surplus `inf_…`, or Venice/UsePod via the dropdown) automatically (see [LLM Gateways](#llm-gateways)).
+The dashboard's Authenticate modal handles both — and routes gateway keys (Bankr `bk_…`, OpenRouter `sk-or-…`, Surplus `inf_…`, or Venice/UsePod/BEAMR via the dropdown) automatically (see [LLM Gateways](#llm-gateways)).
 
 ### Notifications
 
@@ -356,8 +356,9 @@ Route Claude Code through an alternative gateway instead of the direct Anthropic
 | [UsePod](https://usepod.ai) | `USEPOD_TOKEN` | dropdown | passthrough | Solana marketplace; token is embedded in the base URL, keep it secret |
 | [Venice](https://venice.ai) | `VENICE_API_KEY` | dropdown | up to Opus 4.6 | Privacy-first; OpenAI-compatible, bridged via a per-run [claude-code-router](https://github.com/musistudio/claude-code-router) sidecar |
 | [Surplus](https://surplusintelligence.ai) | `SURPLUS_API_KEY` | `inf_…` prefix | Opus 4.8 | Settles in USDC on Base — fund the wallet + `approve()` once before use; sidecar-bridged |
+| BEAMR ([x402](https://github.com/coinbase/x402)) | `BEAMR_BASE_URL` | dropdown | router (`auto`) | Self-hostable router — classifies each call and routes to the cheapest capable provider, settling per call in USDC on Base over x402. Point at your own deployment; sidecar-bridged |
 
-Optional model overrides (repo **variables**, consumed by `scripts/llm-gateway.sh`): `OPENROUTER_MODEL` / `_SONNET` / `_HAIKU` (defaults `anthropic/claude-opus-4.8` etc.), `USEPOD_MODEL` / `_SONNET` / `_HAIKU`, `VENICE_MODEL` (default `claude-opus-4-6`), `SURPLUS_MODEL` (default `claude-opus-4.8`). Sidecar debugging: set `CCR_LOG=true`; `VENICE_CLEANCACHE=1` works around Venice's prompt-cache block limit.
+Optional model overrides (repo **variables**, consumed by `scripts/llm-gateway.sh`): `OPENROUTER_MODEL` / `_SONNET` / `_HAIKU` (defaults `anthropic/claude-opus-4.8` etc.), `USEPOD_MODEL` / `_SONNET` / `_HAIKU`, `VENICE_MODEL` (default `claude-opus-4-6`), `SURPLUS_MODEL` (default `claude-opus-4.8`), `BEAMR_MODEL` (default `auto` — lets BEAMR's router pick) + optional `BEAMR_API_KEY` if your deployment is auth-gated. Sidecar debugging: set `CCR_LOG=true`; `VENICE_CLEANCACHE=1` works around Venice's prompt-cache block limit.
 
 ### Soul
 

--- a/apps/dashboard/app/api/auth/route.ts
+++ b/apps/dashboard/app/api/auth/route.ts
@@ -17,7 +17,7 @@ export async function GET() {
     const hasApiKey = secrets.includes('ANTHROPIC_API_KEY')
     const hasOauth = secrets.includes('CLAUDE_CODE_OAUTH_TOKEN')
     const hasBankr = secrets.includes('BANKR_LLM_KEY')
-    const hasGateway = ['BANKR_LLM_KEY', 'OPENROUTER_API_KEY', 'USEPOD_TOKEN', 'VENICE_API_KEY', 'SURPLUS_API_KEY']
+    const hasGateway = ['BANKR_LLM_KEY', 'OPENROUTER_API_KEY', 'USEPOD_TOKEN', 'VENICE_API_KEY', 'SURPLUS_API_KEY', 'BEAMR_BASE_URL']
       .some((name) => secrets.includes(name))
     let hasBaseUrl = false
 

--- a/apps/dashboard/app/api/secrets/route.ts
+++ b/apps/dashboard/app/api/secrets/route.ts
@@ -12,6 +12,7 @@ const BUILTIN_SECRETS: Omit<Secret, 'isSet'>[] = [
   { name: 'USEPOD_TOKEN', group: 'Core', description: 'UsePod proxy token — routes Claude through api.usepod.ai (token embedded in the base URL)' },
   { name: 'VENICE_API_KEY', group: 'Core', description: 'Venice API key — routes Claude through api.venice.ai via a local translator. Create at venice.ai/settings/api' },
   { name: 'SURPLUS_API_KEY', group: 'Core', description: 'Surplus Intelligence API key (inf_...) — routes Claude through surplusintelligence.ai via a local translator' },
+  { name: 'BEAMR_BASE_URL', group: 'Core', description: 'BEAMR router deployment URL (e.g. https://your-beamr.vercel.app) — routes Claude through your BEAMR instance, which picks the cheapest provider per call and settles in USDC on Base over x402. Self-hostable; bridged via a local translator' },
   { name: 'TELEGRAM_BOT_TOKEN', group: 'Telegram', description: 'Bot token from @BotFather' },
   { name: 'TELEGRAM_CHAT_ID', group: 'Telegram', description: 'Your chat ID' },
   { name: 'DISCORD_BOT_TOKEN', group: 'Discord', description: 'Discord bot token' },
@@ -55,6 +56,7 @@ const GATEWAY_SECRETS: Record<string, string> = {
   USEPOD_TOKEN: 'usepod',
   VENICE_API_KEY: 'venice',
   SURPLUS_API_KEY: 'surplus',
+  BEAMR_BASE_URL: 'beamr',
 }
 
 // Valid env var name pattern

--- a/apps/dashboard/lib/types.ts
+++ b/apps/dashboard/lib/types.ts
@@ -20,9 +20,9 @@ export interface GhRunJson {
   jobs: Array<{ name: string; status: string; conclusion: string | null }>
 }
 
-export type GatewayProvider = 'direct' | 'bankr' | 'openrouter' | 'usepod' | 'venice' | 'surplus'
+export type GatewayProvider = 'direct' | 'bankr' | 'openrouter' | 'usepod' | 'venice' | 'surplus' | 'beamr'
 
-export const GATEWAY_PROVIDERS: GatewayProvider[] = ['direct', 'bankr', 'openrouter', 'usepod', 'venice', 'surplus']
+export const GATEWAY_PROVIDERS: GatewayProvider[] = ['direct', 'bankr', 'openrouter', 'usepod', 'venice', 'surplus', 'beamr']
 
 export interface UploadFile { path: string; content: string }
 

--- a/scripts/llm-gateway.sh
+++ b/scripts/llm-gateway.sh
@@ -6,7 +6,7 @@
 # call in the same shell. Place at: scripts/llm-gateway.sh
 #
 # Inputs already present in the step environment:
-#   $GATEWAY                    direct | bankr | openrouter | usepod | surplus | venice
+#   $GATEWAY                    direct | bankr | openrouter | usepod | surplus | venice | beamr
 #   $MODEL                      aeon's resolved model id (may be rewritten here)
 #   <PROVIDER> secret           the secret for the selected gateway (see below)
 #   vars.ANTHROPIC_BASE_URL     optional Anthropic-compatible endpoint (direct path)
@@ -165,6 +165,18 @@ case "${GATEWAY:-direct}" in
       "https://api.venice.ai/api/v1/chat/completions" \
       "$VENICE_API_KEY" "${VENICE_MODEL:-claude-opus-4-6}" "${VENICE_CLEANCACHE:+cleancache}"
     echo "::notice::Routing through Venice via claude-code-router (${VENICE_MODEL:-claude-opus-4-6})"
+    ;;
+
+  beamr)  # SIDECAR — OpenAI-compatible BEAMR router. BEAMR classifies each call,
+          # routes it to the cheapest capable provider, and settles that single
+          # call in USDC on Base over x402. BEAMR is self-hostable, so the routing
+          # trigger is your deployment URL (BEAMR_BASE_URL), not a key prefix;
+          # BEAMR_API_KEY is optional (only if your deployment is auth-gated).
+    require_secret BEAMR_BASE_URL
+    start_ccr_sidecar beamr \
+      "${BEAMR_BASE_URL%/}/api/v1/chat/completions" \
+      "${BEAMR_API_KEY:-x402}" "${BEAMR_MODEL:-auto}"
+    echo "::notice::Routing through BEAMR via claude-code-router (${BEAMR_MODEL:-auto})"
     ;;
 
   direct|"")  # NATIVE — Anthropic API or an Anthropic-compatible endpoint. Unchanged.


### PR DESCRIPTION
## What

Adds **[BEAMR](https://askbeamr.com)** to Aeon's LLM gateway roster (`direct | bankr | openrouter | usepod | surplus | venice | **beamr**`).

BEAMR is an OpenAI-compatible **inference router**: for each request it classifies difficulty, routes to the **cheapest capable provider**, and settles that single call in **USDC on Base over x402**. It's the same SIDECAR shape as Surplus/Venice, so it rides the existing `claude-code-router` bridge — no new payment code in Aeon.

## How it works

- `scripts/llm-gateway.sh` gains a `beamr` case (SIDECAR tier): points `claude-code-router` at `${BEAMR_BASE_URL}/api/v1/chat/completions`, auth optional (`BEAMR_API_KEY`, defaults to `x402`), model `${BEAMR_MODEL:-auto}`.
- Dashboard: `beamr` added to the gateway enum + secrets descriptors; setting `BEAMR_BASE_URL` flips the gateway like the other providers.
- Workflows (`aeon.yml`, `messages.yml`): `BEAMR_BASE_URL` / `BEAMR_API_KEY` / `BEAMR_MODEL` wired through; secrets excluded from the extraction grep.
- README: gateway table row + auth-modal/intro mentions.

## Design note

BEAMR is self-hostable, so the trigger is `BEAMR_BASE_URL` (your deployment) rather than a key prefix; `BEAMR_API_KEY` is optional. Happy to model it as a key instead if you'd prefer consistency with the other gateways.

🤖 Generated with [Claude Code](https://claude.com/claude-code)