### PR TITLE
fix(dashboard): hide top-bar Auth button once any model/provider key is set

### DIFF
--- a/apps/dashboard/app/page.tsx
+++ b/apps/dashboard/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import type { Skill, Run, Secret, SkillOutput, GatewayProvider, UploadFile, AnalyticsData } from '../lib/types'
-import { MODELS } from '../lib/constants'
+import { MODELS, AUTH_SECRETS } from '../lib/constants'
 import { displayName } from '../lib/utils'
 import TargetCursor from '../components/ui/TargetCursor'
 import { LoadingScreen } from '../components/LoadingScreen'
@@ -47,7 +47,6 @@ export default function Dashboard() {
   const [analyticsData, setAnalyticsData] = useState<AnalyticsData | null>(null)
 
   const [showImport, setShowImport] = useState(false)
-  const [authStatus, setAuthStatus] = useState<{ authenticated: boolean } | null>(null)
   const [authLoading, setAuthLoading] = useState(false)
   const [showAuthModal, setShowAuthModal] = useState(false)
 
@@ -64,7 +63,6 @@ export default function Dashboard() {
   const fetchData = useCallback(async () => {
     try { const [sr, rr, secr] = await Promise.all([fetch('/api/skills'), fetch('/api/runs'), fetch('/api/secrets')]); if (sr.ok) { const d = await sr.json(); setSkills(d.skills); if (d.model) setModel(d.model); if (d.gateway?.provider) setGateway(d.gateway.provider); if (d.repo) setRepo(d.repo) }; if (rr.ok) setRuns((await rr.json()).runs); if (secr.ok) { const d = await secr.json(); if (d.secrets) setSecrets(d.secrets) } } catch (e: unknown) { setError(e instanceof Error ? e.message : 'Failed to connect') } finally { setLoading(false) }
     try { const r = await fetch('/api/sync'); if (r.ok) { const d = await r.json(); setHasChanges(d.hasChanges); if (typeof d.behind === 'number') setBehind(d.behind) } } catch {}
-    try { const r = await fetch('/api/auth'); if (r.ok) setAuthStatus(await r.json()) } catch {}
     // Preload MCP servers so each skill's "MCP servers" panel can show install state.
     try { const r = await fetch('/api/mcp'); if (r.ok) { const d = await r.json(); setMcpServers(d.servers || {}); setMcpLoaded(true) } } catch {}
   }, [])
@@ -84,7 +82,7 @@ export default function Dashboard() {
   const deleteSkill = async (n: string) => { setBusy(b => ({ ...b, [`d-${n}`]: true })); try { const r = await fetch('/api/skills', { method: 'DELETE', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: n }) }); if (r.ok) { setSkills(s => s.filter(x => x.name !== n)); setSelectedSkill(null); flash(`${displayName(n)} removed`); setHasChanges(true) } } finally { setBusy(b => ({ ...b, [`d-${n}`]: false })) } }
   const syncToGithub = async () => { setSyncing(true); try { const r = await fetch('/api/sync', { method: 'POST' }); if (r.ok) { flash('Synced'); setHasChanges(false) } } finally { setSyncing(false) } }
   const pullFromGithub = async () => { setPulling(true); try { const r = await fetch('/api/outputs', { method: 'POST' }); if (r.ok) { flash('Pulled'); setFeedKey(k => k + 1); fetchData() } } finally { setPulling(false) } }
-  const setupAuth = async (auth?: string | { key: string, baseUrl?: string, provider?: string }) => { setAuthLoading(true); try { const body = typeof auth === 'string' ? { key: auth } : (auth || {}); const r = await fetch('/api/auth', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }); if (r.ok) { flash('Authenticated'); setAuthStatus({ authenticated: true }); setShowAuthModal(false); fetchData() } else { const d = await r.json().catch(() => ({} as { error?: string })); const msg = typeof d?.error === 'string' ? d.error : (auth ? 'Auth failed' : 'Auto-setup failed'); if (!auth) setShowAuthModal(true); flash(msg) } } finally { setAuthLoading(false) } }
+  const setupAuth = async (auth?: string | { key: string, baseUrl?: string, provider?: string }) => { setAuthLoading(true); try { const body = typeof auth === 'string' ? { key: auth } : (auth || {}); const r = await fetch('/api/auth', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }); if (r.ok) { flash('Authenticated'); setShowAuthModal(false); fetchData() } else { const d = await r.json().catch(() => ({} as { error?: string })); const msg = typeof d?.error === 'string' ? d.error : (auth ? 'Auth failed' : 'Auto-setup failed'); if (!auth) setShowAuthModal(true); flash(msg) } } finally { setAuthLoading(false) } }
   const saveSecret = async (n: string, value: string) => { setBusy(b => ({ ...b, [`sec-${n}`]: true })); try { const r = await fetch('/api/secrets', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: n, value }) }); if (r.ok) { setSecrets(s => { const e = s.some(x => x.name === n); if (e) return s.map(x => x.name === n ? { ...x, isSet: true } : x); return [...s, { name: n, group: 'Skill Keys', description: 'Custom', isSet: true }] }); flash(`${n} saved`) } } finally { setBusy(b => ({ ...b, [`sec-${n}`]: false })) } }
   const deleteSecret = async (n: string) => { setBusy(b => ({ ...b, [`sec-${n}`]: true })); try { const r = await fetch('/api/secrets', { method: 'DELETE', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: n }) }); if (r.ok) { setSecrets(s => s.map(x => x.name === n ? { ...x, isSet: false } : x)); flash(`${n} removed`) } } finally { setBusy(b => ({ ...b, [`sec-${n}`]: false })) } }
   const importSkill = async (files: UploadFile[], name?: string) => { const r = await fetch('/api/upload', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ files, name }) }); if (r.ok) { const d = await r.json(); flash(`${displayName(d.name)} hired`); fetchData() } }
@@ -98,6 +96,9 @@ export default function Dashboard() {
 
   // --- Derived ---
   const skill = selectedSkill ? skills.find(s => s.name === selectedSkill) || null : null
+  // Any model/provider key set means Aeon can authenticate — the "Auth" CTA hides.
+  // Derived from live `secrets` so it reacts the instant a key is saved or removed.
+  const hasModelKey = secrets.some(s => s.isSet && AUTH_SECRETS.includes(s.name))
   const enabledCount = skills.filter(s => s.enabled).length
   const workingCount = runs.filter(r => r.status === 'in_progress').length
 
@@ -122,7 +123,7 @@ export default function Dashboard() {
       <div className="flex-1 flex flex-col min-w-0">
         <TopBar
           skill={skill} view={view} repo={repo} model={model} gateway={gateway}
-          authStatus={authStatus} authLoading={authLoading}
+          hasModelKey={hasModelKey} authLoading={authLoading}
           pulling={pulling} syncing={syncing} hasChanges={hasChanges} behind={behind}
           onSetupAuth={() => setShowAuthModal(true)} onUpdateModel={updateModel}
           onPull={pullFromGithub} onSync={syncToGithub}

--- a/apps/dashboard/components/TopBar.tsx
+++ b/apps/dashboard/components/TopBar.tsx
@@ -8,7 +8,7 @@ interface TopBarProps {
   repo: string
   model: string
   gateway: GatewayProvider
-  authStatus: { authenticated: boolean } | null
+  hasModelKey: boolean
   authLoading: boolean
   pulling: boolean
   syncing: boolean
@@ -20,7 +20,7 @@ interface TopBarProps {
   onSync: () => void
 }
 
-export function TopBar({ skill, view, repo, model, gateway, authStatus, authLoading, pulling, syncing, hasChanges, behind, onSetupAuth, onUpdateModel, onPull, onSync }: TopBarProps) {
+export function TopBar({ skill, view, repo, model, gateway, hasModelKey, authLoading, pulling, syncing, hasChanges, behind, onSetupAuth, onUpdateModel, onPull, onSync }: TopBarProps) {
   const dept = skill ? (CATEGORY_BY_KEY[skill.category || 'meta'] || null) : null
   const modelOptions = MODELS
 
@@ -43,7 +43,7 @@ export function TopBar({ skill, view, repo, model, gateway, authStatus, authLoad
         {gateway !== 'direct' && gateway !== 'auto' && (
           <span className="text-[10px] font-mono px-2 py-0.5 bg-aeon-red/10 text-eva-orange uppercase tracking-[0.18em] border border-aeon-red/30">{gateway}</span>
         )}
-        {authStatus && !authStatus.authenticated && (
+        {!hasModelKey && (
           <button onClick={onSetupAuth} disabled={authLoading} className="btn-solid-sm disabled:opacity-50">
             {authLoading ? '…' : 'Auth'}
           </button>

--- a/apps/dashboard/lib/constants.ts
+++ b/apps/dashboard/lib/constants.ts
@@ -6,6 +6,21 @@ export const MODELS = [
   { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5' },
 ]
 
+// Secret names that authenticate Aeon's model access: Claude's own credentials
+// (OAuth token or Anthropic key) plus the gateway-provider keys that route
+// Claude through a third party. Setting any one means the agent can run, so the
+// top-bar "Auth" call-to-action hides once at least one is present. Mirrors the
+// hasApiKey/hasOauth/hasGateway check in app/api/auth/route.ts.
+export const AUTH_SECRETS = [
+  'CLAUDE_CODE_OAUTH_TOKEN',
+  'ANTHROPIC_API_KEY',
+  'BANKR_LLM_KEY',
+  'OPENROUTER_API_KEY',
+  'USEPOD_TOKEN',
+  'VENICE_API_KEY',
+  'SURPLUS_API_KEY',
+]
+
 export const DAYS = [
   { label: 'All', value: -1 }, { label: 'Mon', value: 1 }, { label: 'Tue', value: 2 },
   { label: 'Wed', value: 3 }, { label: 'Thu', value: 4 }, { label: 'Fri', value: 5 },


### PR DESCRIPTION
## What

The TopBar **"Auth"** CTA now hides as soon as **any** model/provider API key is set, and reappears if they're all removed — driven off the **live** `secrets` state.

## Why

The button read from `authStatus`, fetched once on load via `/api/auth` and never refreshed by `saveSecret`/`deleteSecret`. Setting a provider key (e.g. `OPENROUTER_API_KEY`) from the Settings panel left the nag visible until a full reload. The backend already counted all 7 keys (`ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, plus gateway keys `BANKR_LLM_KEY`/`OPENROUTER_API_KEY`/`USEPOD_TOKEN`/`VENICE_API_KEY`/`SURPLUS_API_KEY`) — only the client was stale.

## How

- **`lib/constants.ts`** — add `AUTH_SECRETS` (single source of truth; mirrors the route's `hasApiKey`/`hasOauth`/`hasGateway` check).
- **`app/page.tsx`** — derive `hasModelKey = secrets.some(s => s.isSet && AUTH_SECRETS.includes(s.name))` and pass to TopBar. Retire the redundant `authStatus` state, its `/api/auth` GET fetch, and the optimistic `setAuthStatus` call.
- **`components/TopBar.tsx`** — swap the `authStatus` prop for `hasModelKey`; render the Auth button only when `!hasModelKey`.

## Test

Type-consistent by inspection; could not run `tsc`/`next lint` in this checkout (deps not installed). Recommend confirming via CI build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)