### PR TITLE
Add ./notify -f for reliable multi-line notifications

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -339,7 +339,22 @@ jobs:
           cat > ./notify << 'NOTIFY_SCRIPT'
           #!/usr/bin/env bash
           set -euo pipefail
-          MSG="$1"
+
+          # Usage:
+          #   ./notify "message"           — inline arg (short messages only; multi-line OK)
+          #   ./notify -f path/to/file.md  — read message from file (safe for any length/content)
+          #   ./notify --file path/to/file — same as -f
+          # Prefer -f for anything with embedded newlines: Claude's sandbox trips on
+          #   ./notify "$(cat file)" with "Unhandled node type: string".
+          if [ "${1:-}" = "-f" ] || [ "${1:-}" = "--file" ]; then
+            if [ -z "${2:-}" ] || [ ! -f "$2" ]; then
+              echo "notify: -f requires an existing file path" >&2
+              exit 2
+            fi
+            MSG=$(cat "$2")
+          else
+            MSG="${1:-}"
+          fi
 
           # Suppress obvious diagnostic probes (short messages containing test/trace/ping/debug/hello).
           # Claude sometimes issues these to verify the notify script works — they should not reach channels.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,7 @@ When consolidating memory (reflect, memory-flush), move detail into topic files 
 ## Tools
 
 - **`./notify "message"`** — Send to all configured notification channels (Telegram, Discord, Slack, json-render). Skips unconfigured channels silently.
+  - **For multi-line content: use `./notify -f path/to/file.md`** (read from file; `--file` also works). Do NOT use `./notify "$(cat file.md)"` — the sandbox trips on long multi-line argv with "Unhandled node type: string" and the call silently falls back to `.pending-notify/`. The `-f` flag reads the file inside the script, so argv stays short.
 - **`./notify-jsonrender <skill_name> <markdown>`** — Convert skill output to a json-render spec and write to `apps/dashboard/outputs/`. Called automatically by `./notify` when `JSONRENDER_ENABLED=true`.
 - **`./scripts/skill-runs [--hours N] [--full] [--json] [--failures]`** — Audit recent GitHub Actions skill runs. Shows counts, pass/fail rates, anomalies.
 - Use Claude Code's built-in **WebSearch** and **WebFetch** for web searches and URL fetching.


### PR DESCRIPTION
## Problem

The generated `./notify` only accepts an inline arg (`MSG="$1"`). Skills that need to send multi-line content do `./notify "$(cat file.md)"`, which trips Claude Code's sandbox with **`Unhandled node type: string`** on long multi-line argv. When that happens the call **silently falls back to `.pending-notify/`** instead of delivering — the notification just doesn't go out.

## Fix

Add an optional `-f` / `--file` flag that reads the message from a file **inside** the generated script, so argv stays short and any-length multi-line content delivers reliably:

```bash
./notify -f .pending-notify-temp/report.md   # safe for any length / embedded newlines
./notify "short inline message"               # unchanged
```

Purely **additive** — existing inline usage is untouched. Documented in `CLAUDE.md` so skills know to prefer `-f` for multi-line output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)