### PR TITLE
feat(gateway): VENICE_BASE_URL override for the Venice sidecar

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -267,6 +267,7 @@ jobs:
           USEPOD_MODEL_SONNET: ${{ vars.USEPOD_MODEL_SONNET }}
           USEPOD_MODEL_HAIKU: ${{ vars.USEPOD_MODEL_HAIKU }}
           VENICE_MODEL: ${{ vars.VENICE_MODEL }}
+          VENICE_BASE_URL: ${{ vars.VENICE_BASE_URL }}
           VENICE_CLEANCACHE: ${{ vars.VENICE_CLEANCACHE }}
           SURPLUS_MODEL: ${{ vars.SURPLUS_MODEL }}
           CCR_LOG: ${{ vars.CCR_LOG }}
@@ -711,6 +712,7 @@ jobs:
           USEPOD_MODEL_SONNET: ${{ vars.USEPOD_MODEL_SONNET }}
           USEPOD_MODEL_HAIKU: ${{ vars.USEPOD_MODEL_HAIKU }}
           VENICE_MODEL: ${{ vars.VENICE_MODEL }}
+          VENICE_BASE_URL: ${{ vars.VENICE_BASE_URL }}
           VENICE_CLEANCACHE: ${{ vars.VENICE_CLEANCACHE }}
           SURPLUS_MODEL: ${{ vars.SURPLUS_MODEL }}
           CCR_LOG: ${{ vars.CCR_LOG }}
@@ -836,6 +838,7 @@ jobs:
           USEPOD_MODEL_SONNET: ${{ vars.USEPOD_MODEL_SONNET }}
           USEPOD_MODEL_HAIKU: ${{ vars.USEPOD_MODEL_HAIKU }}
           VENICE_MODEL: ${{ vars.VENICE_MODEL }}
+          VENICE_BASE_URL: ${{ vars.VENICE_BASE_URL }}
           VENICE_CLEANCACHE: ${{ vars.VENICE_CLEANCACHE }}
           SURPLUS_MODEL: ${{ vars.SURPLUS_MODEL }}
           CCR_LOG: ${{ vars.CCR_LOG }}

--- a/.github/workflows/messages.yml
+++ b/.github/workflows/messages.yml
@@ -677,6 +677,7 @@ jobs:
           USEPOD_MODEL_SONNET: ${{ vars.USEPOD_MODEL_SONNET }}
           USEPOD_MODEL_HAIKU: ${{ vars.USEPOD_MODEL_HAIKU }}
           VENICE_MODEL: ${{ vars.VENICE_MODEL }}
+          VENICE_BASE_URL: ${{ vars.VENICE_BASE_URL }}
           VENICE_CLEANCACHE: ${{ vars.VENICE_CLEANCACHE }}
           SURPLUS_MODEL: ${{ vars.SURPLUS_MODEL }}
           CCR_LOG: ${{ vars.CCR_LOG }}

--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ Override the order with the repo variable **`GATEWAY_ORDER`** (space-separated n
 | <img src="https://icons.duckduckgo.com/ip3/bankr.bot.ico" width="16" valign="middle"> [Bankr](https://docs.bankr.bot/llm-gateway/overview) | `BANKR_LLM_KEY` | Discounted Opus access |
 | <img src="https://icons.duckduckgo.com/ip3/openrouter.ai.ico" width="16" valign="middle"> [OpenRouter](https://openrouter.ai) | `OPENROUTER_API_KEY` | Anthropic-native passthrough; lowest-risk option |
 | <img src="https://icons.duckduckgo.com/ip3/usepod.ai.ico" width="16" valign="middle"> [UsePod](https://usepod.ai) | `USEPOD_TOKEN` | Solana marketplace; token is embedded in the base URL, keep it secret |
-| <img src="https://icons.duckduckgo.com/ip3/venice.ai.ico" width="16" valign="middle"> [Venice](https://venice.ai) | `VENICE_API_KEY` | Privacy-first; OpenAI-compatible, bridged via a per-run [claude-code-router](https://github.com/musistudio/claude-code-router) sidecar |
+| <img src="https://icons.duckduckgo.com/ip3/venice.ai.ico" width="16" valign="middle"> [Venice](https://venice.ai) | `VENICE_API_KEY` | Privacy-first; OpenAI-compatible, bridged via a per-run [claude-code-router](https://github.com/musistudio/claude-code-router) sidecar. Point it at any Venice-compatible endpoint with the `VENICE_BASE_URL` repo variable |
 | <img src="https://icons.duckduckgo.com/ip3/surplusintelligence.ai.ico" width="16" valign="middle"> [Surplus](https://surplusintelligence.ai) | `SURPLUS_API_KEY` | Routed via The Bridge; settles in USDC on Base — fund the wallet + `approve()` once before use |
 
 #### Adding a gateway

--- a/scripts/llm-gateway.sh
+++ b/scripts/llm-gateway.sh
@@ -227,6 +227,9 @@ case "${GATEWAY:-direct}" in
     # only for models Venice is known to carry (dash-form, date suffix stripped);
     # anything else keeps the safe opus-4-6 default. VENICE_MODEL overrides.
     # (Confirm/extend the allowlist when Venice is live-validated.)
+    # VENICE_BASE_URL (repo variable) points the sidecar at any Venice-compatible
+    # endpoint — a self-hosted relay, a billing proxy, a regional mirror — same
+    # override pattern as VENICE_MODEL. Defaults to Venice's public API.
     venice_model="${VENICE_MODEL:-}"
     if [ -z "$venice_model" ]; then
       m="$(printf '%s' "${MODEL:-}" | sed -E 's/-[0-9]{8}$//')"
@@ -236,9 +239,9 @@ case "${GATEWAY:-direct}" in
       esac
     fi
     start_ccr_sidecar venice \
-      "https://api.venice.ai/api/v1/chat/completions" \
+      "${VENICE_BASE_URL:-https://api.venice.ai/api/v1/chat/completions}" \
       "$VENICE_API_KEY" "$venice_model" "${VENICE_CLEANCACHE:+cleancache}"
-    echo "::notice::Routing through Venice via claude-code-router (${venice_model})"
+    echo "::notice::Routing through Venice via claude-code-router (${venice_model} @ ${VENICE_BASE_URL:-https://api.venice.ai/api/v1/chat/completions})"
     ;;
 
   direct|"")  # NATIVE — Anthropic API or an Anthropic-compatible endpoint. Unchanged.


### PR DESCRIPTION
## What

Adds a `VENICE_BASE_URL` repo **variable** that points the Venice gateway's claude-code-router sidecar at any Venice-compatible (OpenAI-format) endpoint. Defaults unchanged — `api.venice.ai` — so existing setups are untouched.

Mirrors the existing `VENICE_MODEL` / `VENICE_CLEANCACHE` override pattern exactly:

- `scripts/llm-gateway.sh` — `${VENICE_BASE_URL:-https://api.venice.ai/api/v1/chat/completions}` in the venice sidecar branch (+ the routing notice now prints the endpoint)
- `.github/workflows/aeon.yml` (3 env blocks) + `messages.yml` — pass `vars.VENICE_BASE_URL` through, same as `vars.VENICE_MODEL`
- README gateway table — one-line doc

## Why

Lets Aeon route Venice traffic through a self-hosted relay, billing proxy, or regional mirror without forking the gateway script. Concretely: we run a managed OpenAI-compatible Venice proxy for hosted Aeon users (key custody + wallet billing on our side), and this variable is the only thing missing to point the existing sidecar at it.

## Verify

`bash -n scripts/llm-gateway.sh` passes; both workflows parse. With the variable unset, the resolved URL is byte-identical to today's hard-coded one. Set `VENICE_BASE_URL` + run any skill → the log prints `Routing through Venice via claude-code-router (<model> @ <url>)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)