### PR TITLE
fix(dashboard): forward pack `path` as --path on install + copy command

### DIFF
--- a/apps/dashboard/app/page.tsx
+++ b/apps/dashboard/app/page.tsx
@@ -228,7 +228,7 @@ export default function Dashboard() {
             <HQOverview skills={visibleSkills} runs={runs} enabledCount={enabledCount} workingCount={workingCount} categoryFilter={categoryFilter} onCategoryClick={(key) => setCategoryFilter(categoryFilter === key ? null : key)} onViewRun={() => {}} onOpenPacks={() => setView('packs')} />
           )}
           {view === 'packs' && !selectedSkill && (
-            <PacksPanel firstParty={packs?.firstParty ?? []} community={packs?.community ?? []} skills={skills} enabledPacks={enabledPacks} loading={!packsLoaded} busy={busy} onTogglePack={togglePack} onToggleSkill={toggleSkill} onSelectSkill={(name) => { setSelectedSkill(name); setView('hq') }} onInstallPack={(repo) => runSkill('install-skill', repo)} />
+            <PacksPanel firstParty={packs?.firstParty ?? []} community={packs?.community ?? []} skills={skills} enabledPacks={enabledPacks} loading={!packsLoaded} busy={busy} onTogglePack={togglePack} onToggleSkill={toggleSkill} onSelectSkill={(name) => { setSelectedSkill(name); setView('hq') }} onInstallPack={(arg) => runSkill('install-skill', arg)} />
           )}
           {skill && (
             <SkillDetail

--- a/apps/dashboard/components/PacksPanel.tsx
+++ b/apps/dashboard/components/PacksPanel.tsx
@@ -15,7 +15,14 @@ interface PacksPanelProps {
   onTogglePack: (key: string) => void
   onToggleSkill: (slug: string, enabled: boolean) => void
   onSelectSkill: (slug: string) => void
-  onInstallPack: (repo: string) => Promise<void> | void
+  onInstallPack: (arg: string) => Promise<void> | void
+}
+
+// A pack's skills can live in a subdirectory of its repo (declared via `path` in
+// skill-packs.json). Forward it as a `--path` flag so both the one-click install
+// and the copyable command point the installer at the right manifest. See #492.
+function installArg(pack: CommunityPack): string {
+  return pack.path ? `${pack.repo} --path ${pack.path}` : pack.repo
 }
 
 function Section({ index, label, children }: { index: string; label: string; children: React.ReactNode }) {
@@ -41,17 +48,17 @@ export function PacksPanel({ firstParty, community, skills, enabledPacks, loadin
   const [copied, setCopied] = useState<string | null>(null)
   const [installing, setInstalling] = useState<string | null>(null)
 
-  const handleCopy = async (repo: string) => {
+  const handleCopy = async (pack: CommunityPack) => {
     try {
-      await navigator.clipboard.writeText(`./install-skill-pack ${repo}`)
-      setCopied(repo)
-      setTimeout(() => setCopied(c => (c === repo ? null : c)), 1500)
+      await navigator.clipboard.writeText(`./install-skill-pack ${installArg(pack)}`)
+      setCopied(pack.repo)
+      setTimeout(() => setCopied(c => (c === pack.repo ? null : c)), 1500)
     } catch { /* clipboard blocked — the command is still shown in the tooltip */ }
   }
 
-  const handleInstall = async (repo: string) => {
-    setInstalling(repo)
-    try { await onInstallPack(repo) } finally { setInstalling(null) }
+  const handleInstall = async (pack: CommunityPack) => {
+    setInstalling(pack.repo)
+    try { await onInstallPack(installArg(pack)) } finally { setInstalling(null) }
   }
 
   // Live enabled state comes from the skills roster (single source of truth), so
@@ -222,7 +229,7 @@ export function PacksPanel({ firstParty, community, skills, enabledPacks, loadin
                 ) : null}
                 <div className="mt-auto flex items-center gap-2 pt-2">
                   <button
-                    onClick={() => handleInstall(pack.repo)}
+                    onClick={() => handleInstall(pack)}
                     disabled={installing === pack.repo}
                     title={`Install into your fork — runs the install-skill skill (security-scanned) and opens a PR for review. Skills land disabled.`}
                     className="flex-1 text-[10px] font-mono uppercase tracking-[0.14em] px-3 py-1.5 border transition-colors cursor-target text-aeon-fg border-[rgba(250,250,250,0.25)] hover:border-aeon-red hover:text-aeon-red disabled:opacity-50 disabled:cursor-default"
@@ -230,8 +237,8 @@ export function PacksPanel({ firstParty, community, skills, enabledPacks, loadin
                     {installing === pack.repo ? 'Installing…' : installed ? 'Reinstall' : 'Install pack'}
                   </button>
                   <button
-                    onClick={() => handleCopy(pack.repo)}
-                    title={`Copy: ./install-skill-pack ${pack.repo}`}
+                    onClick={() => handleCopy(pack)}
+                    title={`Copy: ./install-skill-pack ${installArg(pack)}`}
                     className="shrink-0 px-2 py-1.5 border border-[rgba(250,250,250,0.12)] text-primary-50 hover:text-primary-100 hover:border-[rgba(250,250,250,0.22)] transition-colors cursor-target"
                   >
                     {copied === pack.repo ? (


### PR DESCRIPTION
## What

Fixes the dashboard's one-click **Install pack** button (and the **Copy command** button) so they forward a community pack's `path` field. Previously both dropped it, so any pack whose skills live in a repo *subdirectory* failed to install from the dashboard.

Closes #492.

## Why

`apps/dashboard/app/page.tsx` wired `onInstallPack={(repo) => runSkill('install-skill', repo)}` — passing only `pack.repo`. With no `--path`, `install-skill-pack` defaults `PACK_DIR` to the repo root, finds no root `skills-pack.json`, falls back to scanning a nonexistent root `skills/`, and exits 1.

Affected community packs (those declaring a `path` in `skill-packs.json`):

- `rajkaria/hunch` → `aeon-skill-pack`
- `codexvritra/signa` → `aeon-skills`
- `mandateseal/mandateseal-guard` → `aeon`

## How

Frontend-only — the `install-skill` skill already passes anything after `owner/repo` straight through to `./install-skill-pack` as flags (`skills/install-skill/SKILL.md`). So:

- New `installArg(pack)` helper builds `` `${pack.repo} --path ${pack.path}` `` when a `path` is set, else just `pack.repo`.
- `handleInstall` / `handleCopy` now take the `CommunityPack` and use `installArg(pack)`; busy/copied state still keys on `pack.repo`.
- The copy button's text and tooltip include the `--path` suffix too.
- `onInstallPack`'s param renamed `repo → arg` to reflect that it's now the full install argument.

Packs with a root-level manifest are unaffected (`installArg` returns just the repo).

## Test

No CI builds/typechecks `apps/dashboard`, so verified by inspection: the change is type-correct (`CommunityPack.path?: string`, `installArg` returns `string`, handlers receive the `CommunityPack` that `community.map` already provides) and the resulting `owner/repo --path <subdir>` argument matches the `--path` flag `install-skill-pack` parses. Recommend a quick manual install of Hunch from the dashboard to confirm end-to-end.
