### PR TITLE
Fix scheduler silently skipping skills reformatted to multi-line

### DIFF
--- a/.github/workflows/messages.yml
+++ b/.github/workflows/messages.yml
@@ -118,21 +118,27 @@ jobs:
               CURRENT_SKILL=""
               continue
             fi
-            # Multi-line format
-            if [[ "$line" =~ ^\ \ ([a-zA-Z0-9_-]+):\ *$ ]]; then
+            # Multi-line format — covers both block-mapping (name: then 4-space
+            # fields) and split flow maps an editor/formatter may produce (name:
+            # then a lone "{", then deeper-indented "enabled:"/"schedule:" fields,
+            # then "}"). The optional trailing "{" also catches "name: {" on one
+            # line. Field regexes accept 3+ spaces so 4- and 6-space indents both
+            # parse — otherwise a reformatted *enabled* skill silently loses its
+            # schedule and is never dispatched (the default below is enabled=true).
+            if [[ "$line" =~ ^\ \ ([a-zA-Z0-9_-]+):\ *\{?\ *$ ]]; then
               CURRENT_SKILL="${BASH_REMATCH[1]}"
               SKILL_ORDER+=("$CURRENT_SKILL")
               SKILL_ENABLED["$CURRENT_SKILL"]="true"
               SKILL_SCHEDULE["$CURRENT_SKILL"]=""
               SKILL_VAR["$CURRENT_SKILL"]=""
             fi
-            if [[ "$line" =~ ^\ \ \ \ enabled:\ *false ]] && [ -n "$CURRENT_SKILL" ]; then
+            if [[ "$line" =~ ^\ \ \ +enabled:\ *false ]] && [ -n "$CURRENT_SKILL" ]; then
               SKILL_ENABLED["$CURRENT_SKILL"]="false"
             fi
-            if [[ "$line" =~ ^\ \ \ \ schedule:\ *\"([^\"]+)\" ]] && [ -n "$CURRENT_SKILL" ]; then
+            if [[ "$line" =~ ^\ \ \ +schedule:\ *\"([^\"]+)\" ]] && [ -n "$CURRENT_SKILL" ]; then
               SKILL_SCHEDULE["$CURRENT_SKILL"]="${BASH_REMATCH[1]}"
             fi
-            if [[ "$line" =~ ^\ \ \ \ var:\ *\"([^\"]+)\" ]] && [ -n "$CURRENT_SKILL" ]; then
+            if [[ "$line" =~ ^\ \ \ +var:\ *\"([^\"]+)\" ]] && [ -n "$CURRENT_SKILL" ]; then
               SKILL_VAR["$CURRENT_SKILL"]="${BASH_REMATCH[1]}"
             fi
           done < aeon.yml


### PR DESCRIPTION
## Problem

The scheduler (`messages.yml`) parses `aeon.yml` to decide which skills to dispatch. It fully handles **inline** entries:

```yaml
repo-scanner: { enabled: true, schedule: "0 7 2/2 * *", var: "..." }
```

but the multi-line branch defaults to `enabled=true` and only reads fields indented at **exactly 4 spaces**. When an editor/formatter (Prettier, etc.) wraps a long entry to a split flow map:

```yaml
repo-scanner:
    {
      enabled: true,
      schedule: "0 7 2/2 * *",
      var: "..."
    }
```

the 6-space-indented `schedule:` is never read → the skill is treated as enabled with an **empty schedule** and is **silently never dispatched**. No error — the skill just stops running.

This is **latent upstream** (all `aeon.yml` entries are inline today) but bites **any fork** the moment an operator's editor reformats a single enabled entry. I hit it on a fork where `repo-scanner` had been silently dead. Even the default `heartbeat` would die this way if reformatted.

## Fix

Skills parser only (the chains and reactive parsers are separate and unaffected):
- accept an optional `{` after the skill name, and
- relax the field-indent regexes from exactly-4-spaces to 3-or-more.

Pure-bash, no new dependencies, fully backward-compatible (inline entries parse exactly as before).

## Validation

- Patched parser vs a PyYAML ground-truth on a real 45-skill fork config: **45/45 exact match**; on this repo's `aeon.yml`: **1/1**.
- Synthetic test reformatting an enabled skill to multi-line: **old parser drops it (0), patched keeps it (1)**, with no other skill affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)