### PR TITLE
Add Hunch Prediction Markets skill pack (crypto)

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,7 @@ The script reads the pack's `skills-pack.json` manifest, runs the security scann
 | [aeon-skill-pack-noelclaw](https://github.com/noelclaw/aeon-skill-pack-noelclaw) | 2 | Persistent versioned memory and multi-agent swarm coordination - save typed artifacts to Noel Vault and manage shared agent session state across runs |
 | [signa](https://github.com/codexvritra/signa) (`--path aeon-skills`) | 20 | Full SIGNA suite - wallet-signed cross-platform agent messaging, multi-agent broadcast and delegate, encrypted rooms + ERC-8004 trust gate, plus Bankr resolver / launches, gitlawb, MiroShark, and **x402 receipts + bounded spend mandates** (a human grants a signed budget, the agent spends within it and asks for more) |
 | [aeon-skill-pack-mneme](https://github.com/mnemedb/aeon-skill-pack-mneme) | 8 | Mneme as Aeon's persistent memory layer - vector recall across runs, entity/relation graph, live Base chain streams, async LLM "dream" reflections, and schema-aware /chat. One `MNEME_API_KEY`, zero infra. |
+| [Hunch Prediction Markets](https://github.com/rajkaria/hunch/tree/main/aeon-skill-pack) (`--path aeon-skill-pack`) | 3 | Crowd-conviction signal, market discovery, and **x402 betting** on PlayHunch - onchain prediction markets on Base. Unlike monitor-only packs, hunch-bet places real positions (simulate-by-default, $1-$10, USDC payout + onchain proof) |
 
 **To list a pack here**, open a PR adding a row. Guidelines:
 

--- a/skill-packs.json
+++ b/skill-packs.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "updated": "2026-06-08",
+  "updated": "2026-06-16",
   "description": "Machine-readable registry of community skill packs installable via ./install-skill-pack. Mirrors the human-readable table in README.md.",
   "packs": [
     {
@@ -253,6 +253,18 @@
       "category": "memory",
       "trust_level": "community",
       "skills": ["mneme-remember", "mneme-recall", "mneme-entity", "mneme-relate", "mneme-find", "mneme-dream", "mneme-watch", "mneme-ask"]
+    },
+    {
+      "repo": "rajkaria/hunch",
+      "path": "aeon-skill-pack",
+      "name": "Hunch Prediction Markets",
+      "description": "Crowd-conviction signal, market discovery, and autonomous x402 betting on PlayHunch - onchain prediction markets on Base. Unlike monitor-only market packs, hunch-bet lets the agent take a real position: simulate-by-default, $1-$10, settlement opt-in with a funded Base wallet, USDC payout + onchain proof.",
+      "author": "rajkaria",
+      "license": "MIT",
+      "homepage": "https://www.playhunch.xyz/agents",
+      "category": "crypto",
+      "trust_level": "community",
+      "skills": ["hunch-intel", "hunch-markets", "hunch-bet"]
     }
   ]
 }


### PR DESCRIPTION
Adds **Hunch Prediction Markets** to the community registry + README table.

[PlayHunch](https://www.playhunch.xyz) runs onchain prediction markets on Base. AEON already ships `monitor-polymarket` / `monitor-kalshi` and a couple of market-intel packs — but those only *watch* markets. This is the first pack where an agent can actually **take a position** over x402.

**3 skills** (`crypto`, all `default_enabled: false` — nothing runs or spends until enabled):

- **`hunch-intel`** — pool-weighted 0–100 crowd-conviction signal for any token via the free, read-only `/api/partner/intel` endpoint, with confidence + whale-concentration quality flags and the single most-backed bet.
- **`hunch-markets`** — discover live Hunch markets for a token or theme (odds, pool, deadline, quote + bet links). Read-only.
- **`hunch-bet`** — place a bet through the agent x402 rail. **Simulate-by-default** (nothing moves); real settlement is opt-in, $1–$10, and needs a funded Base wallet within a bounded-spend mandate. USDC payout + onchain proof.

Also ships a `.mcp.json.example` wiring Hunch's public **13-tool MCP server** (`https://www.playhunch.xyz/api/mcp`).

**Install:** `./install-skill-pack rajkaria/hunch --path aeon-skill-pack`

**Guidelines check**
- Public repo, MIT, per-skill `SKILL.md`, `skills-pack.json` at the pack root — monorepo via `--path`, same pattern as `signa`.
- No private endpoints: every read path is a public PlayHunch API (verified live); the only secret is the operator's own optional wallet key for live settlement.

Pack → https://github.com/rajkaria/hunch/tree/main/aeon-skill-pack
Agent docs → https://www.playhunch.xyz/agents/docs
