### PR TITLE
Port hardening §6 capability tiers + §3 issues-as-state + §7 votable health Issues

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -51,7 +51,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  issues: read
+  issues: write   # write (was read) for Issues-as-state append (§3) + votable health Issues (§7); harmless when STATE_BACKEND / HEALTH_ISSUES unset
   actions: read
 
 env:
@@ -238,6 +238,24 @@ jobs:
           fi
           echo "::notice::Fleet Watcher ALLOWED skill '$SKILL' (audit: $AUDIT_REF, ref: $REF)"
 
+      # Materialize cron state (Issues backend, opt-in) — hardening §3 reader cutover.
+      # With STATE_BACKEND=issues, runs APPEND immutable events to a pinned Issue
+      # (conflict-free, no commit/rebase). But readers (heartbeat, skill-health,
+      # prune_skills.py …) still read memory/cron-state.json — so before the skill runs,
+      # fold the Issue's events back into that file: readers work UNCHANGED and see a
+      # fresh projection, not stale committed state. Commit results drops the projection
+      # afterward so it isn't committed. No-op when STATE_BACKEND is unset.
+      - name: Materialize cron state (Issues backend)
+        if: steps.work.outputs.mode != '' && vars.STATE_BACKEND == 'issues'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if GH_REPO="$GITHUB_REPOSITORY" bash scripts/state_store.sh materialize "aeon:cron-state" memory/cron-state.json; then
+            echo "cron-state projected from the Issues backend; readers see fresh state"
+          else
+            echo "::warning::could not materialize cron-state from the Issue; readers use the committed file"
+          fi
+
       - name: Run
         id: run
         if: steps.work.outputs.mode != ''
@@ -340,12 +358,16 @@ jobs:
           cp scripts/notify.sh ./notify
           chmod +x ./notify
 
-          ALLOWED="Read,Write,Edit,Glob,Grep,WebFetch,WebSearch"
-          ALLOWED="$ALLOWED,Bash(curl:*),Bash(gh:*),Bash(git:*),Bash(jq:*)"
-          ALLOWED="$ALLOWED,Bash(./notify:*),Bash(./notify-jsonrender:*)"
-          ALLOWED="$ALLOWED,Bash(mkdir:*),Bash(ls:*),Bash(cat:*),Bash(chmod:*)"
-          ALLOWED="$ALLOWED,Bash(date:*),Bash(echo:*),Bash(node:*),Bash(npm:*),Bash(npx:*)"
-          ALLOWED="$ALLOWED,Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(sort:*),Bash(grep:*)"
+          # Capability tier (hardening §6): the toolset is resolved per-skill from
+          # scripts/skill_mode.sh. Default is `write` (backward compatible — a superset
+          # of the previous static list, additionally granting Bash(python3/python:*)
+          # the helper scripts need). A skill with `mode: read-only` frontmatter gets a
+          # toolset with no Write/Edit/git/gh, so it physically cannot mutate the repo;
+          # the post-run read-only guard reverts any stray redirected writes.
+          SKILL_MODE=$(bash scripts/skill_mode.sh mode "${{ steps.skill.outputs.name }}")
+          ALLOWED=$(bash scripts/skill_mode.sh allowed-tools "$SKILL_MODE")
+          echo "SKILL_MODE=$SKILL_MODE" >> "$GITHUB_ENV"
+          echo "Capability mode: $SKILL_MODE"
 
           # MCP (opt-in): when a project .mcp.json exists, load it for this run
           # and allow each server's tools. No-op when the file is absent, so
@@ -645,6 +667,7 @@ jobs:
           fi
 
           echo "QUALITY_SCORE=$SCORE" >> "$GITHUB_OUTPUT"
+          echo "FLAGS=$FLAGS" >> "$GITHUB_OUTPUT"   # consumed by the votable-health step (§7)
 
           # Write skill health file with rolling history
           mkdir -p memory/skill-health
@@ -812,12 +835,38 @@ jobs:
             ./"$script" || echo "::notice::$(basename "$script") failed (non-fatal)"
           done
 
+      - name: Read-only capability guard
+        if: steps.work.outputs.mode != '' && env.SKILL_MODE == 'read-only'
+        run: |
+          # read-only skills (mode: read-only) get no Write/Edit/git/gh, so they can't
+          # mutate the repo. Two jobs here: (1) record the run-log entry on their behalf
+          # (they couldn't), (2) revert any code/config that slipped through a shell
+          # redirection. State/memory/outputs/articles are preserved for the commit step.
+          SKILL="${{ steps.skill.outputs.name }}"
+          TODAY=$(date -u +%Y-%m-%d)
+          mkdir -p memory/logs
+          printf '\n## %s (read-only)\nRan %s UTC.\n' "$SKILL" "$(date -u +%FT%TZ)" >> "memory/logs/${TODAY}.md"
+          CODE_PATHS="skills .github apps/a2a-server apps/mcp-server apps/webhook apps/dashboard/app apps/dashboard/lib apps/dashboard/components scripts skill-templates workflow-templates docs *.md *.json *.yml aeon add-skill add-mcp add-a2a export-skill new-from-template onboard install-skill-pack install-from-atrium generate-skills-json generate-packs-json notify-jsonrender"
+          git checkout -- $CODE_PATHS 2>/dev/null || true
+          git clean -fd -- skills scripts skill-templates workflow-templates .github 2>/dev/null || true
+          echo "read-only guard: logged run + reverted code/config writes for $SKILL"
+
       - name: Commit results
         if: steps.work.outputs.mode != ''
+        env:
+          STATE_BACKEND: ${{ vars.STATE_BACKEND }}
         run: |
           git config user.name "aeonframework"
           git config user.email "aeonframework@proton.me"
           rm -f ./notify .notify-sent-hashes  # Remove generated notify script + dedup log before committing
+
+          # Issues-as-state (hardening §3): cron-state.json was materialized from the
+          # pinned Issue for this run's readers — it's a projection, not source of truth.
+          # Drop the working-tree change so it isn't committed (that churn is exactly
+          # what the Issues backend exists to avoid). No-op when STATE_BACKEND is unset.
+          if [ "${STATE_BACKEND:-}" = "issues" ]; then
+            git checkout -- memory/cron-state.json 2>/dev/null || rm -f memory/cron-state.json
+          fi
 
           CURRENT_BRANCH=$(git branch --show-current)
           LABEL="${{ steps.work.outputs.label }}"
@@ -883,6 +932,9 @@ jobs:
 
       - name: Update cron state
         if: always() && steps.skill.outputs.name != ''
+        env:
+          STATE_BACKEND: ${{ vars.STATE_BACKEND }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           SKILL="${{ steps.skill.outputs.name }}"
           RUN_OUTCOME="${{ steps.run.outcome }}"
@@ -901,6 +953,23 @@ jobs:
           ERROR_SIG=""
           if [ "$CRON_STATUS" = "failed" ] && [ -f /tmp/skill-error.txt ]; then
             ERROR_SIG=$(cat /tmp/skill-error.txt)
+          fi
+
+          # Issues-as-state (hardening §3) — opt-in via repo var STATE_BACKEND=issues.
+          # Append an IMMUTABLE event to the state Issue (conflict-free) and skip the
+          # file-commit + 5x rebase-retry below entirely. Readers fold via
+          # scripts/state_store.sh read (materialized into cron-state.json pre-run).
+          # Default (unset) keeps the file path unchanged.
+          if [ "${STATE_BACKEND:-}" = "issues" ]; then
+            EVENT=$(jq -cn --arg s "$SKILL" --arg st "$CRON_STATUS" --arg ts "$NOW_ISO" \
+              --argjson q "${QUALITY_SCORE:-0}" --arg err "$ERROR_SIG" \
+              '{skill:$s,status:$st,ts:$ts,quality_score:$q,error:$err}')
+            ISSUE=$(GH_REPO="$GITHUB_REPOSITORY" bash scripts/state_store.sh ensure "aeon:cron-state" 2>/dev/null || true)
+            if [ -n "$ISSUE" ] && GH_REPO="$GITHUB_REPOSITORY" bash scripts/state_store.sh append "$ISSUE" "$EVENT"; then
+              echo "cron state appended to issue #$ISSUE (no commit, no rebase)"
+              exit 0
+            fi
+            echo "::warning::Issues-as-state append failed; falling back to file path"
           fi
 
           # Function: apply quality metrics update to STATE
@@ -998,3 +1067,29 @@ jobs:
             sleep "$i"
           done
           echo "::warning::Failed to commit cron state (non-fatal)"
+
+      # Votable health Issues (hardening §7) — opt-in via repo var HEALTH_ISSUES=1.
+      # On a regression (low score / failure flag / failed run) post to the skill's
+      # per-skill health Issue; humans 👍/👎 it to set repair priority. Silent on clean
+      # runs (no Issue spam). Off by default = zero new issues on forks.
+      - name: Health regression to votable Issue (opt-in)
+        if: always() && steps.skill.outputs.name != '' && vars.HEALTH_ISSUES == '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          SKILL="${{ steps.skill.outputs.name }}"
+          SCORE="${{ steps.analyze.outputs.QUALITY_SCORE }}"; [ -z "$SCORE" ] && SCORE=0
+          FLAGS='${{ steps.analyze.outputs.FLAGS }}'; [ -z "$FLAGS" ] && FLAGS='[]'
+          if [ "${{ steps.run.outcome }}" != "success" ]; then SCORE=1; FLAGS='["run_failed"]'; fi
+          REC=$(jq -cn --arg s "$SKILL" --argjson sc "$SCORE" --argjson fl "$FLAGS" '{skill:$s,score:$sc,flags:$fl}')
+          NEEDS=$(printf '%s' "$REC" | python3 -c "import sys,json; sys.path.insert(0,'scripts'); import health_triage as h; print('yes' if h.needs_comment(json.load(sys.stdin)) else 'no')" 2>/dev/null || echo no)
+          if [ "$NEEDS" = "yes" ]; then
+            ISSUE=$(GH_REPO="$GITHUB_REPOSITORY" bash scripts/health_issue.sh ensure "$SKILL" 2>/dev/null || true)
+            if [ -n "$ISSUE" ]; then
+              GH_REPO="$GITHUB_REPOSITORY" bash scripts/health_issue.sh comment "$ISSUE" \
+                "⚠️ Regression — score $SCORE, flags $FLAGS ($(date -u +%FT%TZ)). 👍/👎 to set repair priority." \
+                && echo "health regression -> issue #$ISSUE"
+            fi
+          else
+            echo "no regression for $SKILL; health issue silent"
+          fi

--- a/.github/workflows/chain-runner.yml
+++ b/.github/workflows/chain-runner.yml
@@ -283,11 +283,26 @@ jobs:
         if: always()
         env:
           GH_TOKEN: ${{ secrets.GH_GLOBAL || secrets.GITHUB_TOKEN }}
+          STATE_BACKEND: ${{ vars.STATE_BACKEND }}
         run: |
           CHAIN="${{ inputs.chain }}"
           NOW_ISO=$(date -u +%FT%TZ)
           STATUS="${CHAIN_STATUS:-failed}"
           STATE_FILE="memory/cron-state.json"
+
+          # Issues backend (hardening §3): append the chain event to the shared state
+          # Issue (same store the main workflow uses) instead of committing the file —
+          # keeps chain state in one place and off the rebase loop. No-op when unset.
+          if [ "${STATE_BACKEND:-}" = "issues" ]; then
+            EVENT=$(jq -cn --arg s "chain:$CHAIN" --arg st "$STATUS" --arg ts "$NOW_ISO" \
+              '{skill:$s,status:$st,ts:$ts}')
+            ISSUE=$(GH_REPO="$GITHUB_REPOSITORY" bash scripts/state_store.sh ensure "aeon:cron-state" 2>/dev/null || true)
+            if [ -n "$ISSUE" ] && GH_REPO="$GITHUB_REPOSITORY" bash scripts/state_store.sh append "$ISSUE" "$EVENT"; then
+              echo "chain state appended to issue #$ISSUE (no commit, no rebase)"
+              exit 0
+            fi
+            echo "::warning::Issues-as-state append failed; falling back to file path"
+          fi
 
           git checkout main 2>/dev/null || true
           git pull --rebase origin main 2>/dev/null || true

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -41,3 +41,9 @@ jobs:
         run: bash scripts/tests/test_schedule_clusters.sh
       - name: prune analyzer tests
         run: python3 scripts/tests/test_prune_skills.py
+      - name: capability mode tests
+        run: bash scripts/tests/test_skill_mode.sh
+      - name: state reducer tests
+        run: python3 scripts/tests/test_state_reduce.py
+      - name: health triage tests
+        run: python3 scripts/tests/test_health_triage.py

--- a/scripts/health_issue.sh
+++ b/scripts/health_issue.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# health_issue — per-skill votable health thread on GitHub Issues (hardening §7).
+#
+# One Issue per skill. The agent comments ONLY on a regression (see health_triage.py);
+# humans 👍/👎 the Issue to set repair priority, which self-improve/skill-repair read.
+# Moves the existing memory/issues/ tracker onto visible, votable, conflict-free Issues.
+#
+# Honors GH_REPO. Usage:
+#   health_issue.sh ensure  <skill>            -> issue number (creates if absent)
+#   health_issue.sh comment <issue> <body>     -> post a regression comment
+#   health_issue.sh votes   <issue>            -> net 👍-👎 on the issue (for priority)
+set -euo pipefail
+REPO_ARGS=(); [ -n "${GH_REPO:-}" ] && REPO_ARGS=(--repo "$GH_REPO")
+
+cmd="${1:-}"; shift || true
+case "$cmd" in
+  ensure)
+    skill="${1:?skill required}"; title="health: $skill"
+    n=$(gh issue list "${REPO_ARGS[@]}" --state open --search "\"$title\" in:title" \
+          --json number,title --jq "map(select(.title==\"$title\")) | .[0].number // empty" 2>/dev/null || true)
+    if [ -z "$n" ]; then
+      url=$(gh issue create "${REPO_ARGS[@]}" --title "$title" \
+            --body "Health thread for \`$skill\` (hardening §7). The agent comments here on a regression; 👍/👎 this issue to set repair priority. Machine-managed.")
+      n=$(printf '%s' "$url" | grep -oE '[0-9]+$')
+    fi
+    echo "$n" ;;
+  comment)
+    n="${1:?issue number required}"; shift
+    gh issue comment "$n" "${REPO_ARGS[@]}" --body "$*" >/dev/null ;;
+  votes)
+    n="${1:?issue number required}"
+    gh api "repos/{owner}/{repo}/issues/$n/reactions" \
+      --jq '[.[].content] | (map(select(.=="+1")) | length) - (map(select(.=="-1")) | length)' \
+      2>/dev/null || echo 0 ;;
+  *)
+    echo "usage: health_issue.sh {ensure <skill>|comment <issue> <body>|votes <issue>}" >&2
+    exit 2 ;;
+esac

--- a/scripts/health_triage.py
+++ b/scripts/health_triage.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""
+health_triage — decide when a skill's health warrants a votable Issue, and rank the
+open ones for the repair loop (hardening §7).
+
+Two pure decisions, kept testable:
+  - needs_comment(record): post to the skill's health Issue ONLY on a regression
+    (score < 3, or a failure flag). A clean run says nothing — no Issue spam,
+    mirroring how heartbeat notifies on state change only.
+  - prioritize(records): rank open health items by human VOTES first, then severity,
+    so self-improve / skill-repair fix what people care about + what's worst.
+
+The GitHub glue (ensure issue, comment, read 👍/👎 reactions) lives in
+scripts/health_issue.sh; this module is offline and unit-tested.
+"""
+import json
+import sys
+
+FAILURE_FLAGS = {"api_error", "empty_output", "rate_limited", "dead_citation", "stale_data"}
+HIGH_FLAGS = {"api_error", "empty_output"}
+MED_FLAGS = {"dead_citation", "stale_data", "rate_limited"}
+_SEV_RANK = {"high": 3, "medium": 2, "low": 1, "none": 0}
+
+
+def _flags(record):
+    return set(record.get("flags") or [])
+
+
+def needs_comment(record):
+    """Regression = score in 1..2, or any failure flag present."""
+    score = record.get("score")
+    if isinstance(score, (int, float)) and 0 < score < 3:
+        return True
+    return bool(_flags(record) & FAILURE_FLAGS)
+
+
+def severity(record):
+    score = record.get("score")
+    flags = _flags(record)
+    if score == 1 or (flags & HIGH_FLAGS):
+        return "high"
+    if score == 2 or (flags & MED_FLAGS):
+        return "medium"
+    if needs_comment(record):
+        return "low"
+    return "none"
+
+
+def prioritize(records):
+    """Open health items (those needing attention), ranked by votes then severity."""
+    items = []
+    for r in records:
+        if not needs_comment(r):
+            continue
+        items.append({
+            "skill": r.get("skill"),
+            "score": r.get("score"),
+            "votes": int(r.get("votes", 0)),
+            "severity": severity(r),
+            "flags": sorted(_flags(r)),
+        })
+    items.sort(key=lambda x: (x["votes"], _SEV_RANK[x["severity"]]), reverse=True)
+    return items
+
+
+def main():
+    records = []
+    for line in sys.stdin.read().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(obj, dict):
+            records.append(obj)
+        elif isinstance(obj, list):
+            records.extend(x for x in obj if isinstance(x, dict))
+    json.dump(prioritize(records), sys.stdout, indent=2)
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/skill_mode.sh
+++ b/scripts/skill_mode.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# skill_mode — capability tier resolution for a skill run (hardening §6).
+#
+# Two axes of capability: network (egress:, future proxy) and *write* (this).
+# A skill declares its write tier in SKILL.md frontmatter:
+#     mode: read-only      # may read repo + fetch web + notify; may NOT mutate the repo
+#     mode: write          # full access (default, current behaviour)
+#
+# Rollout note: default is `write` for backward compatibility — none of the 183
+# existing skills are annotated yet, and many legitimately write (create-skill,
+# article, reflect…). read-only is opt-in now; once writers are annotated we flip
+# the default to read-only (the design intent). Enforcement is by allowedTools:
+# read-only drops Write,Edit,Bash(git:*),Bash(gh:*) so the skill physically can't
+# commit/push/edit. A post-run guard in the workflow reverts any stray writes that
+# slipped through redirections, as defense-in-depth.
+#
+# Usage:
+#   scripts/skill_mode.sh mode <skill-name>     -> prints read-only | write
+#   scripts/skill_mode.sh allowed-tools <mode>  -> prints the --allowedTools string
+set -euo pipefail
+
+# Tools every tier gets: read, search, notify, and read-only/local shell helpers.
+# curl stays (network is the *other* axis, governed by egress:, not by mode).
+BASE_TOOLS="Read,Glob,Grep,WebFetch,WebSearch"
+BASE_TOOLS="$BASE_TOOLS,Bash(curl:*),Bash(jq:*)"
+BASE_TOOLS="$BASE_TOOLS,Bash(./notify:*),Bash(./notify-jsonrender:*)"
+BASE_TOOLS="$BASE_TOOLS,Bash(mkdir:*),Bash(ls:*),Bash(cat:*),Bash(chmod:*)"
+BASE_TOOLS="$BASE_TOOLS,Bash(date:*),Bash(echo:*),Bash(node:*),Bash(npm:*),Bash(npx:*)"
+BASE_TOOLS="$BASE_TOOLS,Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(sort:*),Bash(grep:*)"
+
+# Write tier additionally gets repo-mutation tools + python (an interpreter is itself
+# a write vector, so it stays out of the read-only base; skills' python helpers run here).
+WRITE_TOOLS="Write,Edit,Bash(gh:*),Bash(git:*),Bash(python3:*),Bash(python:*)"
+
+resolve_mode() {
+  local skill="$1" f="skills/$1/SKILL.md" m=""
+  if [ -f "$f" ]; then
+    # value after 'mode:', stripping an inline '# comment', quotes, and surrounding ws
+    m=$(awk '/^---$/{n++; next}
+             n==1 && /^mode:/{
+               v=$0; sub(/^mode:[ \t]*/,"",v); sub(/[ \t]*#.*$/,"",v);
+               gsub(/^[ \t"]+|[ \t"]+$/,"",v); print v; exit
+             }' "$f")
+  fi
+  case "$m" in
+    read-only|readonly|read_only) echo "read-only" ;;
+    write|"")                     echo "write" ;;
+    *) echo "write" ;;  # unknown value -> safe default, never silently over-restrict
+  esac
+}
+
+# Write tier = base tools + the repo-mutation tools.
+write_tools() { echo "$BASE_TOOLS,$WRITE_TOOLS"; }
+
+case "${1:-}" in
+  mode)          resolve_mode "${2:?skill name required}" ;;
+  allowed-tools)
+    case "${2:-write}" in
+      read-only|readonly|read_only) echo "$BASE_TOOLS" ;;
+      *)                            write_tools ;;
+    esac ;;
+  *) echo "usage: skill_mode.sh {mode <skill>|allowed-tools <mode>}" >&2; exit 2 ;;
+esac

--- a/scripts/state_reduce.py
+++ b/scripts/state_reduce.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""
+state_reduce — fold append-only run events into the cron-state schema (hardening §3).
+
+Today `memory/cron-state.json` is a shared file rewritten on every skill run, which
+forces the rebase-retry + auto-conflict-resolver loop in aeon.yml (git used as a
+concurrent DB). The fix: each run *appends* an immutable event (a GitHub Issue
+comment — no commit, no conflict), and the canonical state is *derived* by folding
+the events. This module is that fold, kept pure so it's unit-testable.
+
+Event (one JSON object per line on stdin):
+  {"skill":"x","status":"success|failed","ts":"2026-06-17T12:00:00Z",
+   "quality_score":4,"error":"sig"}   # quality_score/error optional
+
+Output: the same aggregate shape aeon.yml's apply_state_update produces, so heartbeat
+/ skill-health read it unchanged.
+"""
+import json
+import sys
+
+
+def _blank():
+    return {
+        "last_status": None, "last_success": None, "last_failed": None,
+        "total_runs": 0, "total_successes": 0, "total_failures": 0,
+        "consecutive_failures": 0, "success_rate": 0.0,
+        "last_quality_score": None, "last_error": None,
+    }
+
+
+def reduce_events(events):
+    """Fold a list of event dicts (any order) into {skill: aggregate}."""
+    state = {}
+    for e in sorted(events, key=lambda x: (x.get("ts") or "")):
+        skill = e.get("skill")
+        if not skill:
+            continue
+        s = state.setdefault(skill, _blank())
+        status = "success" if e.get("status") == "success" else "failed"
+        s["total_runs"] += 1
+        if status == "success":
+            s["total_successes"] += 1
+            s["consecutive_failures"] = 0
+            s["last_status"] = "success"
+            if e.get("ts"):
+                s["last_success"] = e["ts"]
+        else:
+            s["total_failures"] += 1
+            s["consecutive_failures"] += 1
+            s["last_status"] = "failed"
+            if e.get("ts"):
+                s["last_failed"] = e["ts"]
+            if e.get("error"):
+                s["last_error"] = e["error"]
+        if e.get("quality_score") not in (None, 0):
+            s["last_quality_score"] = e["quality_score"]
+        s["success_rate"] = round(s["total_successes"] / s["total_runs"], 2)
+    return state
+
+
+def parse_jsonl(text):
+    """Lenient JSONL: skip blank lines and non-JSON lines (e.g. comment chatter)."""
+    out = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(obj, dict):
+            out.append(obj)
+        elif isinstance(obj, list):
+            out.extend(x for x in obj if isinstance(x, dict))
+    return out
+
+
+def main():
+    events = parse_jsonl(sys.stdin.read())
+    json.dump(reduce_events(events), sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/state_store.sh
+++ b/scripts/state_store.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# state_store — append-only run state on a GitHub Issue (hardening §3).
+#
+# Replaces the shared memory/cron-state.json file (rewritten + force-pushed with a
+# 5x rebase-retry + auto-conflict-resolver on every run) with conflict-free appends:
+# each run posts an immutable comment; canonical state is derived by folding them
+# (scripts/state_reduce.py). Concurrent runs never race — comments are independent.
+#
+# Repo: honors the GH_REPO env var (else gh's current-dir repo).
+# Usage:
+#   scripts/state_store.sh ensure <title>             -> prints issue number (creates if absent)
+#   scripts/state_store.sh append <issue> <json>      -> post one event comment
+#   scripts/state_store.sh read   <issue>             -> fold comments -> cron-state JSON (stdout)
+#   scripts/state_store.sh materialize <title> <file> -> ensure+read, atomically write the
+#                                                        folded projection to <file> (for readers)
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ARGS=(); [ -n "${GH_REPO:-}" ] && REPO_ARGS=(--repo "$GH_REPO")
+
+_ensure() {
+  local title="${1:?title required}" n
+  n=$(gh issue list "${REPO_ARGS[@]}" --state open --search "\"$title\" in:title" \
+        --json number,title --jq "map(select(.title==\"$title\")) | .[0].number // empty" 2>/dev/null || true)
+  if [ -z "$n" ]; then
+    local url
+    url=$(gh issue create "${REPO_ARGS[@]}" --title "$title" \
+          --body "Append-only Aeon state store (hardening §3). Machine-managed; do not edit by hand.")
+    n=$(printf '%s' "$url" | grep -oE '[0-9]+$')
+  fi
+  printf '%s' "$n"
+}
+
+_append() {
+  local n="${1:?issue number required}"; shift
+  gh issue comment "$n" "${REPO_ARGS[@]}" --body "$*" >/dev/null
+}
+
+_read() {
+  local n="${1:?issue number required}"
+  gh api "repos/{owner}/{repo}/issues/$n/comments" --paginate --jq '.[].body' 2>/dev/null \
+    | python3 "$HERE/state_reduce.py"
+}
+
+# Fold the issue's events and write them to a file the readers expect, atomically.
+# Returns non-zero (leaving <file> untouched) if the issue can't be resolved or the
+# fold yields no valid JSON — callers then fall back to whatever file is committed.
+_materialize() {
+  local title="${1:?title required}" out="${2:?output path required}" n tmp
+  n=$(_ensure "$title") || return 1
+  [ -n "$n" ] || return 1
+  mkdir -p "$(dirname "$out")"
+  tmp="$out.materializing.$$"
+  if _read "$n" > "$tmp" 2>/dev/null && jq empty "$tmp" 2>/dev/null; then
+    mv "$tmp" "$out"
+    echo "state_store: materialized '$title' (issue #$n) -> $out ($(jq 'length' "$out") entries)" >&2
+    return 0
+  fi
+  rm -f "$tmp"
+  return 1
+}
+
+cmd="${1:-}"; shift || true
+case "$cmd" in
+  ensure)      _ensure "$@"; echo ;;
+  append)      _append "$@" ;;
+  read)        _read "$@" ;;
+  materialize) _materialize "$@" ;;
+  *)
+    echo "usage: state_store.sh {ensure <title>|append <issue> <json>|read <issue>|materialize <title> <file>}" >&2
+    exit 2 ;;
+esac

--- a/scripts/tests/test_health_issue.sh
+++ b/scripts/tests/test_health_issue.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Live integration test for scripts/health_issue.sh — ensure/comment + vote round-trip.
+# Gated (creates + closes a throwaway issue, adds a reaction):
+#   HEALTH_ISSUE_LIVE=1 GH_REPO=<owner>/<repo> bash scripts/tests/test_health_issue.sh
+set -uo pipefail
+cd "$(dirname "$0")/../.." || exit 1
+
+if ! command -v gh >/dev/null 2>&1 || ! gh auth status >/dev/null 2>&1; then
+  echo "SKIP - gh not installed/authenticated"; exit 0
+fi
+if [ -z "${HEALTH_ISSUE_LIVE:-}" ]; then
+  echo "SKIP - set HEALTH_ISSUE_LIVE=1 (and GH_REPO) to run; creates + closes a test issue"; exit 0
+fi
+: "${GH_REPO:?set GH_REPO}"; export GH_REPO
+fail=0; pass(){ echo "ok   - $1"; }; bad(){ echo "FAIL - $1"; fail=1; }
+H="scripts/health_issue.sh"
+
+SKILL="zz-health-test-$$-$(date +%s)"
+N=$(bash "$H" ensure "$SKILL")
+[ -n "$N" ] && pass "created health issue #$N" || { bad "ensure"; echo SOME FAILED; exit 1; }
+
+bash "$H" comment "$N" "Regression: score 1, flags [api_error] on $(date -u +%FT%TZ)" \
+  && pass "posted regression comment" || bad "comment"
+
+V0=$(bash "$H" votes "$N")
+[ "$V0" = "0" ] && pass "initial votes = 0" || bad "initial votes (got $V0)"
+
+# react 👍 as the authenticated user, then re-read
+gh api "repos/{owner}/{repo}/issues/$N/reactions" -f content=+1 >/dev/null 2>&1
+sleep 1
+V1=$(bash "$H" votes "$N")
+[ "$V1" = "1" ] && pass "vote registered (net = 1)" || bad "vote after 👍 (got $V1)"
+
+gh issue close "$N" -c "test complete" >/dev/null 2>&1 && pass "closed issue #$N" || bad "close"
+echo "---"; [ "$fail" = "0" ] && echo "ALL PASS" || echo "SOME FAILED"; exit "$fail"

--- a/scripts/tests/test_health_triage.py
+++ b/scripts/tests/test_health_triage.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Unit tests for health_triage. Run: python3 scripts/tests/test_health_triage.py"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import health_triage as ht  # noqa: E402
+
+
+class TestNeedsComment(unittest.TestCase):
+    def test_clean_run_silent(self):
+        self.assertFalse(ht.needs_comment({"skill": "x", "score": 4, "flags": []}))
+        self.assertFalse(ht.needs_comment({"skill": "x", "score": 3, "flags": []}))
+
+    def test_low_score_regresses(self):
+        self.assertTrue(ht.needs_comment({"skill": "x", "score": 2}))
+        self.assertTrue(ht.needs_comment({"skill": "x", "score": 1}))
+
+    def test_failure_flag_regresses_even_at_good_score(self):
+        self.assertTrue(ht.needs_comment({"skill": "x", "score": 4, "flags": ["dead_citation"]}))
+        self.assertTrue(ht.needs_comment({"skill": "x", "score": 5, "flags": ["api_error"]}))
+
+    def test_nonfailure_flag_at_good_score_silent(self):
+        self.assertFalse(ht.needs_comment({"skill": "x", "score": 4, "flags": ["generic_content"]}))
+
+
+class TestSeverity(unittest.TestCase):
+    def test_high(self):
+        self.assertEqual(ht.severity({"score": 1}), "high")
+        self.assertEqual(ht.severity({"score": 5, "flags": ["api_error"]}), "high")
+
+    def test_medium(self):
+        self.assertEqual(ht.severity({"score": 2}), "medium")
+        self.assertEqual(ht.severity({"score": 4, "flags": ["dead_citation"]}), "medium")
+
+    def test_none_for_clean(self):
+        self.assertEqual(ht.severity({"score": 4, "flags": []}), "none")
+
+
+class TestPrioritize(unittest.TestCase):
+    def test_filters_clean_and_ranks_by_votes_then_severity(self):
+        records = [
+            {"skill": "clean", "score": 5, "flags": []},                     # dropped
+            {"skill": "low-votes-high-sev", "score": 1, "votes": 0},          # high sev, 0 votes
+            {"skill": "high-votes-med-sev", "score": 2, "votes": 9},          # med sev, 9 votes
+            {"skill": "mid", "score": 2, "votes": 3, "flags": ["stale_data"]},
+        ]
+        out = ht.prioritize(records)
+        self.assertEqual([i["skill"] for i in out],
+                         ["high-votes-med-sev", "mid", "low-votes-high-sev"])
+        self.assertNotIn("clean", [i["skill"] for i in out])
+
+    def test_votes_dominate_severity(self):
+        # a heavily-upvoted medium beats a zero-vote high — humans set priority
+        records = [
+            {"skill": "a", "score": 1, "votes": 0},   # high sev
+            {"skill": "b", "score": 2, "votes": 5},   # med sev, more votes
+        ]
+        self.assertEqual([i["skill"] for i in ht.prioritize(records)], ["b", "a"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/tests/test_skill_mode.sh
+++ b/scripts/tests/test_skill_mode.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Tests for scripts/skill_mode.sh. Run: bash scripts/tests/test_skill_mode.sh
+set -uo pipefail
+cd "$(dirname "$0")/../.." || exit 1
+M="scripts/skill_mode.sh"
+fail=0
+pass() { echo "ok   - $1"; }
+bad()  { echo "FAIL - $1"; fail=1; }
+
+# Fixtures live under real skills/ so resolve_mode finds them; use temp names + cleanup.
+mk() { mkdir -p "skills/$1"; printf '%s\n' "---" "name: $1" "${2:-}" "---" "body" > "skills/$1/SKILL.md"; }
+RO="zzz-test-readonly-$$"; WR="zzz-test-write-$$"; NM="zzz-test-nomode-$$"; BAD="zzz-test-bad-$$"; CMT="zzz-test-comment-$$"
+cleanup() { rm -rf "skills/$RO" "skills/$WR" "skills/$NM" "skills/$BAD" "skills/$CMT"; }
+trap cleanup EXIT
+mk "$RO" "mode: read-only"
+mk "$WR" "mode: write"
+mk "$NM" ""
+mk "$BAD" "mode: banana"
+mk "$CMT" "mode: read-only   # with an inline comment and trailing space   "
+
+# mode resolution
+[ "$(bash "$M" mode "$RO")"  = "read-only" ] && pass "declared read-only resolves" || bad "declared read-only resolves"
+[ "$(bash "$M" mode "$CMT")" = "read-only" ] && pass "read-only with inline comment resolves" || bad "read-only with inline comment resolves"
+[ "$(bash "$M" mode "$WR")"  = "write" ]     && pass "declared write resolves"     || bad "declared write resolves"
+[ "$(bash "$M" mode "$NM")"  = "write" ]     && pass "no mode defaults to write"   || bad "no mode defaults to write"
+[ "$(bash "$M" mode "$BAD")" = "write" ]     && pass "unknown mode falls back to write" || bad "unknown mode falls back to write"
+[ "$(bash "$M" mode "nonexistent-skill-xyz")" = "write" ] && pass "missing skill defaults to write" || bad "missing skill defaults to write"
+
+# allowed-tools: write tier has the mutation tools
+WT=$(bash "$M" allowed-tools write)
+echo "$WT" | grep -q "Write" && echo "$WT" | grep -q "Edit" \
+  && echo "$WT" | grep -q "Bash(git:\*)" && echo "$WT" | grep -q "Bash(gh:\*)" \
+  && pass "write tier includes Write/Edit/git/gh" || bad "write tier includes Write/Edit/git/gh"
+
+# allowed-tools: read-only tier drops mutation tools but keeps read+notify+curl
+RT=$(bash "$M" allowed-tools read-only)
+if echo "$RT" | grep -q "Write" || echo "$RT" | grep -q "Edit" \
+   || echo "$RT" | grep -q "Bash(git:\*)" || echo "$RT" | grep -q "Bash(gh:\*)"; then
+  bad "read-only tier drops Write/Edit/git/gh"
+else
+  pass "read-only tier drops Write/Edit/git/gh"
+fi
+echo "$RT" | grep -q "Read" && echo "$RT" | grep -q "WebFetch" \
+  && echo "$RT" | grep -q "Bash(curl:\*)" && echo "$RT" | grep -q "Bash(./notify:\*)" \
+  && pass "read-only tier keeps read/web/curl/notify" || bad "read-only tier keeps read/web/curl/notify"
+
+echo "---"
+[ "$fail" = "0" ] && echo "ALL PASS" || echo "SOME FAILED"
+exit "$fail"

--- a/scripts/tests/test_state_reduce.py
+++ b/scripts/tests/test_state_reduce.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Unit tests for state_reduce. Run: python3 scripts/tests/test_state_reduce.py"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import state_reduce as sr  # noqa: E402
+
+
+class TestReduce(unittest.TestCase):
+    def test_empty(self):
+        self.assertEqual(sr.reduce_events([]), {})
+
+    def test_single_success(self):
+        st = sr.reduce_events([{"skill": "x", "status": "success", "ts": "2026-06-17T10:00:00Z", "quality_score": 4}])
+        x = st["x"]
+        self.assertEqual(x["total_runs"], 1)
+        self.assertEqual(x["total_successes"], 1)
+        self.assertEqual(x["consecutive_failures"], 0)
+        self.assertEqual(x["success_rate"], 1.0)
+        self.assertEqual(x["last_status"], "success")
+        self.assertEqual(x["last_success"], "2026-06-17T10:00:00Z")
+        self.assertEqual(x["last_quality_score"], 4)
+
+    def test_consecutive_failures_and_reset(self):
+        ev = [
+            {"skill": "x", "status": "failed", "ts": "2026-06-17T10:00:00Z", "error": "e1"},
+            {"skill": "x", "status": "failed", "ts": "2026-06-17T11:00:00Z", "error": "e2"},
+            {"skill": "x", "status": "success", "ts": "2026-06-17T12:00:00Z"},
+            {"skill": "x", "status": "failed", "ts": "2026-06-17T13:00:00Z", "error": "e3"},
+        ]
+        x = sr.reduce_events(ev)["x"]
+        self.assertEqual(x["total_runs"], 4)
+        self.assertEqual(x["total_failures"], 3)
+        self.assertEqual(x["consecutive_failures"], 1)   # reset at success, then one fail
+        self.assertEqual(x["success_rate"], 0.25)
+        self.assertEqual(x["last_status"], "failed")
+        self.assertEqual(x["last_error"], "e3")
+        self.assertEqual(x["last_failed"], "2026-06-17T13:00:00Z")
+        self.assertEqual(x["last_success"], "2026-06-17T12:00:00Z")
+
+    def test_order_independence(self):
+        # events arrive out of order (concurrent appends) — ts ordering makes the fold deterministic
+        ev_in_order = [
+            {"skill": "x", "status": "success", "ts": "2026-06-17T10:00:00Z"},
+            {"skill": "x", "status": "failed", "ts": "2026-06-17T11:00:00Z", "error": "boom"},
+        ]
+        a = sr.reduce_events(ev_in_order)
+        b = sr.reduce_events(list(reversed(ev_in_order)))
+        self.assertEqual(a, b)
+        self.assertEqual(a["x"]["last_status"], "failed")
+
+    def test_multiple_skills(self):
+        st = sr.reduce_events([
+            {"skill": "a", "status": "success", "ts": "2026-06-17T10:00:00Z"},
+            {"skill": "b", "status": "failed", "ts": "2026-06-17T10:00:00Z", "error": "x"},
+        ])
+        self.assertEqual(set(st), {"a", "b"})
+        self.assertEqual(st["a"]["success_rate"], 1.0)
+        self.assertEqual(st["b"]["success_rate"], 0.0)
+
+    def test_quality_score_keeps_latest_nonzero(self):
+        x = sr.reduce_events([
+            {"skill": "x", "status": "success", "ts": "2026-06-17T10:00:00Z", "quality_score": 5},
+            {"skill": "x", "status": "success", "ts": "2026-06-17T11:00:00Z", "quality_score": 0},
+        ])["x"]
+        self.assertEqual(x["last_quality_score"], 5)   # 0 (unscored) doesn't overwrite
+
+    def test_schema_parity_with_file_writer(self):
+        # The Issues-backend fold must produce EXACTLY the per-skill keys that
+        # aeon.yml's file-mode apply_state_update writes, or a reader cut over to
+        # the materialized file silently loses a field. This is the contract that
+        # makes the reader cutover safe — guard it explicitly.
+        EXPECTED = {
+            "last_status", "last_success", "last_failed",
+            "total_runs", "total_successes", "total_failures",
+            "consecutive_failures", "success_rate",
+            "last_quality_score", "last_error",
+        }
+        x = sr.reduce_events([{"skill": "x", "status": "success", "ts": "t"}])["x"]
+        self.assertEqual(set(x.keys()), EXPECTED)
+        # _blank() (the zero-event shape) must carry the same keys too.
+        self.assertEqual(set(sr._blank().keys()), EXPECTED)
+
+
+class TestParse(unittest.TestCase):
+    def test_jsonl_skips_noise(self):
+        text = '{"skill":"x","status":"success","ts":"t"}\n\nnot json\n{"skill":"y","status":"failed"}\n'
+        evs = sr.parse_jsonl(text)
+        self.assertEqual(len(evs), 2)
+        self.assertEqual(evs[0]["skill"], "x")
+
+    def test_accepts_array_lines(self):
+        self.assertEqual(len(sr.parse_jsonl('[{"skill":"a","status":"success"}]')), 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/tests/test_state_store.sh
+++ b/scripts/tests/test_state_store.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Live integration test for scripts/state_store.sh — proves concurrent appends to the
+# Issues-backed state store do NOT conflict (the whole point vs the file + rebase loop).
+# Creates and closes a throwaway issue, so it's gated:
+#   STATE_STORE_LIVE=1 GH_REPO=<owner>/<repo> bash scripts/tests/test_state_store.sh
+# SKIPS otherwise (no gh auth, or flag unset).
+set -uo pipefail
+cd "$(dirname "$0")/../.." || exit 1
+
+if ! command -v gh >/dev/null 2>&1 || ! gh auth status >/dev/null 2>&1; then
+  echo "SKIP - gh not installed/authenticated"; exit 0
+fi
+if [ -z "${STATE_STORE_LIVE:-}" ]; then
+  echo "SKIP - set STATE_STORE_LIVE=1 (and GH_REPO) to run; creates + closes a test issue"; exit 0
+fi
+: "${GH_REPO:?set GH_REPO to a test repo (e.g. you/aeon-dev)}"
+export GH_REPO
+
+fail=0; pass(){ echo "ok   - $1"; }; bad(){ echo "FAIL - $1"; fail=1; }
+S="scripts/state_store.sh"
+
+TITLE="aeon-state-test-$$-$(date +%s)"
+N=$(bash "$S" ensure "$TITLE")
+if [ -n "$N" ]; then pass "created state issue #$N"; else bad "create state issue"; echo "SOME FAILED"; exit 1; fi
+
+# two CONCURRENT appends — independent comments, no read-modify-write race
+bash "$S" append "$N" '{"skill":"alpha","status":"success","ts":"2026-06-17T10:00:00Z","quality_score":4}' &
+bash "$S" append "$N" '{"skill":"alpha","status":"failed","ts":"2026-06-17T11:00:00Z","error":"boom"}' &
+bash "$S" append "$N" '{"skill":"beta","status":"success","ts":"2026-06-17T10:30:00Z"}' &
+wait
+
+STATE=$(bash "$S" read "$N")
+if echo "$STATE" | python3 -c "
+import sys,json; d=json.load(sys.stdin)
+assert d['alpha']['total_runs']==2, d
+assert d['alpha']['last_status']=='failed', d
+assert d['alpha']['success_rate']==0.5, d
+assert d['beta']['total_runs']==1, d
+" 2>/dev/null; then
+  pass "3 concurrent appends landed + folded correctly (no conflict, no rebase)"
+else
+  bad "concurrent appends fold: $STATE"
+fi
+
+gh issue close "$N" -c "test complete" >/dev/null 2>&1 && pass "closed test issue #$N" || bad "close issue #$N"
+
+echo "---"; [ "$fail" = "0" ] && echo "ALL PASS" || echo "SOME FAILED"; exit "$fail"

--- a/skills/approval-audit/SKILL.md
+++ b/skills/approval-audit/SKILL.md
@@ -1,4 +1,5 @@
 ---
+mode: read-only
 name: Approval Audit
 category: onchain-security
 description: List a wallet's live ERC-20 token approvals on Base and flag unlimited / risky spender grants. Keyless via Base RPC (eth_getLogs + eth_call) — no explorer key needed.

--- a/skills/base-mcp/SKILL.md
+++ b/skills/base-mcp/SKILL.md
@@ -1,4 +1,5 @@
 ---
+mode: read-only
 name: Base MCP
 category: crypto
 description: Access a Base Account via the Base MCP server (mcp.base.org) — wallet, portfolio, sending, swapping, signing, x402 payments, batched contract calls, and transaction history across supported chains.

--- a/skills/beamr-route/SKILL.md
+++ b/skills/beamr-route/SKILL.md
@@ -1,4 +1,5 @@
 ---
+mode: read-only
 name: BEAMR Route
 category: crypto
 description: Route a prompt through a BEAMR x402 gateway and report the answer + onchain receipt

--- a/skills/contract-audit/SKILL.md
+++ b/skills/contract-audit/SKILL.md
@@ -1,4 +1,5 @@
 ---
+mode: read-only
 name: Contract Audit
 category: onchain-security
 description: Audit any contract on Base — verification, proxy/upgradeability, ownership/admin roles, and mint/freeze/pause/drain powers as a live capability matrix. Keyless via Etherscan v2 + Base RPC.

--- a/skills/deployer-trace/SKILL.md
+++ b/skills/deployer-trace/SKILL.md
@@ -1,4 +1,5 @@
 ---
+mode: read-only
 name: Deployer Trace
 category: onchain-security
 description: Map every contract deployed by an address on Base, link reused patterns, and surface serial-rug signals. Keyless via Etherscan v2 + Base RPC.

--- a/skills/digest/SKILL.md
+++ b/skills/digest/SKILL.md
@@ -1,4 +1,5 @@
 ---
+mode: read-only
 name: Digest
 category: research
 description: Generate and send a digest on a configurable topic

--- a/skills/fund-flow/SKILL.md
+++ b/skills/fund-flow/SKILL.md
@@ -1,4 +1,5 @@
 ---
+mode: read-only
 name: Fund Flow
 category: onchain-security
 description: Trace where funds move to (or came from) across multiple hops from a Base address and render a Mermaid flow graph. Keyless — no explorer key needed.

--- a/skills/github-trending/SKILL.md
+++ b/skills/github-trending/SKILL.md
@@ -1,4 +1,5 @@
 ---
+mode: read-only
 name: GitHub Trending
 category: dev
 description: Curated trending GitHub repos — clustered, filtered, and labeled by momentum

--- a/skills/holder-concentration/SKILL.md
+++ b/skills/holder-concentration/SKILL.md
@@ -1,4 +1,5 @@
 ---
+mode: read-only
 name: Holder Concentration
 category: onchain-security
 description: Analyze token holder distribution on Base — top-N share, HHI concentration, LP/lock/burn exclusions, and whale clusters. Keyless via Etherscan v2 + Base RPC.

--- a/skills/honeypot-check/SKILL.md
+++ b/skills/honeypot-check/SKILL.md
@@ -1,4 +1,5 @@
 ---
+mode: read-only
 name: Honeypot Check
 category: onchain-security
 description: Detect un-sellable / restricted (honeypot) tokens on Base by simulating a real holder's sell via eth_call. Keyless — no explorer key needed.

--- a/skills/huggingface-trending/SKILL.md
+++ b/skills/huggingface-trending/SKILL.md
@@ -1,4 +1,5 @@
 ---
+mode: read-only
 name: Hugging Face Trending
 category: research
 description: Curated trending Hugging Face models, datasets, and spaces — filtered, clustered, and labeled with a "why notable" line per pick

--- a/skills/investigation-report/SKILL.md
+++ b/skills/investigation-report/SKILL.md
@@ -1,4 +1,5 @@
 ---
+mode: read-only
 name: Investigation Report
 category: onchain-security
 description: One-shot composite investigation of a Base token — runs rug-scan, contract-audit, deployer-trace and holder-concentration and merges them into a single report with an at-a-glance verdict. Keyless core; a Basescan key deepens it.

--- a/skills/linked-wallets/SKILL.md
+++ b/skills/linked-wallets/SKILL.md
@@ -1,4 +1,5 @@
 ---
+mode: read-only
 name: Linked Wallets
 category: onchain-security
 description: Cluster addresses likely controlled by the same entity on Base via shared-funder and co-spend heuristics. Keyless — no explorer key needed.

--- a/skills/lp-lock/SKILL.md
+++ b/skills/lp-lock/SKILL.md
@@ -1,4 +1,5 @@
 ---
+mode: read-only
 name: LP Lock
 category: onchain-security
 description: Resolve a token's main liquidity pool on Base and classify whether its LP is burned/locked or removable (rug-pull risk). Keyless — no explorer key needed.

--- a/skills/monitor-kalshi/SKILL.md
+++ b/skills/monitor-kalshi/SKILL.md
@@ -1,4 +1,5 @@
 ---
+mode: read-only
 name: Monitor Kalshi
 category: crypto
 description: Monitor specific Kalshi prediction markets for 24h price moves, volume changes, and top events

--- a/skills/narrative-tracker/SKILL.md
+++ b/skills/narrative-tracker/SKILL.md
@@ -1,4 +1,5 @@
 ---
+mode: read-only
 name: Narrative Tracker
 category: crypto
 description: Track rising, peaking, and fading crypto/tech narratives with quantitative mindshare + velocity signals and explicit positioning calls

--- a/skills/paper-pick/SKILL.md
+++ b/skills/paper-pick/SKILL.md
@@ -1,4 +1,5 @@
 ---
+mode: read-only
 name: Paper Pick
 category: research
 description: Find the one paper most worth reading from Hugging Face Papers

--- a/skills/routine/SKILL.md
+++ b/skills/routine/SKILL.md
@@ -1,4 +1,5 @@
 ---
+mode: read-only
 name: Routine
 category: productivity
 description: Combined briefing — token movers, tweet roundup, paper pick, GitHub issues, and HN digest in one run

--- a/skills/rug-scan/SKILL.md
+++ b/skills/rug-scan/SKILL.md
@@ -1,4 +1,5 @@
 ---
+mode: read-only
 name: Rug Scan
 category: onchain-security
 description: Assess rug-pull risk for any token on Base — ownership, mint/freeze powers, LP lock, and holder concentration rolled into one risk verdict. Keyless via Etherscan v2 + Base RPC.

--- a/skills/security-digest/SKILL.md
+++ b/skills/security-digest/SKILL.md
@@ -1,4 +1,5 @@
 ---
+mode: read-only
 name: Security Digest
 category: research
 description: Lead with confirmed exploitation (CISA KEV), enrich with EPSS, filter GitHub Advisories to your tracked stack, output one action per item

--- a/skills/startup-idea/SKILL.md
+++ b/skills/startup-idea/SKILL.md
@@ -1,4 +1,5 @@
 ---
+mode: read-only
 name: Startup Idea
 category: productivity
 description: 2 evidence-backed startup memos with ICP, wedge, monetization, and numeric kill criteria

--- a/skills/telegram-digest/SKILL.md
+++ b/skills/telegram-digest/SKILL.md
@@ -1,4 +1,5 @@
 ---
+mode: read-only
 name: Telegram Digest
 category: research
 description: Cross-channel digest of public Telegram posts — ranked by signal, clustered by narrative, not by channel

--- a/skills/token-pick/SKILL.md
+++ b/skills/token-pick/SKILL.md
@@ -1,4 +1,5 @@
 ---
+mode: read-only
 name: Token Pick
 category: crypto
 description: One token recommendation and one prediction market pick — scored, quantified, with a skip branch when signals are weak

--- a/skills/tx-explain/SKILL.md
+++ b/skills/tx-explain/SKILL.md
@@ -1,4 +1,5 @@
 ---
+mode: read-only
 name: Tx Explain
 category: onchain-security
 description: Decode any Base transaction into a plain-English story — method, token movements, swaps/approvals, counterparties, and suspicious-approval flags. Keyless via Base RPC + Etherscan v2.

--- a/skills/wallet-profile/SKILL.md
+++ b/skills/wallet-profile/SKILL.md
@@ -1,4 +1,5 @@
 ---
+mode: read-only
 name: Wallet Profile
 category: onchain-security
 description: Behavioral profile of any wallet on Base — age, activity class (bot/whale/sniper/trader), funding source, top counterparties, and risk flags. Keyless via Etherscan v2 + Base RPC.


### PR DESCRIPTION
Ports the next three hardening items from `aeon-dev`. **§6 is always-on** (default `write` is a verified superset of the old `ALLOWED`, so existing skills are unchanged + `python3` is now allowed, which the §10 helper scripts need). **§3 and §7 are off-by-default** — every new branch is guarded by `STATE_BACKEND=issues` / `HEALTH_ISSUES=1`, so with both repo vars unset the run path is byte-for-byte the old behaviour. All 9 pure test suites pass; both live gh tests SKIP cleanly.

### §6 — Capability tiers (`mode: read-only`)
- `scripts/skill_mode.sh` resolves the per-skill toolset (was a static `ALLOWED` block). `read-only` drops `Write/Edit/git/gh` so a skill **physically cannot mutate the repo**; `write` (default) is a superset of the previous list + `python3/python`.
- Post-run **read-only guard** logs the run on the skill's behalf and reverts any write that slipped through a shell redirection.
- Annotates the **25 pure read+notify skills** aeon-dev validated as read-only-safe (digest, rug-scan, tx-explain, wallet-profile, …).
- **No `skills.json` change** — the generator ignores `mode` and `ci-skills-json` normalizes git-churn fields (verified locally).

### §3 — Issues-as-state
- `state_store.sh` + `state_reduce.py`: replace the shared `cron-state.json` (rewritten + force-pushed with a 5× rebase-retry + auto-conflict-resolver every run) with **conflict-free Issue-comment appends**; canonical state is the pure fold. `state_reduce` is schema-parity-locked to the file writer so readers cut over safely.
- Wiring (all gated `STATE_BACKEND=issues`): materialize the projection before the run (readers unchanged) → append the event + skip the file-commit/rebase → drop the projection in `Commit results` → same append in `chain-runner`.

### §7 — Votable health Issues
- `health_triage.py` + `health_issue.sh`: one Issue per skill, a comment **only on a regression** (score <3 or failure flag) — silent on clean runs. Humans 👍/👎 to set repair priority (votes-then-severity). Injects the human ground truth the self-graded healing loop lacks.
- Wiring (gated `HEALTH_ISSUES=1`): emit `FLAGS` from the analyze step + post the regression comment.

### Safety
- `permissions: issues: read → write` (needed by §3/§7 append; harmless when both vars unset).
- Both workflows validated as YAML; default path provably unchanged (guards on every new branch).
- `ci-tests` extended with `skill_mode`, `state_reduce`, `health_triage` suites.

### Tested
```
9/9 pure suites pass · skill_mode: digest→read-only, reflect→write, write tier ⊇ python3
live tests (state_store, health_issue) SKIP without *_LIVE=1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)