### PR TITLE
feat(models): add Claude Sonnet 5 as a selectable model

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -17,6 +17,7 @@ on:
           - '(config default)'
           - claude-opus-4-8
           - claude-fable-5
+          - claude-sonnet-5
           - claude-sonnet-4-6
           - claude-haiku-4-5-20251001
       var:

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ The default model for all skills is set in `aeon.yml` (or from the dashboard hea
 model: claude-opus-4-8
 ```
 
-Options: `claude-opus-4-8`, `claude-fable-5`, `claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5-20251001`. Per-run overrides are available via workflow dispatch, and individual skills can override to optimize cost:
+Options: `claude-opus-4-8`, `claude-fable-5`, `claude-opus-4-7`, `claude-sonnet-5`, `claude-sonnet-4-6`, `claude-haiku-4-5-20251001`. Per-run overrides are available via workflow dispatch, and individual skills can override to optimize cost:
 
 ```yaml
 skills:

--- a/aeon.yml
+++ b/aeon.yml
@@ -479,7 +479,7 @@ chains:
   #     - skill: routine, consume: [token-movers, paper-pick, issue-triage, hn-digest]
 
 # Default model for all skills. Override per-run via workflow_dispatch.
-# Options: claude-opus-4-8, claude-fable-5, claude-sonnet-4-6, claude-haiku-4-5-20251001
+# Options: claude-opus-4-8, claude-fable-5, claude-sonnet-5, claude-sonnet-4-6, claude-haiku-4-5-20251001
 model: claude-sonnet-4-6
 
 # AI Gateway — route Claude Code requests through an LLM provider.

--- a/apps/dashboard/lib/constants.ts
+++ b/apps/dashboard/lib/constants.ts
@@ -4,6 +4,7 @@ export const MODELS = [
   { id: 'claude-opus-4-8', label: 'Opus 4.8' },
   { id: 'claude-fable-5', label: 'Fable 5' },
   { id: 'claude-opus-4-7', label: 'Opus 4.7' },
+  { id: 'claude-sonnet-5', label: 'Sonnet 5' },
   { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
   { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5' },
 ]

--- a/skills/cost-report/SKILL.md
+++ b/skills/cost-report/SKILL.md
@@ -20,6 +20,7 @@ First read `aeon.yml` and find the `gateway.provider` value. Use the matching ta
 | Model | Input | Output | Cache Read | Cache Write |
 |-------|-------|--------|------------|-------------|
 | claude-opus-4-7 | $15.00 | $75.00 | $1.50 | $18.75 |
+| claude-sonnet-5 | $3.00 | $15.00 | $0.30 | $3.75 |
 | claude-sonnet-4-6 | $3.00 | $15.00 | $0.30 | $3.75 |
 | claude-haiku-4-5-20251001 | $0.80 | $4.00 | $0.08 | $1.00 |
 
@@ -28,10 +29,12 @@ First read `aeon.yml` and find the `gateway.provider` value. Use the matching ta
 | Model | Input | Output |
 |-------|-------|--------|
 | claude-opus-4-7 | $5.00 | $25.00 |
+| claude-sonnet-5 | $3.00 | $15.00 |
 | claude-sonnet-4-6 | $3.00 | $15.00 |
 | claude-haiku-4-5-20251001 | $0.80 | $4.00 |
 
 Bankr does not expose cache read/write pricing separately. Treat cache columns as $0 for Bankr rows.
+> `claude-sonnet-5` launched with introductory pricing of $2.00 input / $10.00 output per million tokens through 2026-08-31; the rates above are the post-intro standard. They overstate (never understate) spend during the intro window — flag this in the "Pricing drift" callout if Sonnet 5 usage is material and you need exact intro-window costs.
 
 If a CSV row references a model not in the active table, treat it as an **unknown model**: price it at Opus rates (conservative), add it to the "Pricing drift" callout in the report so rates can be updated, and continue. Do not crash.
 

--- a/skills/spend-monitor/SKILL.md
+++ b/skills/spend-monitor/SKILL.md
@@ -29,6 +29,7 @@ First read `aeon.yml` and find the `gateway.provider` value. Use the matching ta
 | Model | Input | Output | Cache Read | Cache Write |
 |-------|-------|--------|------------|-------------|
 | claude-opus-4-7 | $15.00 | $75.00 | $1.50 | $18.75 |
+| claude-sonnet-5 | $3.00 | $15.00 | $0.30 | $3.75 |
 | claude-sonnet-4-6 | $3.00 | $15.00 | $0.30 | $3.75 |
 | claude-haiku-4-5-20251001 | $0.80 | $4.00 | $0.08 | $1.00 |
 
@@ -37,10 +38,12 @@ First read `aeon.yml` and find the `gateway.provider` value. Use the matching ta
 | Model | Input | Output |
 |-------|-------|--------|
 | claude-opus-4-7 | $5.00 | $25.00 |
+| claude-sonnet-5 | $3.00 | $15.00 |
 | claude-sonnet-4-6 | $3.00 | $15.00 |
 | claude-haiku-4-5-20251001 | $0.80 | $4.00 |
 
 For Bankr, treat cache read/write as zero cost.
+> `claude-sonnet-5` launched with introductory pricing of $2.00 input / $10.00 output per million tokens through 2026-08-31; the rates above are the post-intro standard. They overstate (never understate) spend during the intro window — fine for a budget watchdog, but adjust if reconciling exact bills before that date.
 For any unlisted model, default to Opus pricing (conservative estimate).
 
 ## Steps


### PR DESCRIPTION
Adds **Claude Sonnet 5** (`claude-sonnet-5`, launched 2026-06-30) as a selectable model. Sonnet 5 reaches near-Opus quality on coding and agentic work at Sonnet pricing, so it's a strong cost/quality option for skill runs.

This **adds the option everywhere it needs to appear** but does **not** change any operational default — the default model stays the operator's choice (set in `aeon.yml` / the dashboard dropdown).

### Changes
- **Dashboard dropdown** — `apps/dashboard/lib/constants.ts` `MODELS`
- **Per-run override** — `claude-sonnet-5` added to the `workflow_dispatch` model choice in `.github/workflows/aeon.yml`
- **Docs / option lists** — `aeon.yml` comment + `README.md`
- **Cost tracking** — pricing rows added to `spend-monitor` and `cost-report` skill tables

### Pricing
Listed at the **post-intro standard $3 / $15** per MTok (input/output), identical to Sonnet 4.6. Sonnet 5 launched with **introductory pricing of $2 / $10 through 2026-08-31**, documented inline in both tables. Standard rates were chosen deliberately: they over- (never under-) state spend during the intro window, which is the safe direction for a budget watchdog.

### Gateway routing — no code change needed
- `direct` / `usepod`: pass `claude-sonnet-5` through to the Anthropic-native surface.
- `surplus`: the existing dot-form `sed` conversion already yields the correct `claude-sonnet-5` id (no minor version to dot).
- `venice`: intentionally **left out** of its allowlist — Venice's catalog caps at ~Opus 4.6, so a brand-new model would 404; it correctly falls back to `claude-opus-4-6`.

### Notes / optional follow-ups (not in this PR)
- Operational defaults left unchanged (`aeon.yml model:`, dashboard fallback, `messages.yml` fallback).
- The OpenRouter "sonnet" slot default (`scripts/llm-gateway.sh`, `anthropic/claude-sonnet-4.6`) was left as-is — it's overridable via `OPENROUTER_MODEL_SONNET`. Bump to `anthropic/claude-sonnet-5` if you want OpenRouter subagents on Sonnet 5.

Model facts verified against the canonical Claude API model reference.
