### PR TITLE
fix(grok): harness hardening — no thought-leak, safe cancels, harness-routed scorer, drop grok-build

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -21,7 +21,6 @@ on:
           - claude-sonnet-4-6
           - claude-haiku-4-5-20251001
           - grok-composer-2.5-fast
-          - grok-build
       harness:
         description: 'Agent harness'
         required: false
@@ -367,6 +366,7 @@ jobs:
           fi
           echo "Using harness: $HARNESS  |  model: $MODEL"
           echo "SKILL_MODEL=$MODEL" >> "$GITHUB_OUTPUT"
+          echo "HARNESS=$HARNESS" >> "$GITHUB_OUTPUT"   # read by the post-run scorer / feed-convert steps
 
           # --- AI Gateway routing ---
           # provider: auto → cascade through every provider whose key is set, in
@@ -648,7 +648,8 @@ jobs:
           USEPOD_TOKEN: ${{ secrets.USEPOD_TOKEN }}
           VENICE_API_KEY: ${{ secrets.VENICE_API_KEY }}
           SURPLUS_API_KEY: ${{ secrets.SURPLUS_API_KEY }}
-          XAI_API_KEY: ${{ secrets.XAI_API_KEY }}   # grok gateway: score grok-harness output via xAI
+          XAI_API_KEY: ${{ secrets.XAI_API_KEY }}   # grok scorer: API-key auth path
+          GROK_CREDENTIALS: ${{ secrets.GROK_CREDENTIALS }}   # grok scorer: X-account OAuth (restored by run-grok.sh)
           OPENROUTER_MODEL: ${{ vars.OPENROUTER_MODEL }}
           OPENROUTER_MODEL_SONNET: ${{ vars.OPENROUTER_MODEL_SONNET }}
           OPENROUTER_MODEL_HAIKU: ${{ vars.OPENROUTER_MODEL_HAIKU }}
@@ -666,9 +667,15 @@ jobs:
           # Skip analysis for meta skills (they don't produce scorable output)
           case "$SKILL" in heartbeat|skill-health|skill-analytics|reflect|memory-flush|self-review|cost-report) echo "Skipping analysis for meta skill"; exit 0;; esac
 
-          # Route through gateway if configured
-          GATEWAY="${{ steps.run.outputs.GATEWAY }}"
-          source "${GITHUB_WORKSPACE}/scripts/llm-gateway.sh"
+          HARNESS="${{ steps.run.outputs.HARNESS }}"
+          # Route the scorer's claude call through the gateway (claude harness only).
+          # On grok we score via run-grok.sh below and don't touch the gateway, so
+          # skip the source entirely — otherwise it prints "Using direct Anthropic
+          # API" noise on a grok-only repo.
+          if [ "$HARNESS" != "grok" ]; then
+            GATEWAY="${{ steps.run.outputs.GATEWAY }}"
+            source "${GITHUB_WORKSPACE}/scripts/llm-gateway.sh"
+          fi
 
           # Read and truncate skill output for analysis
           OUTPUT=""
@@ -695,7 +702,18 @@ jobs:
           JSON format: {\"score\": N, \"assessment\": \"one line\", \"flags\": []}"
 
           SCORE_MODEL="${ANTHROPIC_DEFAULT_HAIKU_MODEL:-claude-haiku-4-5-20251001}"
-          if ! RAW=$(echo "$ANALYSIS_PROMPT" | claude -p - \
+          if [ "$HARNESS" = "grok" ]; then
+            # Score through the SAME harness the skill ran on. A grok-only repo has
+            # no Claude credentials, so `claude -p` would just print "Not logged in";
+            # run-grok.sh reuses the run's X-account/API-key auth and emits the same
+            # {result,usage} envelope. MODEL= → grok's default (grok-composer-2.5-fast,
+            # the only grok model that completes in CI). Its notices go to stderr.
+            if ! RAW=$(echo "$ANALYSIS_PROMPT" | MODEL= SKILL_MODE=read-only \
+                bash "${GITHUB_WORKSPACE}/scripts/run-grok.sh" 2>/dev/null); then
+              echo "::notice::Skill scoring skipped — grok scorer unavailable (non-fatal)"
+              exit 0
+            fi
+          elif ! RAW=$(echo "$ANALYSIS_PROMPT" | claude -p - \
             --model "$SCORE_MODEL" --output-format json 2>&1); then
             echo "::warning::Skill analysis failed (non-fatal). Raw: $(printf '%s' "$RAW" | head -c 800 | tr '\n' ' ')"
             exit 0
@@ -706,13 +724,14 @@ jobs:
           # this call (seen twice on OpenRouter's haiku slug, while its opus
           # slug always returns text). Retry once on the run's main model —
           # llm-gateway.sh only sets MODEL here when the gateway remaps it.
-          if [ -z "$ANALYSIS_TEXT" ] && [ -n "${MODEL:-}" ] && [ "$MODEL" != "$SCORE_MODEL" ]; then
+          # (claude harness only; grok already used its default.)
+          if [ "$HARNESS" != "grok" ] && [ -z "$ANALYSIS_TEXT" ] && [ -n "${MODEL:-}" ] && [ "$MODEL" != "$SCORE_MODEL" ]; then
             echo "::warning::Empty analysis result from ${SCORE_MODEL} — retrying with ${MODEL}. Raw: $(printf '%s' "$RAW" | head -c 800 | tr '\n' ' ')"
             if RAW=$(echo "$ANALYSIS_PROMPT" | claude -p - --model "$MODEL" --output-format json 2>&1); then
               ANALYSIS_TEXT=$(echo "$RAW" | jq -r '.result // empty')
             fi
           fi
-          if [ -z "$ANALYSIS_TEXT" ]; then echo "::warning::Empty analysis result. Raw: $(printf '%s' "$RAW" | head -c 800 | tr '\n' ' ')"; exit 0; fi
+          if [ -z "$ANALYSIS_TEXT" ]; then echo "::notice::Empty analysis result — skipping score (non-fatal)."; exit 0; fi
 
           # Parse score: accept raw JSON, else strip code fences, flatten newlines,
           # and grab the outermost {…} object — handles fenced / multi-line output
@@ -766,7 +785,10 @@ jobs:
           echo "::notice::Skill quality — $SKILL: score=$SCORE, avg=$AVG — $ASSESSMENT"
 
       - name: Convert feed outputs
-        if: steps.work.outputs.mode != '' && vars.JSONRENDER_ENABLED != 'false'
+        # Skipped on the grok harness: notify-jsonrender renders via `claude -p`, so
+        # on a grok-only repo (no Claude auth) it can only no-op with noise. The
+        # jsonrender feed is a Claude-Code-side feature.
+        if: steps.work.outputs.mode != '' && vars.JSONRENDER_ENABLED != 'false' && steps.run.outputs.HARNESS != 'grok'
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ The **harness** is the coding-agent CLI that actually runs your skills. It's a s
 | Harness | CLI | Auth | Models |
 |---------|-----|------|--------|
 | `claude` (default) | [Claude Code](https://github.com/anthropics/claude-code) (`claude -p`) | `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY` / any gateway above | `claude-*` |
-| `grok` | [Grok Build](https://x.ai/cli) (`grok -p`) | **X account** (`GROK_CREDENTIALS`) or `XAI_API_KEY` | `grok-composer-2.5-fast` (default), `grok-build` |
+| `grok` | [Grok Build](https://x.ai/cli) (`grok -p`) | **X account** (`GROK_CREDENTIALS`) or `XAI_API_KEY` | `grok-composer-2.5-fast` (grok-build is not offered — it Cancels in the Actions sandbox) |
 
 Everything already configured keeps running on `claude` — the harness is fully additive and defaults to Claude Code. Select it globally in the dashboard top bar, per-run via the workflow-dispatch **Harness** input, or per-skill / globally in `aeon.yml`:
 

--- a/aeon.yml
+++ b/aeon.yml
@@ -217,7 +217,7 @@ chains:
 
 # Default model for all skills. Override per-run via workflow_dispatch.
 # Options: claude-opus-4-8, claude-fable-5, claude-sonnet-5, claude-sonnet-4-6, claude-haiku-4-5-20251001
-# (Grok Build harness models: grok-composer-2.5-fast [default], grok-build)
+# (Grok harness model: grok-composer-2.5-fast — the only one that runs in CI)
 model: grok-composer-2.5-fast
 
 # Agent harness — which coding-agent CLI runs your skills.

--- a/apps/dashboard/lib/constants.ts
+++ b/apps/dashboard/lib/constants.ts
@@ -17,11 +17,13 @@ export const GROK_MODELS = [
   { id: 'grok-build', label: 'Grok Build' },
 ]
 
-// Harnesses (agent CLIs). `claude` = Claude Code (default, uses the AI Gateway);
-// `grok` = Grok Build (own X-account/API-key auth, own model list above).
+// Harnesses (agent CLIs). `claude` = Claude Code (default, uses the AI Gateway),
+// labelled "Anthropic" in the UI; `grok` = Grok Build (own X-account/API-key
+// auth, own model list above), labelled "Grok". The `id`s are the on-disk
+// harness values (aeon.yml `harness:`) and never change — only the labels do.
 export const HARNESSES = [
-  { id: 'claude', label: 'Claude Code' },
-  { id: 'grok', label: 'Grok Build' },
+  { id: 'claude', label: 'Anthropic' },
+  { id: 'grok', label: 'Grok' },
 ] as const
 
 export function modelsForHarness(harness: string) {

--- a/apps/dashboard/lib/constants.ts
+++ b/apps/dashboard/lib/constants.ts
@@ -9,12 +9,14 @@ export const MODELS = [
   { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5' },
 ]
 
-// Models offered when the Grok Build (`grok`) harness is selected (from
-// `grok models`). grok-composer-2.5-fast is grok's default; grok-build is the
-// alternative. Grok also accepts custom models via ~/.grok/config.toml.
+// Models offered when the Grok (`grok`) harness is selected. Only
+// grok-composer-2.5-fast (grok's default) is exposed: it runs cleanly end-to-end
+// in GitHub Actions. grok-build is intentionally NOT offered — it Cancels every
+// time in the Actions sandbox (works locally, drops its relay/entitlement path in
+// CI), so selecting it would be a footgun. Grok still accepts custom model ids
+// via ~/.grok/config.toml for anyone who needs one.
 export const GROK_MODELS = [
   { id: 'grok-composer-2.5-fast', label: 'Composer 2.5 Fast' },
-  { id: 'grok-build', label: 'Grok Build' },
 ]
 
 // Harnesses (agent CLIs). `claude` = Claude Code (default, uses the AI Gateway),

--- a/scripts/run-grok.sh
+++ b/scripts/run-grok.sh
@@ -113,11 +113,18 @@ fi
 # --- 4. run -----------------------------------------------------------------
 PROMPT="$(cat)"
 out_file="$(mktemp)"; err_file="$(mktemp)"
+# --no-subagents: a headless skill run is a single focused agent. The multi-agent
+# models (grok-build) otherwise try to DELEGATE to parallel subagents, whose
+# Task/spawn tool is not in our --permission-mode dontAsk allowlist — the denial
+# aborts the whole turn (observed: grok-build → stopReason=Cancelled, empty text,
+# ~18s). Disabling subagents keeps the model doing the work itself. Composer is
+# single-agent already, so this is a no-op for it.
 # Guard the array expansions for the empty case under bash 3.2 set -u.
 grok -p "$PROMPT" \
   ${MODEL_FLAG[@]+"${MODEL_FLAG[@]}"} \
   --output-format json \
   --no-auto-update \
+  --no-subagents \
   ${GROK_ARGS[@]+"${GROK_ARGS[@]}"} >"$out_file" 2>"$err_file"
 rc=$?
 # Surface grok's own diagnostics into the step log regardless of outcome.
@@ -133,8 +140,13 @@ fi
 # Confirmed shape (grok 0.2.82): {"text": "...", "stopReason", "sessionId",
 # "requestId", "thought"} — the result is in .text and there is NO usage/token
 # field, so token counts normalize to 0 (grok-harness runs report 0 tokens).
-# We still accept common aliases (.result/.output/etc.) for forward-compat, and
-# fall back to wrapping raw stdout if the shape ever changes (never break a run).
+#
+# CRITICAL: `.thought` is grok's internal chain-of-thought. It must NEVER become
+# the skill result — downstream this gets committed to the repo, sent via
+# ./notify, and fed into chains. So .result is built ONLY from recognized text
+# fields, and a valid grok JSON object is NEVER dumped raw (which is how .thought
+# previously leaked when .text was empty). Common aliases are kept for forward-
+# compat; the raw-stdout fallback fires only for genuinely non-JSON output.
 NORMALIZE='
   (.result // .text // .output // .response // .content // .message // "") as $r
   | (.usage // .usageMetadata // {}) as $u
@@ -149,17 +161,34 @@ NORMALIZE='
         cache_creation_input_tokens: (($u.cache_creation_input_tokens // $u.cache_creation // 0) | floor)
       }
     }'
-# Use the normalized envelope only if it parsed AND actually recovered text;
-# otherwise wrap grok's raw stdout so a shape mismatch never looks like "no
-# output". (An empty envelope on genuinely-empty output is fine — the fallback
-# then wraps the empty string, same result.)
-ENVELOPE=""
-if ENVELOPE=$(jq -ce "$NORMALIZE" "$out_file" 2>/dev/null) \
-   && [ -n "$ENVELOPE" ] \
-   && [ -n "$(printf '%s' "$ENVELOPE" | jq -r '.result')" ]; then
+
+if jq -e 'type == "object"' "$out_file" >/dev/null 2>&1; then
+  # A recognized grok JSON envelope. Build the normalized result (text fields
+  # only — never .thought) and inspect how the turn ended.
+  ENVELOPE=$(jq -ce "$NORMALIZE" "$out_file")
+  RESULT_TEXT=$(printf '%s' "$ENVELOPE" | jq -r '.result // ""')
+  STOP=$(jq -r '.stopReason // .stop_reason // ""' "$out_file")
+  # grok exits 0 even when a run is Cancelled / aborted with no output. That is a
+  # FAILED run, not an empty-but-successful one — surface it so the workflow's
+  # grok-error path fires instead of committing/reporting an empty (or partial)
+  # result. A clean EndTurn with empty text is legitimate (the skill did its work
+  # via tool calls and wrote no final message) and passes through as result "".
+  case "$STOP" in
+    Cancelled|cancelled|Aborted|aborted|Interrupted|interrupted|Error|error|Failed|failed|Refusal|refusal)
+      if [ -z "$RESULT_TEXT" ]; then
+        log "::error::grok terminated abnormally (stopReason=$STOP) with no output — failing the run rather than emitting an empty/partial result"
+        rm -f "$out_file" "$err_file"
+        exit 3
+      fi
+      log "::warning::grok stopReason=$STOP — retaining partial output"
+      ;;
+  esac
   printf '%s\n' "$ENVELOPE"
 else
-  log "::warning::grok output was not the expected JSON shape (or had no recoverable text) — wrapping raw stdout (verify grok --output-format json fields)"
+  # Not a single JSON object: shape changed, plain-text output, or leading noise.
+  # Wrap raw stdout so a mismatch never silently looks like "no output". (This
+  # path only fires for non-JSON, so it can't leak a JSON object's .thought.)
+  log "::warning::grok output was not a JSON object (expected --output-format json) — wrapping raw stdout; verify the grok CLI version/output format"
   jq -Rsc '{result: ., usage: {input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0}}' "$out_file"
 fi
 rm -f "$out_file" "$err_file"

--- a/scripts/tests/test_run_grok.sh
+++ b/scripts/tests/test_run_grok.sh
@@ -45,6 +45,28 @@ OUT=$(run '{"text":"ok","stopReason":"EndTurn","sessionId":"s","requestId":"r","
 [ "$(echo "$OUT" | jq -r '.result')" = "ok" ] && pass "real grok shape → .result from .text" || bad "real grok shape → .result (got: $OUT)"
 [ "$(echo "$OUT" | jq -r '.usage.input_tokens')" = "0" ] && pass "real grok shape → 0 tokens (no usage field)" || bad "real grok shape → 0 tokens"
 
+# 2c. grok's internal .thought is NEVER surfaced as the result (leak guard)
+OUT=$(run '{"text":"visible answer","stopReason":"EndTurn","thought":"SECRET_CHAIN_OF_THOUGHT"}')
+{ [ "$(echo "$OUT" | jq -r '.result')" = "visible answer" ] && ! echo "$OUT" | grep -q "SECRET_CHAIN_OF_THOUGHT"; } \
+  && pass "does not leak .thought into result" || bad "leaked .thought (got: $OUT)"
+
+# 2d. Cancelled/aborted with EMPTY text → hard fail; must NOT emit an empty result
+# or raw-wrap the JSON (which would leak .thought). Regression for the grok-build
+# 'Cancelled' run that committed chain-of-thought to the repo.
+if OUT=$(run '{"text":"","stopReason":"Cancelled","thought":"SECRET"}' 0 2>/dev/null); then
+  bad "Cancelled+empty should fail (got rc 0, out: $OUT)"
+else
+  echo "$OUT" | grep -q "SECRET" && bad "Cancelled+empty leaked .thought" || pass "Cancelled+empty fails without leaking .thought"
+fi
+
+# 2e. Clean EndTurn with empty text is a legitimate success (skill acted via tools,
+# no final message) → result "" and exit 0, NOT a failure.
+if OUT=$(run '{"text":"","stopReason":"EndTurn"}' 0 2>/dev/null); then
+  [ "$(echo "$OUT" | jq -r '.result')" = "" ] && pass "empty EndTurn → clean empty result" || bad "empty EndTurn result (got: $OUT)"
+else
+  bad "empty EndTurn should succeed"
+fi
+
 # 3. Non-JSON stdout falls back to raw-text envelope (never "no output")
 OUT=$(run 'plain text, not json')
 [ "$(echo "$OUT" | jq -r '.result')" = "plain text, not json" ] && pass "wraps non-JSON stdout" || bad "wraps non-JSON stdout (got: $OUT)"
@@ -54,6 +76,7 @@ run '{"result":"x"}' >/dev/null
 grep -qx -- "--output-format" "$ARGS_FILE" && grep -qx "json" "$ARGS_FILE" \
   && pass "passes --output-format json" || bad "passes --output-format json"
 grep -qx -- "--no-auto-update" "$ARGS_FILE" && pass "passes --no-auto-update" || bad "passes --no-auto-update"
+grep -qx -- "--no-subagents" "$ARGS_FILE" && pass "passes --no-subagents" || bad "passes --no-subagents"
 grep -qx -- "--model" "$ARGS_FILE" && grep -qx "grok-composer-2.5-fast" "$ARGS_FILE" \
   && pass "passes --model for a real grok model" || bad "passes --model"
 grep -qx -- "--permission-mode" "$ARGS_FILE" && grep -qx "dontAsk" "$ARGS_FILE" \


### PR DESCRIPTION
## What & why

Follow-up hardening for the Grok Build harness (#585) after running skills through it in CI surfaced real bugs. All changes are grok-path only — the Claude Code path is untouched.

### Bugs fixed

**1. Chain-of-thought leak + cancel-reported-as-success** (`scripts/run-grok.sh`)
Running a skill on `harness: grok` in CI produced `{"text":"","stopReason":"Cancelled",…,"thought":"…"}` and grok **exited 0**. The old normalizer required a non-empty `.result`, else raw-wrapped grok's **entire JSON object — including `.thought`** — into `.result`, which got auto-committed to the repo and would have gone out via `./notify`.
- Never raw-wrap a valid JSON object; `.result` is built from recognized text fields only, never `.thought`.
- An abnormal terminal `stopReason` (`Cancelled`/`Aborted`/`Error`/…) with empty text now **exits 3** (hard fail → the workflow's grok-error path fires; no garbage commit). A clean `EndTurn` with empty text stays a legit success.
- Added `--no-subagents` (a headless skill run is a single focused agent).

**2. Scorer + feed-convert noise on grok-only repos** (`.github/workflows/aeon.yml`)
On a grok-only repo (no Claude auth) the post-run steps still called `claude -p` → `Not logged in · Please run /login`.
- **Analyze step** scores through the run's harness: on `harness: grok` it routes the scoring prompt through `run-grok.sh` (grok-composer, reusing the run's X-account/API-key auth) and skips sourcing `llm-gateway.sh` (which printed `Using direct Anthropic API`). Falls back to a clean `::notice::` skip.
- **Convert feed outputs** step is skipped on grok (`notify-jsonrender` renders via `claude -p`).
- New `HARNESS` run-step output; `GROK_CREDENTIALS` added to the analyze env.

**3. Removed `grok-build` from the model options**
grok-build Cancels every time in the Actions sandbox (works locally; drops its relay/entitlement path in CI), so offering it is a footgun. Only `grok-composer-2.5-fast` is exposed (dashboard, workflow choice, README). Custom grok model ids via `~/.grok/config.toml` still work.

**4. Dashboard: relabel harness picker to Anthropic / Grok** (labels only; `id`s + default `claude` unchanged).

### Known limitation (grok-side, not fixed here)
The CI `Cancelled` is **intermittent and affects composer too** (not just grok-build) — variable timing, no stderr, looks like grok's relay/entitlement connection being dropped by the Actions sandbox. This PR makes it **degrade safely** (partial-with-warning if text is present, hard-fail if empty) instead of committing garbage.

## Tests
- `scripts/tests/test_run_grok.sh`: +thought-leak guard, +Cancelled→fail, +empty-EndTurn→clean, +`--no-subagents`. **20 pass.**
- Dashboard: **145 pass**; `skill_mode` tests pass; both YAML files valid.
- Live-validated on a private fork: scorer produced `score=2` via grok with **zero** `Not logged in` / `Using direct Anthropic` runtime lines; feed step skipped; captured output was clean partial narration (no `.thought`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
