### PR TITLE
feat(dashboard): packs are a visibility lens — show only Core by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Grab the `gh_*_macOS_arm64.zip` (or your platform's binary) from [github.com/cli
 
 ![Skills](./assets/skills-aeon-197.jpg)
 
-**182 skills, grouped into 9 packs.** A small **core** ships present; everything else is opt-in — browse packs in the dashboard's **Packs** view and switch on the individual skills you want (a pack is a lens, not a bulk switch). Every skill is independently installable, schedulable, and chainable. How packs work: [`docs/skill-packs.md`](docs/skill-packs.md).
+**182 skills, grouped into 9 packs.** By default the dashboard shows only the small **core** set; everything else is hidden until you **enable its pack** in the **Packs** view — a visibility switch that reveals a pack's skills across the UI without running anything. Putting a skill on duty stays a per-skill toggle. Every skill is independently installable, schedulable, and chainable. How packs work: [`docs/skill-packs.md`](docs/skill-packs.md).
 
 | Pack | Key | Skills | Examples |
 |------|-----|--------|----------|

--- a/apps/dashboard/app/page.tsx
+++ b/apps/dashboard/app/page.tsx
@@ -8,7 +8,7 @@ import type {
   UploadResponse, ErrorResponse, PacksResponse,
 } from '../lib/types'
 import { postJson, putJson, patchJson, del, scheduleRunRefresh } from '../lib/api-client'
-import { MODELS, AUTH_SECRETS } from '../lib/constants'
+import { MODELS, AUTH_SECRETS, PACK_BY_KEY } from '../lib/constants'
 import { displayName } from '../lib/utils'
 import TargetCursor from '../components/ui/TargetCursor'
 import { LoadingScreen } from '../components/LoadingScreen'
@@ -57,6 +57,11 @@ export default function Dashboard() {
 
   const [packs, setPacks] = useState<PacksResponse | null>(null)
   const [packsLoaded, setPacksLoaded] = useState(false)
+  // Which packs are *visible* across the dashboard. A pack is a visibility lens:
+  // by default only Core shows everywhere; enabling a pack reveals its skills in
+  // the sidebar + HQ. Pure client-side view preference — it never changes what
+  // runs (that's the per-skill `enabled` toggle in aeon.yml). Persisted below.
+  const [enabledPacks, setEnabledPacks] = useState<string[]>(['core'])
 
   const [showImport, setShowImport] = useState(false)
   const [authLoading, setAuthLoading] = useState(false)
@@ -95,6 +100,9 @@ export default function Dashboard() {
   }, [])
   const refreshRuns = useCallback(async () => { try { const r = await fetch('/api/runs'); if (r.ok) setRuns((await r.json() as RunsResponse).runs) } catch {} }, [])
   useEffect(() => { fetchData() }, [fetchData])
+  // Restore the operator's enabled-pack selection from a prior visit (Core is
+  // always on, so it's merged in even if absent from storage).
+  useEffect(() => { try { const raw = localStorage.getItem('aeon.enabledPacks'); if (raw) { const arr = JSON.parse(raw); if (Array.isArray(arr)) setEnabledPacks(Array.from(new Set(['core', ...arr.filter((k: unknown): k is string => typeof k === 'string')]))) } } catch {} }, [])
   useEffect(() => { const id = setInterval(refreshRuns, 10_000); return () => clearInterval(id) }, [refreshRuns])
   useEffect(() => { setFeedLoading(true); fetch('/api/outputs').then(r => r.ok ? r.json() as Promise<OutputsResponse> : { outputs: [] }).then(d => setOutputs(d.outputs || [])).finally(() => setFeedLoading(false)) }, [feedKey])
   useEffect(() => { if (view === 'strategy' && !strategyLoaded) { fetch('/api/strategy').then(r => r.ok ? r.json() as Promise<StrategyResponse> : null).then(d => { if (d) { setStrategy(d.content || ''); setStrategyLoaded(true) } }).catch(() => {}) } }, [view, strategyLoaded])
@@ -121,10 +129,19 @@ export default function Dashboard() {
   const saveSecret = async (n: string, value: string) => { setBusy(b => ({ ...b, [`sec-${n}`]: true })); try { const { ok } = await postJson('/api/secrets', { name: n, value }); if (ok) { setSecrets(s => { const e = s.some(x => x.name === n); if (e) return s.map(x => x.name === n ? { ...x, isSet: true } : x); return [...s, { name: n, group: 'Skill Keys', description: 'Custom', isSet: true }] }); flash(`${n} saved`) } } finally { setBusy(b => ({ ...b, [`sec-${n}`]: false })) } }
   const deleteSecret = async (n: string) => { setBusy(b => ({ ...b, [`sec-${n}`]: true })); try { const { ok } = await del('/api/secrets', { name: n }); if (ok) { setSecrets(s => s.map(x => x.name === n ? { ...x, isSet: false } : x)); flash(`${n} removed`) } } finally { setBusy(b => ({ ...b, [`sec-${n}`]: false })) } }
   const importSkill = async (files: UploadFile[], name?: string, category?: string) => { const { ok, data } = await postJson<UploadResponse>('/api/upload', { files, name, category }); if (ok) { flash(`${displayName(data.name)} hired`); fetchData() } }
-  // From the Packs view: filter the sidebar roster to a pack and jump to HQ so
-  // you can scan and enable its skills in context. (Enabling is per-skill via the
-  // existing toggleSkill — a pack is a lens, not a bulk switch.)
-  const showPack = (key: string) => { setSelectedSkill(null); setCategoryFilter(key); setView('hq') }
+  // Enable/disable a pack's *visibility* (not its skills). Core is always on.
+  // Toggling reveals or hides the pack's skills across the sidebar + HQ; it's a
+  // view preference, persisted to localStorage, with zero effect on what runs.
+  const togglePack = (key: string) => {
+    if (key === 'core') return
+    setEnabledPacks(prev => {
+      const has = prev.includes(key)
+      const next = has ? prev.filter(k => k !== key) : [...prev, key]
+      try { localStorage.setItem('aeon.enabledPacks', JSON.stringify(next.filter(k => k !== 'core'))) } catch {}
+      flash(`${PACK_BY_KEY[key]?.label || key} ${has ? 'hidden' : 'revealed'}`)
+      return next
+    })
+  }
   const saveStrategy = async (content: string) => { setStrategySaving(true); try { const { ok, data } = await putJson<SyncResult>('/api/strategy', { content }); if (ok) { setStrategy(content); flashSynced('Strategy saved', data) } else { flash('Save failed') } } finally { setStrategySaving(false) } }
   const buildStrategy = async (sources: StrategySources) => { setStrategyBuilding(true); try { const { ok, data } = await postJson<ErrorResponse>('/api/strategy/build', { ...sources, model }); if (ok) { flash('Strategy-builder started'); scheduleRunRefresh(refreshRuns) } else { flash(data.error || 'Build failed to dispatch') } } finally { setStrategyBuilding(false) } }
   const saveMcp = async (servers: Record<string, Record<string, unknown>>) => { setMcpSaving(true); try { const { ok, data } = await putJson<SyncResult>('/api/mcp', { servers }); if (ok) { setMcpServers(servers); flashSynced('MCP servers saved', data) } else { flash('Save failed') } } finally { setMcpSaving(false) } }
@@ -142,7 +159,11 @@ export default function Dashboard() {
   // Any model/provider key set means Aeon can authenticate — the "Auth" CTA hides.
   // Derived from live `secrets` so it reacts the instant a key is saved or removed.
   const hasModelKey = secrets.some(s => s.isSet && AUTH_SECRETS.includes(s.name))
-  const enabledCount = skills.filter(s => s.enabled).length
+  // Skills visible across the dashboard = those in an enabled pack (Core always
+  // on). The sidebar + HQ render this; the Packs view keeps the full roster so
+  // you can enable more. Counts track what's visible, so the UI stays consistent.
+  const visibleSkills = skills.filter(s => enabledPacks.includes(s.pack || 'lab'))
+  const enabledCount = visibleSkills.filter(s => s.enabled).length
   const workingCount = runs.filter(r => r.status === 'in_progress').length
 
   if (loading) return <LoadingScreen />
@@ -156,7 +177,7 @@ export default function Dashboard() {
       <LeftSidebar
         view={view} setView={(v) => { setView(v); setSelectedSkill(null) }}
         selectedSkill={selectedSkill} setSelectedSkill={setSelectedSkill}
-        skills={skills} runs={runs} secrets={secrets} repo={repo}
+        skills={visibleSkills} runs={runs} secrets={secrets} repo={repo}
         enabledCount={enabledCount} workingCount={workingCount}
         categoryFilter={categoryFilter} setCategoryFilter={setCategoryFilter}
         onSkillSelect={(name) => { setSelectedSkill(name); setView('hq') }}
@@ -186,10 +207,10 @@ export default function Dashboard() {
             <SoulPanel soul={soul} style={soulStyle} loading={!soulLoaded} saving={soulSaving} building={soulBuilding} installing={soulInstalling} onSave={saveSoul} onBuild={buildSoul} onInstallExample={installSoulExample} />
           )}
           {view === 'hq' && !selectedSkill && (
-            <HQOverview skills={skills} runs={runs} enabledCount={enabledCount} workingCount={workingCount} categoryFilter={categoryFilter} onCategoryClick={(key) => setCategoryFilter(categoryFilter === key ? null : key)} onViewRun={() => {}} />
+            <HQOverview skills={visibleSkills} runs={runs} enabledCount={enabledCount} workingCount={workingCount} categoryFilter={categoryFilter} onCategoryClick={(key) => setCategoryFilter(categoryFilter === key ? null : key)} onViewRun={() => {}} />
           )}
           {view === 'packs' && !selectedSkill && (
-            <PacksPanel firstParty={packs?.firstParty ?? []} community={packs?.community ?? []} skills={skills} loading={!packsLoaded} busy={busy} onToggleSkill={toggleSkill} onSelectSkill={(name) => { setSelectedSkill(name); setView('hq') }} onShowPack={showPack} />
+            <PacksPanel firstParty={packs?.firstParty ?? []} community={packs?.community ?? []} skills={skills} enabledPacks={enabledPacks} loading={!packsLoaded} busy={busy} onTogglePack={togglePack} onToggleSkill={toggleSkill} onSelectSkill={(name) => { setSelectedSkill(name); setView('hq') }} />
           )}
           {skill && (
             <SkillDetail

--- a/apps/dashboard/components/LeftSidebar.tsx
+++ b/apps/dashboard/components/LeftSidebar.tsx
@@ -24,11 +24,11 @@ interface LeftSidebarProps {
 
 export function LeftSidebar({ view, setView, selectedSkill, skills, runs, secrets, repo, enabledCount, workingCount, categoryFilter, setCategoryFilter, onSkillSelect, onShowImport }: LeftSidebarProps) {
   const [skillSearch, setSkillSearch] = useState('')
-  // Default the roster to the active team — only enabled skills. With packs, the
-  // full 180+ catalog is browsed/enabled from the Packs view, so the sidebar
-  // starts focused on what's actually on duty. Toggle "Enabled" off (or "All")
-  // to see the rest.
-  const [enabledOnly, setEnabledOnly] = useState(true)
+  // The roster only ever holds skills from *enabled packs* (Core by default —
+  // the parent filters before passing `skills`), so it's already focused. We
+  // show all of those skills (enabled or not); "Enabled" is an opt-in filter,
+  // off by default, to narrow to what's actually on duty.
+  const [enabledOnly, setEnabledOnly] = useState(false)
   const [availableOnly, setAvailableOnly] = useState(false)
 
   // A skill is "key-blocked" when it's enabled but a required (non-optional)

--- a/apps/dashboard/components/PacksPanel.tsx
+++ b/apps/dashboard/components/PacksPanel.tsx
@@ -8,11 +8,12 @@ interface PacksPanelProps {
   firstParty: Pack[]
   community: CommunityPack[]
   skills: Skill[]
+  enabledPacks: string[]
   loading: boolean
   busy: Record<string, boolean>
+  onTogglePack: (key: string) => void
   onToggleSkill: (slug: string, enabled: boolean) => void
   onSelectSkill: (slug: string) => void
-  onShowPack: (key: string) => void
 }
 
 function Section({ index, label, children }: { index: string; label: string; children: React.ReactNode }) {
@@ -33,25 +34,27 @@ function trustTone(level?: string): string {
   return 'text-primary-40 border-[rgba(250,250,250,0.18)]'
 }
 
-export function PacksPanel({ firstParty, community, skills, loading, busy, onToggleSkill, onSelectSkill, onShowPack }: PacksPanelProps) {
+export function PacksPanel({ firstParty, community, skills, enabledPacks, loading, busy, onTogglePack, onToggleSkill, onSelectSkill }: PacksPanelProps) {
   const [expanded, setExpanded] = useState<string | null>(null)
 
   // Live enabled state comes from the skills roster (single source of truth), so
   // toggling a skill updates the counts here instantly. Hide declared-but-empty
   // packs (e.g. the Lab catch-all when nothing is unsorted).
   const enabledBySlug = new Map(skills.map(s => [s.name, s.enabled]))
+  const isPackOn = (key: string) => key === 'core' || enabledPacks.includes(key)
   const visiblePacks = firstParty.filter(p => p.total > 0).map(p => {
     const members = p.skills.map(s => ({ ...s, enabled: enabledBySlug.get(s.slug) ?? false }))
     return { ...p, skills: members, enabled: members.filter(m => m.enabled).length }
   })
   const totalSkills = visiblePacks.reduce((n, p) => n + p.total, 0)
   const onDuty = visiblePacks.reduce((n, p) => n + p.enabled, 0)
+  const packsOn = visiblePacks.filter(p => isPackOn(p.key)).length
 
   const stats = [
     { label: 'Packs', value: visiblePacks.length },
+    { label: 'Enabled', value: packsOn, tone: 'text-eva-green' },
     { label: 'Skills', value: totalSkills },
     { label: 'On duty', value: onDuty, tone: 'text-eva-green' },
-    { label: 'Community', value: community.length },
   ]
 
   if (loading) {
@@ -77,7 +80,7 @@ export function PacksPanel({ firstParty, community, skills, loading, busy, onTog
             PACKS
           </h1>
           <p className="mt-4 max-w-xl text-sm text-primary-70 leading-relaxed">
-            Curated bundles of skills. Open a pack to see what's inside, then switch on the ones you want — enabling is per-skill. Core is always present; everything else is opt-in.
+            Curated bundles of skills. By default you only see <span className="text-aeon-fg">Core</span> — enable a pack to reveal its skills across the sidebar and HQ. Enabling a pack changes what you <span className="text-aeon-fg">see</span>, not what runs; switch individual skills on to put them on duty.
           </p>
         </div>
         <dl className="relative z-10 grid grid-cols-2 sm:grid-cols-4 border-t border-[rgba(250,250,250,0.10)]">
@@ -95,19 +98,21 @@ export function PacksPanel({ firstParty, community, skills, loading, busy, onTog
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-px bg-[rgba(250,250,250,0.10)] border border-[rgba(250,250,250,0.10)]">
           {visiblePacks.map(pack => {
             const isCore = pack.key === 'core'
+            const on = isPackOn(pack.key)
             const open = expanded === pack.key
             return (
               <div key={pack.key} className="bg-aeon-bg flex flex-col">
                 <div className="px-6 py-5 flex flex-col gap-3 flex-1">
                   <div className="flex items-start gap-3">
-                    <span className="mt-1 w-2.5 h-2.5 rounded-full shrink-0" style={{ backgroundColor: pack.color }} />
+                    <span className="mt-1 w-2.5 h-2.5 rounded-full shrink-0" style={{ backgroundColor: on ? pack.color : 'rgba(250,250,250,0.18)' }} />
                     <div className="min-w-0 flex-1">
                       <div className="flex items-center gap-2">
                         <span className="font-display uppercase tracking-wide text-aeon-fg text-base leading-tight">{pack.name}</span>
                         {isCore && <span className="text-[9px] font-mono uppercase tracking-[0.14em] px-1.5 py-0.5 border border-aeon-red/40 text-aeon-red">core</span>}
                       </div>
                       <div className="text-[11px] text-primary-40 font-mono mt-1 uppercase tracking-[0.14em]">
-                        {pack.enabled} / {pack.total} on duty
+                        {pack.total} skill{pack.total === 1 ? '' : 's'}
+                        {pack.enabled > 0 && <span className="text-eva-green"> · {pack.enabled} on duty</span>}
                       </div>
                     </div>
                   </div>
@@ -115,17 +120,18 @@ export function PacksPanel({ firstParty, community, skills, loading, busy, onTog
 
                   <div className="mt-auto flex items-center gap-2 pt-2">
                     <button
+                      onClick={() => onTogglePack(pack.key)}
+                      disabled={isCore}
+                      title={isCore ? 'Core is always shown' : on ? 'Hide this pack’s skills from the dashboard' : 'Reveal this pack’s skills across the sidebar and HQ'}
+                      className={`text-[10px] font-mono uppercase tracking-[0.14em] px-3 py-1.5 border transition-colors cursor-target disabled:cursor-default ${on ? 'text-eva-green border-eva-green/50 bg-eva-green/10' : 'text-primary-50 border-[rgba(250,250,250,0.18)] hover:text-primary-100 hover:border-[rgba(250,250,250,0.3)]'}`}
+                    >
+                      {isCore ? 'Always on' : on ? '✓ Enabled' : 'Enable pack'}
+                    </button>
+                    <button
                       onClick={() => setExpanded(open ? null : pack.key)}
                       className="text-[10px] font-mono uppercase tracking-[0.14em] px-3 py-1.5 border border-[rgba(250,250,250,0.12)] text-primary-50 hover:text-primary-100 hover:border-[rgba(250,250,250,0.22)] transition-colors cursor-target"
                     >
-                      {open ? 'Hide' : `${pack.total} skill${pack.total === 1 ? '' : 's'}`}
-                    </button>
-                    <button
-                      onClick={() => onShowPack(pack.key)}
-                      title="Filter the sidebar roster to this pack"
-                      className="text-[10px] font-mono uppercase tracking-[0.14em] px-3 py-1.5 border border-[rgba(250,250,250,0.12)] text-primary-50 hover:text-primary-100 hover:border-[rgba(250,250,250,0.22)] transition-colors cursor-target"
-                    >
-                      In sidebar →
+                      {open ? 'Hide skills' : 'View skills'}
                     </button>
                   </div>
                 </div>

--- a/docs/skill-packs.md
+++ b/docs/skill-packs.md
@@ -1,16 +1,19 @@
 # Skill packs
 
 Aeon ships **180+ skills**, but most forks only ever run a handful. Packs make
-that manageable: a small **core** is always present, and everything else is
-grouped into **packs** you browse from the dashboard — open a pack to see what's
-inside, then switch on the individual skills you want. A pack is a lens for
-discovery, not a bulk on-switch; enabling is always per-skill.
+that manageable: by default the dashboard shows only the small **core** set —
+everything else is grouped into **packs** that stay hidden until you enable them.
+**Enabling a pack reveals its skills** across the sidebar and HQ. That's a
+visibility switch (a per-browser preference), not a run switch — to actually put
+a skill on duty you still flip its own on/off toggle. Enabling is always
+per-skill.
 
 There are two kinds:
 
 - **First-party packs** — maintained in this repo. Defined as *data*, not
-  separate repos: a skill's pack is derived from its category. "Installing" a
-  first-party pack just enables its skills in `aeon.yml` — nothing is downloaded.
+  separate repos: a skill's pack is derived from its category. Enabling a
+  first-party pack just **reveals** its skills in the dashboard — nothing is
+  downloaded, and nothing runs until you turn individual skills on.
 - **Community packs** — maintained by others in external repos, listed in
   [`skill-packs.json`](../skill-packs.json) and installed with
   [`./install-skill-pack`](../install-skill-pack).
@@ -126,16 +129,19 @@ both manifests (CI enforces they're fresh).
 
 ## In the dashboard
 
+By default the dashboard shows only **Core** — its skills appear in the sidebar
+and HQ, and nothing else does. Enable packs to reveal more.
+
 The **Packs** view (`/api/packs`):
 
-- **Your packs** — first-party pack cards with live "X / Y on duty" counts.
-  Expand a card to see its skills and switch them **on individually** (an inline
-  toggle per skill), or hit **In sidebar →** to filter the left roster to that
-  pack and enable them in context. There is no bulk "enable pack" — a pack is a
-  lens, not a switch.
-- The **left sidebar** groups the roster by pack and defaults to showing only
-  enabled skills; pick a pack chip to reveal all of its skills (enabled or not)
-  so you can turn them on.
+- **Your packs** — a card per first-party pack. Hit **Enable pack** to reveal
+  that pack's skills across the sidebar and HQ (**Core** is always on). It's a
+  visibility toggle, stored per-browser, that never changes what runs. **View
+  skills** expands the card to list the pack's skills, each with its own on/off
+  toggle to actually put it on duty.
+- The **left sidebar** and **HQ** only show skills from enabled packs, grouped by
+  pack. The sidebar's **Enabled** chip is an optional filter (off by default)
+  that narrows the roster to skills on duty.
 - **Community packs** — browse the registry with author, trust level, required
   secrets/capabilities, and a copy-paste `./install-skill-pack <repo>` command.
 


### PR DESCRIPTION
## What & why

Corrects the pack UX to the intended mental model: **a pack is a visibility lens, not a bulk on-switch.**

- **By default you see only Core skills, everywhere** (sidebar + HQ).
- **Enabling a pack reveals its skills** across the dashboard. It changes what you *see*, not what *runs* — putting a skill on duty is still its own per-skill toggle (writes `aeon.yml`).
- The enabled-pack selection is a per-browser preference (`localStorage`); **Core is always on**.
- Also fixes the prior annoyance: the sidebar's **"Enabled-only" filter no longer defaults to on**.

## Changes

| File | Change |
|---|---|
| `app/page.tsx` | `enabledPacks` state (default `['core']`) + localStorage persistence + `togglePack`; derive `visibleSkills` (skills whose pack is enabled) and pass those to the sidebar + HQ so counts/rosters stay consistent |
| `components/LeftSidebar.tsx` | `enabledOnly` filter now defaults **off** |
| `components/PacksPanel.tsx` | per-pack **Enable / ✓ Enabled** toggle (Core = "Always on"); removed the "In sidebar →" lens jump; hero + stats reworded to the reveal model |
| `docs/skill-packs.md`, `README.md` | describe enabling a pack as a visibility switch |

## Verified live

- **Default:** sidebar + HQ show only Core (Team 13, 1 pack); "Enabled" filter off.
- **Enable Research:** its 26 skills appear in the sidebar + HQ (Team 39, 2 packs); "✓ Enabled" on the card.
- **Reload:** selection persists (localStorage).
- `tsc --noEmit` clean · `next build` clean · 125 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
