### PR TITLE
feat(dashboard): collapsible right panel — narrower, collapse toggle, refresh icon

### DIFF
--- a/apps/dashboard/components/RightPanel.tsx
+++ b/apps/dashboard/components/RightPanel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import type { Run, SkillOutput, AnalyticsData } from '../lib/types'
 import { timeAgo } from '../lib/utils'
 import { SpecNode } from './SpecNode'
@@ -22,6 +22,18 @@ export function RightPanel({ runs, outputs, feedLoading, analyticsData, onViewRu
   const [runSummary, setRunSummary] = useState('')
   const [logsLoading, setLogsLoading] = useState(false)
   const [showFullLogs, setShowFullLogs] = useState(false)
+  const [collapsed, setCollapsed] = useState(false)
+
+  // Restore the collapsed state on mount (set in an effect, not the initializer,
+  // to avoid an SSR/client hydration mismatch).
+  useEffect(() => {
+    if (localStorage.getItem('aeon-panel-collapsed') === '1') setCollapsed(true)
+  }, [])
+
+  const toggleCollapsed = (next: boolean) => {
+    setCollapsed(next)
+    try { localStorage.setItem('aeon-panel-collapsed', next ? '1' : '0') } catch {}
+  }
 
   const viewRunLogs = async (run: Run) => {
     setSelectedRun(run); setRunLogs(''); setRunSummary(''); setShowFullLogs(false); setLogsLoading(true); setRightTab('runs')
@@ -33,14 +45,42 @@ export function RightPanel({ runs, outputs, feedLoading, analyticsData, onViewRu
     onViewRun(run)
   }
 
+  // Collapsed: a thin rail with an expand control and a vertical label.
+  if (collapsed) {
+    return (
+      <div className="w-9 border-l border-[rgba(250,250,250,0.10)] flex flex-col items-center shrink-0 bg-aeon-panel">
+        <button
+          onClick={() => toggleCollapsed(false)}
+          title="Expand panel"
+          aria-label="Expand panel"
+          className="h-12 w-full flex items-center justify-center text-sm text-primary-40 hover:text-aeon-fg transition-colors shrink-0 border-b border-[rgba(250,250,250,0.10)]"
+        >&#8249;</button>
+        <button
+          onClick={() => toggleCollapsed(false)}
+          title="Expand panel"
+          aria-label="Expand panel"
+          className="flex-1 w-full flex items-start justify-center pt-4 group"
+        >
+          <span className="text-[10px] font-mono uppercase tracking-[0.28em] text-primary-35 group-hover:text-primary-70 transition-colors [writing-mode:vertical-rl]">Feed · Runs · Analytics</span>
+        </button>
+      </div>
+    )
+  }
+
   return (
-    <div className="w-[320px] border-l border-[rgba(250,250,250,0.10)] flex flex-col shrink-0 bg-aeon-panel">
+    <div className="w-[288px] border-l border-[rgba(250,250,250,0.10)] flex flex-col shrink-0 bg-aeon-panel">
       <div className="h-12 border-b border-[rgba(250,250,250,0.10)] flex items-center px-3 gap-1 shrink-0">
         {(['feed', 'runs', 'analytics'] as const).map(tab => (
           <button key={tab} onClick={() => { setRightTab(tab); if (tab === 'analytics') onFetchAnalytics() }}
             className={`text-[11px] px-2.5 py-1.5 transition-colors font-mono uppercase tracking-[1px] ${rightTab === tab ? 'bg-aeon-fg text-aeon-bg' : 'text-primary-40 hover:text-primary-70'}`}>{tab}</button>
         ))}
-        <button onClick={onRefresh} className="text-[11px] text-primary-35 hover:text-eva-orange transition-colors ml-auto font-mono">Refresh</button>
+        <button onClick={onRefresh} title="Refresh" aria-label="Refresh" className="text-sm leading-none text-primary-35 hover:text-eva-orange transition-colors ml-auto">&#8635;</button>
+        <button
+          onClick={() => toggleCollapsed(true)}
+          title="Collapse panel"
+          aria-label="Collapse panel"
+          className="text-sm leading-none text-primary-35 hover:text-aeon-fg transition-colors ml-2 px-0.5"
+        >&#8250;</button>
       </div>
 
       <div className="flex-1 overflow-y-auto">


### PR DESCRIPTION
Tightens and adds a collapse control to the feed/runs/analytics right panel.

## Changes
- **Narrower** — trim the panel from 320px → 288px (it was wider than the 240px left sidebar and read oversized).
- **Collapse toggle** — a `›` button in the header collapses the panel to a 36px rail with a vertical "Feed · Runs · Analytics" label; click the rail (or its `‹`) to re-expand. State is persisted in `localStorage` and restored in a `useEffect` (not the state initializer) to avoid an SSR/client hydration mismatch.
- **Refresh icon** — replace the "Refresh" text button with a `↻` glyph, keeping `title`/`aria-label="Refresh"`.

Single-file change (`apps/dashboard/components/RightPanel.tsx`). `tsc --noEmit` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)