### PR TITLE
docs: add apps/mcp-server/README.md with quickstart and Claude Desktop config

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,8 @@ Aeon skills work outside GitHub Actions too - locally via `claude -p -`, identic
 ./add-mcp --uninstall        # remove
 ```
 
+Tool naming, the `var` argument, Claude Desktop config, and a test client are in [`apps/mcp-server/README.md`](apps/mcp-server/README.md).
+
 **Any AI agent (A2A)** - [Google's A2A protocol](https://google.github.io/A2A/) lets LangChain, AutoGen, CrewAI, OpenAI Agents SDK, and Vertex AI invoke skills via HTTP:
 
 ```bash

--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -1,0 +1,97 @@
+# Aeon MCP Server
+
+Expose every Aeon skill as a [Model Context Protocol](https://modelcontextprotocol.io) tool, so you can run any skill straight from **Claude Desktop** or **Claude Code** — no GitHub Actions, no cron, no separate UI. Each skill shows up as an `aeon-<slug>` tool; ask Claude to use it and it runs the exact same `SKILL.md` prompt the scheduled runner uses.
+
+## What it is
+
+The server reads `skills.json` at the repo root and advertises each skill as an MCP tool over stdio. When Claude calls a tool, it spawns `claude -p -` against the matching `skills/<slug>/SKILL.md`, waits for the run to finish (same ~10-minute budget as Actions), and hands the skill's output back as the tool result. It's the bridge that turns "Aeon runs on a schedule in CI" into "Aeon is a set of tools inside my Claude session."
+
+It's the local, push-button sibling of the [A2A gateway](../a2a-server/README.md): MCP is for **Claude clients**, A2A is for **any agent framework over HTTP**. Both spawn the same skill prompt, so behaviour is identical across all three entry points (cron, Claude, remote agent).
+
+## Quickstart
+
+From the **repo root** (the server needs `skills.json` and the `skills/` directory beside it):
+
+```bash
+./add-mcp                    # build + register with Claude Code
+./add-mcp --desktop          # also print the Claude Desktop config snippet
+./add-mcp --build-only       # compile without registering (useful for CI / Claude Desktop)
+./add-mcp --uninstall        # remove the 'aeon' server from Claude Code
+```
+
+`./add-mcp` checks Node, builds the TypeScript, and runs `claude mcp add aeon node <path>` so every skill is immediately available as an `aeon-*` tool in Claude Code. Restart your Claude session and ask: *"Use the aeon-hn-digest tool"* or *"Run aeon-token-movers with var=AEON"*.
+
+Or build this app directly:
+
+```bash
+cd apps/mcp-server
+npm install
+npm run build                # → dist/index.js
+node dist/index.js           # stdio server; normally launched by the MCP client, not by hand
+```
+
+### Requirements
+
+- **Node.js >= 18** and npm (build + runtime).
+- The **`claude` CLI** on `PATH` — skills execute via `claude -p -`. Install with `npm install -g @anthropic-ai/claude-code`.
+- Whatever each skill needs at runtime — `ANTHROPIC_API_KEY` (or a configured gateway), `GITHUB_TOKEN` for repo skills, and any per-skill API keys. The spawned skill process inherits the MCP server's environment, so set these in your shell or a `.env` file at the repo root before launching the client.
+
+## Tools
+
+Every entry in `skills.json` becomes one tool:
+
+| | |
+|---|---|
+| **Name** | `aeon-<slug>` — e.g. `aeon-deep-research`, `aeon-hn-digest`, `aeon-token-movers`. |
+| **Description** | `[Aeon · <Category>] <skill description> (cron: <schedule>)` or `(on-demand)`, generated from the manifest so Claude can pick the right tool. |
+| **Input** | A single optional `var` (string) — the skill's `${var}` input. Its description is the skill's own `var` contract, or a sensible category default. Leave it empty to use the skill's default behaviour. |
+
+Examples of what `var` means per skill: a topic for research skills (`var="AI agent frameworks 2026"`), an `owner/repo` for dev skills, a token symbol for crypto skills. When in doubt, the skill's `SKILL.md` documents its `var` contract.
+
+## Claude Desktop
+
+`./add-mcp` registers with **Claude Code** automatically. For **Claude Desktop**, build once and add the server to your config:
+
+```bash
+./add-mcp --build-only       # produces apps/mcp-server/dist/index.js
+./add-mcp --desktop          # prints the snippet + the config path for your OS
+```
+
+Then add this to your Claude Desktop config (macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`, Windows: `%APPDATA%\Claude\claude_desktop_config.json`), replacing the path with your real repo path — see [`examples/mcp/claude_desktop_config.json`](../../examples/mcp/claude_desktop_config.json):
+
+```json
+{
+  "mcpServers": {
+    "aeon": {
+      "command": "node",
+      "args": ["/ABSOLUTE/PATH/TO/aeon/apps/mcp-server/dist/index.js"]
+    }
+  }
+}
+```
+
+Restart Claude Desktop — Aeon skills appear in the tools list.
+
+## Testing the round-trip
+
+Before wiring it into a client, confirm the server lists and runs tools with the standalone Python client:
+
+```bash
+./add-mcp --build-only                          # produce dist/index.js
+pip install mcp                                 # official Anthropic MCP client
+python examples/mcp/test_connection.py          # lists every aeon-* tool, then calls aeon-cost-report
+python examples/mcp/test_connection.py aeon-token-movers AEON   # call a specific tool with a var
+```
+
+You should see the full `aeon-*` tool list followed by a real skill output. If that works, your Claude Desktop / Claude Code wiring will too. `aeon-cost-report` is the default because it's fast and needs no external API.
+
+## How it works
+
+- **Transport:** stdio (`StdioServerTransport`) using the official `@modelcontextprotocol/sdk`. The MCP client launches `node dist/index.js` as a subprocess and speaks JSON-RPC over stdin/stdout — diagnostics go to stderr (`[aeon-mcp] …`) so they never corrupt the protocol stream.
+- **Skill discovery:** `loadSkills()` parses `skills.json` from the repo root (resolved relative to the compiled file, three levels up from `dist/`). If the manifest is missing the server starts with zero tools rather than crashing.
+- **Execution:** each call spawns `claude -p - --output-format json` with `cwd` set to the repo root and a 600 000 ms (10-minute) timeout — the same budget GitHub Actions gives a skill. The JSON envelope is unwrapped to return `result`; raw output is returned as a fallback.
+- **Errors are returned, not thrown:** a missing skill, a missing `claude` CLI (`ENOENT` → install hint), or a non-zero exit all come back as readable tool text so Claude can react instead of the connection dropping.
+
+## Sandbox / deployment note
+
+This server shells out to the `claude` CLI per tool call, so it must run somewhere that CLI is installed and authenticated (your machine or a container with `ANTHROPIC_API_KEY`). It is **not** part of the GitHub Actions cron path — that path runs skills on their schedule. The MCP server is the on-demand, Claude-native complement: invoke a skill the moment you need it, from inside the assistant you're already using.


### PR DESCRIPTION
## What

Adds `apps/mcp-server/README.md` — a one-page guide for the Aeon MCP server — plus a one-line pointer to it from the main README's MCP section.

The README covers:
- **What it is** — every skill as an `aeon-<slug>` MCP tool for Claude Desktop / Claude Code, and how it relates to the A2A gateway.
- **Quickstart** — `./add-mcp` (build + register) and its flags, plus the direct `npm install && npm run build` path.
- **Requirements** — Node >= 18, the `claude` CLI, and the env/secrets the spawned skill inherits.
- **Tools** — the `aeon-<slug>` naming, the generated description format, and the single optional `var` argument.
- **Claude Desktop** — the config snippet (linked to `examples/mcp/claude_desktop_config.json`).
- **Testing** — the `examples/mcp/test_connection.py` round-trip.
- **How it works** — stdio transport, `skills.json` discovery, `claude -p -` execution with a 10-min budget, and errors-as-text behaviour.

## Why

The MCP server shipped with `src/index.ts`, the root `add-mcp` script, `.mcp.json.example`, and `examples/mcp/` — but no README. Developers landing on `apps/mcp-server/` found raw TypeScript with no quickstart, no tool-naming reference, and no Claude Desktop wiring. This is the same onboarding gap the A2A gateway had before #501, identified as action #4 in the 2026-06-18 repo-actions pass.

## Changes

- `apps/mcp-server/README.md`: new — full quickstart, tool reference, Claude Desktop config, test client, and implementation notes. Every command, flag, env var, and path verified against `apps/mcp-server/src/index.ts`, `add-mcp`, and `examples/mcp/`.
- `README.md`: one-line pointer to the new README under the MCP section, matching the existing A2A link.

Docs-only — no behaviour change. 99 insertions.

---
*Built autonomously by Aeon*
