### PR TITLE
feat(grok): Claude→grok compatibility layer so skills run unchanged on the grok harness

### DIFF
--- a/scripts/run-grok.sh
+++ b/scripts/run-grok.sh
@@ -35,6 +35,8 @@
 #   GROK_CHECK            1/true/yes/on: append a self-verification loop → --check
 #   GROK_JSON_SCHEMA      JSON Schema string → --json-schema (structured output;
 #                         reliably honoured only by grok-build, not composer)
+#   GROK_COMPAT_RULES     override the Claude→grok compatibility preamble appended
+#                         to grok's system prompt via --rules (default below, §3d)
 #
 # MCP: grok discovers the project .mcp.json natively (no flag needed); this script
 # only adds `--allow MCPTool(<server>__*)` so the model may call those tools.
@@ -213,6 +215,35 @@ esac
 # JSON text — both are handled by the normalizer below.
 if [ -n "${GROK_JSON_SCHEMA:-}" ]; then RUN_FLAGS+=(--json-schema "$GROK_JSON_SCHEMA"); fi
 
+# --- 3d. Claude→grok compatibility preamble (--rules) -----------------------
+# Every Aeon skill is authored for the Claude Code harness: its data-fetch steps name
+# Claude's tools (WebFetch), assume Claude's sandbox-bypass patterns, and lean on
+# `gh api`. Rather than reimplement ~100 skills for grok, we append ONE standing
+# ruleset to grok's system prompt (`--rules`) that (a) translates those idioms to
+# grok's tools and (b) — the load-bearing part — tells grok to ROUTE AROUND a
+# missing/failed tool instead of giving up. That give-up-and-Cancel behavior is what
+# turned Claude-authored runs into empty/partial non-answers (see run history). This
+# is skill-agnostic (fix once, applies to every skill) and cheap (~a few hundred
+# tokens/run). It pairs with --permission-mode bypassPermissions from skill_mode.sh:
+# bypass stops the hard turn-abort, these rules stop the soft "I'll try other ways" give-up.
+# Override/extend via GROK_COMPAT_RULES in the environment.
+GROK_COMPAT_RULES="${GROK_COMPAT_RULES:-$(cat <<'RULES'
+This skill was authored for the Claude Code harness. Adapt its instructions to your
+own tools; do not abort when something does not match one-to-one:
+- Tool names are Claude's. Map them: when a skill says "WebFetch", use your web
+  fetch/search tools; when it says to curl a URL the sandbox blocks, fetch the same
+  URL with your web tools instead.
+- When a skill relies on the gh CLI (e.g. `gh api`) and gh is unavailable, call the
+  GitHub REST API directly over the web (https://api.github.com/...) — public for reads.
+- If any tool is missing, denied, or returns unusable content, do NOT stop or end the
+  turn. Try another route and finish the task; only surface a failure after you have
+  exhausted the alternatives the skill names.
+- Never end a run having produced only planning or commentary. Deliver the skill's
+  actual output — the notify/file/log it specifies, or its defined error signal — and
+  never emit interim narration as the result.
+RULES
+)}"
+
 # --- 4. run -----------------------------------------------------------------
 PROMPT="$(cat)"
 out_file="$(mktemp)"; err_file="$(mktemp)"
@@ -231,6 +262,7 @@ grok -p "$PROMPT" \
   ${MODEL_FLAG[@]+"${MODEL_FLAG[@]}"} \
   --output-format json \
   --no-auto-update \
+  --rules "$GROK_COMPAT_RULES" \
   ${SUBAGENT_FLAG[@]+"${SUBAGENT_FLAG[@]}"} \
   ${RUN_FLAGS[@]+"${RUN_FLAGS[@]}"} \
   ${MCP_ALLOW[@]+"${MCP_ALLOW[@]}"} \

--- a/scripts/skill_mode.sh
+++ b/scripts/skill_mode.sh
@@ -68,19 +68,27 @@ write_tools() { echo "$BASE_TOOLS,$WRITE_TOOLS"; }
 # Bash/Edit/Read/Grep/Write/MCPTool/WebFetch, plus a `--permission-mode`.
 # Bash rules use a space-glob — `Bash(git *)` — not Claude's colon `Bash(git:*)`.
 #
-# Deny-by-default, honestly: grok currently wires `--permission-mode` for
-# `bypassPermissions` only (per grok's permissions docs), so the flag alone does
-# NOT enforce dontAsk. What actually gives us deny-by-default is that we always
-# run HEADLESS (`grok -p`): a tool that is neither on grok's read-class fast path
-# nor named by an explicit `--allow` rule has no TTY to prompt, so it is refused.
-# We still pass `--permission-mode dontAsk` (harmless, and future-proof if grok
-# wires the flag), but the enforcement is the explicit allowlist below + the
-# read-only sandbox — not the mode string. So the allowlist must be exhaustive.
+# Permission mode: we pass `--permission-mode bypassPermissions` — the ONE mode
+# grok actually wires headlessly (per grok's permissions docs + our testing). It
+# APPROVES every tool call instead of refusing ones we didn't explicitly allowlist.
+# That is deliberate and load-bearing: skills are authored for Claude Code and WILL
+# reach for tools we never pre-listed (a `gh api` read, a Claude built-in). Under
+# the old refuse-a-non-allowlisted-tool behavior (headless `dontAsk`), grok aborted
+# the ENTIRE turn — stopReason=Cancelled, empty/partial output — which is exactly
+# how Claude-authored skills failed on grok. Approving-all makes grok DEGRADE like
+# Claude (a missing/failed tool returns an error the model routes around) instead
+# of Cancelling. Paired with the --rules compat preamble in run-grok.sh.
 #
-# We mirror the SAME capability intent as BASE_TOOLS / WRITE_TOOLS above, so a
-# skill behaves identically on either harness: read-only gets no Edit and no
-# git/gh/python; write adds them. read-only additionally runs under grok's
-# `--sandbox read-only` profile as defense-in-depth (matches the post-run guard).
+# Consequence: the `--allow` rules below are now ADVISORY (additive grants, redundant
+# under bypass) — kept only to document each tier's intended capability, NOT as the
+# guard. The REAL guarantee that a read-only skill can't mutate is grok's OS-level
+# `--sandbox read-only` profile (added below) plus the workflow's post-run stray-write
+# revert. NEVER add `--deny` rules here: a denied tool can re-trigger the very
+# turn-abort we are removing.
+#
+# We still mirror the SAME capability intent as BASE_TOOLS / WRITE_TOOLS above, so
+# the intent reads identically on either harness: read-only documents no Edit and no
+# git/gh/python; write adds them.
 #
 # Output: one argv token per line, so run-grok.sh can read it with
 #   mapfile -t GROK_ARGS < <(skill_mode.sh grok-args "$MODE")
@@ -94,13 +102,16 @@ GROK_WRITE_BASH="gh git python3 python"
 
 grok_args() {
   local mode="$1"
-  # Non-listed tools have no headless approval path → refused. Allowlist is exhaustive.
-  printf '%s\n' --permission-mode dontAsk
+  # bypassPermissions = approve every tool call (the one mode grok wires headlessly),
+  # so a Claude-authored skill reaching for a non-allowlisted tool degrades instead of
+  # Cancelling the turn. The allow rules below are advisory; --sandbox + the post-run
+  # revert are the read-only guard. See the block comment above.
+  printf '%s\n' --permission-mode bypassPermissions
   if [ "$mode" = "read-only" ]; then
     printf '%s\n' --sandbox read-only
   fi
-  # Always-allowed read/search categories (grok auto-approves read_file/grep/
-  # web_search too, but being explicit is harmless and self-documenting).
+  # Advisory grants (redundant under bypass) that document each tier's capability:
+  # read/search/web everywhere; Edit + git/gh/python added on the write tier below.
   printf '%s\n' --allow Read --allow Grep --allow WebFetch
   local cmd
   for cmd in $GROK_BASE_BASH; do printf '%s\n' --allow "Bash($cmd *)"; done

--- a/scripts/tests/test_run_grok.sh
+++ b/scripts/tests/test_run_grok.sh
@@ -80,8 +80,10 @@ grep -qx -- "--no-auto-update" "$ARGS_FILE" && pass "passes --no-auto-update" ||
 grep -qx -- "--no-subagents" "$ARGS_FILE" && pass "passes --no-subagents" || bad "passes --no-subagents"
 grep -qx -- "--model" "$ARGS_FILE" && grep -qx "grok-composer-2.5-fast" "$ARGS_FILE" \
   && pass "passes --model for a real grok model" || bad "passes --model"
-grep -qx -- "--permission-mode" "$ARGS_FILE" && grep -qx "dontAsk" "$ARGS_FILE" \
+grep -qx -- "--permission-mode" "$ARGS_FILE" && grep -qx "bypassPermissions" "$ARGS_FILE" \
   && pass "passes permission flags from skill_mode" || bad "passes permission flags"
+# compat preamble is appended to grok's system prompt via --rules
+grep -qx -- "--rules" "$ARGS_FILE" && pass "passes --rules compat preamble" || bad "passes --rules compat preamble"
 
 # 4b. --model is OMITTED for a leftover claude-* id or empty (grok uses its default)
 echo "p" | GROK_FAKE_OUT='{"text":"x"}' MODEL=claude-sonnet-4-6 SKILL_MODE=write XAI_API_KEY=xai-test bash "$R" >/dev/null 2>&1

--- a/scripts/tests/test_skill_mode.sh
+++ b/scripts/tests/test_skill_mode.sh
@@ -44,13 +44,15 @@ echo "$RT" | grep -q "Read" && echo "$RT" | grep -q "WebFetch" \
   && echo "$RT" | grep -q "Bash(curl:\*)" && echo "$RT" | grep -q "Bash(./notify:\*)" \
   && pass "read-only tier keeps read/web/curl/notify" || bad "read-only tier keeps read/web/curl/notify"
 
-# grok-args: write tier maps to grok grammar with mutation tools + dontAsk
+# grok-args: write tier maps to grok grammar with mutation tools + bypassPermissions
 # (-F fixed-string for the Bash(cmd *) tokens — the literal * is not a regex here)
 GW=$(bash "$M" grok-args write)
-echo "$GW" | grep -qx -- "--permission-mode" && echo "$GW" | grep -qx "dontAsk" \
+echo "$GW" | grep -qx -- "--permission-mode" && echo "$GW" | grep -qx "bypassPermissions" \
   && echo "$GW" | grep -qx "Edit" && echo "$GW" | grep -Fqx "Bash(git *)" \
   && echo "$GW" | grep -Fqx "Bash(gh *)" \
-  && pass "grok write tier: dontAsk + Edit/git/gh (space-glob)" || bad "grok write tier: dontAsk + Edit/git/gh"
+  && pass "grok write tier: bypassPermissions + Edit/git/gh (space-glob)" || bad "grok write tier: bypassPermissions + Edit/git/gh"
+# never emit --deny (a denied tool can re-trigger the turn-abort bypass removes)
+if echo "$GW" | grep -qx -- "--deny"; then bad "grok args must not emit --deny"; else pass "grok args emit no --deny"; fi
 # grok write must NOT be sandboxed read-only
 if echo "$GW" | grep -qx -- "--sandbox"; then bad "grok write tier must not set --sandbox"; else pass "grok write tier has no --sandbox"; fi
 


### PR DESCRIPTION
## Problem
Skills are authored for the **Claude Code** harness. On the **grok** harness they were Cancelling with empty/partial output. Concrete failure — [`aeon-grok` run 28610488525](https://github.com/aaronjmars/aeon-grok/actions/runs/28610488525): `github-trending` scored **1/5** ("only setup commentary and a failed WebFetch; no curated repos, notification, or log"), grok returned `stopReason=Cancelled` after ~21s.

Root cause was **two generic Claude→grok gaps**, not anything trending-specific — so both are fixed **centrally, with zero per-skill rewrites**.

## Fix

**1. Permission mode `dontAsk` → `bypassPermissions`** (`scripts/skill_mode.sh`)
`bypassPermissions` is the one permission mode grok actually wires headlessly. Under `dontAsk`, a skill reaching for a tool we didn't allowlist (e.g. `gh api`) was **refused → grok aborted the whole turn** (`stopReason=Cancelled`). Approving-all makes grok **degrade like Claude** — a missing/failed tool returns an error the model routes around. Read-only stays guarded by `--sandbox read-only` + the post-run stray-write revert (the allow-list becomes advisory). Never emit `--deny` (a denied tool re-triggers the abort) — now asserted in a test.

**2. A standing `--rules` compat preamble on every grok run** (`scripts/run-grok.sh`)
Translates Claude idioms (`WebFetch` → grok's web tools; `gh api` → `api.github.com` over the web) and — load-bearing — tells grok to **route around a failed tool and never end a run with only commentary**. Skill-agnostic, ~a few hundred tokens/run, overridable via `GROK_COMPAT_RULES`.

## Verification
- `grok 0.2.82` (== CI pin) exposes both `--rules` and `bypassPermissions`.
- Real end-to-end run through `run-grok.sh` (read-only): grok accepts `--rules` + `bypassPermissions` + `--sandbox read-only` together and **completes clean (exit 0, not Cancelled)**, normalized to `{"result":"SMOKE_OK_7788",…}`.
- Both grok test suites pass (exit 0), including 2 new assertions (`--rules` present; no `--deny` emitted).

## Caveat
Closes the **hard** failures (Cancels) for every skill at once. Where grok's tool *quality* still lags Claude's, a *handful* of fetch-heavy skills may underperform and later want a prefetch script — a few, not all.

## Follow-up
Recommend a live `github-trending` run on `aeon-grok` to confirm the trending output actually lands end-to-end.