### PR TITLE
feat(dashboard): add BlueAgent MCP server to the featured catalog

### DIFF
--- a/apps/dashboard/lib/mcp-catalog.ts
+++ b/apps/dashboard/lib/mcp-catalog.ts
@@ -33,6 +33,13 @@ export const MCP_CATALOG: McpCatalogEntry[] = [
     logo: 'https://pbs.twimg.com/profile_images/2055018961746399233/09lx9ZYV_400x400.jpg',
     description: 'RootAI Edge MCP — crypto market intelligence across Hyperliquid, Base & Paradex: funding-arbitrage scans, cross-exchange spreads, and best-execution routing. Discovery and free tools are no-cost; premium tools settle per-call in USDC via x402.',
   },
+  {
+    slug: 'blueagent',
+    name: 'BlueAgent',
+    url: 'https://blueagent.dev/api/mcp',
+    logo: 'https://pbs.twimg.com/profile_images/2047719472455438336/CFrEyoNZ_400x400.jpg',
+    description: 'BlueAgent — the AI founder console for Base builders: idea, build, audit, ship, and raise, from concept to deployment.',
+  },
 ]
 
 export const MCP_BY_SLUG: Record<string, McpCatalogEntry> =


### PR DESCRIPTION
## What

Adds **BlueAgent** as a one-click featured MCP server in the dashboard's MCP section.

| field | value |
|---|---|
| slug | `blueagent` |
| url | `https://blueagent.dev/api/mcp` |
| logo | twitter profile image |

## Why

Requested addition. BlueAgent is "the AI founder console for Base builders" (idea / build / audit / ship / raise), and ships an MCP server for Claude Code / Cursor / Claude Desktop.

## How

Single entry appended to `MCP_CATALOG` in `lib/mcp-catalog.ts`, matching the existing `McpCatalogEntry` convention (`slug`/`name`/`url`/`logo`/`description`). No other changes — the MCP panel and per-skill requirement panel both read from this catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)