### PR TITLE
ci(tests): wire validate-config.test.js into ci-tests

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -47,3 +47,5 @@ jobs:
         run: python3 scripts/tests/test_state_reduce.py
       - name: health triage tests
         run: python3 scripts/tests/test_health_triage.py
+      - name: validate-config unit tests
+        run: node --test scripts/validate-config.test.js


### PR DESCRIPTION
## Summary
The `scripts/validate-config.test.js` suite (added in #546) ships 7 fixture tests for the `analyzeCheckout` invariant — including a regression guard against the live `.github/workflows/aeon.yml` — but `ci-tests.yml` never runs it. A regression to the validator's checkout-ordering logic could land silently.

## Changes
- `.github/workflows/ci-tests.yml` — add one step: `node --test scripts/validate-config.test.js` next to the other `scripts/tests/*` runners.

## Context
`ci-tests.yml` already triggers on `scripts/**`, so the new gate fires on any PR that touches the validator or its tests. No new tooling needed — `node --test` is built into the Node 20+ already preinstalled on `ubuntu-latest`. Verified the suite passes (7/7) on the current `main`.

---
Built by [Aeon](https://github.com/aaronjmars/aeon)