### PR TITLE
fix(dashboard): render installed community packs in the roster (data-driven groups)

### DIFF
--- a/apps/dashboard/app/api/skills/route.ts
+++ b/apps/dashboard/app/api/skills/route.ts
@@ -43,13 +43,18 @@ export async function GET() {
       for (const s of catalog.skills ?? []) categoryBySlug[s.slug] = s.category
     } catch { /* catalog optional - categories default to meta */ }
 
-    // Canonical slug → pack map from packs.json (the grouping the UI uses).
-    // Falls back to 'lab' (the catch-all) for any skill not yet in a pack.
+    // Canonical slug → pack (key + display name) map from packs.json (the
+    // grouping the UI uses). The name lets the roster label community packs
+    // (installed from another repo) by their real name. Falls back to 'lab'.
     const packBySlug: Record<string, string> = {}
+    const packNameBySlug: Record<string, string> = {}
     try {
       const { content: packsRaw } = await getFileContent('packs.json')
-      const packs = JSON.parse(packsRaw) as { packs?: Array<{ key: string; skills?: Array<{ slug: string }> }> }
-      for (const p of packs.packs ?? []) for (const s of p.skills ?? []) packBySlug[s.slug] = p.key
+      const packs = JSON.parse(packsRaw) as { packs?: Array<{ key: string; name?: string; skills?: Array<{ slug: string }> }> }
+      for (const p of packs.packs ?? []) for (const s of p.skills ?? []) {
+        packBySlug[s.slug] = p.key
+        packNameBySlug[s.slug] = p.name ?? p.key
+      }
     } catch { /* packs.json optional - packs default to lab */ }
 
     const meta = await Promise.all(
@@ -75,6 +80,7 @@ export async function GET() {
         mcp: m.mcp,
         category: categoryBySlug[m.name] || 'meta',
         pack: packBySlug[m.name] || 'lab',
+        packName: packNameBySlug[m.name] || '',
         enabled: config.skills[m.name]?.enabled ?? false,
         schedule: config.skills[m.name]?.schedule || '0 12 * * *',
         var: config.skills[m.name]?.var || '',

--- a/apps/dashboard/app/page.tsx
+++ b/apps/dashboard/app/page.tsx
@@ -8,7 +8,7 @@ import type {
   UploadResponse, ErrorResponse, PacksResponse,
 } from '../lib/types'
 import { postJson, putJson, patchJson, del, scheduleRunRefresh } from '../lib/api-client'
-import { MODELS, AUTH_SECRETS, PACK_BY_KEY } from '../lib/constants'
+import { MODELS, AUTH_SECRETS, PACK_BY_KEY, FIRST_PARTY_KEYS } from '../lib/constants'
 import { displayName } from '../lib/utils'
 import TargetCursor from '../components/ui/TargetCursor'
 import { LoadingScreen } from '../components/LoadingScreen'
@@ -159,12 +159,16 @@ export default function Dashboard() {
   // Any model/provider key set means Aeon can authenticate - the "Auth" CTA hides.
   // Derived from live `secrets` so it reacts the instant a key is saved or removed.
   const hasModelKey = secrets.some(s => s.isSet && AUTH_SECRETS.includes(s.name))
-  // Skills visible across the dashboard = those in an enabled pack (Core always
-  // on), plus anything you installed from a community repo (the synthetic
-  // `installed` pack — you added it on purpose, so it's never hidden behind the
-  // pack lens). The sidebar + HQ render this; the Packs view keeps the full
-  // roster so you can enable more. Counts track what's visible for consistency.
-  const visibleSkills = skills.filter(s => s.pack === 'installed' || enabledPacks.includes(s.pack || 'lab'))
+  // Skills visible across the dashboard = first-party skills whose pack is
+  // enabled (Core always on), PLUS every community skill — anything in a pack
+  // that isn't first-party was installed from another repo on purpose, so it's
+  // never hidden behind the pack lens regardless of its pack key (`installed`,
+  // or a per-source pack like `antfleet-pr-review`). The sidebar + HQ render
+  // this; the Packs view keeps the full roster so you can enable more.
+  const visibleSkills = skills.filter(s => {
+    const k = s.pack || 'lab'
+    return FIRST_PARTY_KEYS.has(k) ? enabledPacks.includes(k) : true
+  })
   const enabledCount = visibleSkills.filter(s => s.enabled).length
   const workingCount = runs.filter(r => r.status === 'in_progress').length
 

--- a/apps/dashboard/components/HQOverview.tsx
+++ b/apps/dashboard/components/HQOverview.tsx
@@ -2,7 +2,7 @@
 
 import { useRef } from 'react'
 import type { Skill, Run } from '../lib/types'
-import { PACKS } from '../lib/constants'
+import { packGroups } from '../lib/constants'
 import { timeAgo } from '../lib/utils'
 import { Scramble, Flip, VelocityMarquee } from './ui/Animated'
 
@@ -40,7 +40,7 @@ export function HQOverview({ skills, runs, enabledCount, workingCount, categoryF
     card.style.setProperty('--my', `${e.clientY - r.top}px`)
   }
 
-  const cats = PACKS
+  const cats = packGroups(skills)
     .map(c => ({ ...c, skills: skills.filter(s => (s.pack || 'lab') === c.key) }))
     .filter(c => c.skills.length)
 

--- a/apps/dashboard/components/LeftSidebar.tsx
+++ b/apps/dashboard/components/LeftSidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import type { Skill, Run, Secret } from '../lib/types'
-import { PACKS } from '../lib/constants'
+import { packGroups } from '../lib/constants'
 import { displayName, initials, getSkillStatus, statusDot } from '../lib/utils'
 
 interface LeftSidebarProps {
@@ -127,8 +127,7 @@ export function LeftSidebar({ view, setView, selectedSkill, skills, runs, secret
             <span className="w-1.5 h-1.5 rounded-full shrink-0 bg-eva-amber" />
             Available
           </button>
-          {PACKS.map(cat => {
-            if (!skills.some(s => (s.pack || 'lab') === cat.key)) return null
+          {packGroups(skills).map(cat => {
             const active = categoryFilter === cat.key
             return (
               <button
@@ -145,7 +144,7 @@ export function LeftSidebar({ view, setView, selectedSkill, skills, runs, secret
           })}
         </div>
 
-        {PACKS.map(cat => {
+        {packGroups(skills).map(cat => {
           if (categoryFilter && cat.key !== categoryFilter) return null
           const catSkills = skills.filter(s => (s.pack || 'lab') === cat.key)
           if (!catSkills.length) return null

--- a/apps/dashboard/components/PacksPanel.tsx
+++ b/apps/dashboard/components/PacksPanel.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import type { Pack, CommunityPack, Skill } from '../lib/types'
 import { displayName } from '../lib/utils'
+import { FIRST_PARTY_KEYS } from '../lib/constants'
 
 interface PacksPanelProps {
   firstParty: Pack[]
@@ -57,9 +58,10 @@ export function PacksPanel({ firstParty, community, skills, enabledPacks, loadin
   // toggling a skill updates the counts here instantly. Hide declared-but-empty
   // packs (e.g. the Lab catch-all when nothing is unsorted).
   const enabledBySlug = new Map(skills.map(s => [s.name, s.enabled]))
-  // Core and the synthetic `installed` pack are always shown (not togglable):
-  // Core is load-bearing, and installed skills are ones you added on purpose.
-  const isPackOn = (key: string) => key === 'core' || key === 'installed' || enabledPacks.includes(key)
+  // Core and community packs (anything not first-party — installed from another
+  // repo) are always shown, not togglable: Core is load-bearing, and community
+  // skills are ones you added on purpose.
+  const isPackOn = (key: string) => key === 'core' || !FIRST_PARTY_KEYS.has(key) || enabledPacks.includes(key)
   const visiblePacks = firstParty.filter(p => p.total > 0).map(p => {
     const members = p.skills.map(s => ({ ...s, enabled: enabledBySlug.get(s.slug) ?? false }))
     return { ...p, skills: members, enabled: members.filter(m => m.enabled).length }
@@ -116,8 +118,8 @@ export function PacksPanel({ firstParty, community, skills, enabledPacks, loadin
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-px bg-[rgba(250,250,250,0.10)] border border-[rgba(250,250,250,0.10)]">
           {visiblePacks.map(pack => {
             const isCore = pack.key === 'core'
-            const isInstalled = pack.key === 'installed'
-            const isLocked = isCore || isInstalled
+            const isCommunity = !FIRST_PARTY_KEYS.has(pack.key)
+            const isLocked = isCore || isCommunity
             const on = isPackOn(pack.key)
             const open = expanded === pack.key
             return (
@@ -129,7 +131,7 @@ export function PacksPanel({ firstParty, community, skills, enabledPacks, loadin
                       <div className="flex items-center gap-2">
                         <span className="font-display uppercase tracking-wide text-aeon-fg text-base leading-tight">{pack.name}</span>
                         {isCore && <span className="text-[9px] font-mono uppercase tracking-[0.14em] px-1.5 py-0.5 border border-aeon-red/40 text-aeon-red">core</span>}
-                        {isInstalled && <span className="text-[9px] font-mono uppercase tracking-[0.14em] px-1.5 py-0.5 border border-primary-40 text-primary-70">installed</span>}
+                        {isCommunity && <span className="text-[9px] font-mono uppercase tracking-[0.14em] px-1.5 py-0.5 border border-primary-40 text-primary-70">installed</span>}
                       </div>
                       <div className="text-[11px] text-primary-40 font-mono mt-1 uppercase tracking-[0.14em]">
                         {pack.total} skill{pack.total === 1 ? '' : 's'}
@@ -143,7 +145,7 @@ export function PacksPanel({ firstParty, community, skills, enabledPacks, loadin
                     <button
                       onClick={() => onTogglePack(pack.key)}
                       disabled={isLocked}
-                      title={isInstalled ? 'Skills you installed are always shown' : isCore ? 'Core is always shown' : on ? 'Hide this pack’s skills from the dashboard' : 'Reveal this pack’s skills across the sidebar and HQ'}
+                      title={isCommunity ? 'Skills you installed are always shown' : isCore ? 'Core is always shown' : on ? 'Hide this pack’s skills from the dashboard' : 'Reveal this pack’s skills across the sidebar and HQ'}
                       className={`text-[10px] font-mono uppercase tracking-[0.14em] px-3 py-1.5 border transition-colors cursor-target disabled:cursor-default ${on ? 'text-eva-green border-eva-green/50 bg-eva-green/10' : 'text-primary-50 border-[rgba(250,250,250,0.18)] hover:text-primary-100 hover:border-[rgba(250,250,250,0.3)]'}`}
                     >
                       {isLocked ? 'Always on' : on ? '✓ Enabled' : 'Enable pack'}

--- a/apps/dashboard/lib/constants.test.ts
+++ b/apps/dashboard/lib/constants.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Tests for apps/dashboard/lib/constants.ts - the data-driven pack grouping that
+ * keeps installed community skills visible in the roster (regression: a skill in
+ * a community pack like `antfleet-pr-review` used to vanish because the roster
+ * iterated a hardcoded pack list).
+ *
+ * Run with:  node --import tsx --test apps/dashboard/lib/constants.test.ts
+ */
+import { describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+
+import { packGroups, FIRST_PARTY_KEYS } from "./constants";
+
+const sk = (name: string, pack: string, packName = "") => ({ pack, packName });
+
+describe("packGroups", () => {
+  it("orders Core first, then community, then the rest of first-party", () => {
+    const groups = packGroups([
+      sk("heartbeat", "core"),
+      sk("pr-review", "dev"),
+      sk("pr-review-antfleet", "antfleet-pr-review", "AntFleet PR Review"),
+    ]);
+    assert.deepEqual(groups.map(g => g.key), ["core", "antfleet-pr-review", "dev"]);
+  });
+
+  it("labels a community pack by its joined packName, marked community", () => {
+    const [g] = packGroups([sk("x", "antfleet-pr-review", "AntFleet PR Review")]);
+    assert.equal(g.key, "antfleet-pr-review");
+    assert.equal(g.label, "AntFleet PR Review");
+    assert.equal(g.community, true);
+    assert.equal(FIRST_PARTY_KEYS.has("antfleet-pr-review"), false);
+  });
+
+  it("falls back to the pack key when no packName is joined", () => {
+    const [g] = packGroups([sk("x", "some-pack")]);
+    assert.equal(g.label, "some-pack");
+    assert.equal(g.community, true);
+  });
+
+  it("treats every first-party pack as non-community", () => {
+    const groups = packGroups([sk("a", "dev"), sk("b", "research"), sk("c", "lab")]);
+    assert.ok(groups.every(g => g.community === false));
+  });
+
+  it("only emits packs that actually contain skills", () => {
+    const groups = packGroups([sk("a", "core")]);
+    assert.deepEqual(groups.map(g => g.key), ["core"]);
+  });
+
+  it("defaults a missing pack to the lab catch-all", () => {
+    const groups = packGroups([{ pack: "", packName: "" }]);
+    assert.deepEqual(groups.map(g => g.key), ["lab"]);
+  });
+});

--- a/apps/dashboard/lib/constants.ts
+++ b/apps/dashboard/lib/constants.ts
@@ -44,9 +44,6 @@ export const CATEGORY_BY_KEY: Record<string, { label: string; color: string }> =
 // /api/skills); `lab` is the catch-all for uncategorized skills.
 export const PACKS: { key: string; label: string; short: string; color: string }[] = [
   { key: 'core',         label: 'Core',                  short: 'Core',         color: '#E5484D' },
-  // Skills installed from community repos (skills.lock). Synthetic pack emitted
-  // by generate-packs-json; always visible, never hidden behind the pack lens.
-  { key: 'installed',    label: 'Installed',             short: 'Installed',    color: '#A1A1AA' },
   { key: 'fleet',        label: 'Fleet & Replication',   short: 'Fleet',        color: '#30A46C' },
   { key: 'research',     label: 'Research & Content',     short: 'Research',     color: '#8B5CF6' },
   { key: 'dev',          label: 'Dev & Code',             short: 'Dev',          color: '#3B82F6' },
@@ -60,3 +57,38 @@ export const PACKS: { key: string; label: string; short: string; color: string }
 
 export const PACK_BY_KEY: Record<string, { label: string; color: string }> =
   Object.fromEntries(PACKS.map(p => [p.key, { label: p.label, color: p.color }]))
+
+// The fixed set of first-party pack keys. Any pack key NOT in here is a
+// community pack (installed from another repo — see generate-packs-json's
+// `installed` pack and install-skill's per-source community packs). Community
+// packs are always shown; the Core-only visibility lens only governs
+// first-party packs.
+export const FIRST_PARTY_KEYS = new Set(PACKS.map(p => p.key))
+
+const COMMUNITY_COLOR = '#A1A1AA'
+
+export interface PackGroup { key: string; label: string; short: string; color: string; community: boolean }
+
+// Build the ordered roster/HQ group list from whatever packs the given skills
+// actually belong to — driven by data, not a hardcoded list, so a skill in a
+// community pack (`installed`, or a per-source pack like `antfleet-pr-review`)
+// renders instead of vanishing. Order: Core, then community packs (the things
+// you installed, surfaced up top), then the rest of the first-party packs.
+// Community labels come from the skill's joined `packName` (falling back to the
+// key). Only packs that actually contain skills appear.
+export function packGroups(skills: { pack?: string; packName?: string }[]): PackGroup[] {
+  const present = new Set(skills.map(s => s.pack || 'lab'))
+  const firstParty = PACKS.filter(p => present.has(p.key))
+    .map(p => ({ key: p.key, label: p.label, short: p.short, color: p.color, community: false }))
+  const core = firstParty.filter(g => g.key === 'core')
+  const restFirstParty = firstParty.filter(g => g.key !== 'core')
+  const community = [...present]
+    .filter(k => !FIRST_PARTY_KEYS.has(k))
+    .sort()
+    .map(k => {
+      const named = skills.find(s => (s.pack || 'lab') === k && s.packName)
+      const label = named?.packName || k
+      return { key: k, label, short: label, color: COMMUNITY_COLOR, community: true }
+    })
+  return [...core, ...community, ...restFirstParty]
+}

--- a/apps/dashboard/lib/types.ts
+++ b/apps/dashboard/lib/types.ts
@@ -2,7 +2,7 @@ import { GATEWAY_SLUGS, type GatewaySlug } from './gateway-registry'
 
 export interface SkillKeyRef { key: string; optional: boolean }
 export interface SkillMcpRef { slug: string; optional: boolean }
-export interface Skill { name: string; description: string; tags: string[]; category: string; pack: string; enabled: boolean; schedule: string; var: string; model: string; requires: SkillKeyRef[]; mcp: SkillMcpRef[] }
+export interface Skill { name: string; description: string; tags: string[]; category: string; pack: string; packName: string; enabled: boolean; schedule: string; var: string; model: string; requires: SkillKeyRef[]; mcp: SkillMcpRef[] }
 export interface Run { id: number; workflow: string; status: string; conclusion: string | null; created_at: string; url: string }
 
 // --- Skill packs ---


### PR DESCRIPTION
## Why

Installing an external skill *still* left it invisible in the bottom-left roster, and it required "turning the pack on" — even after #486. Root cause, traced on a fresh fork: a real install tags the new skills with an **arbitrary community-pack key** (e.g. `antfleet-pr-review`, written into `packs.json` with `kind: "community"` + the pack's manifest name). But the dashboard's roster (`LeftSidebar`) and HQ grouped skills off a **hardcoded `PACKS` list**, and the visibility filter only special-cased the literal `installed` key. So a skill in `antfleet-pr-review` rendered **nowhere** and wasn't treated as always-visible.

## What

Make pack grouping **data-driven** instead of a fixed list:

- **`constants.ts`** — `FIRST_PARTY_KEYS` (the fixed pack set) + a `packGroups()` helper that builds the ordered group list from whatever packs the skills actually belong to: **Core → community packs → rest of first-party**. Any pack key not in `FIRST_PARTY_KEYS` is community → always shown, labeled by its real name.
- **`api/skills` + `types`** — join each skill's pack display name (`packName`) from `packs.json`, so a community group shows **"AntFleet PR Review"**, not a raw key.
- **`page.tsx`** — a skill is visible if its first-party pack is enabled **or** it's in any non-first-party (community) pack. Community installs are never hidden by the Core-only lens, regardless of pack key.
- **`LeftSidebar` / `HQOverview`** — render via `packGroups()`. **`PacksPanel`** — lock *every* community pack as always-on (not just `installed`).

This is robust to *how* the install names the pack (`installed`, `antfleet-pr-review`, anything) — if it's not first-party, it shows.

## Verification
- New `constants.test.ts` covers the regression (community pack visible, labeled, ordered after Core). **131/131** dashboard tests pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)