### PR TITLE
fix(mcp): use Litebeam's X avatar for the catalog logo

### DIFF
--- a/apps/dashboard/lib/mcp-catalog.ts
+++ b/apps/dashboard/lib/mcp-catalog.ts
@@ -65,7 +65,7 @@ export const MCP_CATALOG: McpCatalogEntry[] = [
     slug: 'litebeam',
     name: 'Litebeam',
     url: 'https://mcp.litebeam.xyz',
-    logo: 'https://litebeam.xyz/litebeam.svg',
+    logo: 'https://pbs.twimg.com/profile_images/2065063781042954241/zcTqmW5j_400x400.jpg',
     description: 'Litebeam — one MCP connection to every microservice. An AI-microservice routing layer: discover and call paid services through a single endpoint, settled from your agent\'s wallet (managed Litebeam wallet or BYO via x402), with budget controls and HITL approvals.',
     transport: 'sse',
     authSecret: 'LITEBEAM_API_KEY',


### PR DESCRIPTION
Follow-up to #508. The SVG (`litebeam.xyz/litebeam.svg`) didn't render well in the MCP panel's 36px logo slot, so swap to Litebeam's X profile image (400×400 JPEG) — matching the convention used by the other featured entries (Base, Ctrl, RootAI, …). Verified the new URL resolves (200, image/jpeg).

🤖 Generated with [Claude Code](https://claude.com/claude-code)