### PR TITLE
chore: code-quality pass — DRY, shared types, dead code, weak types + load-error UX fix

### DIFF
--- a/apps/a2a-server/src/index.ts
+++ b/apps/a2a-server/src/index.ts
@@ -481,7 +481,7 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
       return;
     }
 
-    const task = result as Task;
+    const task = result;
     res.writeHead(200, {
       "Content-Type": "text/event-stream",
       "Cache-Control": "no-cache",
@@ -530,7 +530,7 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
           json(res, 200, { jsonrpc: "2.0", id: rpc.id, error: r.error });
           return;
         }
-        const { _subscribers: _, ...safe } = r as Task;
+        const { _subscribers: _, ...safe } = r;
         json(res, 200, { jsonrpc: "2.0", id: rpc.id, result: safe });
         return;
       }

--- a/apps/dashboard/app/api/import/route.ts
+++ b/apps/dashboard/app/api/import/route.ts
@@ -8,7 +8,8 @@ import {
   getDirectory,
   commitAndPush,
 } from '@/lib/github'
-import { errorResponse } from '@/lib/http'
+import type { CommitResult } from '@/lib/github'
+import { errorResponse, syncFields } from '@/lib/http'
 import { addSkillToConfig } from '@/lib/config'
 import { parseFrontmatter } from '@/lib/frontmatter'
 
@@ -109,11 +110,11 @@ export async function POST(request: Request) {
       }
 
       // Push the new skill dirs + aeon.yml to GitHub in one commit (local mode).
-      const sync: { synced: boolean; reason?: string } = written.length
+      const sync: CommitResult = written.length
         ? commitAndPush(['aeon.yml', ...written.map(n => `skills/${n}`)], `feat: import ${written.join(', ')}`)
         : { synced: true }
 
-      return NextResponse.json({ installed, partial, failed, synced: sync.synced, ...(sync.reason ? { syncError: sync.reason } : {}) })
+      return NextResponse.json({ installed, partial, failed, ...syncFields(sync) })
     }
 
     return NextResponse.json({ error: 'Invalid action' }, { status: 400 })

--- a/apps/dashboard/app/api/skills/route.ts
+++ b/apps/dashboard/app/api/skills/route.ts
@@ -11,6 +11,7 @@ import {
   removeSkillFromConfig,
 } from '@/lib/config'
 import { deleteDirectory } from '@/lib/github'
+import type { CommitResult } from '@/lib/github'
 import { parseFrontmatter } from '@/lib/frontmatter'
 import type { Skill } from '@/lib/types'
 
@@ -117,7 +118,7 @@ export async function PATCH(request: Request) {
       })
     }
 
-    let sync: { synced: boolean; reason?: string } = { synced: true }
+    let sync: CommitResult = { synced: true }
     if (updated !== content) {
       const msg = model
         ? `chore: set model to ${model}`

--- a/apps/dashboard/app/api/soul/examples/route.ts
+++ b/apps/dashboard/app/api/soul/examples/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 import { getRemoteDirectory, getRemoteFileContent, createFile, commitAndPush } from '@/lib/github'
-import { errorResponse } from '@/lib/http'
+import { errorResponse, syncFields } from '@/lib/http'
 import { displayName } from '@/lib/utils'
 
 // One-click install of a ready-made soul from the soul.md examples gallery into
@@ -51,7 +51,7 @@ export async function POST(request: Request) {
     if (good) { await createFile('soul/examples/good-outputs.md', good, msg); paths.push('soul/examples/good-outputs.md') }
 
     const sync = commitAndPush(paths, msg)
-    return NextResponse.json({ ok: true, soul, style: style || '', synced: sync.synced, ...(sync.reason ? { syncError: sync.reason } : {}) })
+    return NextResponse.json({ ok: true, soul, style: style || '', ...syncFields(sync) })
   } catch (error: unknown) {
     return errorResponse(error, 'Failed to install example')
   }

--- a/apps/dashboard/app/api/upload/route.ts
+++ b/apps/dashboard/app/api/upload/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { createFile, getFileContent, updateFile, commitAndPush } from '@/lib/github'
-import { errorResponse } from '@/lib/http'
-import { isRecord } from '@/lib/utils'
+import { errorResponse, syncFields } from '@/lib/http'
+import { isRecord, slugify } from '@/lib/utils'
 import { addSkillToConfig } from '@/lib/config'
 import { parseFrontmatter, setFrontmatterCategory, SKILL_CATEGORIES } from '@/lib/frontmatter'
 import type { UploadFile } from '@/lib/types'
@@ -22,7 +22,7 @@ function detectSecretsFromContent(content: string): string[] {
 function extractSkillName(content: string): string {
   // Slugify the frontmatter name: "Fleet Scorecard" → "fleet-scorecard"
   const { name } = parseFrontmatter(content)
-  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
+  return slugify(name)
 }
 
 // Validate a single element of an untrusted `files` array. We only require the
@@ -56,14 +56,14 @@ function deriveSkillName(files: UploadFile[]): { name: string; prefix: string } 
   if (dotSkillFile) {
     const parts = dotSkillFile.path.split('/')
     const fileName = parts[parts.length - 1]
-    const name = stripSkillExt(fileName).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
+    const name = slugify(stripSkillExt(fileName))
 
     if (parts.length === 1) {
       // Single file: "my-skill.skill"
       return { name, prefix: '' }
     }
     // In a folder: "folder/my-skill.skill"
-    const folderName = stripSkillExt(parts[0]).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
+    const folderName = slugify(stripSkillExt(parts[0]))
     return { name: folderName || name, prefix: parts.slice(0, -1).join('/') + '/' }
   }
 
@@ -118,7 +118,7 @@ export async function POST(request: Request) {
     }
 
     const { name: derivedName, prefix } = deriveSkillName(files)
-    const skillName = overrideName?.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '') || derivedName
+    const skillName = slugify(overrideName?.trim() ?? '') || derivedName
 
     if (!skillName) {
       return NextResponse.json({
@@ -186,8 +186,7 @@ export async function POST(request: Request) {
       detectedSecrets,
       configUpdated,
       ...(configError ? { configError } : {}),
-      synced: sync.synced,
-      ...(sync.reason ? { syncError: sync.reason } : {}),
+      ...syncFields(sync),
     })
   } catch (error: unknown) {
     return errorResponse(error, 'Unknown error')

--- a/apps/dashboard/app/page.tsx
+++ b/apps/dashboard/app/page.tsx
@@ -25,6 +25,7 @@ import { PacksPanel } from '../components/PacksPanel'
 import { RightPanel } from '../components/RightPanel'
 import { ImportModal } from '../components/ImportModal'
 import { AuthModal } from '../components/AuthModal'
+import { PanelError } from '../components/PanelError'
 
 export default function Dashboard() {
   const [view, setView] = useState<'hq' | 'packs' | 'secrets' | 'strategy' | 'mcp' | 'soul'>('hq')
@@ -53,10 +54,13 @@ export default function Dashboard() {
 
   const [outputs, setOutputs] = useState<SkillOutput[]>([])
   const [feedLoading, setFeedLoading] = useState(false)
+  const [feedError, setFeedError] = useState(false)
   const [analyticsData, setAnalyticsData] = useState<AnalyticsData | null>(null)
+  const [analyticsError, setAnalyticsError] = useState(false)
 
   const [packs, setPacks] = useState<PacksResponse | null>(null)
   const [packsLoaded, setPacksLoaded] = useState(false)
+  const [packsError, setPacksError] = useState(false)
   // Which packs are *visible* across the dashboard. A pack is a visibility lens:
   // by default only Core shows everywhere; enabling a pack reveals its skills in
   // the sidebar + HQ. Pure client-side view preference - it never changes what
@@ -69,14 +73,17 @@ export default function Dashboard() {
 
   const [strategy, setStrategy] = useState('')
   const [strategyLoaded, setStrategyLoaded] = useState(false)
+  const [strategyError, setStrategyError] = useState(false)
   const [strategySaving, setStrategySaving] = useState(false)
   const [strategyBuilding, setStrategyBuilding] = useState(false)
   const [mcpServers, setMcpServers] = useState<McpServers>({})
   const [mcpLoaded, setMcpLoaded] = useState(false)
+  const [mcpError, setMcpError] = useState(false)
   const [mcpSaving, setMcpSaving] = useState(false)
   const [soul, setSoul] = useState('')
   const [soulStyle, setSoulStyle] = useState('')
   const [soulLoaded, setSoulLoaded] = useState(false)
+  const [soulError, setSoulError] = useState(false)
   const [soulSaving, setSoulSaving] = useState(false)
   const [soulBuilding, setSoulBuilding] = useState(false)
   const [soulInstalling, setSoulInstalling] = useState<string | null>(null)
@@ -116,11 +123,11 @@ export default function Dashboard() {
     setEnabledPacks(Array.from(new Set(['core', ...saved])))
   }, [repo])
   useEffect(() => { const id = setInterval(refreshRuns, 10_000); return () => clearInterval(id) }, [refreshRuns])
-  useEffect(() => { setFeedLoading(true); fetch('/api/outputs').then(r => r.ok ? r.json() as Promise<OutputsResponse> : { outputs: [] }).then(d => setOutputs(d.outputs || [])).finally(() => setFeedLoading(false)) }, [feedKey])
-  useEffect(() => { if (view === 'strategy' && !strategyLoaded) { fetch('/api/strategy').then(r => r.ok ? r.json() as Promise<StrategyResponse> : null).then(d => { if (d) { setStrategy(d.content || ''); setStrategyLoaded(true) } }).catch(() => {}) } }, [view, strategyLoaded])
-  useEffect(() => { if (view === 'mcp' && !mcpLoaded) { fetch('/api/mcp').then(r => r.ok ? r.json() as Promise<McpResponse> : null).then(d => { if (d) { setMcpServers(d.servers || {}); setMcpLoaded(true) } }).catch(() => {}) } }, [view, mcpLoaded])
-  useEffect(() => { if (view === 'soul' && !soulLoaded) { fetch('/api/soul').then(r => r.ok ? r.json() as Promise<SoulResponse> : null).then(d => { if (d) { setSoul(d.soul?.content || ''); setSoulStyle(d.style?.content || ''); setSoulLoaded(true) } }).catch(() => {}) } }, [view, soulLoaded])
-  useEffect(() => { if (view === 'packs' && !packsLoaded) { fetch('/api/packs').then(r => r.ok ? r.json() as Promise<PacksResponse> : null).then(d => { if (d) { setPacks(d); setPacksLoaded(true) } }).catch(() => {}) } }, [view, packsLoaded])
+  useEffect(() => { setFeedLoading(true); setFeedError(false); fetch('/api/outputs').then(r => r.ok ? r.json() as Promise<OutputsResponse> : Promise.reject(new Error(`HTTP ${r.status}`))).then(d => setOutputs(d.outputs || [])).catch(() => setFeedError(true)).finally(() => setFeedLoading(false)) }, [feedKey])
+  useEffect(() => { if (view === 'strategy' && !strategyLoaded) { fetch('/api/strategy').then(r => r.ok ? r.json() as Promise<StrategyResponse> : Promise.reject(new Error(`HTTP ${r.status}`))).then(d => { setStrategy(d.content || ''); setStrategyLoaded(true) }).catch(() => { setStrategyError(true); setStrategyLoaded(true) }) } }, [view, strategyLoaded])
+  useEffect(() => { if (view === 'mcp' && !mcpLoaded) { fetch('/api/mcp').then(r => r.ok ? r.json() as Promise<McpResponse> : Promise.reject(new Error(`HTTP ${r.status}`))).then(d => { setMcpServers(d.servers || {}); setMcpLoaded(true) }).catch(() => { setMcpError(true); setMcpLoaded(true) }) } }, [view, mcpLoaded])
+  useEffect(() => { if (view === 'soul' && !soulLoaded) { fetch('/api/soul').then(r => r.ok ? r.json() as Promise<SoulResponse> : Promise.reject(new Error(`HTTP ${r.status}`))).then(d => { setSoul(d.soul?.content || ''); setSoulStyle(d.style?.content || ''); setSoulLoaded(true) }).catch(() => { setSoulError(true); setSoulLoaded(true) }) } }, [view, soulLoaded])
+  useEffect(() => { if (view === 'packs' && !packsLoaded) { fetch('/api/packs').then(r => r.ok ? r.json() as Promise<PacksResponse> : Promise.reject(new Error(`HTTP ${r.status}`))).then(d => { setPacks(d); setPacksLoaded(true) }).catch(() => { setPacksError(true); setPacksLoaded(true) }) } }, [view, packsLoaded])
   // Reset the main content scroll to the top whenever the active view or the
   // selected skill changes, so each screen (Soul, Strategy, a skill, …) opens at the top.
   useEffect(() => { mainScrollRef.current?.scrollTo({ top: 0 }) }, [view, selectedSkill])
@@ -216,19 +223,27 @@ export default function Dashboard() {
             <SecretsPanel secrets={secrets} skills={skills} busy={busy} repo={repo} focusKey={secretFocus} onFocusHandled={() => setSecretFocus(null)} onSave={saveSecret} onDelete={deleteSecret} onSelectSkill={(name) => { setSelectedSkill(name); setView('hq') }} onConnectClaude={() => setupAuth()} connecting={authLoading} />
           )}
           {view === 'strategy' && !selectedSkill && (
-            <StrategyPanel content={strategy} loading={!strategyLoaded} saving={strategySaving} building={strategyBuilding} onSave={saveStrategy} onBuild={buildStrategy} />
+            strategyError
+              ? <PanelError label="strategy" onRetry={() => { setStrategyError(false); setStrategyLoaded(false) }} />
+              : <StrategyPanel content={strategy} loading={!strategyLoaded} saving={strategySaving} building={strategyBuilding} onSave={saveStrategy} onBuild={buildStrategy} />
           )}
           {view === 'mcp' && !selectedSkill && (
-            <McpPanel servers={mcpServers} loading={!mcpLoaded} saving={mcpSaving} secrets={secrets} busy={busy} onSave={saveMcp} onSetSecret={saveSecret} onDeleteSecret={deleteSecret} />
+            mcpError
+              ? <PanelError label="MCP servers" onRetry={() => { setMcpError(false); setMcpLoaded(false) }} />
+              : <McpPanel servers={mcpServers} loading={!mcpLoaded} saving={mcpSaving} secrets={secrets} busy={busy} onSave={saveMcp} onSetSecret={saveSecret} onDeleteSecret={deleteSecret} />
           )}
           {view === 'soul' && !selectedSkill && (
-            <SoulPanel soul={soul} style={soulStyle} loading={!soulLoaded} saving={soulSaving} building={soulBuilding} installing={soulInstalling} onSave={saveSoul} onBuild={buildSoul} onInstallExample={installSoulExample} />
+            soulError
+              ? <PanelError label="soul" onRetry={() => { setSoulError(false); setSoulLoaded(false) }} />
+              : <SoulPanel soul={soul} style={soulStyle} loading={!soulLoaded} saving={soulSaving} building={soulBuilding} installing={soulInstalling} onSave={saveSoul} onBuild={buildSoul} onInstallExample={installSoulExample} />
           )}
           {view === 'hq' && !selectedSkill && (
             <HQOverview skills={visibleSkills} runs={runs} enabledCount={enabledCount} workingCount={workingCount} categoryFilter={categoryFilter} onCategoryClick={(key) => setCategoryFilter(categoryFilter === key ? null : key)} onViewRun={() => {}} onOpenPacks={() => setView('packs')} />
           )}
           {view === 'packs' && !selectedSkill && (
-            <PacksPanel firstParty={packs?.firstParty ?? []} community={packs?.community ?? []} skills={skills} enabledPacks={enabledPacks} loading={!packsLoaded} busy={busy} onTogglePack={togglePack} onToggleSkill={toggleSkill} onSelectSkill={(name) => { setSelectedSkill(name); setView('hq') }} onInstallPack={(arg) => runSkill('install-skill', arg)} />
+            packsError
+              ? <PanelError label="packs" onRetry={() => { setPacksError(false); setPacksLoaded(false) }} />
+              : <PacksPanel firstParty={packs?.firstParty ?? []} community={packs?.community ?? []} skills={skills} enabledPacks={enabledPacks} loading={!packsLoaded} busy={busy} onTogglePack={togglePack} onToggleSkill={toggleSkill} onSelectSkill={(name) => { setSelectedSkill(name); setView('hq') }} onInstallPack={(arg) => runSkill('install-skill', arg)} />
           )}
           {skill && (
             <SkillDetail
@@ -243,10 +258,10 @@ export default function Dashboard() {
       </div>
 
       <RightPanel
-        runs={runs} outputs={outputs} feedLoading={feedLoading} analyticsData={analyticsData}
+        runs={runs} outputs={outputs} feedLoading={feedLoading} feedError={feedError} analyticsData={analyticsData} analyticsError={analyticsError}
         onViewRun={() => {}}
-        onRefresh={() => { fetchData(); setFeedKey(k => k + 1); setAnalyticsData(null) }}
-        onFetchAnalytics={() => { if (!analyticsData) fetch('/api/analytics').then(r => r.ok ? r.json() as Promise<AnalyticsData> : null).then(d => { if (d) setAnalyticsData(d) }) }}
+        onRefresh={() => { fetchData(); setFeedKey(k => k + 1); setAnalyticsData(null); setAnalyticsError(false) }}
+        onFetchAnalytics={() => { if (!analyticsData) { setAnalyticsError(false); fetch('/api/analytics').then(r => r.ok ? r.json() as Promise<AnalyticsData> : Promise.reject(new Error(`HTTP ${r.status}`))).then(d => setAnalyticsData(d)).catch(() => setAnalyticsError(true)) } }}
       />
 
       {showImport && <ImportModal onClose={() => setShowImport(false)} onImport={importSkill} />}

--- a/apps/dashboard/app/page.tsx
+++ b/apps/dashboard/app/page.tsx
@@ -5,7 +5,7 @@ import type {
   Skill, Run, Secret, SkillOutput, GatewayProvider, UploadFile, AnalyticsData,
   SkillsResponse, RunsResponse, SecretsResponse, SyncStatusResponse, McpResponse,
   OutputsResponse, StrategyResponse, SoulResponse, SyncResult, SoulExampleResponse,
-  UploadResponse, ErrorResponse, PacksResponse,
+  UploadResponse, ErrorResponse, PacksResponse, McpServers,
 } from '../lib/types'
 import { postJson, putJson, patchJson, del, scheduleRunRefresh } from '../lib/api-client'
 import { MODELS, AUTH_SECRETS, PACK_BY_KEY, FIRST_PARTY_KEYS } from '../lib/constants'
@@ -71,7 +71,7 @@ export default function Dashboard() {
   const [strategyLoaded, setStrategyLoaded] = useState(false)
   const [strategySaving, setStrategySaving] = useState(false)
   const [strategyBuilding, setStrategyBuilding] = useState(false)
-  const [mcpServers, setMcpServers] = useState<Record<string, Record<string, unknown>>>({})
+  const [mcpServers, setMcpServers] = useState<McpServers>({})
   const [mcpLoaded, setMcpLoaded] = useState(false)
   const [mcpSaving, setMcpSaving] = useState(false)
   const [soul, setSoul] = useState('')
@@ -156,7 +156,7 @@ export default function Dashboard() {
   }
   const saveStrategy = async (content: string) => { setStrategySaving(true); try { const { ok, data } = await putJson<SyncResult>('/api/strategy', { content }); if (ok) { setStrategy(content); flashSynced('Strategy saved', data) } else { flash('Save failed') } } finally { setStrategySaving(false) } }
   const buildStrategy = async (sources: StrategySources) => { setStrategyBuilding(true); try { const { ok, data } = await postJson<ErrorResponse>('/api/strategy/build', { ...sources, model }); if (ok) { flash('Strategy-builder started'); scheduleRunRefresh(refreshRuns) } else { flash(data.error || 'Build failed to dispatch') } } finally { setStrategyBuilding(false) } }
-  const saveMcp = async (servers: Record<string, Record<string, unknown>>) => { setMcpSaving(true); try { const { ok, data } = await putJson<SyncResult>('/api/mcp', { servers }); if (ok) { setMcpServers(servers); flashSynced('MCP servers saved', data) } else { flash('Save failed') } } finally { setMcpSaving(false) } }
+  const saveMcp = async (servers: McpServers) => { setMcpSaving(true); try { const { ok, data } = await putJson<SyncResult>('/api/mcp', { servers }); if (ok) { setMcpServers(servers); flashSynced('MCP servers saved', data) } else { flash('Save failed') } } finally { setMcpSaving(false) } }
   const saveSoul = async (file: SoulFile, content: string) => { setSoulSaving(true); try { const { ok, data } = await putJson<SyncResult>('/api/soul', { file, content }); if (ok) { if (file === 'soul') setSoul(content); else setSoulStyle(content); flashSynced(`${file === 'soul' ? 'SOUL.md' : 'STYLE.md'} saved`, data) } else { flash('Save failed') } } finally { setSoulSaving(false) } }
   const buildSoul = async (sources: SoulSources) => { setSoulBuilding(true); try { const { ok, data } = await postJson<ErrorResponse>('/api/soul/build', { ...sources, model }); if (ok) { const label = sources.handle ? `@${sources.handle}` : sources.name || 'your links'; flash(`Soul-builder started for ${label}`); scheduleRunRefresh(refreshRuns) } else { flash(data.error || 'Build failed to dispatch') } } finally { setSoulBuilding(false) } }
   const installSoulExample = async (key: string) => { setSoulInstalling(key); try { const { ok, data } = await postJson<SoulExampleResponse>('/api/soul/examples', { example: key }); if (ok) { setSoul(data.soul || ''); setSoulStyle(data.style || ''); setSoulLoaded(true); flashSynced(`Installed ${key} soul`, data) } else { flash(data.error || 'Install failed') } } finally { setSoulInstalling(null) } }

--- a/apps/dashboard/components/ImportModal.tsx
+++ b/apps/dashboard/components/ImportModal.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef } from 'react'
 import type { UploadFile } from '../lib/types'
-import { inputCls } from '../lib/utils'
+import { inputCls, slugify } from '../lib/utils'
 import { CATEGORIES } from '../lib/constants'
 
 interface ImportModalProps {
@@ -25,13 +25,13 @@ export function ImportModal({ onClose, onImport }: ImportModalProps) {
     const files: UploadFile[] = []
     for (let i = 0; i < fl.length; i++) {
       const f = fl[i]
-      files.push({ path: (f as { webkitRelativePath?: string }).webkitRelativePath || f.name, content: await f.text() })
+      files.push({ path: f.webkitRelativePath || f.name, content: await f.text() })
     }
     setUploadFiles(files)
     const sf = files.find(f => { const l = f.path.toLowerCase(); return l === 'skill.md' || l.endsWith('/skill.md') || l.endsWith('.skill') })
     if (sf) {
       const fm = sf.content.match(/^---\s*\n([\s\S]*?)\n---/)
-      if (fm) { const n = fm[1].match(/name:\s*(.+)/); if (n) { const slug = n[1].trim().replace(/^['"]|['"]$/g, '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, ''); if (slug) setUploadName(slug) } }
+      if (fm) { const n = fm[1].match(/name:\s*(.+)/); if (n) { const slug = slugify(n[1].trim().replace(/^['"]|['"]$/g, '')); if (slug) setUploadName(slug) } }
     }
   }
 

--- a/apps/dashboard/components/PanelError.tsx
+++ b/apps/dashboard/components/PanelError.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+// Shown when a panel's lazy data fetch fails, in place of an indefinite
+// spinner. Surfaces the failure and offers a retry instead of hiding it.
+export function PanelError({ label, onRetry }: { label: string; onRetry: () => void }) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 px-4 py-16 text-center">
+      <div className="text-sm text-eva-red font-mono">Couldn&apos;t load {label}</div>
+      <div className="text-[11px] text-primary-35 font-mono">The request failed — check your connection and retry.</div>
+      <button
+        onClick={onRetry}
+        className="cursor-target bg-aeon-bg text-primary-70 text-[11px] px-4 py-2 font-mono uppercase tracking-[1px] border border-[rgba(250,250,250,0.10)] hover:border-eva-orange hover:text-eva-orange transition-colors"
+      >Retry</button>
+    </div>
+  )
+}

--- a/apps/dashboard/components/RightPanel.tsx
+++ b/apps/dashboard/components/RightPanel.tsx
@@ -4,18 +4,21 @@ import { useEffect, useState } from 'react'
 import type { Run, SkillOutput, AnalyticsData } from '../lib/types'
 import { timeAgo } from '../lib/utils'
 import { SpecNode } from './SpecNode'
+import { PanelError } from './PanelError'
 
 interface RightPanelProps {
   runs: Run[]
   outputs: SkillOutput[]
   feedLoading: boolean
+  feedError: boolean
   analyticsData: AnalyticsData | null
+  analyticsError: boolean
   onViewRun: (run: Run) => void
   onRefresh: () => void
   onFetchAnalytics: () => void
 }
 
-export function RightPanel({ runs, outputs, feedLoading, analyticsData, onViewRun, onRefresh, onFetchAnalytics }: RightPanelProps) {
+export function RightPanel({ runs, outputs, feedLoading, feedError, analyticsData, analyticsError, onViewRun, onRefresh, onFetchAnalytics }: RightPanelProps) {
   const [rightTab, setRightTab] = useState<'feed' | 'runs' | 'analytics'>('feed')
   const [selectedRun, setSelectedRun] = useState<Run | null>(null)
   const [runLogs, setRunLogs] = useState('')
@@ -87,6 +90,7 @@ export function RightPanel({ runs, outputs, feedLoading, analyticsData, onViewRu
         {/* Feed */}
         {rightTab === 'feed' && (
           feedLoading ? <div className="flex justify-center py-12"><div className="w-2 h-2 rounded-full bg-eva-orange animate-pulse" /></div> :
+          feedError ? <PanelError label="the feed" onRetry={onRefresh} /> :
           outputs.length > 0 ? (
           <div className="space-y-3 p-3">
             {outputs.map(o => (
@@ -160,6 +164,7 @@ export function RightPanel({ runs, outputs, feedLoading, analyticsData, onViewRu
 
         {/* Analytics */}
         {rightTab === 'analytics' && (
+          analyticsError ? <PanelError label="analytics" onRetry={onFetchAnalytics} /> :
           !analyticsData ? <div className="flex justify-center py-12"><div className="w-2 h-2 rounded-full bg-eva-orange animate-pulse" /></div> : (
             <div className="p-3 space-y-4">
               <div className="grid grid-cols-2 gap-[var(--space-xs)]">

--- a/apps/dashboard/components/SkillDetail.tsx
+++ b/apps/dashboard/components/SkillDetail.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import type { Skill, Run, Secret, SkillMcpRef } from '../lib/types'
+import type { Skill, Run, Secret, SkillMcpRef, McpServers } from '../lib/types'
 import { MODELS, CATEGORY_BY_KEY } from '../lib/constants'
 import { MCP_BY_SLUG } from '../lib/mcp-catalog'
 import { displayName, getSkillStatus, cronLabel, statusDot, inputCls } from '../lib/utils'
@@ -14,7 +14,7 @@ interface SkillDetailProps {
   runs: Run[]
   model: string
   secrets: Secret[]
-  mcpServers: Record<string, Record<string, unknown>>
+  mcpServers: McpServers
   busy: Record<string, boolean>
   onToggle: (name: string, enabled: boolean) => void
   onRun: (name: string, v?: string, m?: string) => void

--- a/apps/dashboard/lib/catalog.ts
+++ b/apps/dashboard/lib/catalog.ts
@@ -19,5 +19,3 @@ export const catalog = defineCatalog(schema, {
   },
   actions: {},
 });
-
-export const CATALOG_PROMPT = catalog.prompt();

--- a/apps/dashboard/lib/github.ts
+++ b/apps/dashboard/lib/github.ts
@@ -9,6 +9,11 @@ const GITHUB_API = 'https://api.github.com'
 interface GitHubContentFile { content: string; sha: string; encoding: string }
 interface GitHubContentEntry { name: string; type: 'file' | 'dir' | 'symlink' | 'submodule'; path: string }
 
+// Outcome of the local-mode git commit+push. `reason` is set only when the push
+// failed (surfaced to the UI as `syncError`). Distinct from the wire-level
+// SyncResult in lib/types.ts, which is the client-facing JSON response body.
+export interface CommitResult { synced: boolean; reason?: string }
+
 export function isLocal() {
   return !process.env.GITHUB_TOKEN || !process.env.GITHUB_REPO
 }
@@ -23,7 +28,7 @@ export function isLocal() {
  * failing the request. Only the given paths are committed, so unrelated
  * working-tree changes are left untouched.
  */
-export function commitAndPush(paths: string[], message: string): { synced: boolean; reason?: string } {
+export function commitAndPush(paths: string[], message: string): CommitResult {
   if (isLocal() === false) return { synced: true } // hosted mode: edit already committed via API
   const git = (...args: string[]) =>
     execFileSync('git', args, { stdio: 'pipe', cwd: REPO_ROOT }).toString().trim()
@@ -145,7 +150,7 @@ export async function saveFile(
   path: string,
   content: string,
   opts: { updateMsg: string; createMsg: string },
-): Promise<{ synced: boolean; reason?: string }> {
+): Promise<CommitResult> {
   let sha: string | undefined
   try {
     sha = (await getFileContent(path)).sha

--- a/apps/dashboard/lib/http.ts
+++ b/apps/dashboard/lib/http.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server'
+import type { CommitResult } from './github'
 
 /**
  * Standard JSON error response for API routes. Surfaces `error.message` when the
@@ -13,10 +14,19 @@ export function errorResponse(error: unknown, fallback = 'Unknown error', status
 }
 
 /**
- * Standard success body for routes that write a file and sync it. Returns the
- * `{ ok, synced, syncError? }` object (only including `syncError` when the sync
- * step reported a reason) so callers can pass it straight to `NextResponse.json`.
+ * Maps a commit/sync outcome to its response fields: `{ synced, syncError? }`
+ * (only including `syncError` when the sync step reported a reason). Use this
+ * when composing a larger response body alongside other fields.
  */
-export function syncResult(sync: { synced: boolean; reason?: string }) {
-  return { ok: true, synced: sync.synced, ...(sync.reason ? { syncError: sync.reason } : {}) }
+export function syncFields(sync: CommitResult) {
+  return { synced: sync.synced, ...(sync.reason ? { syncError: sync.reason } : {}) }
+}
+
+/**
+ * Standard success body for routes that write a file and sync it. Returns the
+ * `{ ok, synced, syncError? }` object so callers can pass it straight to
+ * `NextResponse.json`.
+ */
+export function syncResult(sync: CommitResult) {
+  return { ok: true, ...syncFields(sync) }
 }

--- a/apps/dashboard/lib/utils.test.ts
+++ b/apps/dashboard/lib/utils.test.ts
@@ -6,7 +6,7 @@
 import { describe, it } from "node:test";
 import { strict as assert } from "node:assert";
 
-import { displayName, initials, parseCron, cronLabel, buildCron, timeAgo, getSkillStatus, localToUtc24 } from "./utils";
+import { displayName, initials, parseCron, cronLabel, buildCron, timeAgo, getSkillStatus, localToUtc24, slugify } from "./utils";
 import type { Run } from "./types";
 
 // ── displayName ──────────────────────────────────────────────────────
@@ -57,6 +57,28 @@ describe("initials", () => {
   it("is case insensitive for output", () => {
     // initials returns uppercase regardless of input
     assert.equal(initials("test-skill"), "TS");
+  });
+});
+
+// ── slugify ───────────────────────────────────────────────────────────
+
+describe("slugify", () => {
+  it("lowercases and hyphenates", () => {
+    assert.equal(slugify("Fleet Scorecard"), "fleet-scorecard");
+  });
+
+  it("collapses non-alphanumeric runs into a single hyphen", () => {
+    assert.equal(slugify("a  --  b__c"), "a-b-c");
+  });
+
+  it("trims leading and trailing hyphens", () => {
+    assert.equal(slugify("  Hello! "), "hello");
+    assert.equal(slugify("--x--"), "x");
+  });
+
+  it("returns empty string for input with no alphanumerics", () => {
+    assert.equal(slugify("!!!"), "");
+    assert.equal(slugify(""), "");
   });
 });
 

--- a/apps/dashboard/lib/utils.ts
+++ b/apps/dashboard/lib/utils.ts
@@ -13,6 +13,12 @@ export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
+// Normalise an arbitrary string into a slug: lowercase, non-alphanumeric runs
+// collapsed to single hyphens, leading/trailing hyphens trimmed.
+export function slugify(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
+}
+
 export function initials(slug: string): string {
   const words = slug.split('-')
   return words.length === 1 ? words[0].slice(0, 2).toUpperCase() : (words[0][0] + words[1][0]).toUpperCase()

--- a/scripts/llm-gateway.sh
+++ b/scripts/llm-gateway.sh
@@ -169,7 +169,7 @@ case "${GATEWAY:-direct}" in
     fi
     ;;
 
-  bankr)  # NATIVE — unchanged from aeon's existing behavior
+  bankr)  # NATIVE — Bankr Gateway (Anthropic-compatible base URL)
     require_secret BANKR_LLM_KEY
     export ANTHROPIC_BASE_URL="https://llm.bankr.bot"
     export ANTHROPIC_AUTH_TOKEN="$BANKR_LLM_KEY"
@@ -244,7 +244,7 @@ case "${GATEWAY:-direct}" in
     echo "::notice::Routing through Venice via claude-code-router (${venice_model} @ ${VENICE_BASE_URL:-https://api.venice.ai/api/v1/chat/completions})"
     ;;
 
-  direct|"")  # NATIVE — Anthropic API or an Anthropic-compatible endpoint. Unchanged.
+  direct|"")  # NATIVE — Anthropic API or an Anthropic-compatible endpoint
     if [ -n "${ANTHROPIC_BASE_URL:-}" ]; then
       echo "::notice::Using Anthropic-compatible API at ${ANTHROPIC_BASE_URL}"
     else


### PR DESCRIPTION
Cleanups from an 8-dimension code-quality audit (duplication, shared types, unused code, circular deps, weak types, defensive code, legacy paths, comments/slop), plus the one high-value behavior fix the audit surfaced.

**Headline:** the codebase was already very clean — the audit found little to fix, and the aggressive dimensions (defensive-code / legacy removal) produced zero auto-applyable changes.

## Verified-safe cleanups
- **DRY** — extract `slugify()` to `lib/utils` (5 sites) and `syncFields()` to `lib/http` (3 sites that bypassed the existing helper); +`slugify` tests.
- **Types** — name `CommitResult` for the `{ synced, reason? }` commit outcome (5 sites); reuse the existing `McpServers` alias instead of inline `Record<string, Record<string, unknown>>` (3 sites).
- **Dead code** — remove the never-read `CATALOG_PROMPT` export (only dead code knip + grep found).
- **Weak types** — drop an unnecessary `File` cast in `ImportModal` and two redundant `as Task` casts in `a2a-server`. (No `any`/`@ts-ignore` existed to begin with.)
- **Comments** — drop dev-history narration from two `llm-gateway.sh` case labels.

## Behavior fix (DEF-24/26)
The dashboard's lazy-loaded views (strategy, MCP, soul, packs) and the feed/analytics fetches swallowed failures — a non-ok response or rejected fetch left the panel spinning "Loading…" forever with no error and no recovery. Each fetch now rejects on non-ok and renders a `PanelError` with a **Retry** instead of hiding the failure.

## Verification
- `tsc --noEmit` exit 0 — dashboard, a2a-server, mcp-server
- **135/135** dashboard tests pass
- `next build` exit 0 (all 26 routes)
- `madge` ✔ no circular dependencies
- `shellcheck` clean

## Deferred (behavior-changing — surfaced, not applied)
Legacy dual-paths (gateway write hardcoded to `auto`, `.skill` upload shim, legacy CSS color aliases), runtime validators on externally-mutable JSON, and the `dispatchSkill()`/`applyConfigEdit()` refactors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)