### PR TITLE
feat(dashboard): community installs land in an always-visible "Installed" pack

### DIFF
--- a/apps/dashboard/app/page.tsx
+++ b/apps/dashboard/app/page.tsx
@@ -160,9 +160,11 @@ export default function Dashboard() {
   // Derived from live `secrets` so it reacts the instant a key is saved or removed.
   const hasModelKey = secrets.some(s => s.isSet && AUTH_SECRETS.includes(s.name))
   // Skills visible across the dashboard = those in an enabled pack (Core always
-  // on). The sidebar + HQ render this; the Packs view keeps the full roster so
-  // you can enable more. Counts track what's visible, so the UI stays consistent.
-  const visibleSkills = skills.filter(s => enabledPacks.includes(s.pack || 'lab'))
+  // on), plus anything you installed from a community repo (the synthetic
+  // `installed` pack — you added it on purpose, so it's never hidden behind the
+  // pack lens). The sidebar + HQ render this; the Packs view keeps the full
+  // roster so you can enable more. Counts track what's visible for consistency.
+  const visibleSkills = skills.filter(s => s.pack === 'installed' || enabledPacks.includes(s.pack || 'lab'))
   const enabledCount = visibleSkills.filter(s => s.enabled).length
   const workingCount = runs.filter(r => r.status === 'in_progress').length
 

--- a/apps/dashboard/components/PacksPanel.tsx
+++ b/apps/dashboard/components/PacksPanel.tsx
@@ -57,7 +57,9 @@ export function PacksPanel({ firstParty, community, skills, enabledPacks, loadin
   // toggling a skill updates the counts here instantly. Hide declared-but-empty
   // packs (e.g. the Lab catch-all when nothing is unsorted).
   const enabledBySlug = new Map(skills.map(s => [s.name, s.enabled]))
-  const isPackOn = (key: string) => key === 'core' || enabledPacks.includes(key)
+  // Core and the synthetic `installed` pack are always shown (not togglable):
+  // Core is load-bearing, and installed skills are ones you added on purpose.
+  const isPackOn = (key: string) => key === 'core' || key === 'installed' || enabledPacks.includes(key)
   const visiblePacks = firstParty.filter(p => p.total > 0).map(p => {
     const members = p.skills.map(s => ({ ...s, enabled: enabledBySlug.get(s.slug) ?? false }))
     return { ...p, skills: members, enabled: members.filter(m => m.enabled).length }
@@ -114,6 +116,8 @@ export function PacksPanel({ firstParty, community, skills, enabledPacks, loadin
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-px bg-[rgba(250,250,250,0.10)] border border-[rgba(250,250,250,0.10)]">
           {visiblePacks.map(pack => {
             const isCore = pack.key === 'core'
+            const isInstalled = pack.key === 'installed'
+            const isLocked = isCore || isInstalled
             const on = isPackOn(pack.key)
             const open = expanded === pack.key
             return (
@@ -125,6 +129,7 @@ export function PacksPanel({ firstParty, community, skills, enabledPacks, loadin
                       <div className="flex items-center gap-2">
                         <span className="font-display uppercase tracking-wide text-aeon-fg text-base leading-tight">{pack.name}</span>
                         {isCore && <span className="text-[9px] font-mono uppercase tracking-[0.14em] px-1.5 py-0.5 border border-aeon-red/40 text-aeon-red">core</span>}
+                        {isInstalled && <span className="text-[9px] font-mono uppercase tracking-[0.14em] px-1.5 py-0.5 border border-primary-40 text-primary-70">installed</span>}
                       </div>
                       <div className="text-[11px] text-primary-40 font-mono mt-1 uppercase tracking-[0.14em]">
                         {pack.total} skill{pack.total === 1 ? '' : 's'}
@@ -137,11 +142,11 @@ export function PacksPanel({ firstParty, community, skills, enabledPacks, loadin
                   <div className="mt-auto flex items-center gap-2 pt-2">
                     <button
                       onClick={() => onTogglePack(pack.key)}
-                      disabled={isCore}
-                      title={isCore ? 'Core is always shown' : on ? 'Hide this pack’s skills from the dashboard' : 'Reveal this pack’s skills across the sidebar and HQ'}
+                      disabled={isLocked}
+                      title={isInstalled ? 'Skills you installed are always shown' : isCore ? 'Core is always shown' : on ? 'Hide this pack’s skills from the dashboard' : 'Reveal this pack’s skills across the sidebar and HQ'}
                       className={`text-[10px] font-mono uppercase tracking-[0.14em] px-3 py-1.5 border transition-colors cursor-target disabled:cursor-default ${on ? 'text-eva-green border-eva-green/50 bg-eva-green/10' : 'text-primary-50 border-[rgba(250,250,250,0.18)] hover:text-primary-100 hover:border-[rgba(250,250,250,0.3)]'}`}
                     >
-                      {isCore ? 'Always on' : on ? '✓ Enabled' : 'Enable pack'}
+                      {isLocked ? 'Always on' : on ? '✓ Enabled' : 'Enable pack'}
                     </button>
                     <button
                       onClick={() => setExpanded(open ? null : pack.key)}

--- a/apps/dashboard/lib/constants.ts
+++ b/apps/dashboard/lib/constants.ts
@@ -44,6 +44,9 @@ export const CATEGORY_BY_KEY: Record<string, { label: string; color: string }> =
 // /api/skills); `lab` is the catch-all for uncategorized skills.
 export const PACKS: { key: string; label: string; short: string; color: string }[] = [
   { key: 'core',         label: 'Core',                  short: 'Core',         color: '#E5484D' },
+  // Skills installed from community repos (skills.lock). Synthetic pack emitted
+  // by generate-packs-json; always visible, never hidden behind the pack lens.
+  { key: 'installed',    label: 'Installed',             short: 'Installed',    color: '#A1A1AA' },
   { key: 'fleet',        label: 'Fleet & Replication',   short: 'Fleet',        color: '#30A46C' },
   { key: 'research',     label: 'Research & Content',     short: 'Research',     color: '#8B5CF6' },
   { key: 'dev',          label: 'Dev & Code',             short: 'Dev',          color: '#3B82F6' },

--- a/generate-packs-json
+++ b/generate-packs-json
@@ -79,6 +79,27 @@ if unassigned:
     for slug in unassigned:
         assigned[slug] = catch_all
 
+# 5) community installs override everything above. Anything recorded in
+# skills.lock was deliberately installed from another repo — it must NOT be
+# folded into a first-party category pack (where the Core-only visibility lens
+# would hide it). Pull it into a synthetic, always-visible "installed" pack so
+# the dashboard surfaces it as yours. Runs LAST so it overrides whatever
+# first-party pack claimed the slug by category. No skills.lock (the upstream
+# case) → no override → packs.json is byte-identical to before.
+installed_src = {}  # slug -> source_repo
+lock_path = os.path.join(root, "skills.lock")
+if os.path.exists(lock_path):
+    try:
+        with open(lock_path) as f:
+            lock = json.load(f)
+    except (ValueError, OSError):
+        lock = []
+    for rec in lock or []:
+        slug = rec.get("skill_name")
+        if slug in skills:
+            installed_src[slug] = rec.get("source_repo", "")
+            assigned[slug] = "installed"
+
 def skill_entry(slug):
     s = skills[slug]
     return {"slug": slug, "name": s["name"],
@@ -98,6 +119,24 @@ out_packs = [pack_out("core", core["name"], core["description"], core["color"],
 for p in config["packs"]:
     out_packs.append(pack_out(p["key"], p["name"], p["description"], p["color"],
                               p.get("category"), p.get("default_enabled", [])))
+
+# Append the synthetic "installed" pack only when something was installed, so
+# the upstream manifest (no skills.lock) is unchanged. Each entry carries its
+# source_repo so the dashboard can show where it came from.
+if installed_src:
+    inst_skills = []
+    for sl in members("installed"):
+        e = skill_entry(sl)
+        e["source_repo"] = installed_src.get(sl, "")
+        inst_skills.append(e)
+    out_packs.append({
+        "key": "installed", "name": "Installed",
+        "description": "Skills you installed from community repos (recorded in "
+                       "skills.lock). Always shown; never folded into a "
+                       "first-party pack.",
+        "color": "#A1A1AA", "category": None, "kind": "community",
+        "default_enabled": [], "skills": inst_skills,
+    })
 
 result = {
     "version": "1.0",


### PR DESCRIPTION
## Why

Following the install-visibility thread: even once an installed community skill reaches `main`, it was still invisible. The catalog generators assign **every** skill to a first-party pack by its `category:` frontmatter — the AntFleet skills declare `category: dev`, so they got folded into the built-in **Dev** pack and stamped `kind: "first-party"`. The dashboard then hides them behind its Core-only visibility lens until you manually enable Dev.

That's wrong: **you installed them on purpose — they should show.** Their real identity (`source_repo`, the community pack name) lived only in `skills.lock`, which the visibility filter never read.

## What

Treat anything in `skills.lock` as a deliberate install and surface it as yours, in its own always-visible group.

- **`generate-packs-json`** — read `skills.lock` and pull installed skills **out** of their first-party pack into a synthetic **`installed`** pack (`kind: "community"`), each entry carrying its `source_repo`. Runs *last*, so it overrides category assignment. **Emitted only when `skills.lock` has entries** — upstream (no `skills.lock`) produces a byte-identical `packs.json`, so nothing changes for first-party-only forks.
- **dashboard** — add `installed` to the `PACKS` list; make it **always visible** like Core (never hidden behind the pack lens) and **locked-on** in the Packs view (with an `installed` badge).

```
SIDEBAR (default)
  Core
    heartbeat   on duty
  Installed
    pr-review-antfleet       off
    pr-review-antfleet-x402  off
  + enable more packs →
```

## Verification

- Injected a synthetic `skills.lock` → the named skills move into **Installed** (carrying `source_repo`) and disappear from `research`/`dev`; removing it restores the 10-pack manifest. `packs.json` on this branch is unchanged (no `skills.lock` upstream).
- `tsc --noEmit` clean; **125/125** dashboard tests pass.

## Note

This groups all installs under one "Installed" header (simple + matches the static pack-rendering model). Per-source sub-grouping (e.g. "Installed · AntFleet PR Review") is a possible follow-up — `source_repo` is already in the manifest for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)