### PR TITLE
dashboard: one-click install real souls + fix save copy

### DIFF
--- a/apps/dashboard/app/api/soul/examples/route.ts
+++ b/apps/dashboard/app/api/soul/examples/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from 'next/server'
+import { getRemoteDirectory, getRemoteFileContent, createFile, commitAndPush } from '@/lib/github'
+
+// One-click install of a ready-made soul from the soul.md examples gallery into
+// the operator's own repo. GET lists the available example people; POST copies
+// one example's SOUL.md / STYLE.md / voice examples into soul/ and commits.
+const SOURCE_REPO = 'aaronjmars/soul.md'
+
+// Short blurbs for the known examples; unknown ones still list with just a name.
+const BLURBS: Record<string, string> = {
+  karpathy: 'AI researcher & educator — builds from scratch, Software 2.0',
+  'garry-tan': 'YC president — founder-first, optimistic, direct',
+  steipete: 'Indie Apple-platform dev — sharp, technical, opinionated',
+  'vivian-balakrishnan': "Singapore's foreign minister — measured, statesmanlike",
+}
+
+function humanize(slug: string): string {
+  return slug.split('-').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ')
+}
+
+export async function GET() {
+  try {
+    const entries = await getRemoteDirectory(SOURCE_REPO, 'examples')
+    const examples = entries
+      .filter(e => e.type === 'dir' && !e.name.startsWith('_') && !e.name.startsWith('.'))
+      .map(d => ({ key: d.name, label: humanize(d.name), blurb: BLURBS[d.name] || '' }))
+    return NextResponse.json({ examples })
+  } catch {
+    return NextResponse.json({ examples: [] })
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const { example } = (await request.json()) as { example?: string }
+    if (typeof example !== 'string' || !/^[a-z0-9-]+$/.test(example)) {
+      return NextResponse.json({ error: 'Invalid example name' }, { status: 400 })
+    }
+
+    const base = `examples/${example}`
+    const soul = await getRemoteFileContent(SOURCE_REPO, `${base}/SOUL.md`)
+    if (!soul) {
+      return NextResponse.json({ error: `Example "${example}" not found` }, { status: 404 })
+    }
+    const style = await getRemoteFileContent(SOURCE_REPO, `${base}/STYLE.md`)
+    const good = await getRemoteFileContent(SOURCE_REPO, `${base}/examples/good-outputs.md`)
+
+    const msg = `chore: install ${example} soul example from soul.md`
+    const paths = ['soul/SOUL.md']
+    // createFile overwrites-or-creates in both local and hosted modes.
+    await createFile('soul/SOUL.md', soul, msg)
+    if (style) { await createFile('soul/STYLE.md', style, msg); paths.push('soul/STYLE.md') }
+    if (good) { await createFile('soul/examples/good-outputs.md', good, msg); paths.push('soul/examples/good-outputs.md') }
+
+    const sync = commitAndPush(paths, msg)
+    return NextResponse.json({ ok: true, soul, style: style || '', synced: sync.synced, ...(sync.reason ? { syncError: sync.reason } : {}) })
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : 'Failed to install example'
+    return NextResponse.json({ error: msg }, { status: 500 })
+  }
+}

--- a/apps/dashboard/app/page.tsx
+++ b/apps/dashboard/app/page.tsx
@@ -62,6 +62,7 @@ export default function Dashboard() {
   const [soulLoaded, setSoulLoaded] = useState(false)
   const [soulSaving, setSoulSaving] = useState(false)
   const [soulBuilding, setSoulBuilding] = useState(false)
+  const [soulInstalling, setSoulInstalling] = useState<string | null>(null)
 
   const flash = (msg: string) => { setToast(msg); setTimeout(() => setToast(''), 3000) }
   // Config writes auto-commit+push in local mode (no-op in hosted mode). Reflect
@@ -105,6 +106,7 @@ export default function Dashboard() {
   const saveMcp = async (servers: Record<string, Record<string, unknown>>) => { setMcpSaving(true); try { const r = await fetch('/api/mcp', { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ servers }) }); if (r.ok) { const d = await r.json().catch(() => ({})); setMcpServers(servers); flashSynced('MCP servers saved', d) } else { flash('Save failed') } } finally { setMcpSaving(false) } }
   const saveSoul = async (file: SoulFile, content: string) => { setSoulSaving(true); try { const r = await fetch('/api/soul', { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ file, content }) }); if (r.ok) { const d = await r.json().catch(() => ({})); if (file === 'soul') setSoul(content); else setSoulStyle(content); flashSynced(`${file === 'soul' ? 'SOUL.md' : 'STYLE.md'} saved`, d) } else { flash('Save failed') } } finally { setSoulSaving(false) } }
   const buildSoul = async (sources: SoulSources) => { setSoulBuilding(true); try { const r = await fetch('/api/soul/build', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ ...sources, model }) }); if (r.ok) { const label = sources.handle ? `@${sources.handle}` : sources.name || 'your links'; flash(`Soul-builder started for ${label}`); for (const d of [2000, 5000, 10000]) setTimeout(refreshRuns, d) } else { const d = await r.json().catch(() => ({} as { error?: string })); flash(d.error || 'Build failed to dispatch') } } finally { setSoulBuilding(false) } }
+  const installSoulExample = async (key: string) => { setSoulInstalling(key); try { const r = await fetch('/api/soul/examples', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ example: key }) }); if (r.ok) { const d = await r.json().catch(() => ({})); setSoul(d.soul || ''); setSoulStyle(d.style || ''); setSoulLoaded(true); flashSynced(`Installed ${key} soul`, d) } else { const d = await r.json().catch(() => ({} as { error?: string })); flash(d.error || 'Install failed') } } finally { setSoulInstalling(null) } }
 
   // Jump from a skill's API-keys panel straight to Settings → Access Keys,
   // scrolled to the chosen key with its input open and ready to paste.
@@ -157,7 +159,7 @@ export default function Dashboard() {
             <McpPanel servers={mcpServers} loading={!mcpLoaded} saving={mcpSaving} secrets={secrets} busy={busy} onSave={saveMcp} onSetSecret={saveSecret} onDeleteSecret={deleteSecret} />
           )}
           {view === 'soul' && !selectedSkill && (
-            <SoulPanel soul={soul} style={soulStyle} loading={!soulLoaded} saving={soulSaving} building={soulBuilding} onSave={saveSoul} onBuild={buildSoul} />
+            <SoulPanel soul={soul} style={soulStyle} loading={!soulLoaded} saving={soulSaving} building={soulBuilding} installing={soulInstalling} onSave={saveSoul} onBuild={buildSoul} onInstallExample={installSoulExample} />
           )}
           {view === 'hq' && !selectedSkill && (
             <HQOverview skills={skills} runs={runs} enabledCount={enabledCount} workingCount={workingCount} categoryFilter={categoryFilter} onCategoryClick={(key) => setCategoryFilter(categoryFilter === key ? null : key)} onViewRun={() => {}} />

--- a/apps/dashboard/components/SoulPanel.tsx
+++ b/apps/dashboard/components/SoulPanel.tsx
@@ -6,6 +6,7 @@ import { SOUL_SCAFFOLD, STYLE_SCAFFOLD, ARCHETYPES } from '../lib/soul-templates
 
 export type SoulFile = 'soul' | 'style'
 export interface SoulSources { handle: string; name: string; links: string }
+interface SoulExample { key: string; label: string; blurb: string }
 
 interface SoulPanelProps {
   soul: string
@@ -13,8 +14,10 @@ interface SoulPanelProps {
   loading: boolean
   saving: boolean
   building: boolean
+  installing: string | null
   onSave: (file: SoulFile, content: string) => void
   onBuild: (sources: SoulSources) => void
+  onInstallExample: (key: string) => void
 }
 
 const EXAMPLES_URL = 'https://github.com/aaronjmars/soul.md/tree/main/examples'
@@ -31,7 +34,7 @@ function isBlank(md: string): boolean {
 
 const SOFT_LIMIT = 6000
 
-export function SoulPanel({ soul, style, loading, saving, building, onSave, onBuild }: SoulPanelProps) {
+export function SoulPanel({ soul, style, loading, saving, building, installing, onSave, onBuild, onInstallExample }: SoulPanelProps) {
   const [active, setActive] = useState<SoulFile>('soul')
   const [soulDraft, setSoulDraft] = useState(soul)
   const [styleDraft, setStyleDraft] = useState(style)
@@ -39,9 +42,18 @@ export function SoulPanel({ soul, style, loading, saving, building, onSave, onBu
   const [name, setName] = useState('')
   const [links, setLinks] = useState('')
   const [showTemplates, setShowTemplates] = useState(false)
+  const [examples, setExamples] = useState<SoulExample[]>([])
 
   useEffect(() => { setSoulDraft(soul) }, [soul])
   useEffect(() => { setStyleDraft(style) }, [style])
+  // Ready-made souls from the soul.md gallery — installable into soul/ in one click.
+  useEffect(() => { fetch('/api/soul/examples').then(r => r.ok ? r.json() : { examples: [] }).then(d => setExamples(d.examples || [])).catch(() => {}) }, [])
+
+  const installExample = (ex: SoulExample) => {
+    if (installing) return
+    if (!window.confirm(`Install ${ex.label}'s soul? This overwrites soul/SOUL.md and soul/STYLE.md on your repo.`)) return
+    onInstallExample(ex.key)
+  }
 
   const content = active === 'soul' ? soul : style
   const draft = active === 'soul' ? soulDraft : styleDraft
@@ -224,6 +236,33 @@ export function SoulPanel({ soul, style, loading, saving, building, onSave, onBu
                 </button>
               ))}
             </div>
+
+            {/* Install a ready-made real soul straight into the repo */}
+            {examples.length > 0 && (
+              <div className="pt-3 mt-1 border-t border-[rgba(250,250,250,0.08)]">
+                <p className="text-[11px] text-primary-50 font-mono mb-2">
+                  Or install a real soul from the gallery — writes SOUL.md + STYLE.md + examples to{' '}
+                  <span className="text-primary-80">soul/</span> and syncs to GitHub.
+                </p>
+                <div className="grid grid-cols-2 gap-2">
+                  {examples.map(ex => (
+                    <div key={ex.key} className="border border-[rgba(250,250,250,0.12)] px-3 py-2.5 flex items-start justify-between gap-2">
+                      <div className="min-w-0">
+                        <div className="text-[12px] text-primary-100 font-medium truncate">{ex.label}</div>
+                        {ex.blurb && <div className="text-[10px] text-primary-40 font-mono leading-snug">{ex.blurb}</div>}
+                      </div>
+                      <button
+                        onClick={() => installExample(ex)}
+                        disabled={!!installing}
+                        className="shrink-0 text-[10px] font-mono uppercase tracking-[0.14em] px-2.5 py-1.5 border border-aeon-red/50 text-aeon-red hover:bg-aeon-red/10 transition-colors disabled:opacity-40 cursor-target"
+                      >
+                        {installing === ex.key ? 'Installing…' : 'Install'}
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
           </div>
         )}
 
@@ -257,8 +296,7 @@ export function SoulPanel({ soul, style, loading, saving, building, onSave, onBu
               </div>
             </div>
             <p className="mt-3 text-[11px] text-primary-35 font-mono">
-              Save writes <span className="text-primary-70">soul/{active === 'soul' ? 'SOUL.md' : 'STYLE.md'}</span> — then hit{' '}
-              <span className="text-primary-70">Push</span> in the top bar to commit it to GitHub.
+              Save writes <span className="text-primary-70">soul/{active === 'soul' ? 'SOUL.md' : 'STYLE.md'}</span> and syncs to GitHub automatically.
             </p>
           </>
         )}

--- a/apps/dashboard/components/StrategyPanel.tsx
+++ b/apps/dashboard/components/StrategyPanel.tsx
@@ -84,7 +84,7 @@ export function StrategyPanel({ content, loading, saving, onSave }: StrategyPane
               </div>
             </div>
             <p className="mt-3 text-[11px] text-primary-35 font-mono">
-              Save writes STRATEGY.md — then hit <span className="text-primary-70">Push</span> in the top bar to commit it to GitHub.
+              Save writes STRATEGY.md and syncs to GitHub automatically.
             </p>
           </>
         )}


### PR DESCRIPTION
Follow-up to #448.

## One-click install
Adds **`/api/soul/examples`** — GET lists the example people in [soul.md](https://github.com/aaronjmars/soul.md/tree/main/examples), POST copies a chosen example's `SOUL.md` + `STYLE.md` + voice examples straight into the operator's `soul/` and commits.

In the Soul tab's template picker there's now an **"install a real soul"** grid (Karpathy, Garry Tan, Steipete, Vivian Balakrishnan — fetched live, so new examples appear automatically). One click writes the files and syncs to GitHub, then refreshes the editors. Confirm dialog guards the overwrite.

## Copy fix
Saves already auto-commit + push (`commitAndPush`), so the "then hit **Push** in the top bar to commit it to GitHub" line was wrong — replaced with "syncs to GitHub automatically" in both the Soul and Strategy panels.

## Verified
`tsc` clean, `next build` green (`/api/soul/examples` in the manifest). GET returns the four examples with labels/blurbs; install cards render in the picker (verified on the live dashboard). POST mirrors the proven `/api/soul` write+commit path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)