### PR TITLE
Add Charon AEON skill pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,7 @@ Either way the installer reads the pack's `skills-pack.json` manifest, runs the 
 | [Hunch Prediction Markets](https://github.com/rajkaria/hunch/tree/main/aeon-skill-pack) (`--path aeon-skill-pack`) | 3 | Crowd-conviction signal, market discovery, and **x402 betting** on PlayHunch - onchain prediction markets on Base. Unlike monitor-only packs, hunch-bet places real positions (simulate-by-default, $1-$10, USDC payout + onchain proof) |
 | [clawhunter-skills](https://github.com/clawhunter/clawhunter-skills) | 2 | Pump Fun GO bounty discovery + vetting, and the content tools to win them (voice tones, images, video direction). x402 on Solana or Base. |
 | [Polymarket Trader by Simmer](https://github.com/SpartanLabsXyz/aeon-skill-pack-polymarket/tree/main/aeon-skill-pack) (`--path aeon-skill-pack`) | 3 | Signal, discovery, and real position-taking on **Polymarket** - the deepest prediction-market venue - powered by Simmer. Unlike monitor-only packs, polymarket-trade places actual orders (simulate-by-default, live opt-in, bounded) |
+| [Charon for AEON](https://github.com/CharonAI-code/charon/tree/main/skills/aeon) (`--path skills/aeon`) | 2 | Repo-local policy enforcement for AEON runs, with guided setup and natural-language policy management |
 
 **To list a pack here**, open a PR adding a row. Guidelines:
 

--- a/skill-packs.json
+++ b/skill-packs.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "updated": "2026-06-18",
+  "updated": "2026-06-20",
   "description": "Machine-readable registry of community skill packs installable via ./install-skill-pack. Mirrors the human-readable table in README.md.",
   "packs": [
     {
@@ -290,6 +290,20 @@
       "skills": ["polymarket-intel", "polymarket-markets", "polymarket-trade"],
       "secrets_required": ["SIMMER_API_KEY"],
       "capabilities": ["external_api", "writes_external_host", "onchain_writes", "sends_notifications"]
+    },
+    {
+      "repo": "CharonAI-code/charon",
+      "path": "skills/aeon",
+      "name": "Charon for AEON",
+      "description": "Repo-local policy enforcement for AEON runs, with guided setup and natural-language policy management.",
+      "author": "CharonAI-code",
+      "license": "MIT",
+      "homepage": "https://charon.codes",
+      "category": "dev",
+      "trust_level": "community",
+      "skills": ["charon-setup", "charon-policy"],
+      "secrets_required": [],
+      "capabilities": ["external_api", "writes_external_host"]
     }
   ]
 }


### PR DESCRIPTION
## What

Lists the Charon for AEON community pack with two skills:

- `charon-setup` installs and verifies Charon in an AEON repo
- `charon-policy` manages repo-local policy through natural language

Charon runs in workflow preflight before the selected skill reaches Claude. It evaluates `charon.aeon.yml`, returns `PASS`, `PAUSE`, or `DENY`, and records the decision.

## Why

This makes both Charon skills installable through AEON's community-pack flow without copying skill files or modifying AEON internals.

Validated with AEON's pack validator and a public GitHub installer dry run. Both skill security scans pass.

## Type of change

- [x] Community skill pack listing

### Community skill pack listing

- [x] Pack repo is public with a clear license (MIT)
- [x] Pack has a `skills-pack.json` manifest and a `SKILL.md` per skill
- [x] Write-capable skills are `default_enabled: false`
- [x] This PR adds both a README table row and a matching `skill-packs.json` entry
- [x] No monkey-patching of AEON internals or private endpoints
