### PR TITLE
chore: remove dangling refs to 4 more skills deleted on 2026-06-15 (token-alert, defi-monitor, wallet-digest, feature)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     id: skill
     attributes:
       label: Which skill (or area)?
-      description: The skill name from `aeon.yml` (e.g. `token-movers`, `feature`, `deep-research`). Use `dashboard`, `runtime`, or `gateway` if it's not a single skill.
+      description: The skill name from `aeon.yml` (e.g. `token-movers`, `pr-review`, `deep-research`). Use `dashboard`, `runtime`, or `gateway` if it's not a single skill.
       placeholder: token-movers
     validations:
       required: true

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Aeon can spawn and manage copies of itself. `spawn-instance` forks the repo into
 ./add-skill aaronjmars/aeon --list        # browse the built-in catalog
 ./add-skill BankrBot/skills bankr hydrex  # install from any GitHub repo
 ./add-skill BankrBot/skills --all         # install everything from a repo
-./export-skill token-alert                # package one for standalone use
+./export-skill token-movers               # package one for standalone use
 ```
 
 Installed skills land in `skills/` and are added to `aeon.yml` disabled - flip `enabled: true` to activate. You can also:

--- a/SHOWCASE.md
+++ b/SHOWCASE.md
@@ -28,7 +28,7 @@ The full ranking — including the per-week skill-divergence buckets and the con
 
 ### What forks teach upstream
 
-The fleet is **infrastructure-first**: 18 of 24 active forks run only `heartbeat`. Of the rest, the most common second skills are `github-trending`, `morning-brief`, and the crypto cluster (`token-alert`, `token-movers`). When two or more forks independently flip the same default, the `fork-digest` skill flags it as a `DEFAULT_FLIP` candidate and surfaces it for upstream consideration.
+The fleet is **infrastructure-first**: 18 of 24 active forks run only `heartbeat`. Of the rest, the most common second skills are `github-trending`, `morning-brief`, and the crypto cluster (`token-movers`, `price-alert`). When two or more forks independently flip the same default, the `fork-digest` skill flags it as a `DEFAULT_FLIP` candidate and surfaces it for upstream consideration.
 
 If you're spinning up a new fork, the leaderboard is the cheapest map of what other operators have already validated.
 

--- a/docs/smithery-manifest.json
+++ b/docs/smithery-manifest.json
@@ -82,10 +82,6 @@
           "description": "[Aeon · Research] Exhaustive multi-source synthesis on any topic using full-context ingestion — far beyond a digest (on-demand)"
         },
         {
-          "name": "aeon-defi-monitor",
-          "description": "[Aeon · Crypto] Check pool health, positions, and yield rates for tracked protocols (cron: 0 12 * * *)"
-        },
-        {
           "name": "aeon-defi-overview",
           "description": "[Aeon · Crypto] Daily overview of DeFi activity from DeFiLlama — TVL changes, top chains, top protocols (cron: 0 12 * * *)"
         },
@@ -340,10 +336,6 @@
         {
           "name": "aeon-thread-formatter",
           "description": "[Aeon · Social] Score the day's events from memory/logs and format the top one as a 5-tweet thread ready to paste (cron: 30 17 * * *)"
-        },
-        {
-          "name": "aeon-token-alert",
-          "description": "[Aeon · Crypto] Notify on price or volume anomalies for tracked tokens (cron: 0 12 * * *)"
         },
         {
           "name": "aeon-token-movers",

--- a/docs/smithery-submission.md
+++ b/docs/smithery-submission.md
@@ -46,7 +46,6 @@ Aeon is an autonomous agent framework that runs on GitHub Actions and exposes it
 | `aeon-routine` | Productivity | Combined briefing — token movers, tweet roundup, paper pick, GitHub issues, and HN digest in one run |
 | `aeon-deal-flow` | Productivity | Funding round tracker across configurable verticals |
 | `aeon-deep-research` | Research | Exhaustive multi-source synthesis on any topic using full-context ingestion — far beyond a digest |
-| `aeon-defi-monitor` | Crypto | Check pool health, positions, and yield rates for tracked protocols |
 | `aeon-defi-overview` | Crypto | Overview of DeFi activity from DeFiLlama — TVL changes, top chains, top protocols |
 | `aeon-deploy-prototype` | Dev | Generate a small app or tool and deploy it live to Vercel via API |
 | `aeon-digest` | Research | Generate and send a digest on a configurable topic |
@@ -111,7 +110,6 @@ Aeon is an autonomous agent framework that runs on GitHub Actions and exposes it
 | `aeon-technical-explainer` | Research | Generate a visual technical explanation of a recent topic using Replicate for the hero image |
 | `aeon-telegram-digest` | Research | Digest of recent posts from tracked public Telegram channels |
 | `aeon-thread-formatter` | Social | Score the day's events from memory/logs and format the top one as a 5-tweet thread ready to paste |
-| `aeon-token-alert` | Crypto | Notify on price or volume anomalies for tracked tokens |
 | `aeon-token-movers` | Crypto | Top movers, losers, and trending coins from CoinGecko |
 | `aeon-token-pick` | Crypto | One token recommendation and one prediction market pick based on live data |
 | `aeon-tool-builder` | Productivity | Build automation scripts from action-converter suggestions and recurring manual tasks |

--- a/export-skill
+++ b/export-skill
@@ -37,9 +37,9 @@ Options:
   --help              Show this help
 
 Examples:
-  ./export-skill token-alert
-  ./export-skill token-alert --tar
-  ./export-skill token-alert --output ~/my-skills/token-alert
+  ./export-skill token-movers
+  ./export-skill token-movers --tar
+  ./export-skill token-movers --output ~/my-skills/token-movers
   ./export-skill --list
 EOF
   exit 0

--- a/skills/auto-workflow/SKILL.md
+++ b/skills/auto-workflow/SKILL.md
@@ -82,7 +82,7 @@ Use this hint table — but **only emit skills whose slug exists in `skills.json
 | github-org | github-monitor, repo-pulse, repo-scanner | `owner` resolves as Organization or User with ≥5 repos |
 | x-account | fetch-tweets, tweet-roundup, list-digest, refresh-x | `x_handle` extracted |
 | blog-or-news | rss-digest, digest, article | ≥1 `feed_url` OR dated articles |
-| crypto-project | token-alert, token-movers, onchain-monitor, defi-monitor, treasury-info | `token_contract` OR `token_symbol` |
+| crypto-project | price-alert, token-movers, onchain-monitor, defi-overview, treasury-info | `token_contract` OR `token_symbol` |
 | api-or-docs | deep-research | product is genuinely new + operator interest match |
 | research | paper-pick, paper-digest, research-brief | arXiv-like URL or lab site |
 | community | reddit-digest, telegram-digest, farcaster-digest, channel-recap | corresponding channel URL on page |

--- a/skills/compute-pulse/SKILL.md
+++ b/skills/compute-pulse/SKILL.md
@@ -279,4 +279,4 @@ None. Uses `gh` CLI (GITHUB_TOKEN via workflow), WebFetch, WebSearch. No additio
 
 - `article` skill — Compute Pulse data feeds compute/infra articles
 - `digest` / `weekly-newsletter` — compute developments slot into the agent-infra or DePIN section
-- `defi-monitor` / `token-pick` — DePIN token signals cross-reference with broader token picks
+- `defi-overview` / `token-pick` — DePIN token signals cross-reference with broader token picks

--- a/skills/narrative-convergence/SKILL.md
+++ b/skills/narrative-convergence/SKILL.md
@@ -34,7 +34,7 @@ spend-monitor, cost-report, fleet-scorecard, fleet-control, repo-scanner, narrat
 ## Signal categories (skill → category)
 | Category | Skills |
 |----------|--------|
-| market | market-context, token-pick, token-movers, rwa-pulse, defi-monitor |
+| market | market-context, token-pick, token-movers, rwa-pulse, defi-overview |
 | social | tweet-roundup, list-digest, narrative-tracker, remix-tweets, refresh-x |
 | ecosystem | github-issues, github-trending, project-lens, builder-map, external-feature, milestone-tracker |
 | sector | mcp-pulse, compute-pulse, x402-monitor, agent-displacement, pm-pulse |

--- a/skills/skill-evals/evals.json
+++ b/skills/skill-evals/evals.json
@@ -83,15 +83,6 @@
         { "label": "probability", "pattern": "([\\d.]+)%", "min": 0, "max": 100 }
       ]
     },
-    "token-alert": {
-      "output_pattern": "articles/token-alert-*.md",
-      "min_words": 50,
-      "required_patterns": ["AEON|aeon|token|Token|price|Price"],
-      "forbidden_patterns": ["\\$\\{var\\}", "\\[TODO\\]"],
-      "numeric_checks": [
-        { "label": "price", "pattern": "\\$([\\d.]+)", "min": 0, "max": 1000000 }
-      ]
-    },
     "skill-health": {
       "output_pattern": "articles/skill-health-*.md",
       "min_words": 80,

--- a/skills/spawn-instance/SKILL.md
+++ b/skills/spawn-instance/SKILL.md
@@ -73,7 +73,7 @@ Read `memory/instances.json`. If it doesn't exist, create it with `{"instances":
       "purpose": "monitor DeFi protocols and token movements",
       "created": "2026-04-20",
       "status": "pending_secrets",
-      "skills_enabled": ["token-movers", "defi-monitor", "heartbeat"],
+      "skills_enabled": ["token-movers", "defi-overview", "heartbeat"],
       "parent": "OWNER/aeon"
     }
   ]

--- a/skills/syndicate-article/SKILL.md
+++ b/skills/syndicate-article/SKILL.md
@@ -101,7 +101,7 @@ Where `<slug>` matches `update-gallery`'s Jekyll post filename convention: title
 
 a. **Derive tags** (max 4, Dev.to hard limit) from the filename slug:
    - `repo-article`, `article` → `ai, github, automation, agents`
-   - `token-alert`, `defi-overview`, `defi-monitor` → `crypto, defi, blockchain, trading`
+   - `defi-overview` → `crypto, defi, blockchain, trading`
    - `changelog`, `push-recap`, `shiplog` → `opensource, devops, changelog, github`
    - `digest`, `rss-digest`, `hacker-news` → `news, tech, ai, digest`
    - `deep-research`, `research-brief`, `paper-pick` → `research, ai, machinelearning, papers`

--- a/skills/update-gallery/SKILL.md
+++ b/skills/update-gallery/SKILL.md
@@ -67,7 +67,7 @@ For each article:
 |---|---|
 | `article` | `article`, `research-brief`, `repo-article`, `technical-explainer`, `deep-research`, `project-lens`, `paper-pick`, `idea-capture` |
 | `changelog` | `changelog`, `push-recap`, `code-health`, `repo-actions`, `repo-pulse` |
-| `crypto` | `token-alert`, `token-movers`, `token-pick`, `defi-overview`, `defi-monitor`, `treasury-info`, `onchain-monitor`, `polymarket`, `kalshi`, `market-context`, `narrative-tracker`, `unlock-monitor` |
+| `crypto` | `token-movers`, `token-pick`, `defi-overview`, `treasury-info`, `onchain-monitor`, `polymarket`, `kalshi`, `market-context`, `narrative-tracker`, `unlock-monitor` |
 | `digest` | `digest`, `rss-digest`, `hacker-news`, `reddit-digest`, `telegram-digest`, `farcaster-digest`, `vibecoding-digest`, `agent-buzz`, `list-digest`, `tweet-roundup`, `channel-recap` |
 | `security` | `security-digest`, `vuln-scanner`, `workflow-audit`, `skill-scan` |
 | `repo` | `repo-scanner`, `vercel-projects`, `github-monitor`, `github-issues`, `github-trending`, `github-releases`, `star-milestone`, `external-feature` |

--- a/skills/wallet-profile/SKILL.md
+++ b/skills/wallet-profile/SKILL.md
@@ -9,7 +9,7 @@ capabilities: [external_api, sends_notifications]
 ---
 > **${var}** — Wallet address (`0x...`) on Base to profile. Required. If empty, log `WALLET_PROFILE_NO_TARGET` and exit cleanly (no notify).
 
-Behavioral profiling, not a balance digest (Aeon's `wallet-digest` covers balances). Answers: how old is this wallet, how does it behave, where did its funds come from, and does anything look risky? Runs keyless on public endpoints.
+Behavioral profiling, not a balance digest (Aeon's `treasury-info` covers balances). Answers: how old is this wallet, how does it behave, where did its funds come from, and does anything look risky? Runs keyless on public endpoints.
 
 Read `memory/known-addresses.yml` (if present) for counterparty labels and the last 2 days of `memory/logs/` for prior flags.
 


### PR DESCRIPTION
Follow-up to #503 (which cleaned up `token-report`). Same class of bug: `token-alert`, `defi-monitor`, `wallet-digest`, and `feature` were removed on 2026-06-15 but left dangling references behind. Repointed to live successors or de-listed.

## Successor mapping

| Deleted | → | Live successor | Rationale |
|---|---|---|---|
| `token-alert` | → | `price-alert` | real-time price/volume alerts |
| `defi-monitor` | → | `defi-overview` | DeFi activity overview |
| `wallet-digest` | → | `treasury-info` | wallet balances/holdings |
| `feature` | → | `pr-review` | example skill name in the issue template |

## Changed (14 files)

- **`docs/smithery-manifest.json` + `docs/smithery-submission.md`** — removed the orphaned `aeon-token-alert` / `aeon-defi-monitor` tool entries (JSON re-validated)
- **`export-skill` + `README.md`** — example commands pointed at a deleted skill → `token-movers`
- **`.github/ISSUE_TEMPLATE/bug_report.yml`** — example skill name `feature` → `pr-review`
- **`skills/update-gallery`, `skills/syndicate-article`, `SHOWCASE.md`** — dropped dead slugs from catalog/tag lists
- **`skills/auto-workflow`, `skills/narrative-convergence`, `skills/compute-pulse`, `skills/spawn-instance`** — cross-references + example skill lists repointed to successors
- **`skills/wallet-profile`** — "covers balances" pointer → `treasury-info`
- **`skills/skill-evals/evals.json`** — removed the dead `token-alert` eval block (the skill can't run, so the eval can't either)

## Deliberately NOT in this PR

- **`docs/index.md`** — a stale *sample* catalog referencing ~10 skills deleted on 2026-06-15 (also `polymarket`, `memory-flush`, `github-issues`, `trending-coins`, `write-tweet`, `monitor-runners`). Wants a **full catalog refresh**, not a 4-skill surgical edit.
- **`docs/skill-graph.md`** — **auto-generated** by the `skill-graph` skill, currently carrying 8+ dead nodes. **Re-running that skill** regenerates it clean against the live catalog; hand-editing 4 of N nodes is the wrong fix.
- **False positives left intact** — `feature` as an issue **label** (`issue-triage`, `shiplog`, `github-releases`, `workflow-templates`), the `displayName("defi-monitor")` string-formatting unit test, dated blog posts, the `spawn-instance` note that *correctly* lists these as non-existent, `liquidpad-token-alert` (a different **live** skill), and illustrative sample-output blocks.
- **Other 2026-06-15 deletions** (`thread-formatter`, `polymarket`, `monitor-runners`, …) still in some shared lists — out of scope here; happy to do one more sweep.

Companion to #503; no behavior change to any live skill.