### PR TITLE
Add LENS skill pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Installed skills land in `skills/` and are added to `aeon.yml` disabled - flip `
 
 ## Why "the most autonomous"?
 
-Most agent tools put you in the driver's seat - approve this tool call, review this diff, confirm this action. Aeon is built for the work you want *done* while you're not there: briefings, market monitoring, PR reviews, research digests, security scans.
+Most agent tools put you in the driver's seat - approve this tool call, review this diff, confirm this action. Aeon is built for the work you want *done* while you're not there: briefings, market monitoring, PR reviews, research digests.
 
 |  | Aeon | Claude Code | Hermes | OpenClaw |
 |--|------|------------|--------|---------|
@@ -497,6 +497,7 @@ Either way the installer reads the pack's `skills-pack.json` manifest, runs the 
 | [Hunch Prediction Markets](https://github.com/rajkaria/hunch/tree/main/aeon-skill-pack) (`--path aeon-skill-pack`) | 3 | Crowd-conviction signal, market discovery, and **x402 betting** on PlayHunch - onchain prediction markets on Base. Unlike monitor-only packs, hunch-bet places real positions (simulate-by-default, $1-$10, USDC payout + onchain proof) |
 | [clawhunter-skills](https://github.com/clawhunter/clawhunter-skills) | 2 | Pump Fun GO bounty discovery + vetting, and the content tools to win them (voice tones, images, video direction). x402 on Solana or Base. |
 | [Polymarket Trader by Simmer](https://github.com/SpartanLabsXyz/aeon-skill-pack-polymarket/tree/main/aeon-skill-pack) (`--path aeon-skill-pack`) | 3 | Signal, discovery, and real position-taking on **Polymarket** - the deepest prediction-market venue - powered by Simmer. Unlike monitor-only packs, polymarket-trade places actual orders (simulate-by-default, live opt-in, bounded) |
+| [lens-skill-pack](https://github.com/Tholynceus/lens-skill-pack) | 1 | Read the deployer wallet behind any X profile and flag rug/scam token devs on Base - resolves the dev behind a handle and returns a CLEAR/CAUTION/STOP verdict via the public LENS API |
 
 **To list a pack here**, open a PR adding a row. Guidelines:
 

--- a/skill-packs.json
+++ b/skill-packs.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "updated": "2026-06-18",
+  "updated": "2026-06-19",
   "description": "Machine-readable registry of community skill packs installable via ./install-skill-pack. Mirrors the human-readable table in README.md.",
   "packs": [
     {
@@ -290,6 +290,19 @@
       "skills": ["polymarket-intel", "polymarket-markets", "polymarket-trade"],
       "secrets_required": ["SIMMER_API_KEY"],
       "capabilities": ["external_api", "writes_external_host", "onchain_writes", "sends_notifications"]
+    },
+    {
+      "repo": "Tholynceus/lens-skill-pack",
+      "name": "LENS Skill Pack",
+      "description": "Read the on-chain deployer wallet behind any X profile and flag rug/scam token devs on Base. Resolves the deployer behind a handle and returns a CLEAR/CAUTION/STOP verdict via the public LENS API. Bios lie, chains don't.",
+      "author": "lnsx_io",
+      "license": "MIT",
+      "homepage": "https://lnsx.io",
+      "category": "crypto",
+      "trust_level": "community",
+      "skills": ["lens-scan"],
+      "secrets_required": [],
+      "capabilities": ["read_only", "external_api"]
     }
   ]
 }


### PR DESCRIPTION
## What

Adds the LENS skill pack to the community skill packs registry.

## Why

LENS reads the on-chain deployer wallet behind any X profile and returns a CLEAR/CAUTION/STOP rug-risk verdict via the public LENS API. Resolves the dev behind a handle, flags rug/scam token devs on Base / Bankrbot. No key, public data only. Pack repo: https://github.com/Tholynceus/lens-skill-pack

## Type of change

- [x] Community skill pack listing

---

### Community skill pack listing

- [x] Pack repo is public with a clear license (MIT / Apache-2.0)
- [x] Pack has a `skills-pack.json` manifest at its root and a `SKILL.md` per skill
- [x] Write / onchain / bet skills are `default_enabled: false`
- [x] This PR adds **both** a README table row and a matching `skill-packs.json` entry
- [x] No monkey-patching of Aeon internals; no private or auth-walled endpoints required to run

bios lie, chains don't