### PR TITLE
chore: purge remaining dangling refs to 2026-06-15 deleted skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ After completing any task, append a log entry to `memory/logs/YYYY-MM-DD.md` wit
   - **Categories:** `config`, `api-change`, `rate-limit`, `timeout`, `sandbox-limitation`, `permanent-limitation`, `prompt-bug`, `missing-secret`, `quality-regression`, `output-format`, `optimization`, `unknown`
   - Health skills (skill-health, skill-evals, heartbeat, self-review) **file** issues. Repair skills (skill-repair, autoresearch) **close** them.
 
-When consolidating memory (reflect, memory-flush), move detail into topic files rather than cramming everything into MEMORY.md.
+When consolidating memory (reflect), move detail into topic files rather than cramming everything into MEMORY.md.
 
 ## Tools
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -29,7 +29,6 @@ Install any skill into your own agent:
 | `list-digest` | Top tweets from tracked X lists in the past 24 hours | Daily 5 PM UTC |
 | `research-brief` | Deep dive on a topic combining web search, papers, and synthesis | Daily 2 PM UTC |
 | `fetch-tweets` | Search X/Twitter for tweets by keyword, username, or both | Daily 5 PM UTC |
-| `search-papers` | Search for recent academic papers on topics of interest | Daily 2 PM UTC |
 | `reddit-digest` | Fetch and summarize top Reddit posts from tracked subreddits | Daily 7 AM UTC |
 | `security-digest` | Monitor recent security advisories from the GitHub Advisory Database | Daily 2 PM UTC |
 
@@ -45,7 +44,6 @@ Install any skill into your own agent:
 | `issue-triage` | Label and prioritize new GitHub issues on watched repos | Daily 9 AM UTC |
 | `changelog` | Generate a changelog from recent commits across watched repos | Daily 4 PM UTC |
 | `code-health` | Report on TODOs, dead code, and test coverage gaps | Daily 4 PM UTC |
-| `build-skill` | Design and build a new reusable skill | Daily 4 PM UTC |
 | `search-skill` | Search the open agent skills ecosystem for useful skills to install | Daily 2 PM UTC |
 
 ---
@@ -55,7 +53,6 @@ Install any skill into your own agent:
 | Skill | Description | Default Schedule |
 |-------|-------------|-----------------|
 | `token-movers` | Top movers, losers, and trending coins from CoinGecko | Daily 12 PM UTC |
-| `trending-coins` | Top trending and most searched coins on CoinGecko | Daily 12 PM UTC |
 | `onchain-monitor` | Monitor blockchain addresses and contracts for notable activity | Daily 12 PM UTC |
 | `defi-overview` | Overview of DeFi activity from DeFiLlama | Daily 12 PM UTC |
 | `token-pick` | One token recommendation and one prediction market pick | Daily 12 PM UTC |

--- a/docs/smithery-manifest.json
+++ b/docs/smithery-manifest.json
@@ -122,10 +122,6 @@
           "description": "[Aeon · Dev] Inventory active Aeon forks, detect diverged work, surface upstream contribution candidates (cron: 0 10 * * 1)"
         },
         {
-          "name": "aeon-github-issues",
-          "description": "[Aeon · Dev] Check all your repos for new open issues in the last 24 hours (cron: 0 9 * * *)"
-        },
-        {
           "name": "aeon-github-monitor",
           "description": "[Aeon · Dev] Watch repos for stale PRs, new issues, and new releases (cron: 0 9 * * *)"
         },
@@ -178,10 +174,6 @@
           "description": "[Aeon · Crypto] Monitor specific prediction markets for 24h price moves, volume changes, and fresh comments (cron: 30 12 * * *)"
         },
         {
-          "name": "aeon-monitor-runners",
-          "description": "[Aeon · Crypto] Find the top 5 tokens that ran hardest in the past 24h across major chains using GeckoTerminal (cron: 0 12 * * *)"
-        },
-        {
           "name": "aeon-priority-brief",
           "description": "[Aeon · Productivity] Aggregated daily briefing — digests, priorities, and what's ahead (cron: 0 7 * * *)"
         },
@@ -200,10 +192,6 @@
         {
           "name": "aeon-paper-pick",
           "description": "[Aeon · Research] Find the one paper you should read today from Hugging Face Papers (cron: 0 14 * * *)"
-        },
-        {
-          "name": "aeon-polymarket-comments",
-          "description": "[Aeon · Crypto] Top trending Polymarket markets and the most interesting comments from them (cron: 0 13 * * *)"
         },
         {
           "name": "aeon-pr-review",
@@ -310,10 +298,6 @@
           "description": "[Aeon · Productivity] Check imported skills for upstream changes and security regressions since the version in skills.lock (cron: 0 19 * * 0)"
         },
         {
-          "name": "aeon-smithery-manifest",
-          "description": "[Aeon · Productivity] Auto-generate Smithery + MCP Registry submission docs from skills.json and the aeon-mcp server (cron: 0 6 1/7 * *)"
-        },
-        {
           "name": "aeon-spawn-instance",
           "description": "[Aeon · Dev] Clone this Aeon agent into a new GitHub repo — fork, configure skills, register in fleet (on-demand)"
         },
@@ -332,10 +316,6 @@
         {
           "name": "aeon-telegram-digest",
           "description": "[Aeon · Research] Digest of recent posts from tracked public Telegram channels (cron: 30 7 * * *)"
-        },
-        {
-          "name": "aeon-thread-formatter",
-          "description": "[Aeon · Social] Score the day's events from memory/logs and format the top one as a 5-tweet thread ready to paste (cron: 30 17 * * *)"
         },
         {
           "name": "aeon-token-movers",
@@ -388,10 +368,6 @@
         {
           "name": "aeon-workflow-audit",
           "description": "[Aeon · Dev] Audit .github/workflows/ for script injection, over-permissioning, unverified actions, and secret exposure. Auto-fixes critical findings and opens a PR. (cron: 0 16 * * 0)"
-        },
-        {
-          "name": "aeon-write-tweet",
-          "description": "[Aeon · Social] Generate 10 tweet drafts across 5 size tiers (2 variations each) on a topic from today's outputs (cron: 0 17 * * *)"
         }
       ],
       "totalSkills": 95,

--- a/docs/smithery-submission.md
+++ b/docs/smithery-submission.md
@@ -56,7 +56,6 @@ Aeon is an autonomous agent framework that runs on GitHub Actions and exposes it
 | `aeon-fetch-tweets` | Research | Search X/Twitter for tweets by keyword, username, or both |
 | `aeon-fleet-control` | Dev | Monitor managed Aeon instances — check health, dispatch skills, aggregate status |
 | `aeon-fork-fleet` | Dev | Inventory active Aeon forks, detect diverged work, surface upstream contribution candidates |
-| `aeon-github-issues` | Dev | Check all your repos for new open issues in the last 24 hours |
 | `aeon-github-monitor` | Dev | Watch repos for stale PRs, new issues, and new releases |
 | `aeon-github-releases` | Dev | Track new releases from key AI, crypto, and infra repos |
 | `aeon-github-trending` | Dev | Top 10 trending repos on GitHub right now |
@@ -70,13 +69,11 @@ Aeon is an autonomous agent framework that runs on GitHub Actions and exposes it
 | `aeon-market-context` | Crypto | Fetch live crypto macro data and update memory/topics/market-context.md |
 | `aeon-monitor-kalshi` | Crypto | Monitor specific Kalshi prediction markets for 24h price moves, volume changes, and top events |
 | `aeon-monitor-polymarket` | Crypto | Monitor specific prediction markets for 24h price moves, volume changes, and fresh comments |
-| `aeon-monitor-runners` | Crypto | Find the top 5 tokens that ran hardest in the past 24h across major chains using GeckoTerminal |
 | `aeon-priority-brief` | Productivity | Aggregated briefing — digests, priorities, and what's ahead |
 | `aeon-narrative-tracker` | Crypto | Track rising, peaking, and fading crypto/tech narratives — identify the stories manufacturing reality before they peak |
 | `aeon-onchain-monitor` | Crypto | Monitor blockchain addresses and contracts for notable activity |
 | `aeon-paper-digest` | Research | Find and summarize new papers matching tracked research interests |
 | `aeon-paper-pick` | Research | Find the one paper most worth reading from Hugging Face Papers |
-| `aeon-polymarket-comments` | Crypto | Top trending Polymarket markets and the most interesting comments from them |
 | `aeon-pr-review` | Dev | Auto-review open PRs on watched repos and post summary comments |
 | `aeon-pr-triage` | Dev | First-touch triage for external pull requests — verdict + label + welcoming comment within minutes of open |
 | `aeon-project-lens` | Dev | Write an article about the project through a surprising lens — connecting it to current events, trends, philosophy, or comparable projects |
@@ -103,13 +100,11 @@ Aeon is an autonomous agent framework that runs on GitHub Actions and exposes it
 | `aeon-skill-repair` | Productivity | Diagnose and fix failing or degraded skills automatically |
 | `aeon-skill-scan` | Dev | Audit imported skills for shell injection, secret exfiltration, path traversal, and prompt injection before they run |
 | `aeon-skill-update` | Productivity | Check imported skills for upstream changes and security regressions since the version in skills.lock |
-| `aeon-smithery-manifest` | Productivity | Auto-generate Smithery + MCP Registry submission docs from skills.json and the aeon-mcp server |
 | `aeon-spawn-instance` | Dev | Clone this Aeon agent into a new GitHub repo — fork, configure skills, register in fleet |
 | `aeon-star-milestone` | Dev | Announces when a watched repo crosses a star-count milestone (100, 150, 200, 250, 500, 1000, ...) with a highlight reel of recent work |
 | `aeon-startup-idea` | Productivity | 2 startup ideas tailored to the user's skills, interests, and context |
 | `aeon-technical-explainer` | Research | Generate a visual technical explanation of a recent topic using Replicate for the hero image |
 | `aeon-telegram-digest` | Research | Digest of recent posts from tracked public Telegram channels |
-| `aeon-thread-formatter` | Social | Score the day's events from memory/logs and format the top one as a 5-tweet thread ready to paste |
 | `aeon-token-movers` | Crypto | Top movers, losers, and trending coins from CoinGecko |
 | `aeon-token-pick` | Crypto | One token recommendation and one prediction market pick based on live data |
 | `aeon-tool-builder` | Productivity | Build automation scripts from action-converter suggestions and recurring manual tasks |
@@ -123,7 +118,6 @@ Aeon is an autonomous agent framework that runs on GitHub Actions and exposes it
 | `aeon-retrospective` | Productivity | Synthesize the week's logs into a structured retrospective |
 | `aeon-shiplog` | Productivity | Narrative of everything shipped — features, fixes, and momentum, written as a compelling update |
 | `aeon-workflow-audit` | Dev | Audit .github/workflows/ for script injection, over-permissioning, unverified actions, and secret exposure. Auto-fixes critical findings and opens a PR. |
-| `aeon-write-tweet` | Social | Generate 10 tweet drafts across 5 size tiers (2 variations each) on a topic from today's outputs |
 
 ## Install instructions for end users
 

--- a/skills/contributor-spotlight/SKILL.md
+++ b/skills/contributor-spotlight/SKILL.md
@@ -13,7 +13,7 @@ Today is ${today}. Convert the most recent `fork-cohort` output into one named r
 
 `fork-cohort` (PR #152) identifies POWER and ACTIVE forks weekly but produces a data table — not a recognition. `contributor-leaderboard` ranks contributors by upstream PRs but doesn't see what's happening inside a fork. Neither closes the loop between *we have fork data* and *we do something social with it*.
 
-contributor-spotlight is the social loop: one fork operator per week gets a named callout — their handle, their fork, the skills they enabled, their star count, a one-line "keep shipping" close. That's the flywheel — operators who feel seen attract other operators. This is also formatted to feed `thread-formatter` directly, so the post is a tweetable artifact, not just a Telegram blip.
+contributor-spotlight is the social loop: one fork operator per week gets a named callout — their handle, their fork, the skills they enabled, their star count, a one-line "keep shipping" close. That's the flywheel — operators who feel seen attract other operators. This is also formatted to feed `thread-writer` directly, so the post is a tweetable artifact, not just a Telegram blip.
 
 ## Config
 
@@ -295,4 +295,4 @@ Uses `gh api` for all GitHub queries — handles auth internally, no env-var-in-
 
 - **`fork-cohort`** (Sunday 19:00 UTC) — produces the source data this skill picks from. Run order matters: schedule contributor-spotlight one hour later (Sunday 20:00 UTC) so today's cohort is fresh.
 - **`contributor-leaderboard`** (Sunday 17:30 UTC) — adjacent recognition skill ranked by upstream-PR contribution. Spotlight focuses on fork-internal work; leaderboard focuses on upstream-PR work. Together they cover both directions of the contributor flywheel.
-- **`thread-formatter`** (when run after this skill) — can pick up the spotlight as the day's top event and reformat into a 5-tweet thread, turning the recognition into a tweetable artifact.
+- **`thread-writer`** (when run after this skill) — can pick up the spotlight as the day's top event and reformat into a 5-tweet thread, turning the recognition into a tweetable artifact.

--- a/skills/pm-manipulation/SKILL.md
+++ b/skills/pm-manipulation/SKILL.md
@@ -243,7 +243,7 @@ Append to `memory/logs/${today}.md`:
 
 ## Guidelines
 
-- **Past 3 days only.** Older windows belong to `pm-intel` or one-off audits. Recency matters — manipulation is a near-term phenomenon, and stale signal turns this skill into noise.
+- **Past 3 days only.** Older windows belong to one-off audits. Recency matters — manipulation is a near-term phenomenon, and stale signal turns this skill into noise.
 - **Multilingual is the differentiator.** A pure English scan is just a worse `monitor-polymarket`. The signal lives in coverage gaps between languages.
 - **No accusations.** Use words like "suspected", "consistent with", "anomalous", "asymmetric coverage". Never name actors as manipulators without direct evidence.
 - **Translate inline.** When quoting non-English press, give the original phrase + English gloss. Never paraphrase a foreign source as if it were English.

--- a/skills/pm-pulse/SKILL.md
+++ b/skills/pm-pulse/SKILL.md
@@ -224,6 +224,6 @@ Append:
 ## Output feeds
 
 - `article` skill — PM Pulse data feeds coordination-markets and regulatory articles
-- `monitor-polymarket` / `polymarket-comments` — paired with this skill's macro signal
+- `monitor-polymarket` — paired with this skill's macro signal
 - `topic-momentum` — PM/coordination signal now has dedicated weekly data
 - `weekly-newsletter` — regulatory moves and volume milestones slot into the infra section

--- a/skills/self-improve/SKILL.md
+++ b/skills/self-improve/SKILL.md
@@ -48,7 +48,7 @@ Read the last 2 days of memory/logs/ for recent errors, failures, and quality is
 
    Do NOT:
    - Rewrite entire skills from scratch
-   - Add new features (that's build-skill's job)
+   - Add new features (that's create-skill's job)
    - Change the core architecture
    - Modify secrets or environment variables
 

--- a/skills/skill-evals/evals.json
+++ b/skills/skill-evals/evals.json
@@ -74,15 +74,6 @@
       "required_patterns": ["feed|article|post|item"],
       "forbidden_patterns": ["\\$\\{var\\}", "\\[TODO\\]"]
     },
-    "polymarket": {
-      "output_pattern": "articles/polymarket-*.md",
-      "min_words": 100,
-      "required_patterns": ["market|Market|probability|volume"],
-      "forbidden_patterns": ["\\$\\{var\\}", "\\[TODO\\]"],
-      "numeric_checks": [
-        { "label": "probability", "pattern": "([\\d.]+)%", "min": 0, "max": 100 }
-      ]
-    },
     "skill-health": {
       "output_pattern": "articles/skill-health-*.md",
       "min_words": 80,

--- a/skills/update-gallery/SKILL.md
+++ b/skills/update-gallery/SKILL.md
@@ -67,7 +67,7 @@ For each article:
 |---|---|
 | `article` | `article`, `research-brief`, `repo-article`, `technical-explainer`, `deep-research`, `project-lens`, `paper-pick`, `idea-capture` |
 | `changelog` | `changelog`, `push-recap`, `code-health`, `repo-actions`, `repo-pulse` |
-| `crypto` | `token-movers`, `token-pick`, `defi-overview`, `treasury-info`, `onchain-monitor`, `polymarket`, `kalshi`, `market-context`, `narrative-tracker`, `unlock-monitor` |
+| `crypto` | `token-movers`, `token-pick`, `defi-overview`, `treasury-info`, `onchain-monitor`, `monitor-polymarket`, `monitor-kalshi`, `market-context`, `narrative-tracker`, `unlock-monitor` |
 | `digest` | `digest`, `rss-digest`, `hacker-news`, `reddit-digest`, `telegram-digest`, `farcaster-digest`, `vibecoding-digest`, `agent-buzz`, `list-digest`, `tweet-roundup`, `channel-recap` |
 | `security` | `security-digest`, `vuln-scanner`, `workflow-audit`, `skill-scan` |
 | `repo` | `repo-scanner`, `vercel-projects`, `github-monitor`, `github-issues`, `github-trending`, `github-releases`, `star-milestone`, `external-feature` |


### PR DESCRIPTION
Final consistency pass after #503/#504/#505. Cleans the **unambiguous** remaining references to skills deleted on 2026-06-15, and deliberately leaves the false-positive / editorial ones (documented below so the scope is auditable).

## Cleaned (10 files)
- **`docs/smithery-manifest.json` + `docs/smithery-submission.md`** — removed the **6 dead tool entries** (`github-issues`, `monitor-runners`, `polymarket-comments`, `smithery-manifest`, `thread-formatter`, `write-tweet`). These are generated by the `smithery-manifest` skill, which was itself deleted → static orphans, safe to hand-edit. JSON re-validated.
- **`docs/skills.md`** — removed the 3 dead catalog rows (`search-papers`, `build-skill`, `trending-coins`).
- **`skills/skill-evals/evals.json`** — removed the dead `polymarket` eval block.
- **Cross-refs repointed to live successors:**
  - `pm-pulse`: dropped `polymarket-comments` (monitor-polymarket covers comments)
  - `contributor-spotlight`: `thread-formatter` → `thread-writer` (×2)
  - `pm-manipulation`: dropped the `pm-intel` reference
  - `self-improve`: `build-skill` → `create-skill`
  - `update-gallery`: `polymarket`/`kalshi` → `monitor-polymarket`/`monitor-kalshi`
  - `CLAUDE.md`: dropped `memory-flush` (`reflect` consolidates memory now)

## Deliberately LEFT — verified false-positive or editorial
| What | Where | Why |
|---|---|---|
| `memory-flush` / `ecosystem-entrants` | `packs.json`, `skills.json`, `memory-dedupe`, `ecosystem-links`, `narrative-convergence`, `skill-freshness` | Only inside **generated skill descriptions** (from SKILL.md frontmatter) — **not entries** (confirmed not slugs). Fixing means editing the `description:` frontmatter + regenerating skills.json/packs.json — CI-coupled, separate task. |
| `competitor-radar` | skill-triage, fork-health, capabilities-map, ecosystem-pulse, sparkleware-catalog, atrium-watch | Interwoven **"Monday intelligence stack" scheduling-rationale prose** referencing its old cron slot. Editorial (needs the current schedule), harmless, not a dependency. |
| `v4-readiness` | capabilities-map, skill-adoption | A historical postmortem reference (`v4-readiness H1`) + a one-shot-tool example — accurate as history. |
| `note-taking` | `apps/dashboard/.../route.ts` | Names the skill in a `SUPERNOTES_API_KEY` secret description; runtime code, left untouched. |
| `memory-flush` | `.github/workflows/aeon.yml` | In a meta-skill analysis-skip list — a harmless no-op case branch; left to avoid touching CI for zero behavior change. |
| various | `memory/topics/skill-spotlight.md` | Agent-maintained memory, not source. |

**Did NOT touch `skills.json` / `packs.json` / `aeon.yml` / `.github`** — the CI-gated config. No workflow references the files I did edit, so `ci-skills-json`/`ci-packs-json`/`ci-capabilities-parity` are unaffected.

Companion to #503/#504/#505.