### PR TITLE
chore: list only Claude models (drop Bankr gateway non-Claude options)

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -19,11 +19,6 @@ on:
           - claude-fable-5
           - claude-sonnet-4-6
           - claude-haiku-4-5-20251001
-          - gemini-3-pro
-          - gemini-3-flash
-          - gpt-5.2
-          - kimi-k2.5
-          - qwen3-coder
       var:
         description: 'Variable (e.g. AI, bitcoin, owner/repo)'
         required: false

--- a/aeon.yml
+++ b/aeon.yml
@@ -445,7 +445,6 @@ chains:
 
 # Default model for all skills. Override per-run via workflow_dispatch.
 # Options: claude-opus-4-8, claude-fable-5, claude-sonnet-4-6, claude-haiku-4-5-20251001
-# Bankr gateway also supports: gemini-3-pro, gemini-3-flash, gpt-5.2, kimi-k2.5, qwen3-coder
 model: claude-sonnet-4-6
 
 # AI Gateway — route Claude Code requests through an LLM provider.

--- a/skills/cost-report/SKILL.md
+++ b/skills/cost-report/SKILL.md
@@ -30,11 +30,6 @@ First read `aeon.yml` and find the `gateway.provider` value. Use the matching ta
 | claude-opus-4-7 | $5.00 | $25.00 |
 | claude-sonnet-4-6 | $3.00 | $15.00 |
 | claude-haiku-4-5-20251001 | $0.80 | $4.00 |
-| gemini-3-pro | $1.25 | $10.00 |
-| gemini-3-flash | $0.15 | $0.60 |
-| gpt-5.2 | $2.50 | $10.00 |
-| kimi-k2.5 | $1.00 | $4.00 |
-| qwen3-coder | $0.50 | $2.00 |
 
 Bankr does not expose cache read/write pricing separately. Treat cache columns as $0 for Bankr rows.
 

--- a/skills/spend-monitor/SKILL.md
+++ b/skills/spend-monitor/SKILL.md
@@ -39,11 +39,6 @@ First read `aeon.yml` and find the `gateway.provider` value. Use the matching ta
 | claude-opus-4-7 | $5.00 | $25.00 |
 | claude-sonnet-4-6 | $3.00 | $15.00 |
 | claude-haiku-4-5-20251001 | $0.80 | $4.00 |
-| gemini-3-pro | $1.25 | $10.00 |
-| gemini-3-flash | $0.15 | $0.60 |
-| gpt-5.2 | $2.50 | $10.00 |
-| kimi-k2.5 | $1.00 | $4.00 |
-| qwen3-coder | $0.50 | $2.00 |
 
 For Bankr, treat cache read/write as zero cost.
 For any unlisted model, default to Opus pricing (conservative estimate).


### PR DESCRIPTION
Removes all non-Claude (Bankr gateway) model references so only the four Claude models remain across config, the run-time dropdown, and pricing tables.

## Changes
- **`aeon.yml`** — drop the `# Bankr gateway also supports:` options comment line.
- **`.github/workflows/aeon.yml`** — remove `gemini-3-pro`, `gemini-3-flash`, `gpt-5.2`, `kimi-k2.5`, `qwen3-coder` from the `workflow_dispatch` model dropdown.
- **`skills/spend-monitor/SKILL.md`** — remove those 5 rows from the Bankr Gateway pricing table.
- **`skills/cost-report/SKILL.md`** — remove those 5 rows from the Bankr Gateway pricing table.

## Notes
- Unlisted models still fall back to conservative **Opus pricing** in both spend-monitor and cost-report, so removing the rows won't crash cost estimation.
- Repo-wide grep for `gemini-3` / `gpt-5.2` / `kimi-k2.5` / `qwen3-coder` returns nothing after these edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)