### PR TITLE
fix(dashboard): stop sanitizeModel stripping the dot from grok model ids

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -13,9 +13,14 @@ on:
         required: false
         type: choice
         default: '(config default)'
+        # Keep in sync with the dashboard's MODELS/GROK_MODELS (apps/dashboard/lib/
+        # constants.ts): the dashboard dispatches `-f model=<id>` and this is a
+        # `choice` input, so any id it offers that's missing here is rejected with
+        # HTTP 422 at dispatch time.
         options:
           - '(config default)'
           - claude-opus-4-8
+          - claude-opus-4-7
           - claude-fable-5
           - claude-sonnet-5
           - claude-sonnet-4-6

--- a/apps/dashboard/lib/dispatch.ts
+++ b/apps/dashboard/lib/dispatch.ts
@@ -18,9 +18,13 @@ export function normLinks(input: unknown): string[] {
 }
 
 /**
- * Reduce a model identifier to the safe charset accepted by `gh workflow run`
- * (alphanumerics, underscore, hyphen). Non-string input yields an empty string.
+ * Reduce a model identifier to a safe charset — alphanumerics, underscore,
+ * hyphen, and dot. The dot matters: grok model ids carry a version like
+ * `grok-composer-2.5-fast`, and stripping it produced `grok-composer-25-fast`,
+ * which the workflow's `model` choice input rejects with HTTP 422. Dispatch uses
+ * `execFileSync('gh', [...])` (argv array, no shell), so this is defense-in-depth
+ * against odd input, not a shell-injection guard. Non-string input yields "".
  */
 export function sanitizeModel(input: unknown): string {
-  return typeof input === 'string' ? input.replace(/[^a-zA-Z0-9_-]/g, '') : ''
+  return typeof input === 'string' ? input.replace(/[^a-zA-Z0-9_.-]/g, '') : ''
 }


### PR DESCRIPTION
### Symptom
Every grok skill run from the dashboard failed:
```
gh workflow run aeon.yml -f skill=github-trending -f model=grok-composer-25-fast
HTTP 422: Provided value 'grok-composer-25-fast' for input 'model' not in the list of allowed values
```

### Root cause
`sanitizeModel` (`apps/dashboard/lib/dispatch.ts`) reduced model ids to `[a-zA-Z0-9_-]`, **stripping the dot**: `grok-composer-2.5-fast` → `grok-composer-25-fast`. The workflow's `model` input is a `choice`, so the mangled value is rejected at dispatch with HTTP 422. Grok's `2.5` is the first model id containing a dot, so this hyphen-only sanitizer (written for Claude ids) never tripped before.

### Fix
- **Allow `.` in `sanitizeModel`.** Dispatch uses `execFileSync('gh', [...])` (argv array, no shell), so the sanitizer is defense-in-depth, not an injection guard — widening it one char is safe. Hostile input (`;`, `$`, backticks, spaces) is still stripped.
- **Add `claude-opus-4-7` to `aeon.yml`'s `model` choices.** The dashboard offers it (`MODELS`) but it was missing from the workflow, so picking "Opus 4.7" 422'd the same way. Added a comment documenting the dashboard↔workflow choice-list sync requirement.

### Verified
- `sanitizeModel` now round-trips `grok-composer-2.5-fast` and every claude id; hostile inputs still sanitized.
- Parity check: **all** dashboard model ids are now valid workflow choices.
- `aeon.yml` valid YAML.

> Note: this fixes the template. A running instance (e.g. `aeongr`) serves its own copy of the dashboard, so it needs to pull this change (sync-upstream) to pick up the fix.