### PR TITLE
skills: fix 3 notify ISS-009 violations, name log paths, drop dead var declarations

### DIFF
--- a/skills/api-health/SKILL.md
+++ b/skills/api-health/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: API Health
 description: Pre-batch API provider health check — detects credit exhaustion or auth failure for every configured provider key before the scheduled batch runs, giving the operator a window to act before skills degrade
-var: ""
 tags: [meta, health, infra]
 schedule: "30 6 * * *"
 ---

--- a/skills/base-mcp/SKILL.md
+++ b/skills/base-mcp/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: Base MCP
 description: Access a Base Account via the Base MCP server (mcp.base.org) — wallet, portfolio, sending, swapping, signing, x402 payments, batched contract calls, and transaction history across supported chains.
-var: ""
 tags: [crypto, onchain]
 mcp: [base]
 version: 0.1.0

--- a/skills/batch-health/SKILL.md
+++ b/skills/batch-health/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: batch-health
 description: Post-batch audit — checks whether all enabled scheduled skills fired in their expected window, alerts on silent misses, files issues on batch-level outages
-var: ""
 tags: [meta, reliability]
 ---
 

--- a/skills/deal-flow/SKILL.md
+++ b/skills/deal-flow/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: Deal Flow
 description: Funding round tracker across configurable verticals
-var: ""
 tags: [research]
 ---
 

--- a/skills/disclosure-tracker/SKILL.md
+++ b/skills/disclosure-tracker/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: disclosure-tracker
 description: Audit of the pending vulnerability disclosure queue — tracks draft advisories in memory/pending-disclosures/, alerts on aging CRITICAL/HIGH findings.
-var: ""
 tags: [security, meta]
 ---
 

--- a/skills/fork-cohort/SKILL.md
+++ b/skills/fork-cohort/SKILL.md
@@ -226,6 +226,8 @@ Write `memory/topics/fork-cohort-state.json`:
 
 ### 10. Append to memory log
 
+Append to `memory/logs/${today}.md`:
+
 ```
 ## fork-cohort
 - Status: FORK_COHORT_OK | FORK_COHORT_NO_FORKS | FORK_COHORT_API_FAIL

--- a/skills/frequency-guard/SKILL.md
+++ b/skills/frequency-guard/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: Frequency Guard
 description: Per-skill run-count watchdog — checks if any capped skills exceeded their configured daily limit and alerts on breach
-var: ""
 tags: [meta]
 ---
 

--- a/skills/hn-digest/SKILL.md
+++ b/skills/hn-digest/SKILL.md
@@ -97,7 +97,12 @@ Hard constraints:
 - every entry has both *Why it matters* and (*HN take* OR *Author claim*) — no headline-only entries
 - no marketing language; if a comment quote runs >220 chars, trim with ellipsis
 
-Send via `./notify "$(cat digest.md)"` (or pipe directly).
+Write the message to a file first, then send with `-f` (never `./notify "$(cat ...)"` — the sandbox trips on long multi-line argv and silently drops to `.pending-notify/`, ISS-009):
+
+```bash
+mkdir -p .pending-notify-temp
+./notify -f .pending-notify-temp/hn-digest-${today}.md
+```
 
 ## 6. Persist and log
 

--- a/skills/milestone-tracker/SKILL.md
+++ b/skills/milestone-tracker/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: milestone-tracker
 description: Progress tracking for key product and growth milestones — celebrates crossings, alerts on approaches, surfaces stalls
-var: ""
 tags: [meta, projects]
 ---
 

--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -81,8 +81,10 @@ Hard cap the message at ~3500 chars (Telegram's safe limit). If exceeded, drop t
 ### 4. Send via `./notify`
 
 ```bash
-./notify "$(cat .outputs/onboard-message.md)"
+./notify -f .outputs/onboard-message.md
 ```
+
+Use `-f` (not `./notify "$(cat ...)"`) — the message is multi-line, and passing it as argv trips the sandbox ("Unhandled node type: string"), silently dropping the send to `.pending-notify/` (ISS-009). The `-f` flag reads the file inside the script, so argv stays short.
 
 `./notify` fans out to every configured channel. If no channel is configured, it silently no-ops — but in that case the checklist itself flagged it under "❌ Failing", so the operator will see it next time they check Actions logs.
 

--- a/skills/pr-tracker/SKILL.md
+++ b/skills/pr-tracker/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: PR Tracker
 description: Track status of cross-repo PRs opened by this aeon instance — merges, stale open, and closures
-var: ""
 tags: [meta, github]
 ---
 

--- a/skills/skill-gap/SKILL.md
+++ b/skills/skill-gap/SKILL.md
@@ -233,6 +233,8 @@ Evict entries whose `last_seen` is more than 35 days old (covers ~5 missed weekl
 
 ### 10. Append to memory log
 
+Append to `memory/logs/${today}.md`:
+
 ```
 ## skill-gap
 - Status: FORK_SKILL_GAP_OK | FORK_SKILL_GAP_QUIET | FORK_SKILL_GAP_NO_ACTIVE | FORK_SKILL_GAP_API_FAIL | FORK_SKILL_GAP_BAD_VAR | FORK_SKILL_GAP_PARENT_CHANGED | FORK_SKILL_GAP_DRY_RUN

--- a/skills/skill-spotlight/SKILL.md
+++ b/skills/skill-spotlight/SKILL.md
@@ -88,8 +88,10 @@ Notes:
 ### 4. Send the tweet to Telegram (or configured channels)
 
 ```bash
-./notify "$(cat .outputs/skill-spotlight.md)"
+./notify -f .outputs/skill-spotlight.md
 ```
+
+Use `-f` (not `./notify "$(cat ...)"`) — the post is multi-line, and passing it as argv trips the sandbox ("Unhandled node type: string"), silently dropping the send to `.pending-notify/` (ISS-009). The `-f` flag reads the file inside the script, so argv stays short.
 
 If the file exceeds 4000 characters, trim bullets (drop the weakest first) until it fits. Telegram caps single messages at 4096.
 

--- a/skills/vuln-tracker/SKILL.md
+++ b/skills/vuln-tracker/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: Vuln Tracker
 description: Status check on every PR / advisory / queued draft produced by vuln-scanner — surfaces merges, stale opens, maintainer responses needing reply, and queued-too-long carve-outs
-var: ""
 tags: [meta, security, github]
 depends_on: [vuln-scanner]
 ---


### PR DESCRIPTION
## What

A guideline-conformance audit across all **198 skills**, fixing the real drift it surfaced. Doc-only edits to `SKILL.md` files — no behavioral code changed.

## The audit (what was checked)

| Dimension | Result |
|---|---|
| `./notify` usage | 189/198 use it; 9 by-design exceptions (MCP/chain/sub-skills) |
| **`./notify "$(cat …)"` anti-pattern (ISS-009)** | **3 real violations → fixed** |
| `var` support | 0 undeclared usages; **9 dead `var: ""` declarations → dropped** |
| `memory/logs/` logging | 195→**197** (2 had the step but didn't name the path) |
| STRATEGY.md | structural — `@`-imported into CLAUDE.md, in context every run; nothing to wire per-skill |
| Sandbox/curl handling | effectively clean — raw-HTTP curls all already have prefetch/cache fallback |

## Fixes in this PR

**1. Notification (ISS-009) — 3 skills.** Passing a multi-line file as argv via `./notify "$(cat …)"` trips the sandbox (`Unhandled node type: string`) and silently drops the send to `.pending-notify/`. Switched to `./notify -f <path>`:
- `hn-digest`, `onboard`, `skill-spotlight`

**2. Memory logging — 2 skills.** `fork-cohort` and `skill-gap` had an "Append to memory log" step but never named the target file. Named it `memory/logs/${today}.md` to match every other skill.

**3. Dead frontmatter — 9 skills.** Declared `var: ""` but never reference `${var}` (a no-op input). Dropped the line — serializes identically in `skills.json` (`"var":""` either way) and matches the 24 skills that already omit it:
- `api-health`, `base-mcp`, `batch-health`, `deal-flow`, `disclosure-tracker`, `frequency-guard`, `milestone-tracker`, `pr-tracker`, `vuln-tracker`

## Notes
- `skills.json` left untouched: `sha`/`updated` derive from committed git history (refresh on next regeneration), and the `var` removals serialize identically. Keeps this a clean 14-file doc diff.
- 8 skills that *mention* `./notify "$(cat …)"` only inside "do NOT do this" warnings were verified as good citizens, not violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)