### PR TITLE
chore(dashboard): default to claude harness, packs skeleton, middleware→proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ The dashboard's `/api/*` routes drive `gh workflow run` and read/write repo secr
 | `AEON_DASHBOARD_ALLOWED_HOSTS=aeon.local,box.tail-xxx.ts.net` | Extends the loopback allowlist by hostnames (comma-separated, case- and port-insensitive) |
 | `AEON_DASHBOARD_ALLOW_ANY_HOST=1` | Disables Host-header checking entirely. Only for a trusted reverse proxy that terminates `Host` upstream - loudly insecure otherwise |
 
-The gate also rejects state-changing requests whose `Origin` isn't allowlisted, so a malicious page can't drive `/api/secrets` via a no-cors POST. Code: [`apps/dashboard/middleware.ts`](apps/dashboard/middleware.ts) + [`apps/dashboard/lib/security/api-gate.ts`](apps/dashboard/lib/security/api-gate.ts).
+The gate also rejects state-changing requests whose `Origin` isn't allowlisted, so a malicious page can't drive `/api/secrets` via a no-cors POST. Code: [`apps/dashboard/proxy.ts`](apps/dashboard/proxy.ts) + [`apps/dashboard/lib/security/api-gate.ts`](apps/dashboard/lib/security/api-gate.ts).
 
 ### Fleet Watcher (authorization layer)
 

--- a/aeon.yml
+++ b/aeon.yml
@@ -218,7 +218,7 @@ chains:
 # Default model for all skills. Override per-run via workflow_dispatch.
 # Options: claude-opus-4-8, claude-fable-5, claude-sonnet-5, claude-sonnet-4-6, claude-haiku-4-5-20251001
 # (Grok harness model: grok-composer-2.5-fast — the only one that runs in CI)
-model: grok-composer-2.5-fast
+model: claude-sonnet-4-6
 
 # Agent harness — which coding-agent CLI runs your skills.
 #   claude (default) — Claude Code (`claude -p`); uses the AI Gateway below.
@@ -228,7 +228,7 @@ model: grok-composer-2.5-fast
 # Override per-skill with `harness: "grok"` in the skill entry, or per-run via
 # the workflow_dispatch `harness` input. Default stays claude — everything
 # already configured keeps working unchanged.
-harness: grok
+harness: claude
 
 # AI Gateway — route Claude Code requests through an LLM provider.
 #

--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -70,12 +70,12 @@ The `/api/*` routes drive `gh workflow run` and read/write repo secrets, so they
 | `AEON_DASHBOARD_ALLOWED_HOSTS=aeon.local,box.tail-xxx.ts.net` | Extends the loopback allowlist by hostname (comma-separated, case- and port-insensitive). |
 | `AEON_DASHBOARD_ALLOW_ANY_HOST=1` | Disables Host-header checking entirely. Only for a trusted reverse proxy that terminates `Host` upstream — insecure otherwise. |
 
-The gate also rejects state-changing requests whose `Origin` isn't allowlisted. Code: [`middleware.ts`](middleware.ts) + [`lib/security/api-gate.ts`](lib/security/api-gate.ts).
+The gate also rejects state-changing requests whose `Origin` isn't allowlisted. Code: [`proxy.ts`](proxy.ts) + [`lib/security/api-gate.ts`](lib/security/api-gate.ts).
 
 ## How it works
 
 - **Frontend:** Next.js App Router (`app/`) with React client components in `components/`. State is the repo itself — the UI reads `skills.json`, `packs.json`, `aeon.yml`, and `STRATEGY.md`, and writes back through the API.
-- **API:** route handlers under `app/api/*` are the only place the dashboard touches your repo. They shell out to `gh` (`lib/gh.ts`) for secrets, workflow dispatch, and content reads, and run behind the loopback gate (`middleware.ts`).
+- **API:** route handlers under `app/api/*` are the only place the dashboard touches your repo. They shell out to `gh` (`lib/gh.ts`) for secrets, workflow dispatch, and content reads, and run behind the loopback gate (`proxy.ts`).
 - **Skill output feed:** skill runs drop json-render specs into `outputs/`; the feed renders them as cards via [`@json-render`](https://github.com/json-render). `./notify-jsonrender` (a post-run workflow step) produces those specs.
 - **Deploy:** the repo auto-deploys `apps/dashboard/` to Vercel on push to `main` — no manual step. Most operators run it locally with `./aeon`; the hosted build is the same app.
 

--- a/apps/dashboard/components/PacksPanel.tsx
+++ b/apps/dashboard/components/PacksPanel.tsx
@@ -74,9 +74,61 @@ export function PacksPanel({ firstParty, community, skills, enabledPacks, loadin
   ]
 
   if (loading) {
+    // Skeleton mirrors the loaded layout (hero + stat grid + card grid) so the
+    // page doesn't reflow when data lands. Static labels stay real; only the
+    // data-driven surfaces pulse.
     return (
-      <div className="max-w-5xl mx-auto py-24 text-center">
-        <p className="font-display uppercase text-aeon-fg text-xl tracking-wide">Loading packs…</p>
+      <div className="max-w-5xl mx-auto pb-16 space-y-10" aria-busy="true" aria-live="polite">
+        <span className="sr-only">Loading packs…</span>
+
+        {/* Hero skeleton */}
+        <section className="relative overflow-hidden border border-[rgba(250,250,250,0.10)] bg-aeon-panel">
+          <div className="dither" aria-hidden="true" />
+          <div className="relative z-10 px-8 pt-10 pb-8">
+            <div className="flex items-center gap-3 mb-5">
+              <span className="w-7 h-px bg-aeon-red/60" />
+              <div className="h-2.5 w-24 bg-[rgba(250,250,250,0.10)] animate-pulse" />
+            </div>
+            <div className="h-14 w-56 bg-[rgba(250,250,250,0.14)] animate-pulse" />
+            <div className="mt-6 max-w-xl space-y-2">
+              <div className="h-3 w-full bg-[rgba(250,250,250,0.07)] animate-pulse" />
+              <div className="h-3 w-4/5 bg-[rgba(250,250,250,0.07)] animate-pulse" />
+            </div>
+          </div>
+          <dl className="relative z-10 grid grid-cols-2 sm:grid-cols-4 border-t border-[rgba(250,250,250,0.10)]">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className={`px-6 py-5 ${i < 3 ? 'border-r border-[rgba(250,250,250,0.10)]' : ''}`}>
+                <div className="h-2.5 w-12 bg-[rgba(250,250,250,0.10)] mb-3 animate-pulse" />
+                <div className="h-8 w-10 bg-[rgba(250,250,250,0.12)] animate-pulse" />
+              </div>
+            ))}
+          </dl>
+        </section>
+
+        {/* Pack card grid skeleton */}
+        <Section index="01" label="Your packs">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-px bg-[rgba(250,250,250,0.10)] border border-[rgba(250,250,250,0.10)]">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="bg-aeon-bg px-6 py-5 flex flex-col gap-3">
+                <div className="flex items-start gap-3">
+                  <span className="mt-1 w-2.5 h-2.5 rounded-full bg-[rgba(250,250,250,0.14)] shrink-0 animate-pulse" />
+                  <div className="flex-1 space-y-2">
+                    <div className="h-3.5 w-32 bg-[rgba(250,250,250,0.14)] animate-pulse" />
+                    <div className="h-2.5 w-20 bg-[rgba(250,250,250,0.08)] animate-pulse" />
+                  </div>
+                </div>
+                <div className="space-y-2 pt-1">
+                  <div className="h-2.5 w-full bg-[rgba(250,250,250,0.06)] animate-pulse" />
+                  <div className="h-2.5 w-5/6 bg-[rgba(250,250,250,0.06)] animate-pulse" />
+                </div>
+                <div className="mt-auto flex items-center gap-2 pt-2">
+                  <div className="h-7 w-24 bg-[rgba(250,250,250,0.08)] animate-pulse" />
+                  <div className="h-7 w-20 bg-[rgba(250,250,250,0.06)] animate-pulse" />
+                </div>
+              </div>
+            ))}
+          </div>
+        </Section>
       </div>
     )
   }

--- a/apps/dashboard/lib/security/api-gate.ts
+++ b/apps/dashboard/lib/security/api-gate.ts
@@ -148,7 +148,7 @@ export function isSameOriginWrite(
 }
 
 /**
- * Top-level gate used by `apps/dashboard/middleware.ts`. Reads the two env
+ * Top-level gate used by `apps/dashboard/proxy.ts`. Reads the two env
  * vars once and applies both checks. Returns `null` on success or a
  * `Response` with a 403 + JSON body explaining the rejection.
  */

--- a/apps/dashboard/proxy.ts
+++ b/apps/dashboard/proxy.ts
@@ -18,7 +18,7 @@ import { gateRequest } from "@/lib/security/api-gate";
  * entirely via `AEON_DASHBOARD_ALLOW_ANY_HOST=1` (intended only for
  * trusted-reverse-proxy setups).
  */
-export function middleware(req: NextRequest) {
+export function proxy(req: NextRequest) {
   const rejected = gateRequest(req);
   if (rejected) return rejected;
   return NextResponse.next();


### PR DESCRIPTION
Three small improvements to the dashboard + config.

## 1. Claude Code as the default harness
`aeon.yml` had `harness: grok` / `model: grok-composer-2.5-fast` at the top level — left over from the Grok Build harness work (#587) and contradicting the config parser's own `claude` default. Restored to `harness: claude` + `model: claude-sonnet-4-6` (the pre-grok default; `grok-composer-2.5-fast` is a grok-only model that would be invalid under the Claude harness). Per-skill (`harness: "grok"`) and per-run overrides are unaffected.

## 2. Better "Loading packs" state
Replaced the bare centered `Loading packs…` text in `PacksPanel` with a **layout-matching skeleton** (hero + 4-cell stat grid + 4 pulsing pack cards) using the existing design tokens and the `animate-pulse` idiom already in `RightPanel`. Mirrors the loaded structure so there's no reflow when data arrives. Keeps an `sr-only` label + `aria-busy`/`aria-live` for accessibility.

## 3. `middleware` → `proxy` (Next.js 16 deprecation)
> The "middleware" file convention is deprecated. Please use "proxy" instead.

Renamed `apps/dashboard/middleware.ts` → `proxy.ts` and the `middleware` export → `proxy`. `config.matcher` is unchanged. The gate is a synchronous host/origin check, so the nodejs-only proxy runtime (no edge) is a non-issue. Updated doc references in `apps/dashboard/README.md`, root `README.md`, and `api-gate.ts`.

## Verification
- `tsc --noEmit` clean
- 145/145 lib tests pass
- `next build` succeeds and the route table shows `ƒ Proxy (Middleware)` on `/api/:path*` (deprecation warning gone)