### PR TITLE
fix(install): install-skill-pack regenerates packs.json so installs aren't invisible

### DIFF
--- a/install-skill-pack
+++ b/install-skill-pack
@@ -805,6 +805,24 @@ else
 fi
 
 if [[ "$DRY_RUN" == "false" ]] && [[ $INSTALLED -gt 0 ]]; then
+  # Deterministically regenerate the catalog so it can never go stale on the
+  # caller. The incremental update_skills_json above is a fast path; this is the
+  # source of truth. Critically it refreshes packs.json — generate-packs-json
+  # reads skills.lock (written above) and routes the new skills into the
+  # synthetic "installed" pack the dashboard surfaces. Leaving this to a caller's
+  # follow-up command is exactly how an install lands skills.json-but-not-
+  # packs.json and the skill never appears. Best-effort: warn, don't abort.
+  if [[ -x "$ROOT_DIR/generate-skills-json" ]]; then
+    "$ROOT_DIR/generate-skills-json" >/dev/null 2>&1 \
+      && echo "  catalog: skills.json regenerated" \
+      || echo "  warning: skills.json regen failed — run ./generate-skills-json"
+  fi
+  if [[ -x "$ROOT_DIR/generate-packs-json" ]] && command -v python3 >/dev/null 2>&1; then
+    "$ROOT_DIR/generate-packs-json" >/dev/null 2>&1 \
+      && echo "  catalog: packs.json regenerated (installed pack)" \
+      || echo "  warning: packs.json regen failed — run ./generate-packs-json"
+  fi
+
   echo ""
   echo "Enable skills in aeon.yml to schedule them, or run manually:"
   echo "  Read skills/<name>/SKILL.md and execute its steps."

--- a/skills/install-skill/SKILL.md
+++ b/skills/install-skill/SKILL.md
@@ -58,13 +58,13 @@ Your job is to drive that script, regenerate the catalog, and wrap the result in
    ```
    Read the output. Note: how many installed, how many were **skipped/blocked** by the security scan, any **`secrets_required`** warnings, and any declared **capabilities**. Trusted sources will say "skipping deep security scan". If everything was blocked and nothing installed, exit `INSTALL_SKILL_BLOCKED`, notify the operator that the source tripped HIGH-severity findings and that they can review and re-run `./install-skill-pack ${var} --force` from a local clone if they trust it. Then stop.
 
-5. **Regenerate the catalog** so the dashboard and packs view pick up the new skills:
+5. **Confirm the catalog regenerated.** `./install-skill-pack` already regenerates **both** `skills.json` and `packs.json` at the end of a successful install — `packs.json` is what routes the new skills into the dashboard's always-visible **Installed** pack, so it must not be skipped. Re-run them yourself only as a safety net (idempotent), and verify both files actually changed before committing — a `skills.json` bump without a matching `packs.json` bump means the skill will be invisible:
    ```bash
-   ./generate-skills-json
-   ./generate-packs-json
+   ./generate-skills-json && ./generate-packs-json
+   git status --short skills.json packs.json   # both should be listed
    ```
 
-6. **Commit, open a PR, and auto-merge it** — never push to `main` directly; the PR is the audit trail and CI gate. Stage the installed skill dirs plus the touched manifests (`aeon.yml`, `skills.json`, `skills.lock`, `packs.json`), commit, push the branch, then open the PR and capture its URL:
+6. **Commit, open a PR, and auto-merge it** — never push to `main` directly; the PR is the audit trail and CI gate. Stage **all** install changes so no manifest is missed — `git add -A` (the install touched only skill dirs + `aeon.yml`, `skills.json`, `skills.lock`, `packs.json`), commit, push the branch, then open the PR and capture its URL:
    ```bash
    PR_URL=$(gh pr create --title "feat: install ${REPO_NAME} community pack" --body "$(cat <<'BODY'
    Installs the **<pack name>** community pack from `${var}` (clicked from the dashboard). Auto-merges once mergeable — skills land **disabled**, so nothing runs until enabled.


### PR DESCRIPTION
## Why

Even with the Installed-pack support merged (#486), a real install on a fresh fork (`aeonb`) still left the skill **invisible**. The skills landed in `skills.json` (185) + `skills.lock`, the install PR auto-merged — but **`packs.json` was never regenerated** (stuck at the pre-install 183, no `installed` pack). PR #1's filelist confirms it: `aeon.yml`, `skills.json`, `skills.lock`, skill dirs — **no `packs.json`**.

Root cause: `install-skill-pack` only updates `skills.json` incrementally; regenerating `packs.json` was delegated to the `install-skill` *agent's* step 5, which it skipped — and nothing staged `packs.json`, so it never committed. Correctness hung on the agent running two generators and staging four files. Fragile.

## What

Make catalog regeneration **deterministic in the script**, not agent-dependent:

- **`install-skill-pack`** — after a successful install, regenerate **both** `skills.json` and `packs.json` itself (best-effort; warns, never aborts). `generate-packs-json` reads `skills.lock` and routes the new skills into the always-visible **Installed** pack — so `packs.json` can't go stale on the caller.
- **`install-skill` SKILL.md** — step 5 now *verifies* both manifests changed (a `skills.json` bump without a matching `packs.json` bump = invisible skill); step 6 stages with `git add -A` so no manifest is ever missed.

## Verification

- On a clone of the affected fork, running its own `generate-packs-json` produced `packs.json` with **11 packs / 185 skills** including the `installed` pack (both AntFleet skills + `source_repo`). The mechanism was always correct — it just wasn't being run.
- `bash -n` clean; both generators run clean; this PR touches only the 2 script/skill files (no catalog churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)