### PR TITLE
Add community skill pack: clawhunter-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,7 @@ The script reads the pack's `skills-pack.json` manifest, runs the security scann
 | [signa](https://github.com/codexvritra/signa) (`--path aeon-skills`) | 20 | Full SIGNA suite - wallet-signed cross-platform agent messaging, multi-agent broadcast and delegate, encrypted rooms + ERC-8004 trust gate, plus Bankr resolver / launches, gitlawb, MiroShark, and **x402 receipts + bounded spend mandates** (a human grants a signed budget, the agent spends within it and asks for more) |
 | [aeon-skill-pack-mneme](https://github.com/mnemedb/aeon-skill-pack-mneme) | 8 | Mneme as Aeon's persistent memory layer - vector recall across runs, entity/relation graph, live Base chain streams, async LLM "dream" reflections, and schema-aware /chat. One `MNEME_API_KEY`, zero infra. |
 | [Hunch Prediction Markets](https://github.com/rajkaria/hunch/tree/main/aeon-skill-pack) (`--path aeon-skill-pack`) | 3 | Crowd-conviction signal, market discovery, and **x402 betting** on PlayHunch - onchain prediction markets on Base. Unlike monitor-only packs, hunch-bet places real positions (simulate-by-default, $1-$10, USDC payout + onchain proof) |
+| [clawhunter-skills](https://github.com/clawhunter/clawhunter-skills) | Pump Fun GO bounty discovery + vetting, and the content tools to win them (voice tones, images, video direction). x402 on Solana or Base. | community |
 
 **To list a pack here**, open a PR adding a row. Guidelines:
 

--- a/README.md
+++ b/README.md
@@ -489,7 +489,7 @@ The script reads the pack's `skills-pack.json` manifest, runs the security scann
 | [signa](https://github.com/codexvritra/signa) (`--path aeon-skills`) | 20 | Full SIGNA suite - wallet-signed cross-platform agent messaging, multi-agent broadcast and delegate, encrypted rooms + ERC-8004 trust gate, plus Bankr resolver / launches, gitlawb, MiroShark, and **x402 receipts + bounded spend mandates** (a human grants a signed budget, the agent spends within it and asks for more) |
 | [aeon-skill-pack-mneme](https://github.com/mnemedb/aeon-skill-pack-mneme) | 8 | Mneme as Aeon's persistent memory layer - vector recall across runs, entity/relation graph, live Base chain streams, async LLM "dream" reflections, and schema-aware /chat. One `MNEME_API_KEY`, zero infra. |
 | [Hunch Prediction Markets](https://github.com/rajkaria/hunch/tree/main/aeon-skill-pack) (`--path aeon-skill-pack`) | 3 | Crowd-conviction signal, market discovery, and **x402 betting** on PlayHunch - onchain prediction markets on Base. Unlike monitor-only packs, hunch-bet places real positions (simulate-by-default, $1-$10, USDC payout + onchain proof) |
-| [clawhunter-skills](https://github.com/clawhunter/clawhunter-skills) | Pump Fun GO bounty discovery + vetting, and the content tools to win them (voice tones, images, video direction). x402 on Solana or Base. | community |
+| [clawhunter-skills](https://github.com/clawhunter/clawhunter-skills) | 2 | Pump Fun GO bounty discovery + vetting, and the content tools to win them (voice tones, images, video direction). x402 on Solana or Base. |
 
 **To list a pack here**, open a PR adding a row. Guidelines:
 

--- a/skill-packs.json
+++ b/skill-packs.json
@@ -275,9 +275,7 @@
       "homepage": "https://clawhunter.fun",
       "category": "crypto",
       "trust_level": "community",
-      "skills": ["clawhunter-bounties", "clawhunter-content-studio"],
-      "secrets_required": [],
-      "capabilities": ["external_api"]
+      "skills": ["clawhunter-bounties", "clawhunter-content-studio"]
     }
   ]
 }

--- a/skill-packs.json
+++ b/skill-packs.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "updated": "2026-06-16",
+  "updated": "2026-06-17",
   "description": "Machine-readable registry of community skill packs installable via ./install-skill-pack. Mirrors the human-readable table in README.md.",
   "packs": [
     {
@@ -265,6 +265,19 @@
       "category": "crypto",
       "trust_level": "community",
       "skills": ["hunch-intel", "hunch-markets", "hunch-bet"]
+    },
+    {
+      "repo": "clawhunter/clawhunter-skills",
+      "name": "clawhunter-skills",
+      "description": "Discover and vet Pump Fun GO bounties, and produce the content to win them — voice tones from real X accounts, logo-grounded images, Veo/Kling video direction. Paid tools settle via x402 (USDC on Solana or Base).",
+      "author": "clawhunter",
+      "license": "MIT",
+      "homepage": "https://clawhunter.fun",
+      "category": "crypto",
+      "trust_level": "community",
+      "skills": ["clawhunter-bounties", "clawhunter-content-studio"],
+      "secrets_required": [],
+      "capabilities": ["external_api"]
     }
   ]
 }


### PR DESCRIPTION
## What

List **clawhunter-skills** as a community skill pack — two skills
(`clawhunter-bounties`, `clawhunter-content-studio`) wrapping the public
clawhunter.fun API for Pump Fun GO bounty discovery/vetting and content creation.

## Why

Claw Hunter is an agent-facing API: free bounty discovery + capability matching,
and x402-paid research and content tools. Packaging it as an Aeon pack lets Aeon
operators discover and install it. No issue — listing a community pack.

## Type of change

- [x] Community skill pack listing

---

### Community skill pack listing

- [x] Pack repo is public with a clear license (MIT) — github.com/clawhunter/clawhunter-skills
- [x] Pack has a `skills-pack.json` manifest at its root and a `SKILL.md` per skill
- [x] Write / onchain / bet skills are `default_enabled: false` — both skills can incur x402 spend (USDC on Solana or Base), so both are marked `default_enabled: false`
- [x] This PR adds **both** a README table row and a matching `skill-packs.json` entry
- [x] No monkey-patching of Aeon internals; no private or auth-walled endpoints required to run — free endpoints need no key; paid endpoints are open x402 pay-per-call (no account/auth)