### PR TITLE
fix(dashboard): show only Aeon-launched runs in feed/runs (drop Dependabot)

### DIFF
--- a/apps/dashboard/app/api/runs/route.ts
+++ b/apps/dashboard/app/api/runs/route.ts
@@ -6,6 +6,14 @@ import type { GhRunJson } from '@/lib/types'
 
 type GhRunListItem = Pick<GhRunJson, 'databaseId' | 'name' | 'status' | 'conclusion' | 'createdAt' | 'url' | 'displayTitle' | 'event'>
 
+// Events that represent genuine Aeon skill activity, taken from the `on:` blocks
+// of the workflows Aeon owns: aeon.yml (workflow_dispatch / workflow_call / issues),
+// messages.yml (schedule / workflow_dispatch / repository_dispatch), chain-runner.yml
+// (workflow_dispatch). Allow-listing these keeps the feed to Aeon-launched runs and
+// structurally excludes repo CI (push / pull_request) and GitHub-managed noise like
+// Dependabot (event: 'dynamic'), without enumerating every bot/managed run by name.
+const AEON_EVENTS = new Set(['workflow_dispatch', 'workflow_call', 'schedule', 'repository_dispatch', 'issues'])
+
 export async function GET() {
   try {
     const out = execFileSync(
@@ -15,10 +23,9 @@ export async function GET() {
     ).toString()
     const raw: GhRunListItem[] = JSON.parse(out)
     const runs = raw
-      // Aeon skill activity fires on workflow_dispatch (dashboard "Run") or
-      // schedule (cron). Repo CI (push / pull_request) and fork-maintenance
-      // runs (upstream sync) are noise - keep them out of the feed and runs list.
-      .filter((r) => r.event !== 'push' && r.event !== 'pull_request')
+      // Keep only Aeon-launched runs; drop CI, Dependabot, and other managed noise.
+      .filter((r) => AEON_EVENTS.has(r.event))
+      // "Sync from upstream" is schedule-triggered fork maintenance, not skill activity.
       .filter((r) => r.name !== 'Sync from upstream')
       .map((r) => ({
         id: r.databaseId,


### PR DESCRIPTION
## Problem

The dashboard FEED / RUNS tabs were flooded with Dependabot rows — `npm_and_yarn in /apps/...`, `github_actions in /.` — the same noise we just cut from the Actions tab in #541.

`/api/runs` used a **blocklist** (exclude `push` / `pull_request` + `Sync from upstream`). Dependabot's `Dependabot Updates` runs carry event **`dynamic`**, which slipped straight through.

## Fix

Switch to an **allow-list** of the events Aeon's own workflows actually fire, read from their `on:` blocks:

| Event | Source |
|-------|--------|
| `workflow_dispatch` | dashboard "Run" button, chain dispatch (aeon.yml, chain-runner.yml) |
| `workflow_call` | aeon.yml |
| `schedule` | messages.yml cron tick / scheduled skills |
| `repository_dispatch` | instant messages / cron-tick (messages.yml) |
| `issues` | issue-triggered skills (aeon.yml) |

This structurally excludes Dependabot (`dynamic`), repo CI (`push`/`pull_request`), and any future GitHub-managed run type — without enumerating bots by name. `Sync from upstream` (schedule-triggered fork maintenance) is still dropped by name.

One change covers both tabs: FEED and RUNS both read the single `runs` state from `/api/runs`.

## Verification

- Applied the same filter to live `gh run` data: **every** Dependabot/CI/sync row dropped, genuine Aeon events kept
- `tsc --noEmit` clean
- 135/135 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)