### PR TITLE
feat(gateway): cascade failover across providers on any failure

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -313,13 +313,21 @@ jobs:
           echo "SKILL_MODEL=$MODEL" >> "$GITHUB_OUTPUT"
 
           # --- AI Gateway routing ---
+          # provider: auto → cascade through every provider whose key is set, in
+          # priority order, failing over to the next on ANY failure. An explicit
+          # provider pins a single one (no failover). Setup runs per-attempt in the
+          # run loop below, so a dead/credit-less provider is skipped, not fatal.
+          BASE_MODEL="$MODEL"
+          GW="${GITHUB_WORKSPACE}/scripts/llm-gateway.sh"
           GATEWAY=$(grep -A1 '^gateway:' aeon.yml | grep 'provider:' | sed 's/.*provider:[[:space:]]*//' | sed "s/[\"' ]//g" || true)
           GATEWAY="${GATEWAY:-auto}"
-          echo "Gateway: $GATEWAY"
-
-          echo "GATEWAY=$GATEWAY" >> "$GITHUB_OUTPUT"
-
-          source "${GITHUB_WORKSPACE}/scripts/llm-gateway.sh"
+          if [ "$GATEWAY" = "auto" ]; then
+            CANDIDATES=$(AEON_LIST_CANDIDATES=1 bash "$GW")
+          else
+            CANDIDATES="$GATEWAY"   # explicit pin → single provider, no failover
+          fi
+          echo "Gateway: $GATEWAY  |  cascade order: $CANDIDATES"
+          echo "GATEWAY=${CANDIDATES%% *}" >> "$GITHUB_OUTPUT"   # provisional; overwritten with the winner below
 
           # Generate notify script in workspace (Claude calls: ./notify "message")
           # Messages are saved to .pending-notify/ for reliable post-run delivery
@@ -522,14 +530,37 @@ jobs:
           Use this variable (override the default in the skill file):
           var=$VAR"
           fi
-          if ! CLAUDE_OUTPUT=$(echo "$PROMPT" | claude -p - \
-            --model "$MODEL" --allowedTools "$ALLOWED" \
-            "${MCP_FLAGS[@]}" --output-format json 2>&1); then
-            echo "::error::Claude CLI failed. Output: $CLAUDE_OUTPUT"
+          # Cascade: try each provider in priority order; on ANY failure fall over
+          # to the next. Each attempt runs in a subshell so provider setup (env +
+          # any claude-code-router sidecar) is isolated and torn down on exit. The
+          # gateway script's notices go to stderr (>&2) so only Claude's JSON is captured.
+          CLAUDE_OK=0
+          USED_GATEWAY=""
+          for cand in $CANDIDATES; do
+            echo "::notice::Routing attempt via '$cand'"
+            # No `set -e` here: the gateway script signals a hard setup failure with
+            # an explicit `exit 1` (which exits this subshell → fall over), and on
+            # success the subshell's status is Claude's own exit code. A benign
+            # non-zero from a trailing test in the gateway script is harmless — we
+            # only fall over on an explicit exit or a failed Claude call.
+            if CLAUDE_OUTPUT=$(
+              GATEWAY="$cand"
+              MODEL="$BASE_MODEL"
+              source "$GW" >&2
+              echo "$PROMPT" | claude -p - --model "$MODEL" --allowedTools "$ALLOWED" "${MCP_FLAGS[@]}" --output-format json 2>&1
+            ); then
+              USED_GATEWAY="$cand"; CLAUDE_OK=1; break
+            fi
+            echo "::warning::provider '$cand' failed — $(printf '%s' "$CLAUDE_OUTPUT" | tail -c 160 | tr '\n' ' ')"
+          done
+          if [ "$CLAUDE_OK" != "1" ]; then
+            echo "::error::All gateway providers failed ($CANDIDATES). Last output: $CLAUDE_OUTPUT"
             # Save error signature for quality tracking (cron-state step reads this)
             echo "$CLAUDE_OUTPUT" | tail -c 500 | tr '\n' ' ' | cut -c1-200 > /tmp/skill-error.txt
             exit 1
           fi
+          [ "$USED_GATEWAY" != "${CANDIDATES%% *}" ] && echo "::notice::Skill ran via fallback provider '$USED_GATEWAY'"
+          echo "GATEWAY=$USED_GATEWAY" >> "$GITHUB_OUTPUT"
 
           # Extract and print the text result so logs still show skill output
           RESULT_TEXT=$(echo "$CLAUDE_OUTPUT" | jq -r '.result // empty')

--- a/scripts/llm-gateway.sh
+++ b/scripts/llm-gateway.sh
@@ -121,29 +121,53 @@ JSON
 #   anthropic  pay-as-you-go Anthropic API (ANTHROPIC_API_KEY)
 #   openrouter bankr usepod venice surplus  — gateway keys
 #
-# `claude` and `anthropic` both route via the `direct` path; we drop the other
-# credential so the chosen one wins deterministically when both happen to be set.
-# `direct` is the implicit final fallback (errors later if no usable key).
+# `claude` and `anthropic` are NATIVE direct-API tiers (handled by the case
+# below). `direct` is the implicit final fallback (errors later if no usable key).
+aeon_present() {  # is the secret for provider $1 set?
+  case "$1" in
+    claude)     [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] ;;
+    anthropic)  [ -n "${ANTHROPIC_API_KEY:-}" ] ;;
+    openrouter) [ -n "${OPENROUTER_API_KEY:-}" ] ;;
+    bankr)      [ -n "${BANKR_LLM_KEY:-}" ] ;;
+    usepod)     [ -n "${USEPOD_TOKEN:-}" ] ;;
+    venice)     [ -n "${VENICE_API_KEY:-}" ] ;;
+    surplus)    [ -n "${SURPLUS_API_KEY:-}" ] ;;
+    *) false ;;
+  esac
+}
 if [ -z "${GATEWAY:-}" ] || [ "${GATEWAY}" = "auto" ]; then
-  resolved=""
+  # Ordered list of every provider whose secret is set (priority via GATEWAY_ORDER).
+  AEON_CANDIDATES=""
   for provider in ${GATEWAY_ORDER:-claude anthropic openrouter bankr usepod venice surplus}; do
-    case "$provider" in
-      claude)     if [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then resolved="direct";     unset ANTHROPIC_API_KEY;       fi ;;
-      anthropic)  if [ -n "${ANTHROPIC_API_KEY:-}" ];       then resolved="direct";     unset CLAUDE_CODE_OAUTH_TOKEN; fi ;;
-      openrouter) if [ -n "${OPENROUTER_API_KEY:-}" ];      then resolved="openrouter"; fi ;;
-      bankr)      if [ -n "${BANKR_LLM_KEY:-}" ];           then resolved="bankr";      fi ;;
-      usepod)     if [ -n "${USEPOD_TOKEN:-}" ];            then resolved="usepod";     fi ;;
-      venice)     if [ -n "${VENICE_API_KEY:-}" ];          then resolved="venice";     fi ;;
-      surplus)    if [ -n "${SURPLUS_API_KEY:-}" ];         then resolved="surplus";    fi ;;
-    esac
-    if [ -n "$resolved" ]; then break; fi
+    if aeon_present "$provider"; then AEON_CANDIDATES="${AEON_CANDIDATES:+$AEON_CANDIDATES }$provider"; fi
   done
-  GATEWAY="${resolved:-direct}"
+  [ -z "$AEON_CANDIDATES" ] && AEON_CANDIDATES="direct"
+  # List mode (RUN, not sourced): print the cascade order and stop. aeon.yml's
+  # Run step uses this to fail over from one provider to the next on any failure.
+  if [ -n "${AEON_LIST_CANDIDATES:-}" ]; then printf '%s\n' "$AEON_CANDIDATES"; exit 0; fi
+  # Single-shot: set up the first present provider (preserves prior behavior).
+  GATEWAY="${AEON_CANDIDATES%% *}"
   echo "::notice::gateway=auto resolved to '${GATEWAY}'"
 fi
 
 # --- route ------------------------------------------------------------------
 case "${GATEWAY:-direct}" in
+
+  claude)  # NATIVE — Claude Code subscription (OAuth token)
+    require_secret CLAUDE_CODE_OAUTH_TOKEN
+    unset ANTHROPIC_API_KEY   # prefer the subscription token over a pay-go key
+    echo "::notice::Using Claude Code subscription (CLAUDE_CODE_OAUTH_TOKEN)"
+    ;;
+
+  anthropic)  # NATIVE — pay-as-you-go Anthropic API key (or compatible endpoint)
+    require_secret ANTHROPIC_API_KEY
+    unset CLAUDE_CODE_OAUTH_TOKEN
+    if [ -n "${ANTHROPIC_BASE_URL:-}" ]; then
+      echo "::notice::Using Anthropic-compatible API at ${ANTHROPIC_BASE_URL}"
+    else
+      echo "::notice::Using direct Anthropic API (ANTHROPIC_API_KEY)"
+    fi
+    ;;
 
   bankr)  # NATIVE — unchanged from aeon's existing behavior
     require_secret BANKR_LLM_KEY


### PR DESCRIPTION
Builds the failover you asked for — a **pure cascade**, no error classification. When `gateway.provider=auto` (default), the Run step tries each provider whose key is set, in `GATEWAY_ORDER` priority, and falls over to the next on **any** failure (no credits / rate limit / auth / outage / failed call all count). An explicit pinned provider stays single-shot (no failover).

### How
- **`scripts/llm-gateway.sh`**
  - Auto-resolver now builds the full ordered list of present providers. `AEON_LIST_CANDIDATES=1 bash llm-gateway.sh` prints that cascade order (used to drive the loop). Sourced single-shot still sets up the first present provider — unchanged for the scoring / `messages.yml` re-source paths.
  - Added explicit `claude)` / `anthropic)` case arms so every candidate (including the two direct tiers) can be set up by name.
- **`.github/workflows/aeon.yml` Run step**
  - Loops the candidates; each attempt is a **subshell** that sources the gateway (its notices go to stderr so only Claude's JSON is captured) then calls `claude`. Subshell isolation tears down any `claude-code-router` sidecar between attempts automatically.
  - Falls over on the gateway's explicit `exit 1` or a failed `claude` call; a benign trailing non-zero from the gateway script does **not** false-skip (no `set -e` footgun).
  - Writes the **winning** provider to the `GATEWAY` output, so the downstream Analyze/Convert steps re-route through whatever actually worked.

### Tested locally (stubbed `claude`)
- hard setup-`exit 1` → cascades ✅
- failed Claude call → cascades ✅
- benign trailing non-zero in setup → does **not** skip ✅
- all providers fail → `exit 1` ✅
- single-shot / pinned resolution unchanged ✅ · `aeon.yml` valid YAML ✅

### Notes / trade-offs
- Each attempt **re-sends the prompt**, so an N-hop fall-through costs ~N× the prompt tokens. Logged per hop (`::warning:: provider 'X' failed …` / `::notice:: Skill ran via fallback provider 'Y'`).
- `messages.yml` keeps single-shot (no failover for the messaging poller).
- Pure cascade by request — it does not distinguish a transient provider error from a bad-prompt error, so a genuinely broken prompt will try every provider before failing.

### Suggested live test (throwaway fork)
Set the **top-priority** provider's key to something invalid and a working provider below it — e.g. `ANTHROPIC_API_KEY=sk-ant-invalid` + a real `OPENROUTER_API_KEY`. Run `rss-digest`; the log should show anthropic fail → fall over → `Skill ran via fallback provider 'openrouter'`, run succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)