### PR TITLE
fix(§7): votable-health was silently default-OFF (unset HEALTH_ISSUES coerced to 0)

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -1081,10 +1081,16 @@ jobs:
       # per-skill health Issue; humans 👍/👎 it to set repair priority. Silent on clean
       # runs (no Issue spam), so a healthy fleet creates zero issues.
       - name: Health regression to votable Issue
-        if: always() && steps.skill.outputs.name != '' && vars.HEALTH_ISSUES != '0'
+        if: always() && steps.skill.outputs.name != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # §7 is default-ON; disable only with repo var HEALTH_ISSUES=0. The toggle is
+          # checked HERE in bash, NOT in the step `if:`. A GitHub Actions `if:` comparison
+          # like `vars.HEALTH_ISSUES != '0'` does numeric coercion, and an UNSET var (null)
+          # coerces to 0 — so `!= '0'` is FALSE when unset, silently skipping the step by
+          # default (the opposite of "default-on"). Bash string comparison has no such trap.
+          if [ "${{ vars.HEALTH_ISSUES }}" = "0" ]; then echo "votable health disabled (HEALTH_ISSUES=0)"; exit 0; fi
           SKILL="${{ steps.skill.outputs.name }}"
           SCORE="${{ steps.analyze.outputs.QUALITY_SCORE }}"; [ -z "$SCORE" ] && SCORE=0
           FLAGS='${{ steps.analyze.outputs.FLAGS }}'; [ -z "$FLAGS" ] && FLAGS='[]'


### PR DESCRIPTION
## What

§7 votable-health has been **silently disabled by default** since #550. The step gate
`if: ... && vars.HEALTH_ISSUES != '0'` looks like "run unless explicitly 0", but GitHub
Actions `if:` comparisons do **numeric coercion**: an **unset** repo var is `null`, and
`null != '0'` evaluates as `0 != 0` → **false**. With `HEALTH_ISSUES` unset (the default),
the step was **skipped on every run** — the opposite of #550's intended default-on.

## How it was caught

A fork canary (`aaronjmars/aeontmp`, byte-identical workflow): dispatched a skill that
emits deliberately low-value output. The analyzer **correctly** scored it `1` with flag
`empty_output` (a real regression), but **no health issue was filed** — because the §7
step never executed. The step's `conclusion` was `skipped` on all runs.

## Fix

- Gate the step only on `always() && steps.skill.outputs.name != ''` (the proven sibling
  pattern used by the "Update cron state" step).
- Move the on/off toggle into **bash**: `if [ "${{ vars.HEALTH_ISSUES }}" = "0" ]; then exit 0; fi`
  — a string compare with no numeric coercion, mirroring how `STATE_BACKEND` is handled.

Behavior after fix: unset → **on**; `HEALTH_ISSUES=0` → off; `1` → on.

Siblings checked and safe (compare against non-numeric strings, no coercion):
`STATE_BACKEND == 'issues'`, `JSONRENDER_ENABLED != 'false'`.

## Verified on the fork

Re-dispatched the canary after the fix → §7 ran `success` → opened `health: t6-canary`
issue with: `⚠️ Regression — score 1, flags ["empty_output"] …`. The other 5 hardening
canary checks (notify delivery, §6 read-only + write/python3, §3 dual-write, §3 issues-mode)
all passed unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)