### PR TITLE
feat(mcp-catalog): add Robinhood Agentic Trading MCP

### DIFF
--- a/apps/dashboard/lib/mcp-catalog.ts
+++ b/apps/dashboard/lib/mcp-catalog.ts
@@ -40,6 +40,13 @@ export const MCP_CATALOG: McpCatalogEntry[] = [
     logo: 'https://pbs.twimg.com/profile_images/2047719472455438336/CFrEyoNZ_400x400.jpg',
     description: 'BlueAgent - the AI founder console for Base builders: idea, build, audit, ship, and raise, from concept to deployment.',
   },
+  {
+    slug: 'robinhood-trading',
+    name: 'Robinhood Trading',
+    url: 'https://agent.robinhood.com/mcp/trading',
+    logo: 'https://pbs.twimg.com/profile_images/1844399977482813442/1fTlYz2c_400x400.png',
+    description: 'Robinhood Agentic Trading - read your portfolio, buying power, positions, and order history, and place trades from your agent. Remote HTTP MCP with OAuth; trades execute in a dedicated Agentic brokerage account you authorize. You are responsible for every order your agent places.',
+  },
 ]
 
 export const MCP_BY_SLUG: Record<string, McpCatalogEntry> =


### PR DESCRIPTION
Adds **Robinhood Trading** to the dashboard's MCP catalog (`apps/dashboard/lib/mcp-catalog.ts`) — the shared source for the MCP page's Featured installs and the per-skill MCP requirement panel.

- **URL:** `https://agent.robinhood.com/mcp/trading` (remote HTTP, OAuth — no API-key secret)
- **What it does:** read access to portfolio, buying power, positions, and order history; can place trades in a dedicated Robinhood Agentic account the user authorizes.
- Same entry shape as the existing remote-HTTP servers (Base, Ctrl, RootAI, BlueAgent); logo is Robinhood's verified X profile image.

The description flags that trades execute on the user's behalf and they're responsible for every order — consistent with Robinhood's own agentic-trading disclosures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)