### PR TITLE
feat(dashboard): default sidebar to enabled skills only

### DIFF
--- a/apps/dashboard/components/LeftSidebar.tsx
+++ b/apps/dashboard/components/LeftSidebar.tsx
@@ -24,7 +24,11 @@ interface LeftSidebarProps {
 
 export function LeftSidebar({ view, setView, selectedSkill, skills, runs, secrets, repo, enabledCount, workingCount, categoryFilter, setCategoryFilter, onSkillSelect, onShowImport }: LeftSidebarProps) {
   const [skillSearch, setSkillSearch] = useState('')
-  const [enabledOnly, setEnabledOnly] = useState(false)
+  // Default the roster to the active team — only enabled skills. With packs, the
+  // full 180+ catalog is browsed/enabled from the Packs view, so the sidebar
+  // starts focused on what's actually on duty. Toggle "Enabled" off (or "All")
+  // to see the rest.
+  const [enabledOnly, setEnabledOnly] = useState(true)
   const [availableOnly, setAvailableOnly] = useState(false)
 
   // A skill is "key-blocked" when it's enabled but a required (non-optional)
@@ -36,6 +40,17 @@ export function LeftSidebar({ view, setView, selectedSkill, skills, runs, secret
 
   // "Available" = runnable out of the box: every declared key is optional.
   const needsNoKey = (s: Skill) => (s.requires ?? []).every(r => r.optional)
+
+  // How many skills survive the active filters — drives the empty-state hint so
+  // the default enabled-only roster never looks broken when little is on duty.
+  const matchesFilters = (s: Skill) => {
+    if (categoryFilter && (s.category || 'meta') !== categoryFilter) return false
+    if (skillSearch && !(displayName(s.name).toLowerCase().includes(skillSearch.toLowerCase()) || s.name.includes(skillSearch.toLowerCase()))) return false
+    if (enabledOnly && !s.enabled) return false
+    if (availableOnly && !needsNoKey(s)) return false
+    return true
+  }
+  const visibleCount = skills.filter(matchesFilters).length
 
   return (
     <div className="w-[240px] border-r border-[rgba(250,250,250,0.10)] flex flex-col shrink-0 bg-aeon-panel">
@@ -171,6 +186,22 @@ export function LeftSidebar({ view, setView, selectedSkill, skills, runs, secret
             </div>
           )
         })}
+
+        {visibleCount === 0 && (
+          <div className="px-4 py-10 text-center">
+            <p className="text-[11px] font-mono uppercase tracking-[0.14em] text-primary-40">
+              {enabledOnly ? 'No skills on duty' : 'No skills match'}
+            </p>
+            {enabledOnly && (
+              <button
+                onClick={() => setEnabledOnly(false)}
+                className="mt-2 text-[10px] font-mono uppercase tracking-[0.14em] text-primary-50 hover:text-eva-orange transition-colors cursor-target"
+              >
+                Show all skills
+              </button>
+            )}
+          </div>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## What

The sidebar Team roster now **defaults to showing only enabled skills**. With the pack system, listing all 180+ skills there is noise — the full catalog is browsed and enabled from the **Packs** view, so the roster should start focused on what's actually on duty.

- Default the `Enabled` filter **on** (`enabledOnly` starts `true`). The **ALL** chip and toggling **Enabled** off still reveal the full catalog — nothing is hidden permanently.
- Adds a graceful **empty-state** (`No skills on duty` + a `Show all skills` button) so the roster never looks broken on a fresh fork with few skills enabled.

## Verify

`tsc --noEmit` clean, `next build` exit 0. Confirmed live: with 16 skills enabled, the roster shows exactly those 16 with the green `ENABLED` chip active; clicking `ALL`/`Enabled` reveals the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)