### PR TITLE
chore(memory): neutralize operator-specific dispatch rule + drop phantom skills

### DIFF
--- a/memory/topics/milestone-dispatch.json
+++ b/memory/topics/milestone-dispatch.json
@@ -1,9 +1,5 @@
 {
   "_comment": "Auto-dispatch rules for star-milestone. Read by skills/star-milestone/SKILL.md step 8 on every announced milestone (gate 5f). `rules` is operator-editable: { owner/repo: { threshold (as string): skill_name } }. `dispatched` is managed automatically — one timestamp per (repo, threshold, skill) tuple, written only on successful dispatch. Step 5a in star-milestone (milestones.md already-recorded check) is the primary idempotency guard; `dispatched` here is a second guard for cases where milestones.md is hand-edited or reverted. Failures do NOT write to `dispatched` — the operator runs the dispatch manually if they want a retry.",
-  "rules": {
-    "aaronjmars/aeon": {
-      "500": "show-hn"
-    }
-  },
+  "rules": {},
   "dispatched": {}
 }

--- a/memory/topics/skill-spotlight.md
+++ b/memory/topics/skill-spotlight.md
@@ -13,7 +13,6 @@ The starter pack below targets *observable* skills with clear single-purpose out
 - priority-brief
 - paper-pick
 - repo-pulse
-- agentic-video-digest
 - reply-maker
 - hn-digest
 - self-improve
@@ -93,7 +92,6 @@ Never feature these — they are meta/internal/repair skills that don't read as 
 - product-hunt
 - create-campaign
 - schedule-ads
-- motion-explainer
 - onchain-monitor
 - price-alert
 - monitor-runners


### PR DESCRIPTION
Template hygiene for `memory/topics/`:

- **`milestone-dispatch.json`** — emptied the `rules` object. It carried an `aaronjmars/aeon`-specific rule (*at 500 stars → dispatch `show-hn`*) that every fork inherited, pointing at the upstream repo rather than their own. The file and its format documentation are kept so `star-milestone` still reads a valid (now empty) ruleset.
- **`skill-spotlight.md`** — removed two phantom entries that don't correspond to real skills: `agentic-video-digest` (Queue) and `motion-explainer` (Blocklist). Verified no other phantoms remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)