### PR TITLE
feat(mcp): add Litebeam as a featured MCP template

### DIFF
--- a/apps/dashboard/components/McpPanel.tsx
+++ b/apps/dashboard/components/McpPanel.tsx
@@ -106,12 +106,17 @@ export function McpPanel({ servers, loading, saving, secrets, busy, onSave, onSe
   const isMcpToken = (r: string) => /^MCP_[A-Z0-9_]+_TOKEN$/.test(r)
 
   // One-click install a featured server: add it to .mcp.json and persist
-  // immediately (same as Save). No token needed - these are public endpoints.
+  // immediately (same as Save). Public / OAuth / x402 servers need no token; a
+  // server with `authSecret` installs with an `Authorization: Bearer ${VAR}`
+  // header, and the per-row paste-token box below collects the key (runs skip
+  // MCP with a warning until it's set, same as any unset ref).
   const isFeaturedInstalled = (url: string) => Object.values(draft).some(s => s.url === url)
   const installFeatured = (f: typeof FEATURED[number]) => {
     if (isFeaturedInstalled(f.url)) return
     const slug = draft[f.slug] ? `${f.slug}-mcp` : f.slug
-    const next = { ...draft, [slug]: { type: 'http', url: f.url } }
+    const server: McpServer = { type: f.transport ?? 'http', url: f.url }
+    if (f.authSecret) server.headers = { Authorization: `Bearer \${${f.authSecret}}` }
+    const next = { ...draft, [slug]: server }
     setDraft(next)
     onSave(next)
   }

--- a/apps/dashboard/lib/mcp-catalog.ts
+++ b/apps/dashboard/lib/mcp-catalog.ts
@@ -9,6 +9,13 @@ export interface McpCatalogEntry {
   url: string
   logo: string
   description?: string
+  // Transport for the installed server. Defaults to 'http' (streamable HTTP);
+  // set 'sse' for servers that speak MCP over Server-Sent Events.
+  transport?: 'http' | 'sse'
+  // When set, one-click install wires an `Authorization: Bearer ${<authSecret>}`
+  // header referencing this repo secret, and the MCP panel surfaces a paste-token
+  // row for it. Omit for public / OAuth / x402 servers (the existing default).
+  authSecret?: string
 }
 
 export const MCP_CATALOG: McpCatalogEntry[] = [
@@ -53,6 +60,15 @@ export const MCP_CATALOG: McpCatalogEntry[] = [
     url: 'https://glim.sh/mcp',
     logo: 'https://raw.githubusercontent.com/glim-sh/glim-mcp/main/assets/icon-400.png',
     description: 'glim.sh — live data for AI agents: web search, full page extraction, Twitter/X, Reddit, GitHub, Amazon, YouTube transcripts. Pay-per-call with x402 (Base/Solana USDC) or MPP (Tempo), or sign in and draw from a prepaid account balance.',
+  },
+  {
+    slug: 'litebeam',
+    name: 'Litebeam',
+    url: 'https://mcp.litebeam.xyz',
+    logo: 'https://litebeam.xyz/litebeam.svg',
+    description: 'Litebeam — one MCP connection to every microservice. An AI-microservice routing layer: discover and call paid services through a single endpoint, settled from your agent\'s wallet (managed Litebeam wallet or BYO via x402), with budget controls and HITL approvals.',
+    transport: 'sse',
+    authSecret: 'LITEBEAM_API_KEY',
   },
 ]
 


### PR DESCRIPTION
Adds **Litebeam** to the dashboard's MCP catalog so it appears under **Featured** for one-click install.

[Litebeam](https://litebeam.xyz) is an AI-microservice routing layer — one MCP connection to every microservice, settled from your agent's wallet (managed wallet or BYO via x402), with budget controls and HITL approvals. It exposes a standard MCP server at `https://mcp.litebeam.xyz`.

## What changed
- **`apps/dashboard/lib/mcp-catalog.ts`** — new `litebeam` catalog entry (name, url, logo, description), plus two **optional, backward-compatible** fields on `McpCatalogEntry`:
  - `transport?: 'http' | 'sse'` — defaults to `'http'`. Litebeam documents `sse` for the Claude Code CLI (which Aeon runs), so the entry sets `'sse'`.
  - `authSecret?` — the repo-secret name holding the bearer token.
- **`apps/dashboard/components/McpPanel.tsx`** — `installFeatured()` now honours `transport` and, when `authSecret` is set, wires an `Authorization: Bearer ${VAR}` header into `.mcp.json`.

## Why the installer change was needed
The existing featured servers are public / OAuth / x402, so the one-click installer wrote a bare `{ type: 'http', url }` with no header. Litebeam authenticates with a static `Authorization: Bearer sk-litebeam-…` key, which that path couldn't express. Now installing Litebeam writes a `${LITEBEAM_API_KEY}` header reference; the panel's **existing** per-row paste-token box collects the key (saved to repo secrets), and the runner resolves it via the standard `${VAR}`-from-secrets flow — skipping MCP with a warning until the key is set, exactly like any other unset ref.

## Notes
- Existing catalog entries are untouched — both new fields are optional with prior defaults preserved.
- Verified: `https://mcp.litebeam.xyz` is live (returns 406 to a bare GET, as expected for an MCP/SSE endpoint); logo `https://litebeam.xyz/litebeam.svg` resolves (vector, crisp at the 36px display size).
- Type-checked by inspection only — the dashboard's TS toolchain isn't vendored in the working tree, and `McpServer` is `Record<string, unknown>` so the additions are type-safe by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)