### PR TITLE
Enable §3 issues-as-state (dual-write) + §7 votable health by default, + read-only/gh-api hardening

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -955,21 +955,29 @@ jobs:
             ERROR_SIG=$(cat /tmp/skill-error.txt)
           fi
 
-          # Issues-as-state (hardening §3) — opt-in via repo var STATE_BACKEND=issues.
-          # Append an IMMUTABLE event to the state Issue (conflict-free) and skip the
-          # file-commit + 5x rebase-retry below entirely. Readers fold via
-          # scripts/state_store.sh read (materialized into cron-state.json pre-run).
-          # Default (unset) keeps the file path unchanged.
-          if [ "${STATE_BACKEND:-}" = "issues" ]; then
+          # Issues-as-state (hardening §3). STATE_BACKEND tri-state:
+          #   dual   (DEFAULT) — append the run event to the pinned state Issue AND keep
+          #                      committing cron-state.json. Readers are unchanged and
+          #                      there is zero staleness risk; the Issue is built up and
+          #                      proven live. This is the dual-write transition.
+          #   issues          — append + SKIP the file-commit/rebase loop (churn-free end
+          #                      state). Requires the pre-run materialize step's reader
+          #                      cutover; flip to this once dual-write is proven.
+          #   file            — legacy file-only escape hatch (no Issue writes).
+          # Append failures never lose data: in dual/issues the file path still records
+          # the run (issues mode only exits early on a SUCCESSFUL append).
+          BACKEND="${STATE_BACKEND:-dual}"
+          if [ "$BACKEND" != "file" ]; then
             EVENT=$(jq -cn --arg s "$SKILL" --arg st "$CRON_STATUS" --arg ts "$NOW_ISO" \
               --argjson q "${QUALITY_SCORE:-0}" --arg err "$ERROR_SIG" \
               '{skill:$s,status:$st,ts:$ts,quality_score:$q,error:$err}')
             ISSUE=$(GH_REPO="$GITHUB_REPOSITORY" bash scripts/state_store.sh ensure "aeon:cron-state" 2>/dev/null || true)
             if [ -n "$ISSUE" ] && GH_REPO="$GITHUB_REPOSITORY" bash scripts/state_store.sh append "$ISSUE" "$EVENT"; then
-              echo "cron state appended to issue #$ISSUE (no commit, no rebase)"
-              exit 0
+              echo "cron state appended to issue #$ISSUE (backend=$BACKEND)"
+              if [ "$BACKEND" = "issues" ]; then echo "(issues mode: skipping file commit + rebase)"; exit 0; fi
+            else
+              echo "::warning::Issues-as-state append failed (backend=$BACKEND); file path records this run"
             fi
-            echo "::warning::Issues-as-state append failed; falling back to file path"
           fi
 
           # Function: apply quality metrics update to STATE
@@ -1068,12 +1076,12 @@ jobs:
           done
           echo "::warning::Failed to commit cron state (non-fatal)"
 
-      # Votable health Issues (hardening §7) — opt-in via repo var HEALTH_ISSUES=1.
+      # Votable health Issues (hardening §7) — ON by default; opt out with HEALTH_ISSUES=0.
       # On a regression (low score / failure flag / failed run) post to the skill's
       # per-skill health Issue; humans 👍/👎 it to set repair priority. Silent on clean
-      # runs (no Issue spam). Off by default = zero new issues on forks.
-      - name: Health regression to votable Issue (opt-in)
-        if: always() && steps.skill.outputs.name != '' && vars.HEALTH_ISSUES == '1'
+      # runs (no Issue spam), so a healthy fleet creates zero issues.
+      - name: Health regression to votable Issue
+        if: always() && steps.skill.outputs.name != '' && vars.HEALTH_ISSUES != '0'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/chain-runner.yml
+++ b/.github/workflows/chain-runner.yml
@@ -290,18 +290,21 @@ jobs:
           STATUS="${CHAIN_STATUS:-failed}"
           STATE_FILE="memory/cron-state.json"
 
-          # Issues backend (hardening §3): append the chain event to the shared state
-          # Issue (same store the main workflow uses) instead of committing the file —
-          # keeps chain state in one place and off the rebase loop. No-op when unset.
-          if [ "${STATE_BACKEND:-}" = "issues" ]; then
+          # Issues backend (hardening §3) — STATE_BACKEND tri-state, matching aeon.yml:
+          # dual (DEFAULT) appends the chain event to the shared state Issue AND keeps
+          # committing the file; issues appends + skips the file/rebase path; file is the
+          # legacy escape hatch. Append failure falls through to the file either way.
+          BACKEND="${STATE_BACKEND:-dual}"
+          if [ "$BACKEND" != "file" ]; then
             EVENT=$(jq -cn --arg s "chain:$CHAIN" --arg st "$STATUS" --arg ts "$NOW_ISO" \
               '{skill:$s,status:$st,ts:$ts}')
             ISSUE=$(GH_REPO="$GITHUB_REPOSITORY" bash scripts/state_store.sh ensure "aeon:cron-state" 2>/dev/null || true)
             if [ -n "$ISSUE" ] && GH_REPO="$GITHUB_REPOSITORY" bash scripts/state_store.sh append "$ISSUE" "$EVENT"; then
-              echo "chain state appended to issue #$ISSUE (no commit, no rebase)"
-              exit 0
+              echo "chain state appended to issue #$ISSUE (backend=$BACKEND)"
+              if [ "$BACKEND" = "issues" ]; then echo "(issues mode: skipping file commit)"; exit 0; fi
+            else
+              echo "::warning::Issues-as-state append failed (backend=$BACKEND); file path records this run"
             fi
-            echo "::warning::Issues-as-state append failed; falling back to file path"
           fi
 
           git checkout main 2>/dev/null || true

--- a/scripts/skill_mode.sh
+++ b/scripts/skill_mode.sh
@@ -21,6 +21,13 @@ set -euo pipefail
 
 # Tools every tier gets: read, search, notify, and read-only/local shell helpers.
 # curl stays (network is the *other* axis, governed by egress:, not by mode).
+#
+# NOTE: `gh` is intentionally NOT in the read-only base — even `gh api` GET reads are
+# excluded, because `gh` is also a write vector (issue/PR/commit/dispatch) and the tool
+# grammar is coarse (Bash(gh:*) is all-or-nothing). A read-only skill that needs GitHub
+# data should fetch it with WebFetch/curl against api.github.com, or stay `mode: write`.
+# (Known degraders today: github-trending + security-digest use `gh api` only as a
+# fallback behind a WebFetch/curl primary, so they degrade gracefully, not break.)
 BASE_TOOLS="Read,Glob,Grep,WebFetch,WebSearch"
 BASE_TOOLS="$BASE_TOOLS,Bash(curl:*),Bash(jq:*)"
 BASE_TOOLS="$BASE_TOOLS,Bash(./notify:*),Bash(./notify-jsonrender:*)"

--- a/scripts/state_store.sh
+++ b/scripts/state_store.sh
@@ -19,13 +19,22 @@ REPO_ARGS=(); [ -n "${GH_REPO:-}" ] && REPO_ARGS=(--repo "$GH_REPO")
 
 _ensure() {
   local title="${1:?title required}" n
-  n=$(gh issue list "${REPO_ARGS[@]}" --state open --search "\"$title\" in:title" \
+  # Search open OR closed. The ledger deliberately lives *closed* so it never
+  # clutters the repo's open-issues list. Commenting on and reading a closed
+  # issue still work (only *locking* an issue blocks comments) — so a closed
+  # issue is a perfectly good append-only store, just an invisible one.
+  n=$(gh issue list "${REPO_ARGS[@]}" --state all --search "\"$title\" in:title" \
         --json number,title --jq "map(select(.title==\"$title\")) | .[0].number // empty" 2>/dev/null || true)
   if [ -z "$n" ]; then
     local url
     url=$(gh issue create "${REPO_ARGS[@]}" --title "$title" \
           --body "Append-only Aeon state store (hardening §3). Machine-managed; do not edit by hand.")
     n=$(printf '%s' "$url" | grep -oE '[0-9]+$')
+    # Close it on creation so it stays out of the open-issues view. Appends still
+    # land on the closed issue; it never needs to be reopened.
+    if [ -n "$n" ]; then
+      gh issue close "$n" "${REPO_ARGS[@]}" >/dev/null 2>&1 || true
+    fi
   fi
   printf '%s' "$n"
 }


### PR DESCRIPTION
Makes §3 and §7 **on by default**, implemented safely, plus the read-only/`gh api` and ensure()-race hardening. Builds on #548.

### §3 issues-as-state — ON by default (dual-write transition)
`STATE_BACKEND` is now **tri-state**:
| value | behaviour |
|---|---|
| **`dual`** (default, unset) | append each run event to the pinned `aeon:cron-state` Issue **AND** keep committing `cron-state.json` — readers unchanged, **zero staleness risk**, Issue store exercised live |
| `issues` | append + **skip** the file-commit/rebase loop (churn-free end state; the gated materialize step handles the reader cutover) |
| `file` | legacy file-only escape hatch |

This is hardening item #3 (the dual-write transition): the file stays authoritative, so even total failure of the Issue path can't corrupt or stale the readers. Append failures always fall through to the file. Graduate to `STATE_BACKEND=issues` to drop the commit churn once dual-write is proven.

### §7 votable health Issues — ON by default
Flipped to default-on (`HEALTH_ISSUES != '0'`; opt out with `=0`). **Silent on clean runs**, so a healthy fleet still creates zero Issues — only regressions auto-open a votable per-skill Issue.

### Hardening
1. **read-only ✕ `gh api`** — documented in `skill_mode.sh`: read-only excludes all `gh` (incl. GET reads) by design; GitHub reads should use WebFetch/curl on `api.github.com` or stay `write`. The two affected skills (`github-trending`, `security-digest`) use `gh api` only as a fallback, so they degrade gracefully.
2. **`ensure()` race** — pre-created the pinned `aeon:cron-state` Issue (#549) so `ensure()` always finds it and never races to create a duplicate under concurrency.
3. **materialize-failure safety** — addressed by the dual-write default above (file remains the safety net).
4. **notify.sh live delivery** — to be confirmed in the canary (next step), not a code change.

### Safety / testing
- Both workflows valid YAML; tri-state logic traced (unset→dual→append+keep-file; issues→append+skip-file; file→legacy). `materialize` + commit-drop fire only on explicit `issues`, so `dual` keeps the file fresh.
- `skill_mode` suite still green.
- Default-path change: every run now does one extra `gh issue comment` (append) — the file path is otherwise unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)