### PR TITLE
chore: add Dependabot for npm apps and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,70 @@
+# Dependabot keeps Aeon's dependencies current and auditable.
+# Aeon runs autonomous code with access to operator secrets and executes
+# community-pack skills on a cron, so silent npm vulns and mutable-tag action
+# hijacks are a real risk. Each ecosystem below opens at most a few PRs per week,
+# routed to the maintainer.
+version: 2
+updates:
+  # GitHub Actions across all workflow files (currently floating @v4/@v5 tags).
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    assignees:
+      - "aaronjmars"
+    commit-message:
+      prefix: "chore(actions)"
+
+  # Next.js dashboard — the largest npm surface (Next 16, React 19, tailwind).
+  - package-ecosystem: "npm"
+    directory: "/apps/dashboard"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    assignees:
+      - "aaronjmars"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+
+  # MCP server — exposes Aeon skills as Claude tools.
+  - package-ecosystem: "npm"
+    directory: "/apps/mcp-server"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    assignees:
+      - "aaronjmars"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+
+  # A2A protocol gateway.
+  - package-ecosystem: "npm"
+    directory: "/apps/a2a-server"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    assignees:
+      - "aaronjmars"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+
+  # Cloudflare Worker that relays Telegram messages to a fork.
+  - package-ecosystem: "npm"
+    directory: "/apps/webhook"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    assignees:
+      - "aaronjmars"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"


### PR DESCRIPTION
## What

Adds `.github/dependabot.yml` so Dependabot tracks dependency updates across the whole repo:

- **GitHub Actions** (`/`) — all 8 workflow files currently float on `@v4`/`@v5` tags
- **npm** — every workspace with a `package.json`: `apps/dashboard`, `apps/mcp-server`, `apps/a2a-server`, `apps/webhook`

Each ecosystem runs weekly (Monday), caps open PRs at 5, routes to `@aaronjmars`, and uses `chore(deps)` / `chore(deps-dev)` commit prefixes to match the repo's commit convention.

## Why

Aeon runs autonomous code with access to operator secrets and executes community-pack skills on a cron. Without Dependabot, npm vulns in the dashboard's Next.js/React stack and mutable-tag action hijacks accumulate silently — no PRs, no audit trail. This turns dependency hygiene from a manual chore into a zero-cost automated signal, and a maintained dep posture is exactly what forks evaluate before adopting.

Surfaced by the 2026-06-20 `repo-actions` scan, which flagged `.github/dependabot.yml` as absent despite four npm workspaces and eight workflows on floating tags.

## Changes

- `.github/dependabot.yml` (new): 5 update blocks — `github-actions` + four `npm` directories — weekly schedule, PR limit 5, maintainer assignee, conventional commit prefixes.

No behavior change; GitHub activates Dependabot automatically on merge.

---
*Built autonomously by Aeon*
