### PR TITLE
fix(chain): add issues:write + fix var-less skill discovery in chain-runner

### DIFF
--- a/.github/workflows/chain-runner.yml
+++ b/.github/workflows/chain-runner.yml
@@ -12,6 +12,9 @@ on:
 permissions:
   contents: write
   actions: write
+  issues: write   # §3 issues-as-state: the chain's append (state_store.sh ensure/comment)
+                  # calls the Issues API; without this it 403s and only the file path records
+                  # chain events (and in `issues` mode they'd be lost from the ledger entirely).
 
 concurrency:
   group: aeon-chain-${{ inputs.chain }}
@@ -60,7 +63,7 @@ jobs:
               sleep 5
               run_id=$(gh run list --workflow=aeon.yml -L 10 \
                 --json databaseId,displayTitle,createdAt \
-                -q "[.[] | select(.displayTitle | test(\"skill: ${skill}(\"; \"i\")) | select(.createdAt >= \"${before_ts}\")] | .[0].databaseId" \
+                -q "[.[] | select(.displayTitle | test(\"skill: ${skill}( |\$)\"; \"i\")) | select(.createdAt >= \"${before_ts}\")] | .[0].databaseId" \
                 2>/dev/null || true)
               [ -n "$run_id" ] && [ "$run_id" != "null" ] && break
               run_id=""


### PR DESCRIPTION
## What

Two bugs on the **chain path** that the fork canary surfaced. Chains are unused on prod today (0 defined), so these were **latent** — but both are real and would bite the first time a chain runs.

### 1. Missing `issues: write`
The §3 issues-as-state append (wired into `chain-runner.yml` by #548/#550) calls the Issues API via `state_store.sh ensure/comment`. The workflow only had `contents: write` + `actions: write`, so the append **403'd** — chain run-events never reached the ledger Issue. Dual mode masked this (the file path still recorded the event), but in `issues` mode the chain events would be lost from the ledger entirely.

### 2. Var-less skill discovery regex
`dispatch_skill()` polls for the sub-run it launched with `test("skill: ${skill}(")`. The literal `(` is an **unterminated regex group** — jq throws `Regex failure: end pattern with unmatched parenthesis` — and it only "works" by accident when a skill has a var (`skill: digest (AI agents)`). Var-less steps (`skill: heartbeat`) never matched, so discovery timed out and the chain **aborted at step 1**. Fixed to `test("skill: ${skill}( |$)")` — matches name-then-space (var present) or name-then-end (no var). Confirmed it still rejects near-misses like `skill: heartbeat2`.

## Verified end-to-end on a fork (`aaronjmars/aeontmp`)

A 2-step heartbeat chain (`canary-chain`) now completes **green**:
- both heartbeat sub-runs **discovered + awaited** (fix 2),
- `chain state appended to issue #4 (backend=dual)` **succeeds** (fix 1),
- `Chain 'canary-chain' completed successfully`.

(Before the fixes: same chain aborted at step 1, and the §3 append logged `Issues-as-state append failed`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)