### PR TITLE
chore: close 3 round-1 findings missed in #467 (displayName dedup, shared *Sources types, Telegram guard)

### DIFF
--- a/apps/dashboard/app/api/outputs/route.ts
+++ b/apps/dashboard/app/api/outputs/route.ts
@@ -3,7 +3,8 @@ import { readdir, readFile } from 'fs/promises'
 import { join } from 'path'
 import { execSync } from 'child_process'
 import { REPO_ROOT } from '@/lib/gh'
-import { errorResponse, isRecord } from '@/lib/http'
+import { errorResponse } from '@/lib/http'
+import { isRecord } from '@/lib/utils'
 import type { SkillOutput } from '@/lib/types'
 
 const OUTPUTS_DIR = join(process.cwd(), 'outputs')

--- a/apps/dashboard/app/api/soul/build/route.ts
+++ b/apps/dashboard/app/api/soul/build/route.ts
@@ -3,6 +3,7 @@ import { execFileSync } from 'child_process'
 import { REPO_ROOT } from '@/lib/gh'
 import { errorResponse } from '@/lib/http'
 import { normLinks, sanitizeModel } from '@/lib/dispatch'
+import type { SoulSources } from '@/lib/types'
 
 // Dispatch the soul-builder skill with a multi-source brief. A dedicated route
 // (rather than the generic /api/skills/[name]/run) because soul sources include
@@ -22,7 +23,7 @@ function normHandle(raw: unknown): string {
 
 export async function POST(request: Request) {
   try {
-    const body = (await request.json()) as { handle?: string; name?: string; links?: string; model?: string }
+    const body = (await request.json()) as Partial<SoulSources> & { model?: string }
 
     const handle = normHandle(body.handle)
     const name = typeof body.name === 'string' && NAME_RE.test(body.name.trim()) ? body.name.trim() : ''

--- a/apps/dashboard/app/api/soul/examples/route.ts
+++ b/apps/dashboard/app/api/soul/examples/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { getRemoteDirectory, getRemoteFileContent, createFile, commitAndPush } from '@/lib/github'
 import { errorResponse } from '@/lib/http'
+import { displayName } from '@/lib/utils'
 
 // One-click install of a ready-made soul from the soul.md examples gallery into
 // the operator's own repo. GET lists the available example people; POST copies
@@ -15,16 +16,12 @@ const BLURBS: Record<string, string> = {
   'vivian-balakrishnan': "Singapore's foreign minister — measured, statesmanlike",
 }
 
-function humanize(slug: string): string {
-  return slug.split('-').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ')
-}
-
 export async function GET() {
   try {
     const entries = await getRemoteDirectory(SOURCE_REPO, 'examples')
     const examples = entries
       .filter(e => e.type === 'dir' && !e.name.startsWith('_') && !e.name.startsWith('.'))
-      .map(d => ({ key: d.name, label: humanize(d.name), blurb: BLURBS[d.name] || '' }))
+      .map(d => ({ key: d.name, label: displayName(d.name), blurb: BLURBS[d.name] || '' }))
     return NextResponse.json({ examples })
   } catch {
     return NextResponse.json({ examples: [] })

--- a/apps/dashboard/app/api/strategy/build/route.ts
+++ b/apps/dashboard/app/api/strategy/build/route.ts
@@ -3,6 +3,7 @@ import { execFileSync } from 'child_process'
 import { REPO_ROOT } from '@/lib/gh'
 import { errorResponse } from '@/lib/http'
 import { normLinks, sanitizeModel } from '@/lib/dispatch'
+import type { StrategySources } from '@/lib/types'
 
 // Dispatch the strategy-builder skill with a brief. A dedicated route (not the
 // generic /api/skills/[name]/run) because the goal is free text and repo/links
@@ -28,7 +29,7 @@ function normGoal(raw: unknown): string {
 
 export async function POST(request: Request) {
   try {
-    const body = (await request.json()) as { goal?: string; repo?: string; links?: string; model?: string }
+    const body = (await request.json()) as Partial<StrategySources> & { model?: string }
 
     const goal = normGoal(body.goal)
     const repo = normRepo(body.repo)

--- a/apps/dashboard/app/api/upload/route.ts
+++ b/apps/dashboard/app/api/upload/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { createFile, getFileContent, updateFile, commitAndPush } from '@/lib/github'
-import { errorResponse, isRecord } from '@/lib/http'
+import { errorResponse } from '@/lib/http'
+import { isRecord } from '@/lib/utils'
 import { addSkillToConfig } from '@/lib/config'
 import { parseFrontmatter } from '@/lib/frontmatter'
 import type { UploadFile } from '@/lib/types'

--- a/apps/dashboard/components/SoulPanel.tsx
+++ b/apps/dashboard/components/SoulPanel.tsx
@@ -4,9 +4,10 @@ import { useState, useEffect } from 'react'
 import { Scramble } from './ui/Animated'
 import { SOUL_SCAFFOLD, STYLE_SCAFFOLD, ARCHETYPES } from '../lib/soul-templates'
 import { editorCls } from '../lib/utils'
+import type { SoulSources } from '../lib/types'
 
 export type SoulFile = 'soul' | 'style'
-export interface SoulSources { handle: string; name: string; links: string }
+export type { SoulSources }
 interface SoulExample { key: string; label: string; blurb: string }
 
 interface SoulPanelProps {

--- a/apps/dashboard/components/StrategyPanel.tsx
+++ b/apps/dashboard/components/StrategyPanel.tsx
@@ -4,8 +4,9 @@ import { useState, useEffect } from 'react'
 import { Scramble } from './ui/Animated'
 import { STRATEGY_SCAFFOLD, ARCHETYPES } from '../lib/strategy-templates'
 import { editorCls } from '../lib/utils'
+import type { StrategySources } from '../lib/types'
 
-export interface StrategySources { goal: string; repo: string; links: string }
+export type { StrategySources }
 
 interface StrategyPanelProps {
   content: string

--- a/apps/dashboard/components/TelegramChatIdHelper.tsx
+++ b/apps/dashboard/components/TelegramChatIdHelper.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { inputCls } from '../lib/utils'
+import { inputCls, isRecord } from '../lib/utils'
 
 interface TelegramChatIdHelperProps {
   // Bot token saved earlier in this session — secrets are write-only on GitHub,
@@ -38,13 +38,16 @@ export function TelegramChatIdHelper({ defaultToken, onFound }: TelegramChatIdHe
     setStatus(null)
     try {
       const res = await fetch(getUpdatesUrl)
-      const data = await res.json() as { ok: boolean; description?: string; result?: TgUpdate[] }
-      if (!data.ok) {
-        setStatus({ ok: false, msg: data.description ?? 'Telegram rejected the token — double-check it.' })
+      const data: unknown = await res.json()
+      if (!isRecord(data) || data.ok !== true) {
+        const msg = isRecord(data) && typeof data.description === 'string'
+          ? data.description
+          : 'Telegram rejected the token — double-check it.'
+        setStatus({ ok: false, msg })
         return
       }
       // Latest update wins — scan backwards for anything with a chat id.
-      const updates = data.result ?? []
+      const updates: TgUpdate[] = Array.isArray(data.result) ? (data.result as TgUpdate[]) : []
       for (let i = updates.length - 1; i >= 0; i--) {
         const id = chatIdFrom(updates[i])
         if (id !== undefined) {

--- a/apps/dashboard/lib/http.ts
+++ b/apps/dashboard/lib/http.ts
@@ -20,12 +20,3 @@ export function errorResponse(error: unknown, fallback = 'Unknown error', status
 export function syncResult(sync: { synced: boolean; reason?: string }) {
   return { ok: true, synced: sync.synced, ...(sync.reason ? { syncError: sync.reason } : {}) }
 }
-
-/**
- * Narrowing guard for an unknown value that is a non-null, non-array object.
- * The building block for validating untrusted JSON bodies / parsed files at API
- * boundaries before reading fields off them.
- */
-export function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
-}

--- a/apps/dashboard/lib/types.ts
+++ b/apps/dashboard/lib/types.ts
@@ -28,6 +28,11 @@ export const GATEWAY_PROVIDERS: GatewayProvider[] = ['auto', 'direct', 'bankr', 
 
 export interface UploadFile { path: string; content: string }
 
+// Client→server build briefs. The panels collect them; the build routes accept
+// them as Partial (every field is untrusted/optional on the wire).
+export interface SoulSources { handle: string; name: string; links: string }
+export interface StrategySources { goal: string; repo: string; links: string }
+
 // `.mcp.json` server map. A server's shape varies by transport (http/stdio),
 // so each entry is an open record; consumers narrow fields as needed.
 export type McpServer = Record<string, unknown>

--- a/apps/dashboard/lib/utils.ts
+++ b/apps/dashboard/lib/utils.ts
@@ -6,6 +6,13 @@ export function displayName(slug: string): string {
   return slug.split('-').map(w => special[w] || (w[0]?.toUpperCase() + w.slice(1))).join(' ')
 }
 
+// Narrowing guard for a non-null, non-array object — the building block for
+// validating untrusted JSON bodies / parsed files before reading fields off
+// them. Lives here (not lib/http) so client components can use it too.
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
 export function initials(slug: string): string {
   const words = slug.split('-')
   return words.length === 1 ? words[0].slice(0, 2).toUpperCase() : (words[0][0] + words[1][0]).toUpperCase()


### PR DESCRIPTION
## Summary

Follow-up to #467. While verifying that PR's "deferred items" list was accurate, I found **3 round-1 findings that shipped as neither code nor documented deferrals** — this closes all three. Small, behavior-preserving, fully verified.

| Finding | Confidence | Fix |
|---|---|---|
| `humanize` duplicated `displayName` (dedup-dry.8) | **high** | `soul/examples/route.ts` now uses `displayName` from `lib/utils`; local `humanize` deleted. Output is byte-identical for every current example; `displayName` only differs by correctly casing acronyms |
| `SoulSources`/`StrategySources` re-typed inline (shared-types.4) | medium | Moved both interfaces to `lib/types.ts` (single contract); panels re-export them; the two build routes now type their bodies as `Partial<SoulSources/StrategySources> & { model?: string }` |
| Untrusted Telegram `res.json()` cast (weak-types.4) | medium | `TelegramChatIdHelper` now parses as `unknown` and guards with `isRecord` before reading fields. To make that guard reusable on the client, `isRecord` was **relocated** from the server-only `lib/http.ts` (it imports `next/server`) to the client-safe `lib/utils.ts`; the two server importers were updated |

## Verification
- `apps/dashboard`: `tsc --noEmit` clean · **120/120 tests pass** · `knip` clean (no new unused exports) · `madge --circular` → none
- **11 files, +34 / −25**, source-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
