### PR TITLE
feat(mcp): add RootAI Edge MCP to catalog

### DIFF
--- a/apps/dashboard/lib/mcp-catalog.ts
+++ b/apps/dashboard/lib/mcp-catalog.ts
@@ -26,6 +26,13 @@ export const MCP_CATALOG: McpCatalogEntry[] = [
     logo: 'https://pbs.twimg.com/profile_images/2039734967681597440/Hh_-fXR8_400x400.jpg',
     description: 'Ctrl MCP server.',
   },
+  {
+    slug: 'rootai',
+    name: 'RootAI',
+    url: 'https://mcp.rootedge.ai/pro',
+    logo: 'https://rootedge.ai/rootai.svg',
+    description: 'RootAI Edge MCP — crypto market intelligence across Hyperliquid, Base & Paradex: funding-arbitrage scans, cross-exchange spreads, and best-execution routing. Discovery and free tools are no-cost; premium tools settle per-call in USDC via x402.',
+  },
 ]
 
 export const MCP_BY_SLUG: Record<string, McpCatalogEntry> =


### PR DESCRIPTION
## What

Adds the **RootAI Edge MCP** as a Featured template in the dashboard MCP catalog (`apps/dashboard/lib/mcp-catalog.ts`).

| Field | Value |
|---|---|
| slug | `rootai` |
| name | RootAI |
| url | `https://mcp.rootedge.ai/pro` |
| logo | `https://rootedge.ai/rootai.svg` (verified 200, image/svg+xml) |

## Why

Surfaces RootAI's crypto market-intelligence tools (funding-arb, cross-spread, best-execution across Hyperliquid / Base / Paradex) as a one-click install on the dashboard MCP page, and lets skills declare it via `mcp: [rootai]` frontmatter.

## Notes

- `MCP_BY_SLUG` derives from `MCP_CATALOG` automatically — no other file needs touching.
- Registered the `/pro` endpoint (canonical per the docs header + curl example; `mcp.rootai.wtf` in the JS snippet is a doc alias). Per RootAI's docs, `/pro` serves all free Edge tools too — `initialize`/`tools/list` are free; only `tools/call` on `pro_*` tools costs ~0.001 USDC via x402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)