### PR TITLE
feat(dashboard): add "Connect with Claude Code" to the Settings tab

### DIFF
--- a/apps/dashboard/app/page.tsx
+++ b/apps/dashboard/app/page.tsx
@@ -130,7 +130,7 @@ export default function Dashboard() {
 
         <div className="flex-1 overflow-y-auto p-[var(--space-lg)]">
           {view === 'secrets' && !selectedSkill && (
-            <SecretsPanel secrets={secrets} skills={skills} busy={busy} repo={repo} focusKey={secretFocus} onFocusHandled={() => setSecretFocus(null)} onSave={saveSecret} onDelete={deleteSecret} onSelectSkill={(name) => { setSelectedSkill(name); setView('hq') }} />
+            <SecretsPanel secrets={secrets} skills={skills} busy={busy} repo={repo} focusKey={secretFocus} onFocusHandled={() => setSecretFocus(null)} onSave={saveSecret} onDelete={deleteSecret} onSelectSkill={(name) => { setSelectedSkill(name); setView('hq') }} onConnectClaude={() => setupAuth()} connecting={authLoading} authenticated={authStatus?.authenticated ?? false} />
           )}
           {view === 'strategy' && !selectedSkill && (
             <StrategyPanel content={strategy} loading={!strategyLoaded} saving={strategySaving} onSave={saveStrategy} />

--- a/apps/dashboard/components/SecretsPanel.tsx
+++ b/apps/dashboard/components/SecretsPanel.tsx
@@ -30,9 +30,12 @@ interface SecretsPanelProps {
   onSave: (name: string, value: string) => void
   onDelete: (name: string) => void
   onSelectSkill: (name: string) => void
+  onConnectClaude: () => void
+  connecting?: boolean
+  authenticated?: boolean
 }
 
-export function SecretsPanel({ secrets, skills, busy, repo, focusKey, onFocusHandled, onSave, onDelete, onSelectSkill }: SecretsPanelProps) {
+export function SecretsPanel({ secrets, skills, busy, repo, focusKey, onFocusHandled, onSave, onDelete, onSelectSkill, onConnectClaude, connecting, authenticated }: SecretsPanelProps) {
   const [editingSecret, setEditingSecret] = useState<string | null>(null)
   const [secretValue, setSecretValue] = useState('')
   const [addingSecret, setAddingSecret] = useState(false)
@@ -93,6 +96,19 @@ export function SecretsPanel({ secrets, skills, busy, repo, focusKey, onFocusHan
           <p className="mt-4 max-w-xl text-sm text-primary-70 leading-relaxed">
             Set a secret, the channel turns on. Unset secrets are silently skipped — every channel is opt-in.
           </p>
+          <div className="mt-6 flex flex-wrap items-center gap-3">
+            <button
+              onClick={onConnectClaude}
+              disabled={connecting}
+              title="Run the Claude Code OAuth flow — powers runs with your Claude Pro/Max plan, no API key needed."
+              className="bg-aeon-fg text-aeon-bg text-xs py-2.5 px-5 font-mono uppercase tracking-[0.18em] hover:opacity-90 transition-opacity disabled:opacity-50"
+            >
+              {connecting ? '…' : 'Connect with Claude Code'}
+            </button>
+            {authenticated
+              ? <span className="text-[11px] font-mono text-eva-green inline-flex items-center gap-1.5"><span className="w-2 h-2 rounded-full bg-eva-green" /> subscription connected</span>
+              : <span className="text-[11px] font-mono text-primary-40">Claude Pro/Max — no API key needed</span>}
+          </div>
         </div>
       </section>
 


### PR DESCRIPTION
The Claude subscription OAuth flow ("Use Claude Subscription") was only reachable from the **Authenticate** modal. This surfaces the same option on **Settings → Access Keys**.

- **`SecretsPanel`** — adds a **"Connect with Claude Code"** button in the panel hero, plus a small status line: *"subscription connected"* (green) when authenticated, or *"Claude Pro/Max — no API key needed"* otherwise.
- **`page.tsx`** — wires it to the existing `setupAuth()` (no-arg → runs the OAuth flow; on failure it falls back to opening the Authenticate modal, same as before). Reuses `authLoading` for the button's busy state and `authStatus` for the connected indicator.

No new backend code — it calls the same `/api/auth` path the modal already uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)