### PR TITLE
chore: update LICENSE copyright to Aeon Inc

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Aaron Elijah Mars
+Copyright (c) 2026 Aeon Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updates the MIT license copyright holder from `Aaron Elijah Mars` to `Aeon Inc`. License terms are otherwise unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)