### PR TITLE
chore(dashboard): align @json-render/core + react on ^0.19 to dedupe

### DIFF
--- a/apps/dashboard/package-lock.json
+++ b/apps/dashboard/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@json-render/core": "^0.15.0",
-        "@json-render/react": "^0.15.0",
+        "@json-render/core": "^0.19.0",
+        "@json-render/react": "^0.19.0",
         "@json-render/shadcn": "^0.19.0",
         "gsap": "^3.15.0",
         "next": "^16.2.9",
@@ -1048,9 +1048,9 @@
       }
     },
     "node_modules/@json-render/core": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@json-render/core/-/core-0.15.0.tgz",
-      "integrity": "sha512-ej5fx6C2Gp5iSit+HyyFh6QenKRIAO9xvFlxal6uzQQTpOJzJlXPsNROL2JT5QjY/iLgLaf4RJohdP1mWSYDNQ==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@json-render/core/-/core-0.19.0.tgz",
+      "integrity": "sha512-vvcyZ+10EDZKbEyB1J2kXOGfDaiZR2LurZGSqi2r5STHyKr+Te85DWaBxTwRGgM7U1LtIvNx85BzzjElRKoAIg==",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^4.3.6"
@@ -1060,12 +1060,12 @@
       }
     },
     "node_modules/@json-render/react": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@json-render/react/-/react-0.15.0.tgz",
-      "integrity": "sha512-2vfevZ3zRQNqVN6Y/WPFDkOe9/LPpUwDS+W4ViQQRJGO2j1wl0RbfMQtiiPai/bWQkJq0aantoQWIbh1/o8Cew==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@json-render/react/-/react-0.19.0.tgz",
+      "integrity": "sha512-kTW6b6cSNRrlEfCUf/69SLoLn+CufC968ruge9tnQlp9pDTGG/SK8pgM541FdgwMFA4zm3s5mpM3G8rdODKc/A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@json-render/core": "0.15.0"
+        "@json-render/core": "0.19.0"
       },
       "peerDependencies": {
         "react": "^19.2.3"
@@ -1092,30 +1092,6 @@
         "react-dom": "^19.0.0",
         "tailwindcss": "^4.0.0",
         "zod": "^4.0.0"
-      }
-    },
-    "node_modules/@json-render/shadcn/node_modules/@json-render/core": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@json-render/core/-/core-0.19.0.tgz",
-      "integrity": "sha512-vvcyZ+10EDZKbEyB1J2kXOGfDaiZR2LurZGSqi2r5STHyKr+Te85DWaBxTwRGgM7U1LtIvNx85BzzjElRKoAIg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "zod": "^4.3.6"
-      },
-      "peerDependencies": {
-        "zod": "^4.0.0"
-      }
-    },
-    "node_modules/@json-render/shadcn/node_modules/@json-render/react": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@json-render/react/-/react-0.19.0.tgz",
-      "integrity": "sha512-kTW6b6cSNRrlEfCUf/69SLoLn+CufC968ruge9tnQlp9pDTGG/SK8pgM541FdgwMFA4zm3s5mpM3G8rdODKc/A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@json-render/core": "0.19.0"
-      },
-      "peerDependencies": {
-        "react": "^19.2.3"
       }
     },
     "node_modules/@next/env": {
@@ -1163,9 +1139,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1181,9 +1154,6 @@
       "integrity": "sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1201,9 +1171,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1219,9 +1186,6 @@
       "integrity": "sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -10,8 +10,8 @@
     "test": "node --import tsx --test 'lib/**/*.test.mjs' 'lib/**/*.test.ts'"
   },
   "dependencies": {
-    "@json-render/core": "^0.15.0",
-    "@json-render/react": "^0.15.0",
+    "@json-render/core": "^0.19.0",
+    "@json-render/react": "^0.19.0",
     "@json-render/shadcn": "^0.19.0",
     "gsap": "^3.15.0",
     "next": "^16.2.9",


### PR DESCRIPTION
Follow-up to #516. That PR bumped `@json-render/shadcn` to `^0.19` but left `@json-render/core` and `@json-render/react` at `^0.15`, forcing **two copies of `@json-render/core`** in the tree (0.15 top-level + 0.19 nested under shadcn). This aligns all three `@json-render/*` packages on `^0.19` so they dedupe to a single copy.

**Verified locally:**
- `npm ls @json-render/core` → single deduped `0.19.0` (zero `0.15.0` entries left in the lockfile)
- `next build` → exit 0
- `npm test` → 131/131 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)