### PR TITLE
chore(ci): pin pyyaml to ==6.0.2

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Install deps
-        run: pip install pyyaml
+        run: pip install pyyaml==6.0.2
       - name: notify_format unit tests
         run: python3 scripts/tests/test_notify_format.py
       - name: notify integration tests


### PR DESCRIPTION
Version-pins the one unpinned CLI install in the workflows — `pip install pyyaml` → `pip install pyyaml==6.0.2` in `ci-tests.yml`.

**Context (supply-chain / Item 7, acceptance criterion #1):** the highest-risk install — the Claude Code CLI in the secret-bearing runner (`aeon.yml`, `messages.yml`) — is already pinned to `@2.1.168`. This was the only remaining unpinned CLI install. It's CI-only (runs the Python unit tests, no secrets), so the risk was low, but pinning is trivially correct and closes the criterion.

Scoped deliberately small: does **not** adopt pnpm or `minimumReleaseAge` — that migration isn't worth it here (3 of 4 apps have 0–1 deps; the dashboard already has a committed lockfile + Dependabot monthly cadence, and switching the webhook to pnpm would change Cloudflare Workers Builds' package-manager detection).