### PR TITLE
feat: add GitHub issue templates (bug report + feature request)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,99 @@
+name: 🐞 Bug report
+description: A skill failed, the dashboard misbehaved, or a run didn't do what it should.
+title: "[bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. Aeon runs unattended, so the details below are what make a report actionable — especially **which skill**, **where it ran** (cron vs. dashboard vs. local), and **whether the failure was an API error or a sandbox limitation**. "It failed" without those is hard to act on.
+
+        ⚠️ **Never paste secrets.** Redact API keys, tokens, wallet addresses, and chat IDs from logs before posting.
+  - type: input
+    id: skill
+    attributes:
+      label: Which skill (or area)?
+      description: The skill name from `aeon.yml` (e.g. `token-report`, `feature`, `deep-research`). Use `dashboard`, `runtime`, or `gateway` if it's not a single skill.
+      placeholder: token-report
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe the bug. What did the run produce, or fail to produce?
+      placeholder: The skill logged FETCH_FAIL and sent no notification.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+      placeholder: A token report notification with the latest price and treasury balance.
+    validations:
+      required: true
+  - type: dropdown
+    id: failure-type
+    attributes:
+      label: Failure type
+      description: If you know it, this routes the issue fastest. Sandbox limitations (blocked outbound network, `$ENV_VAR` not expanding in curl headers) are a distinct class from API errors.
+      options:
+        - "Not sure"
+        - "API error (rate limit, auth, 4xx/5xx from an external service)"
+        - "Sandbox limitation (blocked network / env var not expanding in bash)"
+        - "Config (missing secret, wrong var, schedule)"
+        - "Output format (notification malformed, file not written)"
+        - "Dashboard / setup UI"
+        - "Other"
+    validations:
+      required: true
+  - type: dropdown
+    id: run-context
+    attributes:
+      label: Where did it run?
+      options:
+        - "GitHub Actions (scheduled / cron)"
+        - "Run now (dashboard)"
+        - "Local (./aeon)"
+        - "Other / not sure"
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce / what triggered it
+      description: How can a maintainer hit this? Include the `var` value if you set one, and what you'd changed recently.
+      placeholder: |
+        1. Enabled `token-report` on the default 6h schedule
+        2. Run now from the dashboard
+        3. Run completes but no notification arrives
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Paste the failing chunk of the Actions run log or the `memory/logs/YYYY-MM-DD.md` entry. **Redact secrets first.** This is automatically formatted as code.
+      render: shell
+  - type: dropdown
+    id: notification
+    attributes:
+      label: Did you receive a notification?
+      options:
+        - "Not applicable"
+        - "Yes, but it was wrong/empty"
+        - "No notification at all"
+        - "Yes, as expected (but something else is wrong)"
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Node version (`node -v`) and OS, if relevant (mostly for local `./aeon` or dashboard bugs).
+      placeholder: "node v20.11, macOS 14.5"
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched [existing issues](https://github.com/aaronjmars/aeon/issues) and this isn't a duplicate.
+          required: true
+        - label: I removed all secrets (API keys, tokens, wallet/chat IDs) from the logs and text above.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 📖 Setup & usage help
+    url: https://github.com/aaronjmars/aeon#quick-start
+    about: New to Aeon? Start with the Quick start, then run ./onboard to verify your setup before filing an issue.
+  - name: 🐦 Questions & updates
+    url: https://x.com/aeonframework
+    about: For general questions or to follow what's shipping, reach out on X.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,66 @@
+name: ✨ Feature request
+description: Propose a new skill, gateway, dashboard improvement, or core change.
+title: "[feat]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea. Aeon grows mostly by adding **skills** and **gateways** — both have documented patterns (see the README and `CONTRIBUTING.md`). Tell us what should exist and why; if it's a skill, a rough schedule and `var` shape help a lot.
+  - type: dropdown
+    id: type
+    attributes:
+      label: What kind of feature?
+      options:
+        - "New skill"
+        - "New LLM gateway"
+        - "Dashboard / setup UI"
+        - "Core / runtime (notify, chains, memory, cron)"
+        - "Docs"
+        - "Other"
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What should Aeon be able to do that it can't today?
+      placeholder: A skill that posts a weekly digest of new forks and merged external PRs.
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does it solve?
+      description: Who benefits and how? What's painful or impossible right now?
+    validations:
+      required: true
+  - type: textarea
+    id: approach
+    attributes:
+      label: Proposed approach (optional)
+      description: Data sources / APIs, how it'd integrate, any design thoughts. If it touches secrets, list which ones.
+  - type: input
+    id: skill-shape
+    attributes:
+      label: If it's a skill — schedule & var
+      description: Roughly how often should it run, and what would its `var` input be? Leave blank if not a skill.
+      placeholder: "weekly (Mon 13:00 UTC), var: owner/repo"
+  - type: dropdown
+    id: contribute
+    attributes:
+      label: Would you be willing to open a PR?
+      description: No obligation — this just helps us know whether to pick it up.
+      options:
+        - "No"
+        - "Maybe, with guidance"
+        - "Yes"
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched [existing issues](https://github.com/aaronjmars/aeon/issues) and this isn't already requested.
+          required: true


### PR DESCRIPTION
## What

Adds GitHub issue forms so the repo has a structured way to file bugs and feature requests:

- `.github/ISSUE_TEMPLATE/bug_report.yml` — a YAML issue form with Aeon-specific fields: **which skill**, **failure type** (API error vs. sandbox limitation vs. config vs. output-format), **where it ran** (Actions cron / dashboard Run-now / local `./aeon`), repro steps + `var`, a `render: shell` logs box, and a "did you get a notification?" dropdown. Required checkboxes confirm the reporter searched existing issues and **redacted secrets**.
- `.github/ISSUE_TEMPLATE/feature_request.yml` — a form to propose a new skill / gateway / dashboard / core change, with a "would you open a PR?" field and a skill schedule/`var` shape input.
- `.github/ISSUE_TEMPLATE/config.yml` — sets `blank_issues_enabled: false` so new issues go through the chooser, plus contact links to the Quick start (`#quick-start`) and `@aeonframework` on X.

## Why

`aaronjmars/aeon` is a 512★ / 170-fork repo with active external contributors and **zero issue templates** — every bug report arrives in a different shape. Aeon's failure modes are specific (a skill name, whether it was an API error or a *sandbox limitation*, whether a notification fired) and "it failed" without those is hard to act on. The forms capture exactly those fields up front. Lowering onboarding/reporting friction for forkers is a priority for the project.

This is repo-actions idea #4 from the 2026-06-12 action set (the top remaining autonomously-implementable community-health gap after CONTRIBUTING.md shipped in #465).

## Changes

- `.github/ISSUE_TEMPLATE/bug_report.yml`: new bug report issue form
- `.github/ISSUE_TEMPLATE/feature_request.yml`: new feature request issue form
- `.github/ISSUE_TEMPLATE/config.yml`: disable blank issues, add contact links

Docs-only / config-only — no skills, `aeon.yml`, or taxonomy paths touched, so neither CI gate (`ci-skills-json`, `ci-capabilities-parity`) is affected. No `skills.json` regen needed.

---
*Built autonomously by Aeon*
