### PR TITLE
docs(readme): document one-click dashboard pack install

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,14 +459,18 @@ If the secrets aren't set, both steps no-op - fully backward compatible. If Flee
 
 > Aeon's **built-in (first-party) packs** - Core, Fleet, Research, Dev, Markets, Hound, Social, Productivity, Agent Ops - live in this repo and are enabled from the dashboard's **Packs** view; see [`docs/skill-packs.md`](docs/skill-packs.md). The packs below are **community** collections in their own repos.
 
-Third-party skill collections in their own repos, installable as one bundle:
+Third-party skill collections in their own repos, installable as one bundle - two ways:
+
+**One-click (dashboard).** Open the **Packs** view, scroll to **Community packs**, and hit **Install pack** on any card. That runs the security-scanned installer in the background and ships an **auto-merging PR**, so the skills land on `main` (and show up across the dashboard) with no manual step. Want to merge it yourself instead? The card's copy button hands you the exact CLI command below.
+
+**CLI.**
 
 ```bash
 ./install-skill-pack baseddevoloper/aeon-skill-pack-vvvkernel
 ./install-skill-pack --list      # browse the registry (skill-packs.json)
 ```
 
-The script reads the pack's `skills-pack.json` manifest, runs the security scanner on each `SKILL.md`, and copies approved skills into `skills/` (disabled in `aeon.yml`, provenance in `skills.lock`). Full schema and trust model: [`docs/community-skill-packs.md`](docs/community-skill-packs.md).
+Either way the installer reads the pack's `skills-pack.json` manifest, runs the security scanner on each `SKILL.md`, and copies approved skills into `skills/` - **disabled** in `aeon.yml` (nothing runs until you set the pack's secrets and flip `enabled: true`), with provenance recorded in `skills.lock`. Full schema and trust model: [`docs/community-skill-packs.md`](docs/community-skill-packs.md).
 
 | Pack | Skills | Description |
 |------|--------|-------------|


### PR DESCRIPTION
## What
The **Community skill packs** section of the README documented only the `./install-skill-pack` CLI. It now documents the **dashboard one-click flow** too: open the **Packs** view → **Community packs** → hit **Install pack** on a card, which runs the security-scanned installer in the background and ships an auto-merging PR. Both methods are presented side by side, and the shared post-install behavior (skills land **disabled** until you set secrets and flip `enabled: true`) is stated once for both.

## Why
The dashboard's one-click pack install (`PacksPanel` → `onInstallPack` → the `install-skill` skill) is the lowest-friction way to extend a fork, but a new forker reading the README would never discover it — the docs sent everyone to the CLI. Documenting the path that already ships closes an onboarding gap: every new live instance is the metric, and the easiest install flow was invisible.

## Changes
- `README.md`: split the Community skill packs intro into **One-click (dashboard)** and **CLI** subsections; folded the manifest/security-scan/`disabled`-by-default explanation into a shared "either way" line and made the disabled-until-enabled step explicit.

Docs-only, single file. No code or behavior change.

---
*Built autonomously by Aeon*
