### PR TITLE
Add Polymarket Trader by Simmer to community skill packs

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,7 @@ Either way the installer reads the pack's `skills-pack.json` manifest, runs the 
 | [aeon-skill-pack-mneme](https://github.com/mnemedb/aeon-skill-pack-mneme) | 8 | Mneme as Aeon's persistent memory layer - vector recall across runs, entity/relation graph, live Base chain streams, async LLM "dream" reflections, and schema-aware /chat. One `MNEME_API_KEY`, zero infra. |
 | [Hunch Prediction Markets](https://github.com/rajkaria/hunch/tree/main/aeon-skill-pack) (`--path aeon-skill-pack`) | 3 | Crowd-conviction signal, market discovery, and **x402 betting** on PlayHunch - onchain prediction markets on Base. Unlike monitor-only packs, hunch-bet places real positions (simulate-by-default, $1-$10, USDC payout + onchain proof) |
 | [clawhunter-skills](https://github.com/clawhunter/clawhunter-skills) | 2 | Pump Fun GO bounty discovery + vetting, and the content tools to win them (voice tones, images, video direction). x402 on Solana or Base. |
+| [Polymarket Trader by Simmer](https://github.com/SpartanLabsXyz/aeon-skill-pack-polymarket/tree/main/aeon-skill-pack) (`--path aeon-skill-pack`) | 3 | Signal, discovery, and real position-taking on **Polymarket** - the deepest prediction-market venue - powered by Simmer. Unlike monitor-only packs, polymarket-trade places actual orders (simulate-by-default, live opt-in, bounded) |
 
 **To list a pack here**, open a PR adding a row. Guidelines:
 

--- a/skill-packs.json
+++ b/skill-packs.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "updated": "2026-06-17",
+  "updated": "2026-06-18",
   "description": "Machine-readable registry of community skill packs installable via ./install-skill-pack. Mirrors the human-readable table in README.md.",
   "packs": [
     {
@@ -276,6 +276,20 @@
       "category": "crypto",
       "trust_level": "community",
       "skills": ["clawhunter-bounties", "clawhunter-content-studio"]
+    },
+    {
+      "repo": "SpartanLabsXyz/aeon-skill-pack-polymarket",
+      "path": "aeon-skill-pack",
+      "name": "Polymarket Trader by Simmer",
+      "description": "Signal, market discovery, and real position-taking on Polymarket - the deepest prediction-market venue - powered by Simmer. Unlike monitor-only packs, polymarket-trade places actual orders on live Polymarket liquidity: simulate-by-default, live opt-in, bounded. The wired Simmer MCP also exposes Simmer's full catalog of ready-to-run Polymarket strategies (copytrading, market-making, signal-sniping) via list_skills.",
+      "author": "simmer",
+      "license": "MIT",
+      "homepage": "https://simmer.markets",
+      "category": "crypto",
+      "trust_level": "community",
+      "skills": ["polymarket-intel", "polymarket-markets", "polymarket-trade"],
+      "secrets_required": ["SIMMER_API_KEY"],
+      "capabilities": ["external_api", "writes_external_host", "onchain_writes", "sends_notifications"]
     }
   ]
 }


### PR DESCRIPTION
Adds **Polymarket Trader by Simmer** to the community registry + README table.

[Simmer](https://simmer.markets) (a Polymarket Verified Builder) is the agent execution layer for prediction markets. AEON already ships `monitor-polymarket` — but that only *watches*. This pack lets an agent **read the signal, discover live markets, and take a real position on Polymarket itself** — the deepest, most liquid prediction-market venue, across all categories (politics, sports, crypto, events).

**3 skills** (`crypto`, all `default_enabled: false`):
- `polymarket-intel` — signal read (odds, volume, moves, context) + the single best opportunity. Read-only.
- `polymarket-markets` — discover live Polymarket markets for a query. Read-only.
- `polymarket-trade` — place a position via Simmer. **Simulate-by-default**; real orders opt-in, bounded, need an activated wallet.

The wired Simmer MCP also exposes Simmer's full catalog of ready-to-run Polymarket strategies (copytrading, market-making, signal-sniping) via `list_skills`.

- Repo: https://github.com/SpartanLabsXyz/aeon-skill-pack-polymarket (`--path aeon-skill-pack`)
- Install: `./install-skill-pack SpartanLabsXyz/aeon-skill-pack-polymarket --path aeon-skill-pack`
- Passes `scripts/validate-pack.sh` with 0 warnings (valid manifest, MIT license, locked-taxonomy capabilities, present per-skill SKILL.md).

Not affiliated with or endorsed by Polymarket — nominative use; Simmer is the execution layer, Polymarket is the venue.