### PR TITLE
feat(mcp-catalog): add glim.sh (live-data MCP, x402 + MPP)

### DIFF
--- a/apps/dashboard/lib/mcp-catalog.ts
+++ b/apps/dashboard/lib/mcp-catalog.ts
@@ -40,6 +40,13 @@ export const MCP_CATALOG: McpCatalogEntry[] = [
     logo: 'https://pbs.twimg.com/profile_images/2047719472455438336/CFrEyoNZ_400x400.jpg',
     description: 'BlueAgent — the AI founder console for Base builders: idea, build, audit, ship, and raise, from concept to deployment.',
   },
+  {
+    slug: 'glim',
+    name: 'glim.sh',
+    url: 'https://glim.sh/mcp',
+    logo: 'https://raw.githubusercontent.com/glim-sh/glim-mcp/main/assets/icon-400.png',
+    description: 'glim.sh — live data for AI agents: web search, full page extraction, Twitter/X, Reddit, GitHub, Amazon, YouTube transcripts. Pay-per-call with x402 (Base/Solana USDC) or MPP (Tempo), or sign in and draw from a prepaid account balance.',
+  },
 ]
 
 export const MCP_BY_SLUG: Record<string, McpCatalogEntry> =


### PR DESCRIPTION
Adds **glim.sh** to the featured MCP catalog, per the discussion and your go-ahead in #464.

`glim.sh` is a hosted, read-only MCP server that gives agents live data: semantic web search, full page extraction that survives bot walls and JS rendering, Twitter/X search + threads, Reddit posts + comments, GitHub repos/code/PRs/issues, Amazon products, YouTube transcripts. Useful for any STRATEGY.md loop that needs fresh data.

Payment fits the autonomous model the same way RootAI and BlueAgent do: every tool settles per call via x402 (USDC on Base or Solana) or MPP (USDC on Tempo) - both challenges come back in the same 402, so a funded wallet just calls tools ($0.001-0.01/call). There's also an OAuth + prepaid-balance path for human-managed setups.

Single entry appended to `apps/dashboard/lib/mcp-catalog.ts`; no other files touched. Logo is served from the public `glim-sh/glim-mcp` repo (400x400 PNG).

Docs: https://glim.sh/docs - repo: https://github.com/glim-sh/glim-mcp

Happy to fund a demo wallet for the community call so people can try it live.
