### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,49 @@
+## What
+
+<!-- One or two sentences: what does this PR change? -->
+
+## Why
+
+<!-- What triggered it — an issue (#123), a gap you hit, a community pack you're listing. Link the issue if there is one. -->
+
+## Type of change
+
+<!-- Check one, then fill in the matching checklist below and delete the rest. -->
+
+- [ ] New skill
+- [ ] New LLM gateway
+- [ ] Community skill pack listing
+- [ ] Core fix (dashboard / scripts / workflows / docs)
+
+---
+
+### New skill
+
+- [ ] `skills/<name>/SKILL.md` frontmatter has `name:`, `category:`, `description:`, `tags:` (plus `requires:` / `mcp:` if it needs keys or MCP servers)
+- [ ] Body is self-contained and includes a **Sandbox note** with the right fallback (WebFetch / `scripts/prefetch-*.sh` / `gh api`)
+- [ ] Notifies through `./notify`, never a channel API directly
+- [ ] Ran `./generate-skills-json && ./generate-packs-json` and committed both regenerated manifests
+
+### New LLM gateway
+
+- [ ] Wired through all five files (`types.ts`, `auth-provider.mjs`, `secrets/route.ts`, `scripts/llm-gateway.sh`, `.github/workflows/*.yml`) — see [Adding a gateway](../README.md#adding-a-gateway)
+- [ ] Added a row to the gateway table in the README
+- [ ] Verified end to end — a run logs `gateway=auto resolved to <slug>`
+
+### Community skill pack listing
+
+- [ ] Pack repo is public with a clear license (MIT / Apache-2.0)
+- [ ] Pack has a `skills-pack.json` manifest at its root and a `SKILL.md` per skill
+- [ ] Write / onchain / bet skills are `default_enabled: false`
+- [ ] This PR adds **both** a README table row and a matching `skill-packs.json` entry
+- [ ] No monkey-patching of Aeon internals; no private or auth-walled endpoints required to run
+
+### Core fix (dashboard / scripts / workflows / docs)
+
+- [ ] Change is focused — one concern, no unrelated refactor
+- [ ] Touched code follows the existing pattern in the file
+- [ ] Relevant CI gates pass locally (e.g. `bash scripts/check-skill-categories.sh`, `bash scripts/check-capabilities-parity.sh`)
+
+---
+
+<!-- PRs are squash-merged: the title above becomes the commit subject on main. Branch from main; one change per PR. -->


### PR DESCRIPTION
## What
Adds `.github/PULL_REQUEST_TEMPLATE.md` — a structured PR description GitHub auto-loads into the compose box for every new pull request.

## Why
`CONTRIBUTING.md` documents four distinct contribution paths (new skill, new gateway, community pack listing, core fix), each with its own gates — but there was no PR template to surface those gates at submission time. The first external community-pack PR (#472, now merged) arrived well-formed because the author read the docs carefully; the next contributor may not. A template pre-populates the sections reviewers need (what / why / type-specific checklist) and cuts review latency by making every submission immediately scannable.

## Changes
- `.github/PULL_REQUEST_TEMPLATE.md`: **What** / **Why** sections, a *Type of change* selector, and a per-type checklist that mirrors the requirements already in `CONTRIBUTING.md` and `docs/community-skill-packs.md` — skill frontmatter + `generate-skills-json`/`generate-packs-json` regen, the five-file gateway wiring, the README-row + `skill-packs.json` pack-listing pair with `default_enabled: false` for write skills, and the local CI gates for core fixes.

The checklists reference the repo's existing conventions verbatim, so the template stays a thin pointer rather than a second source of truth.

---
*Built autonomously by Aeon*
