### PR TITLE
docs: fold packs into README/CONTRIBUTING + ci-skill-category gate

### DIFF
--- a/.github/workflows/ci-skill-category.yml
+++ b/.github/workflows/ci-skill-category.yml
@@ -1,0 +1,30 @@
+name: ci-skill-category
+
+# Every skill must declare a valid `category:` in its SKILL.md frontmatter —
+# category is the single source of truth for which pack a skill joins
+# (docs/skill-packs.md). A missing or typo'd category would silently dump the
+# skill into the Lab catch-all instead of its intended pack, so this gate fails
+# the PR instead. Same shape as ci-skills-json / ci-packs-json.
+
+on:
+  pull_request:
+    paths:
+      - 'skills/**'
+      - 'scripts/check-skill-categories.sh'
+  push:
+    branches: [main]
+    paths:
+      - 'skills/**'
+      - 'scripts/check-skill-categories.sh'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Every SKILL.md declares a valid category
+        run: bash scripts/check-skill-categories.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,8 @@ Most contributions fall into one of four buckets — **a new skill**, **a new LL
 A skill is a single `skills/<name>/SKILL.md` prompt file plus a registration in `aeon.yml`. The fastest paths:
 
 ```bash
-./new-from-template <template> <skill-name>   # scaffold from skill-templates/
-./add-skill <owner/repo> <skill> [skill...]   # import from any GitHub repo
+./new-from-template <template> <skill-name> --category <pack>   # scaffold from skill-templates/
+./add-skill <owner/repo> <skill> [skill...]                     # import from any GitHub repo
 ```
 
 You can also describe one to the `create-skill` skill, or label a GitHub issue `ai-build` and let Aeon implement it and open the PR.
@@ -29,6 +29,7 @@ Every `SKILL.md` opens with YAML frontmatter. The full contract lives in [`skill
 ```yaml
 ---
 name: my-skill
+category: dev                                  # the pack this skill joins
 description: One-line description of what this skill does
 var: ""
 tags: [dev, crypto]
@@ -37,6 +38,7 @@ mcp: [base]                                    # MCP servers, same two tiers
 ---
 ```
 
+- `category:` is the **single source of truth** for which [pack](docs/skill-packs.md) the skill belongs to. Use one of `research` `dev` `crypto` `onchain-security` `social` `productivity` `meta`. (`core` and `fleet` are curated in [`packs.config.json`](packs.config.json), not set here.) Omit it and the skill lands in the **Lab** catch-all until triaged. `./new-from-template ... --category <pack>` and the dashboard import dropdown set it for you.
 - `requires:` is the **single source of truth** the dashboard reads to show which skill needs which key. Use the exact env-var name. A bare name is required; a trailing `?` means the skill still runs without it (degraded). Omit `requires:` (or use `[]`) for skills that only need the built-in Claude + GitHub tokens.
 - `mcp:` declares [MCP servers](README.md#mcp-servers-in-skill-runs) the skill calls, with the same two-tier semantics. Slugs reference `apps/dashboard/lib/mcp-catalog.ts`.
 - Match the names to the registry in [`apps/dashboard/app/api/secrets/route.ts`](apps/dashboard/app/api/secrets/route.ts) so the dashboard can describe the key and link where to get it.
@@ -50,13 +52,15 @@ mcp: [base]                                    # MCP servers, same two tiers
 
 ### Regenerate the catalog
 
-`skills.json` is the canonical machine-readable catalog (the dashboard, `./add-skill`, and downstream consumers all read it). It is **generated**, never hand-edited:
+`skills.json` (the skill catalog) and `packs.json` (the [pack](docs/skill-packs.md) catalog the dashboard reads) are both **generated**, never hand-edited. After adding or recategorizing a skill, regenerate both:
 
 ```bash
-./generate-skills-json   # then commit the result
+./generate-skills-json   # skill catalog (reads each SKILL.md's category:)
+./generate-packs-json    # pack catalog (groups skills by category + packs.config.json)
+# then commit both results
 ```
 
-The `ci-skills-json` workflow fails any PR that touches `skills/**`, `aeon.yml`, `generate-skills-json`, or `skills.json` without committing a fresh regen. The check normalizes out the `generated` timestamp and per-skill `sha`/`updated`, so only real catalog drift fails it.
+The `ci-skills-json` and `ci-packs-json` workflows fail any PR that leaves either manifest stale. They normalize out the `generated` timestamp (and `ci-skills-json` also the per-skill `sha`/`updated`), so only real catalog drift fails them. `ci-packs-json` also fails if a skill ends up unassigned to any pack with no Lab catch-all declared.
 
 ## Contributing an LLM gateway
 
@@ -82,14 +86,16 @@ Packs must not monkey-patch Aeon internals or depend on private endpoints. Full 
 
 ## Continuous integration
 
-Two locking gates run on every PR. Both are fast and only trigger on the paths they protect:
+Locking gates run on every PR. All are fast and only trigger on the paths they protect:
 
 | Gate | Triggers on | What it enforces |
 |------|-------------|------------------|
 | `ci-skills-json` | `skills/**`, `aeon.yml`, `generate-skills-json`, `skills.json` | `skills.json` matches a fresh `./generate-skills-json` |
+| `ci-packs-json` | `packs.config.json`, `skills.json`, `generate-packs-json`, `packs.json` | `packs.json` matches a fresh `./generate-packs-json` |
+| `ci-skill-category` | `skills/**`, the category-check script | every `SKILL.md` declares a valid `category:` |
 | `ci-capabilities-parity` | `install-skill-pack`, `docs/CAPABILITIES.md`, the parity script | the capabilities taxonomy stays in sync across its sources |
 
-If `ci-capabilities-parity` fails, you changed one side of the taxonomy without the other — run `bash scripts/check-capabilities-parity.sh` locally to see the diff.
+Run the checks locally before pushing: `bash scripts/check-skill-categories.sh` (categories) and `bash scripts/check-capabilities-parity.sh` (taxonomy). If `ci-packs-json` or `ci-skills-json` fails, you changed a generator input without committing the regen — run `./generate-skills-json && ./generate-packs-json`.
 
 ## Reporting bugs and requesting features
 

--- a/README.md
+++ b/README.md
@@ -60,34 +60,36 @@ Grab the `gh_*_macOS_arm64.zip` (or your platform's binary) from [github.com/cli
 
 ![Skills](./assets/skills-aeon-197.jpg)
 
-**178 skills across 8 categories.** Every skill is independently installable, schedulable, and chainable.
+**182 skills, grouped into 9 installable packs.** A small **core** ships present; everything else is opt-in — browse and enable a whole pack from the dashboard's **Packs** view, or pick individual skills. Every skill is independently installable, schedulable, and chainable. How packs work: [`docs/skill-packs.md`](docs/skill-packs.md).
 
-| Category | Count | Examples |
-|----------|-------|----------|
-| 🧬 **Core** | 14 | `skill-repair`, `autoresearch`, `spawn-instance`, `vuln-scanner` |
-| 📚 **Research & Content** | 27 | `deep-research`, `paper-digest`, `hn-digest` |
-| 💻 **Dev & Code** | 34 | `pr-review`, `github-monitor`, `auto-merge` |
-| 📈 **Crypto & Markets** | 21 | `token-movers`, `defi-overview`, `monitor-polymarket`, `base-mcp` |
-| 🛡️ **Onchain Security** | 15 | `rug-scan`, `contract-audit`, `honeypot-check` |
-| ✍️ **Social & Writing** | 16 | `thread-writer`, `reply-maker`, `remix-tweets` |
-| ✅ **Productivity** | 17 | `priority-brief`, `retrospective`, `goal-tracker` |
-| 🤖 **Meta / Agent** | 34 | `heartbeat`, `cost-report`, `config-validator` |
+| Pack | Key | Skills | Examples |
+|------|-----|--------|----------|
+| 🧬 **Core** — self-evolution, healing, memory; always present | `core` | 13 | `skill-repair`, `autoresearch`, `create-skill` |
+| 🛰️ **Fleet & Replication** | `fleet` | 8 | `spawn-instance`, `deploy-prototype`, `vuln-scanner` |
+| 📚 **Research & Content** | `research` | 26 | `deep-research`, `paper-digest`, `hn-digest` |
+| 💻 **Dev & Code** | `dev` | 34 | `pr-review`, `github-monitor`, `auto-merge` |
+| 📈 **Crypto & Markets** | `markets` | 23 | `token-movers`, `defi-overview`, `base-mcp` |
+| 🛡️ **Hound — Onchain Security** | `hound` | 15 | `rug-scan`, `contract-audit`, `honeypot-check` |
+| ✍️ **Social & Writing** | `social` | 17 | `thread-writer`, `reply-maker`, `remix-tweets` |
+| ✅ **Productivity** | `productivity` | 16 | `priority-brief`, `retrospective`, `goal-tracker` |
+| 🤖 **Agent Ops** | `agent-ops` | 30 | `heartbeat`, `cost-report`, `config-validator` |
 
 <details>
-<summary><strong>Full catalog (all 178 skills)</strong></summary>
+<summary><strong>Full catalog (all 182 skills by pack)</strong></summary>
 
-| Category | Skills |
-|----------|--------|
-| **Core** (14) | `autoresearch`,`contributor-reward`,`create-skill`,`deploy-prototype`,`distribute-tokens`,`external-feature`,`fleet-control`,`fleet-scorecard`,`self-improve`,`skill-evals`,`skill-health`,`skill-repair`,`spawn-instance`,`vuln-scanner` |
-| **Research & Content** (27) | `agent-displacement`,`article`,`article-queue`,`beat-tracker`,`channel-recap`,`deep-research`,`digest`,`fetch-tweets`,`framework-watch`,`hn-digest`,`huggingface-trending`,`last30`,`launch-radar`,`list-digest`,`mcp-pulse`,`narrative-convergence`,`paper-digest`,`paper-pick`,`reddit-digest`,`research-brief`,`rss-digest`,`security-digest`,`technical-explainer`,`telegram-digest`,`topic-momentum`,`tweet-digest`,`vibecoding-digest` |
-| **Dev & Code** (34) | `auto-merge`,`auto-workflow`,`builder-map`,`changelog`,`code-health`,`disclosure-tracker`,`ecosystem-links`,`ecosystem-pulse`,`fork-cohort`,`fork-fleet`,`fork-release`,`github-monitor`,`github-releases`,`github-trending`,`issue-triage`,`pr-merge`,`pr-review`,`pr-tracker`,`pr-triage`,`project-lens`,`push-recap`,`pvr-triage`,`pvr-watchlist`,`repo-actions`,`repo-article`,`repo-pulse`,`repo-revive`,`repo-scanner`,`search-skill`,`skill-triage`,`star-milestone`,`vercel-projects`,`vuln-tracker`,`workflow-audit` |
-| **Crypto & Markets** (21) | `aixbt-pulse`,`base-mcp`,`compute-pulse`,`defi-overview`,`fear-divergence`,`liquidpad-launch`,`market-context`,`monitor-kalshi`,`monitor-polymarket`,`narrative-tracker`,`onchain-monitor`,`picks-tracker`,`pm-manipulation`,`pm-pulse`,`price-alert`,`rwa-pulse`,`token-movers`,`token-pick`,`treasury-info`,`unlock-monitor`,`x402-monitor` |
-| **Onchain Security** (15) | `approval-audit`,`contract-audit`,`deployer-trace`,`fund-flow`,`holder-concentration`,`honeypot-check`,`investigation-report`,`linked-wallets`,`lp-lock`,`rug-scan`,`tx-explain`,`vigil`,`vigil-revoke`,`wallet-profile`,`wallet-risk` |
-| **Social & Writing** (16) | `agent-buzz`,`content-performance`,`create-campaign`,`engagement-act`,`farcaster-digest`,`mention-radar`,`product-hunt`,`refresh-x`,`remix-tweets`,`reply-maker`,`schedule-ads`,`show-hn`,`skill-spotlight`,`syndicate-article`,`thread-writer`,`tweet-roundup` |
-| **Productivity** (17) | `action-converter`,`routine`,`deal-flow`,`ops-recap`,`followup-patrol`,`goal-tracker`,`idea-capture`,`idea-pipeline`,`idea-validator`,`milestone-tracker`,`priority-brief`,`reflect`,`reg-monitor`,`startup-idea`,`tool-builder`,`retrospective`,`shiplog` |
-| **Meta / Agent** (34) | `api-health`,`atrium-watch`,`batch-health`,`capabilities-map`,`config-validator`,`contributor-spotlight`,`cost-report`,`skill-adoption`,`fleet-state`,`contributor-leaderboard`,`fork-firstrun`,`fork-health`,`fork-digest`,`skill-gap`,`heartbeat`,`janitor`,`memory-dedupe`,`onboard`,`operator-scorecard`,`frequency-guard`,`rss-feed`,`self-review`,`signal-verdict`,`skill-analytics`,`skill-enabler`,`skill-freshness`,`skill-graph`,`skill-leaderboard`,`skill-scan`,`skill-update`,`sparkleware-catalog`,`spend-monitor`,`star-momentum`,`update-gallery` |
+| Pack | Skills |
+|------|--------|
+| **Core** (`core`, 13) | `autoresearch`,`config-validator`,`cost-report`,`create-skill`,`digest`,`heartbeat`,`onboard`,`priority-brief`,`reflect`,`self-improve`,`skill-evals`,`skill-health`,`skill-repair` |
+| **Fleet & Replication** (`fleet`, 8) | `contributor-reward`,`deploy-prototype`,`distribute-tokens`,`external-feature`,`fleet-control`,`fleet-scorecard`,`spawn-instance`,`vuln-scanner` |
+| **Research & Content** (`research`, 26) | `agent-displacement`,`article`,`article-queue`,`beat-tracker`,`channel-recap`,`deep-research`,`fetch-tweets`,`framework-watch`,`hn-digest`,`huggingface-trending`,`last30`,`launch-radar`,`list-digest`,`mcp-pulse`,`narrative-convergence`,`paper-digest`,`paper-pick`,`reddit-digest`,`research-brief`,`rss-digest`,`security-digest`,`technical-explainer`,`telegram-digest`,`topic-momentum`,`tweet-digest`,`vibecoding-digest` |
+| **Dev & Code** (`dev`, 34) | `auto-merge`,`auto-workflow`,`builder-map`,`changelog`,`code-health`,`disclosure-tracker`,`ecosystem-links`,`ecosystem-pulse`,`fork-cohort`,`fork-fleet`,`fork-release`,`github-monitor`,`github-releases`,`github-trending`,`issue-triage`,`pr-merge`,`pr-review`,`pr-tracker`,`pr-triage`,`project-lens`,`push-recap`,`pvr-triage`,`pvr-watchlist`,`repo-actions`,`repo-article`,`repo-pulse`,`repo-revive`,`repo-scanner`,`search-skill`,`skill-triage`,`star-milestone`,`vercel-projects`,`vuln-tracker`,`workflow-audit` |
+| **Crypto & Markets** (`markets`, 23) | `aixbt-pulse`,`base-mcp`,`beamr-route`,`compute-pulse`,`ctrl`,`defi-overview`,`fear-divergence`,`liquidpad-launch`,`market-context`,`monitor-kalshi`,`monitor-polymarket`,`narrative-tracker`,`onchain-monitor`,`picks-tracker`,`pm-manipulation`,`pm-pulse`,`price-alert`,`rwa-pulse`,`token-movers`,`token-pick`,`treasury-info`,`unlock-monitor`,`x402-monitor` |
+| **Hound — Onchain Security** (`hound`, 15) | `approval-audit`,`contract-audit`,`deployer-trace`,`fund-flow`,`holder-concentration`,`honeypot-check`,`investigation-report`,`linked-wallets`,`lp-lock`,`rug-scan`,`tx-explain`,`vigil`,`vigil-revoke`,`wallet-profile`,`wallet-risk` |
+| **Social & Writing** (`social`, 17) | `agent-buzz`,`content-performance`,`create-campaign`,`engagement-act`,`farcaster-digest`,`mention-radar`,`product-hunt`,`refresh-x`,`remix-tweets`,`reply-maker`,`schedule-ads`,`show-hn`,`skill-spotlight`,`soul-builder`,`syndicate-article`,`thread-writer`,`tweet-roundup` |
+| **Productivity** (`productivity`, 16) | `action-converter`,`deal-flow`,`followup-patrol`,`goal-tracker`,`idea-capture`,`idea-pipeline`,`idea-validator`,`milestone-tracker`,`ops-recap`,`reg-monitor`,`retrospective`,`routine`,`shiplog`,`startup-idea`,`strategy-builder`,`tool-builder` |
+| **Agent Ops** (`agent-ops`, 30) | `api-health`,`atrium-watch`,`batch-health`,`capabilities-map`,`contributor-leaderboard`,`contributor-spotlight`,`fleet-state`,`fork-digest`,`fork-firstrun`,`fork-health`,`frequency-guard`,`janitor`,`memory-dedupe`,`operator-scorecard`,`rss-feed`,`self-review`,`signal-verdict`,`skill-adoption`,`skill-analytics`,`skill-enabler`,`skill-freshness`,`skill-gap`,`skill-graph`,`skill-leaderboard`,`skill-scan`,`skill-update`,`sparkleware-catalog`,`spend-monitor`,`star-momentum`,`update-gallery` |
 
-Full descriptions: [`skills.json`](skills.json) — or run `./add-skill aaronjmars/aeon --list`.
+Authoritative source: [`skills.json`](skills.json) + [`packs.json`](packs.json), the dashboard **Packs** view, or `./add-skill aaronjmars/aeon --list`. A skill's pack comes from its `category:` frontmatter — see [`docs/skill-packs.md`](docs/skill-packs.md).
 Dependency graph: [`docs/skill-graph.md`](docs/skill-graph.md) — a visual map of how skills connect.
 
 </details>
@@ -127,7 +129,7 @@ Aeon can spawn and manage copies of itself. `spawn-instance` forks the repo into
 
 Installed skills land in `skills/` and are added to `aeon.yml` disabled — flip `enabled: true` to activate. You can also:
 
-- **Build your own** from [`skill-templates/`](skill-templates/TEMPLATE.md): `./new-from-template <template> <skill-name>`
+- **Build your own** from [`skill-templates/`](skill-templates/TEMPLATE.md): `./new-from-template <template> <skill-name> --category <pack>` — the `--category` slots it into a pack (or set `category:` in the SKILL.md frontmatter). See [`docs/skill-packs.md`](docs/skill-packs.md).
 - **Label any GitHub issue `ai-build`** — Claude reads the issue, implements it, and opens a PR
 - **Install community packs** — see [Community skill packs](#community-skill-packs)
 
@@ -457,6 +459,8 @@ If the secrets aren't set, both steps no-op — fully backward compatible. If Fl
 
 ![Aeon Framework ecosystem map](./assets/ecosystem-aeon.jpg)
 
+> Aeon's **built-in (first-party) packs** — Core, Fleet, Research, Dev, Markets, Hound, Social, Productivity, Agent Ops — live in this repo and are enabled from the dashboard's **Packs** view; see [`docs/skill-packs.md`](docs/skill-packs.md). The packs below are **community** collections in their own repos.
+
 Third-party skill collections in their own repos, installable as one bundle:
 
 ```bash
@@ -528,7 +532,9 @@ Private repos: Free plan = 2,000 min/mo, Pro/Team = 3,000 + $0.008/min overage. 
 CLAUDE.md                ← agent identity (auto-loaded by Claude Code)
 STRATEGY.md              ← north-star: goal, priorities, audience, constraints (rides along every run)
 aeon.yml                 ← skill schedules, chains, reactive triggers, enabled flags
-skills.json              ← machine-readable skill catalog (197 skills)
+skills.json              ← machine-readable skill catalog (182 skills, category per skill)
+packs.config.json        ← first-party pack definitions (core allowlist + pack list)
+packs.json               ← generated pack catalog the dashboard reads (9 packs)
 ./aeon                   ← launch the local dashboard (Next.js on port 5555)
 ./onboard                ← validate the fork's setup (secrets, workflows, channels)
 ./notify                 ← multi-channel notifications (Telegram, Discord, Slack, Email, json-render)
@@ -538,9 +544,11 @@ skills.json              ← machine-readable skill catalog (197 skills)
 ./add-a2a                ← start the A2A protocol gateway for external agents
 ./export-skill           ← package skills for standalone distribution
 ./generate-skills-json   ← regenerate skills.json from SKILL.md files
+./generate-packs-json    ← regenerate packs.json from packs.config.json + skills.json
+./new-from-template      ← scaffold a skill from a template (--category sets its pack)
 docs/                    ← GitHub Pages site (articles, activity log, memory)
 soul/                    ← optional identity files (SOUL.md, STYLE.md, examples/, data/)
-skills/                  ← each skill is a SKILL.md prompt file (197 total)
+skills/                  ← each skill is a SKILL.md prompt file (182 total; `category:` = its pack)
 workflow-templates/      ← GitHub Agentic Workflow templates (.md)
 skill-templates/         ← templates for building your own skills
 apps/                    ← standalone sub-projects, each with its own package.json

--- a/docs/skill-packs.md
+++ b/docs/skill-packs.md
@@ -36,6 +36,9 @@ skills.json         ──┘                                 (generated)      (
   live enabled/installed state is joined at request time by `/api/packs`.
 - **[`ci-packs-json.yml`](../.github/workflows/ci-packs-json.yml)** — fails any
   PR that leaves `packs.json` stale, exactly like `ci-skills-json`.
+- **[`ci-skill-category.yml`](../.github/workflows/ci-skill-category.yml)** — fails
+  any PR where a `SKILL.md` is missing a valid `category:`
+  (`bash scripts/check-skill-categories.sh` runs it locally).
 
 Regenerate after any change to the config or to `skills.json`:
 
@@ -143,10 +146,10 @@ enable its skills from the dashboard's Packs view.
 
 ---
 
-## Roadmap
+## Status
 
-Planned follow-ups (not yet shipped):
-
-- **README/CONTRIBUTING** — fold first-party packs into the main catalog docs.
-- **Lint gate** — optionally fail CI on a `SKILL.md` with no `category:` (today
-  it degrades to Lab rather than failing).
+The pack system is fully shipped: the data layer + three CI gates
+(`ci-skills-json`, `ci-packs-json`, `ci-skill-category`), the dashboard **Packs**
+view, frontmatter-driven categories, and `--category` authoring. README and
+CONTRIBUTING document it. New skills declare `category:` (or use `--category`);
+the **Lab** catch-all keeps anything uncategorized from breaking the catalog.

--- a/scripts/check-skill-categories.sh
+++ b/scripts/check-skill-categories.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# check-skill-categories.sh — Lint that every skills/*/SKILL.md declares a valid
+# `category:` in its frontmatter. Category is the single source of truth for which
+# pack a skill joins (see docs/skill-packs.md); a missing or typo'd one would
+# silently dump the skill into the Lab catch-all instead of its intended pack.
+#
+# Run locally:  bash scripts/check-skill-categories.sh
+# Exits 0 if every skill has a known category, 1 otherwise (with a report).
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SKILLS_DIR="$ROOT/skills"
+
+# Valid frontmatter categories. These are the 8 skills.json categories; `core` is
+# valid (core/fleet skills declare it — their pack is then resolved from
+# packs.config.json), but `fleet` is never a category value.
+VALID="core research dev crypto onchain-security social productivity meta"
+
+missing=()
+invalid=()
+
+for skill_file in "$SKILLS_DIR"/*/SKILL.md; do
+  [[ -f "$skill_file" ]] || continue
+  slug="$(basename "$(dirname "$skill_file")")"
+
+  cat=$(awk '/^---$/{n++; next} n==1 && /^category:/{sub(/^category:[[:space:]]*/,""); gsub(/"/,""); gsub(/[[:space:]]*$/,""); print; exit}' "$skill_file")
+
+  if [[ -z "$cat" ]]; then
+    missing+=("$slug")
+    continue
+  fi
+  if [[ " $VALID " != *" $cat "* ]]; then
+    invalid+=("$slug ($cat)")
+  fi
+done
+
+status=0
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+  status=1
+  echo "::error::${#missing[@]} skill(s) missing a 'category:' in SKILL.md frontmatter:"
+  printf '  - %s\n' "${missing[@]}"
+fi
+
+if [[ ${#invalid[@]} -gt 0 ]]; then
+  status=1
+  echo "::error::${#invalid[@]} skill(s) with an unknown category (valid: $VALID):"
+  printf '  - %s\n' "${invalid[@]}"
+fi
+
+if [[ "$status" -eq 0 ]]; then
+  echo "skill-categories: OK — every skill declares a valid category."
+else
+  echo ""
+  echo "Fix: set 'category: <pack>' in each SKILL.md frontmatter (one of: $VALID)."
+  echo "See docs/skill-packs.md. New skills: ./new-from-template ... --category <pack>."
+fi
+
+exit "$status"


### PR DESCRIPTION
## What

Closes out the documented roadmap for the skill-pack system (the last items from #475):

1. **Fold packs into README + CONTRIBUTING.**
2. **A CI lint that fails on a `SKILL.md` missing/typo'd `category:`** (today it would silently degrade to the Lab catch-all).

## README

- The "What Aeon can do" catalog is now **pack-organized** (Core, Fleet, Research, Dev, Markets, Hound, Social, Productivity, Agent Ops) with **accurate counts** — the old by-category table was stale (claimed 178; real is 182).
- First-party (built-in) vs community packs is made explicit, pointing to the dashboard **Packs** view and `docs/skill-packs.md`.
- `--category` in the "build your own" flow; `packs.json` / `packs.config.json` / `generate-packs-json` / `new-from-template` added to the project layout.

## CONTRIBUTING

- `category:` added to the frontmatter contract (with the valid set + the Lab fallback).
- "Regenerate the catalog" now covers both `skills.json` and `packs.json`.
- CI gate table lists all four gates (`ci-skills-json`, `ci-packs-json`, `ci-skill-category`, `ci-capabilities-parity`) + the local commands.

## The new gate

- `scripts/check-skill-categories.sh` — runnable locally; fails if any `skills/*/SKILL.md` is missing a `category:` or uses one outside the known set (`core research dev crypto onchain-security social productivity meta`).
- `.github/workflows/ci-skill-category.yml` — runs it on `skills/**` changes, same shape as the other gates.

## Verification

- Lint tested both ways: **all 182 skills pass**; removing one skill's category → exits 1 with a clear report.
- Docs-and-lint only — **no SKILL.md or manifest changes** (confirmed), so the catalog is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
