### PR TITLE
feat(telegram): wire buttons + force-reply across 16 skills

### DIFF
--- a/skills/deal-flow/SKILL.md
+++ b/skills/deal-flow/SKILL.md
@@ -2,10 +2,13 @@
 name: Deal Flow
 category: productivity
 description: Funding round tracker across configurable verticals
+var: ""
 tags: [research]
 ---
 
 <!-- autoresearch: variation B — sharper output via leverage scoring, valuation context, and banned-phrase quality gates -->
+
+> **${var}** — Optional. Normally empty (runs the full weekly digest across tracked verticals). A value starting with `add-topic:` (e.g. `add-topic:stablecoin infra`) is the Telegram force-reply shape — it appends `<topic>` to the tracked verticals in `memory/MEMORY.md` and ends the run without producing a digest (see Step 0).
 
 Read `memory/MEMORY.md` for context (tracked verticals, active theses).
 Read the last 14 days of `memory/logs/` and extract company names from prior `### deal-flow` entries to build the dedup set.
@@ -15,6 +18,25 @@ Read the last 14 days of `memory/logs/` and extract company names from prior `##
 Produce a weekly funding-round digest that tells the reader **what the capital reveals**, not just what closed. A flat list of rounds is noise; a ranked, contextualized read is signal.
 
 ## Steps
+
+### 0. Inbound reply + onboarding offer (Telegram force-reply wiring)
+
+**Handle a reply first — this branch takes priority over the digest below.** If `${var}` starts with `add-topic:`, this run is the operator answering the "track a new vertical?" prompt, not a scheduled digest:
+
+1. Strip the prefix and trim: `topic="${var#add-topic:}"` then strip surrounding whitespace. The value is free text and may contain spaces (e.g. `stablecoin infra`, `prediction markets`) — keep it whole.
+2. If `topic` is empty/blank after trimming, send a friendly re-ask (no force-reply loop) and END the run:
+   `./notify "No vertical received — reply to the prompt with a vertical to track (for example: stablecoin infra, or prediction markets), and I'll add it to deal-flow's tracked verticals."`
+3. Otherwise append `topic` as a `- ${topic}` bullet under a `## Tracked Verticals` section in `memory/MEMORY.md` (create the section if it doesn't exist — this is the same section Tier 2 reads). **Dedup:** skip the append if the vertical already appears there (case-insensitive).
+4. Confirm (keep it ≥120 chars so a topic containing a filtered word can't be dropped as a probe):
+   `./notify "Now tracking \"${topic}\" for deal-flow. It's been added to the Tracked Verticals in memory/MEMORY.md and will get its own source sweep in next week's funding-round digest."`
+5. Log under `### deal-flow`: `- add-topic: "${topic}" → appended to ## Tracked Verticals in memory/MEMORY.md` and **END the run** (skip all steps below).
+
+**Onboarding offer (normal runs only, deduped).** If `${var}` did NOT start with `add-topic:` AND `memory/MEMORY.md` has no `## Tracked Verticals` section (or it's empty) AND the last 14 days of `memory/logs/` contain no `FORCE_REPLY_OFFERED: add-topic` marker for this skill, send one force-reply offer, then continue the normal digest below:
+```bash
+./notify "Want deal-flow to track another vertical beyond AI / crypto / infra? Reply with one (e.g. stablecoin infra) and I'll sweep it each week." \
+  --force-reply --placeholder "a topic to track" --context "deal-flow::add-topic"
+```
+Then log a `FORCE_REPLY_OFFERED: add-topic` marker line under `### deal-flow` so it doesn't re-offer next run. (The force-reply is a separate notify, never combined with other output.)
 
 ### 1. Gather candidates from tiered sources
 
@@ -28,7 +50,9 @@ Run searches in parallel. Use the **current month + year** in queries. Aim for �
 - WebSearch: `"Series A" OR "Series B" OR "seed" raised ${month} ${year} startup`
 - WebFetch `https://news.crunchbase.com/sections/venture/` — extract this week's roundup if present (apply source-miss rule above)
 
-**Tier 2 — vertical-specific (run for verticals in MEMORY.md; defaults: AI, crypto, infra/devtools):**
+**Tier 2 — vertical-specific (run for the operator's tracked verticals; defaults: AI, crypto, infra/devtools):**
+
+Read the `## Tracked Verticals` section of `memory/MEMORY.md` (Step 0 maintains it — one `- ` bullet per vertical) and merge those with the defaults below. For any operator-added vertical not already covered by the three built-in sweeps, add one `WebSearch: "<vertical>" funding round OR raised ${month} ${year}`.
 - AI: WebFetch `https://aifundingtracker.com/`; WebSearch `"AI startup" "raised" Series ${month} ${year}`
 - Crypto: WebFetch `https://crypto-fundraising.info/` and `https://cryptorank.io/funding-rounds` (apply source-miss rule); WebSearch `crypto funding round ${month} ${year}`
 - Infra/devtools: WebSearch `developer tools OR infrastructure OR compute startup raised ${month} ${year}`

--- a/skills/feature/SKILL.md
+++ b/skills/feature/SKILL.md
@@ -10,7 +10,7 @@ requires: [GH_GLOBAL?]
 tags: [dev, build, growth]
 depends_on: [repo-scanner]
 ---
-> **${var}** — Selector `target[:arg] [--fix-issues]`, `target ∈ {watched, external, dormant}`. Empty or `watched` = build a feature on every watched repo (one PR each); `external:<owner/repo>` = one best enhancement on that external repo; `dormant` = revive the highest-scoring dormant repo. `--fix-issues` biases the chosen branch toward fixing an open GitHub issue. Full grammar below.
+> **${var}** — Selector `target[:arg] [--fix-issues]`, `target ∈ {watched, external, dormant}`. Empty or `watched` = build a feature on every watched repo (one PR each); `external:<owner/repo>` = one best enhancement on that external repo; `dormant` = revive the highest-scoring dormant repo. A leading `build:<owner/repo | issue-url | free-text instruction>` — the shape the Telegram "ship which opportunity?" force-reply sends via `repo-scanner`'s offer — is intercepted **first** and routed into the **external** branch on that target/instruction. `--fix-issues` biases the chosen branch toward fixing an open GitHub issue. Full grammar below.
 
 This skill merges three repo-work modes behind one selector so no capability is lost:
 
@@ -23,6 +23,15 @@ This skill merges three repo-work modes behind one selector so no capability is 
 Today is ${today}. Read `memory/MEMORY.md` and the last 7 days of `memory/logs/` before starting — and before notifying, drop anything already reported in the last ~3 days of logs.
 
 ## Selector
+
+**Telegram force-reply interception — check this FIRST, before parsing anything else.** If `${var}` starts with `build:`, it is the "ship which opportunity?" force-reply that `repo-scanner` offers (routed here as `feature` with `var="build:<the operator's reply>"`). Strip the prefix with `${var#build:}` and treat the remainder as an **external build target/instruction** — route it straight into the **external** branch (§B), reusing that branch's existing logic (do **not** run the watched or dormant branches for a `build:` value, and do not duplicate §B). Normalize the remainder into a §B target:
+
+- `owner/repo` → run §B as if `external:owner/repo` (B2 "clone that repo").
+- an issue URL (`https://github.com/owner/repo/issues/N`) or `owner/repo#N` → run §B as if `external:owner/repo#N` (B2 "fetch that issue").
+- free text like `owner/repo: add retry to the client` → run §B on `owner/repo`, using the trailing text as the **explicit enhancement to build** (see §B4's "requested enhancement" note — skip the auto-pick).
+- anything else with no parseable repo → run §B passing the whole remainder as the enhancement instruction; §B B2/B4 already reason about selecting and scoping a target.
+
+The remainder may itself contain colons — keep them. This is a complete run once §B ships its PR (or cleanly skips); do not then fall through to the normal selector.
 
 Parse `${var}` into a **target** and optional flags:
 
@@ -249,6 +258,8 @@ Before doing anything, deeply understand the codebase:
 - Understand the test setup if tests exist
 
 ### B4. Decide what to do
+
+**Requested enhancement (force-reply `build:` path).** If this run was reached via the Selector's `build:` interception carrying a trailing free-text instruction (e.g. `owner/repo: add retry to the client`), that instruction **is** the change — implement it directly and skip the priority list below (still honor `--fix-issues` if it was passed). Only fall through to the priority list when the `build:` value was a bare repo/issue with no explicit instruction, or when this run wasn't reached via `build:` at all.
 
 Pick ONE thing from this priority list:
 

--- a/skills/github-monitor/SKILL.md
+++ b/skills/github-monitor/SKILL.md
@@ -14,6 +14,7 @@ permissions: []
 > - **`issues [scope]`** → new-issue triage queue. `scope` accepts `owner/repo`, `org:foo`, `user:bar`, or a bare login; empty = all repos owned by the authenticated user.
 > - **`releases [repo,repo,…]`** → release upgrade-triage digest. Comma-separated repo list; empty = the built-in watch list.
 > - **`prs`** → status tracker for PRs this aeon instance opened across external repos.
+> - **`add-repo:<owner/repo>`** → append `owner/repo` to `memory/watched-repos.md`, confirm, and end (the shape the Telegram force-reply sends — see the config-capture note in Shared setup). No view runs.
 
 This skill is four focused views of the same GitHub surface. The combined monitor is the default; `issues`, `releases`, and `prs` each drill into one dimension with the sibling view's own filtering, ranking, and output format. Only the `monitor` and `issues` views take a repo scope; `releases` takes a repo list; `prs` takes no scope (it reads its config from `aeon.yml`/env).
 
@@ -27,6 +28,30 @@ This skill is four focused views of the same GitHub surface. The combined monito
 
 ```bash
 RAW="$(printf '%s' "${var}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+
+# Config capture (Telegram force-reply): var="add-repo:<owner/repo>" appends to the watchlist,
+# confirms, and ends — it is NOT a view, so it must be intercepted before the VIEW parse below.
+case "$RAW" in
+  add-repo:*)
+    CAND="$(printf '%s' "${RAW#add-repo:}" \
+      | sed -e 's#^https\?://github.com/##' -e 's/^@//' -e 's/\.git$//' \
+            -e 's/^[[:space:]]*//' -e 's/[[:space:]].*$//')"
+    if ! printf '%s' "$CAND" | grep -qE '^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$'; then
+      ./notify "Couldn't read \"$CAND\" as a repo. Reply with owner/repo (e.g. acme/api)."
+      # log: - view: add-repo (var="${var}") → BAD_VALUE
+      exit 0
+    fi
+    mkdir -p memory; touch memory/watched-repos.md
+    if grep -qiE "^[[:space:]]*-[[:space:]]*${CAND}[[:space:]]*$" memory/watched-repos.md; then
+      ./notify "Already watching $CAND."
+    else
+      printf -- '- %s\n' "$CAND" >> memory/watched-repos.md
+      ./notify "Now watching $CAND — it'll show up in the next GitHub Monitor run."
+    fi
+    # log under ### github-monitor: - view: add-repo (var="${var}") → $CAND
+    exit 0 ;;
+esac
+
 if [ -z "$RAW" ]; then
   VIEW=monitor; SCOPE=""
 else
@@ -53,7 +78,15 @@ Tiered urgency scan of PRs, new issues, and new releases across watched repos, w
 
 ### Config
 
-Read repos from `memory/watched-repos.md`. If the file is missing or empty, log `GITHUB_MONITOR_EMPTY_CONFIG` (under `### github-monitor`) and end.
+Read repos from `memory/watched-repos.md`. If the file is missing or empty, offer to add the first repo via a Telegram force-reply, then log `GITHUB_MONITOR_EMPTY_CONFIG` (under `### github-monitor`) and end. Send the offer **only** if no `add-repo` prompt was already offered in the last 2 days of `memory/logs/` (dedup so an unconfigured fork isn't nagged every run):
+
+```bash
+./notify "No repos on the watchlist yet. Which repo should I watch? Reply with owner/repo." \
+  --force-reply --placeholder "owner/repo" \
+  --context "github-monitor::add-repo"
+```
+
+The reply routes back as `var=add-repo:<owner/repo>`, handled by the config-capture branch in Shared setup. Record `FORCE_REPLY_OFFERED: add-repo` in the log when you send it.
 
 ```markdown
 # memory/watched-repos.md

--- a/skills/idea-forge/SKILL.md
+++ b/skills/idea-forge/SKILL.md
@@ -6,9 +6,25 @@ var: ""
 tags: [research, ideas, creative, meta]
 ---
 
-> **${var}** — Selector `mode [theme/constraint]`. First token picks the mode: `generate` (default) collides the zeitgeist with the capability surface into ranked wedges; `validate` screens the existing backlog for viability; `memo` writes 2 rigorous evidence-backed startup memos. Anything after the mode is a theme/constraint bias. A bare theme with no mode keyword (e.g. `payments`, `crypto`) = `generate` biased to that theme. `dry-run` anywhere skips the notify. Examples: `` (empty → generate, open-ended) · `simulation` (generate, themed) · `validate crypto` (screen crypto ideas) · `memo solo founder` (memos under a constraint) · `generate payments dry-run` (generate, no notify).
+> **${var}** — Selector `mode [theme/constraint]`. First token picks the mode: `generate` (default) collides the zeitgeist with the capability surface into ranked wedges; `validate` screens the existing backlog for viability; `memo` writes 2 rigorous evidence-backed startup memos. Anything after the mode is a theme/constraint bias. A bare theme with no mode keyword (e.g. `payments`, `crypto`) = `generate` biased to that theme. `dry-run` anywhere skips the notify. Examples: `` (empty → generate, open-ended) · `simulation` (generate, themed) · `validate crypto` (screen crypto ideas) · `memo solo founder` (memos under a constraint) · `generate payments dry-run` (generate, no notify). A `pick:<id|name>` value (from the "build next?" force-reply — e.g. `pick:Onchain reputation`) is intercepted **before** mode dispatch: it marks that idea as chosen-to-build in the shared backlog and ends — see "Force-reply interception" below.
 
 Today is ${today}. **Read `soul/SOUL.md` + `soul/STYLE.md` + `STRATEGY.md` first and read them closely** — this skill thinks *as the operator*, in their worldview, not about them. If `soul/` is the empty template, ground purely on `STRATEGY.md` + the capability surface and write in a clear, direct tone. Then read `memory/MEMORY.md` for current goals and active topics. Each mode below names its own `memory/logs/` scan window for dedup — honor it.
+
+## Force-reply interception — `pick:<idea>` (run FIRST, before mode dispatch)
+
+Before tokenizing `${var}` for the mode, check it. If `${var}` **starts with `pick:`**, this run is the operator answering the "which idea to build next?" force-reply — do **not** run generate/validate/memo. Handle it and end. This is behaviorally identical to idea-pipeline's step 0 (same backlog, same marking convention), so a `pick` reply works whichever skill it routes to:
+
+1. Strip the prefix: `sel="${var#pick:}"`, then trim whitespace (the remainder may contain colons/spaces — keep them).
+2. If `sel` is empty → `./notify "Which idea should I mark as next to build? Reply with its name or backlog number."` and end.
+3. Read the shared backlog `memory/topics/startup-ideas.md`. If missing or no idea rows → `./notify "No idea backlog yet — nothing to mark. Run generate first to fill it."` and end.
+4. Resolve `sel` to exactly one row in the table (`| date | name | one-liner | fit | T+F+E |`):
+   - **By name (preferred):** case-insensitive exact match on the `name` cell; else fuzzy — most significant-word overlap, or `sel` a substring of the name (or vice-versa). Require one clear best match.
+   - **By number:** a bare integer N with no name match → the Nth data row (1-based, in file order).
+   - No match / ambiguous tie → `./notify "Couldn't find an idea matching \"<sel>\". Reply with the exact name or backlog number. Candidates: <name1>, <name2>, <name3>."` and end.
+5. **Mark it chosen-to-build** — the shared marking convention, identical to idea-pipeline: append ` ✓ selected ${today}` to the end of that row's `name` cell, keeping the table pipes intact. If already marked, leave it (idempotent).
+6. Confirm with a short `./notify` (keep it clean — no `test`/`trace`/`ping`/`debug` substrings): `./notify "Marked \"<idea name>\" as next to build — flagged in the backlog. Run /feature or /deploy-prototype on it when you're ready."` Do not auto-dispatch any skill — marking chosen is the safe action.
+7. Log under a `### idea-forge` heading in `memory/logs/${today}.md`: a `- Mode: pick` line, then `- IDEA_FORGE_PICK: marked "<idea name>" as chosen-to-build (from a pick: reply)`.
+8. **End the run** — do not run mode dispatch.
 
 ## Mode dispatch
 
@@ -85,6 +101,17 @@ For each kept idea, write:
 
 #### 6. Notify (gated)
 Unless `DRY_RUN`: `./notify` the **single best idea** — one-liner + why-now + the smallest shippable cut, in the operator's voice, with a link to the full digest. One paragraph. This is a deliberate weekly think, so it's worth one push even on a quiet week — but only the #1, never the whole list. Build the digest URL via `gh repo view --json url -q .url` (not the SSH remote), and send multi-line content with `./notify -f <file>`.
+
+#### 6b. Offer a "build next?" follow-up (force-reply)
+Unless `DRY_RUN`, and only when **≥1 idea was appended to the backlog** this run: offer the operator a one-tap pick of which fresh idea to build — a **separate** `./notify` after the step-6 push (a digest and a force-reply prompt can't share one Telegram message).
+
+Dedup once per day: scan the last ~2 days of `memory/logs/` for `FORCE_REPLY_OFFERED: idea-forge::pick`; if present, skip. Otherwise:
+```bash
+./notify "Which of this week's ideas should I mark as next to build? Reply with the idea's name." \
+  --force-reply --placeholder "idea name" \
+  --context "idea-forge::pick"
+```
+Then record `FORCE_REPLY_OFFERED: idea-forge::pick` in the generate log block (Log section). A `pick:` reply routes back to this skill and is handled by the "Force-reply interception" section above.
 
 ---
 
@@ -327,6 +354,12 @@ After any mode, append to `memory/logs/${today}.md` under a single `### idea-for
 - Config: `products.md` | `NO_PRODUCTS_CONFIG→watched-repos.md`
 - Theme: [var theme or "open-ended"]
 - Notification: sent / skipped (dry-run)
+- Force-reply offer: offered / skipped (already offered in last 2 days / dry-run / no ideas appended)
+- FORCE_REPLY_OFFERED: idea-forge::pick   ← include this exact line ONLY when the offer was actually sent (it's the once/day dedup marker)
+
+**pick (force-reply handler):**
+- Mode: pick
+- IDEA_FORGE_PICK: marked "<idea name>" as chosen-to-build (from a pick: reply)
 
 **validate:**
 - Mode: validate

--- a/skills/idea-pipeline/SKILL.md
+++ b/skills/idea-pipeline/SKILL.md
@@ -5,7 +5,7 @@ description: Execution-gap audit — cross-references the startup idea backlog a
 var: ""
 tags: [meta, creative]
 ---
-> **${var}** — Optional theme filter (e.g. "crypto", "AI agents", "consumer"). If empty, scans all ideas.
+> **${var}** — Optional theme filter (e.g. "crypto", "AI agents", "consumer"). If empty, scans all ideas. A `pick:<id|name>` value (from the "build next?" force-reply — e.g. `pick:2` or `pick:Onchain reputation`) instead marks that idea as chosen-to-build in the backlog and ends, skipping the audit — see step 0.
 
 Today is ${today}. Read `memory/MEMORY.md` before starting. If `soul/SOUL.md` + `soul/STYLE.md` exist and are populated, read them to ground "operator fit" scoring; otherwise score on the idea's general buildability and timing alone.
 
@@ -14,6 +14,22 @@ Today is ${today}. Read `memory/MEMORY.md` before starting. If `soul/SOUL.md` + 
 `idea-validator` evaluates ideas. Nothing tracks execution. Backlogs of dozens of ideas accumulate — some validated, most unscreened — with zero visibility into which ones have been acted on vs which are rotting. This skill gives that view: pipeline size, execution rate, and the 3 ideas closest to being buildable right now.
 
 ## Steps
+
+### 0. Force-reply interception — `pick:<idea>` (run FIRST, before anything else)
+
+Before any other work, inspect `${var}`. If it **starts with `pick:`**, this run is the operator answering the "which idea to build next?" force-reply — do **not** run the normal audit. Handle it and end:
+
+1. Strip the prefix: `sel="${var#pick:}"`, then trim surrounding whitespace. The remainder may contain colons/spaces — keep them.
+2. If `sel` is empty, send a plain re-ask (no force-reply) and end: `./notify "Which idea should I mark as next to build? Reply with its name or backlog number."`
+3. Read the shared backlog `memory/topics/startup-ideas.md`. If it's missing or has no idea rows, `./notify "No idea backlog yet — nothing to mark. Run idea-forge generate to fill it first."` and end.
+4. Resolve `sel` to exactly one idea row in the table (columns `| date | name | one-liner | fit | T+F+E |`):
+   - **By name (preferred):** case-insensitive exact match on the `name` cell; else fuzzy — the row whose name shares the most significant words with `sel`, or where `sel` is a substring of the name (or vice-versa). Require one clear best match.
+   - **By number:** if `sel` is a bare integer N and no name matches, take the Nth data row (1-based, in file order).
+   - If nothing matches, or two rows tie with no clear winner, send a plain re-ask listing 3–5 candidate names and end: `./notify "Couldn't find an idea matching \"<sel>\". Reply with the exact name or backlog number. Candidates: <name1>, <name2>, <name3>."`
+5. **Mark it chosen-to-build** — the shared marking convention (identical in idea-forge): append ` ✓ selected ${today}` to the end of that row's `name` cell, keeping the table pipes intact. If the cell already carries a `✓ selected` marker, leave it (idempotent) — it's already queued.
+6. Confirm with a short `./notify` (keep it clean — no `test`/`trace`/`ping`/`debug` substrings): `./notify "Marked \"<idea name>\" as next to build — flagged in the backlog. Run /feature or /deploy-prototype on it when you're ready."` Do not auto-dispatch any skill — marking chosen is the safe action.
+7. Log to `memory/logs/${today}.md` under a `## Idea Pipeline` heading: `- IDEA_PIPELINE_PICK: marked "<idea name>" as chosen-to-build (from a pick: reply)`.
+8. **End the run.** Do not proceed to step 1 or run the audit.
 
 ### 1. Load the idea backlog
 
@@ -172,6 +188,20 @@ build this week:
 
 Keep under 3000 chars.
 
+### 9b. Offer a "build next?" follow-up (force-reply)
+
+If **at least one** idea was surfaced under "Build This Week", offer the operator a one-tap way to pick which to build — as a **separate** `./notify` after the digest (a digest and a force-reply prompt can't share one Telegram message). Skip the offer entirely on a run that surfaced no picks.
+
+Dedup to once per day: scan the last ~2 days of `memory/logs/` for `FORCE_REPLY_OFFERED: idea-pipeline::pick`; if present, skip this offer. Otherwise send:
+
+```bash
+./notify "Which of these should I mark as next to build? Reply with the idea's number or name." \
+  --force-reply --placeholder "idea # or name" \
+  --context "idea-pipeline::pick"
+```
+
+Then record the `FORCE_REPLY_OFFERED: idea-pipeline::pick` marker in step 10. A `pick:` reply routes back to this skill and is handled by step 0.
+
 ### 10. Log to memory
 
 Append to `memory/logs/${today}.md`:
@@ -186,6 +216,8 @@ Append to `memory/logs/${today}.md`:
 - **Ecosystem feed:** [available / unavailable] — [N underserved categories, M adjacent verticals] (from builder-map ecosystem.md, last run [date])
 - **Filter:** [var value or "none"]
 - **Notification:** sent
+- **Force-reply offer:** [offered / skipped — already offered in last 2 days / skipped — no picks]
+- FORCE_REPLY_OFFERED: idea-pipeline::pick   ← include this exact line ONLY when the offer was actually sent (it's the once/day dedup marker)
 - IDEA_PIPELINE_OK
 ```
 

--- a/skills/onchain-monitor/SKILL.md
+++ b/skills/onchain-monitor/SKILL.md
@@ -9,13 +9,21 @@ capabilities: [external_api, sends_notifications]
 ---
 <!-- autoresearch: variation B — sharper output (decoded transfers + counterparty labels + ranked USD-denominated one-liners + TL;DR lede); folds in A's Alchemy+Etherscan-v2 input path and C's persistent state + source-status footer + dedup. -->
 
-> **${var}** — Watch label or chain to check. Empty = all watches.
+> **${var}** — Watch label or chain to check. Empty = all watches. `add-address:<0x… [chain]>` is the shape the Telegram force-reply sends — it appends a new watch and exits (see step 0).
 
 If `${var}` is set, only monitor the watch with that label or watches on that chain.
 
 ## Config
 
-Reads `memory/on-chain-watches.yml`. If the file is missing or `watches: []`, log `ON_CHAIN_NO_CONFIG` and exit cleanly (do **not** notify — empty config is not an error).
+Reads `memory/on-chain-watches.yml`. If the file is missing or `watches: []`, offer to add the first watch via a Telegram force-reply (only if no `add-address` prompt was offered in the last 2 days of `memory/logs/` — dedup so an unconfigured fork isn't nagged every run), then log `ON_CHAIN_NO_CONFIG` and exit cleanly (do **not** send an alert — empty config is not an error):
+
+```bash
+./notify "No addresses on watch yet. Paste one to monitor — a 0x… wallet, optionally its chain." \
+  --force-reply --placeholder "0x… base" \
+  --context "onchain-monitor::add-address"
+```
+
+The reply routes back as `var=add-address:<0x… [chain]>`, handled by the config-capture branch in step 0. Record `FORCE_REPLY_OFFERED: add-address` in the log when you send it.
 
 ```yaml
 # memory/on-chain-watches.yml
@@ -66,6 +74,45 @@ Write the file via `mv` from a tempfile so a mid-run failure cannot corrupt stat
 ## Steps
 
 Read `memory/MEMORY.md`, `memory/on-chain-watches.yml`, `memory/on-chain-state.json`, and the last 2 days of `memory/logs/` (for visibility only — state lives in the JSON file).
+
+### 0. Config capture (Telegram force-reply)
+
+Before the per-watch loop, intercept the add-a-watch reply. When `${var}` starts with `add-address:`, the operator replied to the force-reply prompt (offered in the Config section on an empty config) — append a watch and **exit** (no monitoring this invocation). The remainder is `<address> [chain]`:
+
+```bash
+case "${var}" in
+  add-address:*)
+    REST="$(printf '%s' "${var#add-address:}" | sed 's/^[[:space:]]*//')"
+    ADDR="$(printf '%s' "$REST" | awk '{print $1}')"
+    CHAIN="$(printf '%s' "$REST" | awk '{print tolower($2)}')"; CHAIN="${CHAIN:-ethereum}"
+    case "$CHAIN" in ethereum|base|arbitrum|optimism|polygon) ;; *) CHAIN=ethereum ;; esac
+    if ! printf '%s' "$ADDR" | grep -qiE '^0x[0-9a-f]{40}$'; then
+      ./notify "Couldn't read \"$ADDR\" as an address. Reply with a 0x… wallet, optionally a chain."
+      exit 0
+    fi
+    mkdir -p memory; touch memory/on-chain-watches.yml
+    # Normalize an empty inline list so we can append block items, and ensure a watches: key exists.
+    sed -i.bak -E 's/^watches:[[:space:]]*\[\][[:space:]]*$/watches:/' memory/on-chain-watches.yml && rm -f memory/on-chain-watches.yml.bak
+    grep -q '^watches:' memory/on-chain-watches.yml || printf 'watches:\n' >> memory/on-chain-watches.yml
+    if grep -qi "$ADDR" memory/on-chain-watches.yml; then
+      ./notify "Already watching ${ADDR}."
+    else
+      SHORT="$(printf '%s' "$ADDR" | sed -E 's/^(0x.{4}).*(.{4})$/\1…\2/')"
+      cat >> memory/on-chain-watches.yml <<EOF
+  - label: "$SHORT"
+    address: "$ADDR"
+    chain: $CHAIN
+    type: wallet
+    threshold_usd: 1000
+EOF
+      ./notify "Now watching ${SHORT} on ${CHAIN} (wallet, moves ≥\$1000). Edit memory/on-chain-watches.yml to tune."
+    fi
+    # log under ### onchain-monitor: - view: add-address (var="${var}") → $ADDR on $CHAIN
+    exit 0 ;;
+esac
+```
+
+Defaults for a captured watch: `type: wallet`, `threshold_usd: 1000`, `label` = the shortened address. The operator refines chain/type/threshold by editing `memory/on-chain-watches.yml` directly. (This appends to the end of the file, which is correct because `watches:` is the only top-level key — if a future config grows more keys, insert under `watches:` instead of at EOF.)
 
 For each watch (filtered by `${var}`):
 
@@ -135,7 +182,11 @@ Native ETH/MATIC/etc. use `simple/price?ids=ethereum,matic-network,...`. If Coin
 
 ### 4. Filter
 
-Drop an event if any of:
+**Per-watch mute gate (Telegram).** First, if a watch is muted or snoozed via a Telegram button, drop **all** of its events (note `muted`/`snoozed` in the step-7 log and skip it in the notification). This is what the per-watch Mute/Snooze buttons in step 6 act on — no `--mute-key` needed because suppression is per-watch, not per-message:
+- muted if `memory/mutes.log` contains a line exactly `onchain-monitor:<label>` (or the global `onchain-monitor:all`);
+- snoozed if `memory/snoozes.log` has `onchain-monitor:<label>:<until_epoch>` (or `onchain-monitor:all:<until_epoch>`) with `until_epoch` still in the future.
+
+Then drop an individual event if any of:
 - `value_usd < threshold_usd` (watch config, default $1000)
 - `value_usd < $0.10` (hard dust floor — prevents airdrop / phishing spam)
 - `tx_hash` already present in this watch's `alerted_tx` (cross-run dedup)
@@ -176,6 +227,18 @@ TL;DR: My Wallet sent $1.2M USDC to Binance 14 (biggest move on any watch in 30d
 
 Cap the notification body at 10 events; if more survived, append `+N more — see memory/logs/${today}.md`. The `./notify` call should use the explorer URL for each chain (`etherscan.io`, `basescan.org`, `arbiscan.io`, `optimistic.etherscan.io`, `polygonscan.com`).
 
+**Interactive controls (Telegram).** Attach a per-watch Mute button for each watch that appears in the message, plus a Snooze 24h for the busiest watch, so a chatty address can be quieted in one tap (suppression is honoured in step 4 — see [`docs/telegram-commands.md`](../../docs/telegram-commands.md)):
+
+```bash
+# one row per watch present in the message; the busiest watch also gets a Snooze.
+# key each button on the EXACT label string step 4 checks against memory/mutes.log.
+./notify -f alert.md --buttons "[[
+  {\"text\":\"Mute My Wallet\",\"callback_data\":\"mute:onchain-monitor:My Wallet\"},
+  {\"text\":\"Snooze 24h\",\"callback_data\":\"snooze:onchain-monitor:My Wallet:86400\"}]]"
+```
+
+Rules: `callback_data` must stay ≤64 bytes — `mute:onchain-monitor:` already spends 21 bytes, so keep watch `label`s short (rename a long label in the config). A label must not contain `:` (the router splits `callback_data` on it). If more than ~3 watches fired, attach Mute buttons for the top 3 by event count and rely on the log for the rest.
+
 ### 7. Persist state and log
 
 For each watch whose fetch **succeeded** (success ≠ "events found"):
@@ -203,7 +266,7 @@ This honest log matters: it powers the next run's median computation and lets th
 - All watches ran, zero events survived → no notify; log `ON_CHAIN_OK (n_watches=X, n_raw=Y, n_dropped=Y)`.
 - Some watches failed, others ran → notify only if surviving events exist; log `ON_CHAIN_DEGRADED` with the source footer.
 - Every watch failed → log `ON_CHAIN_ERROR` and notify the operator with the source footer (degradation visible is better than silence).
-- Config missing/empty → log `ON_CHAIN_NO_CONFIG`, exit, no notify.
+- Config missing/empty → offer the `add-address` force-reply (deduped — see Config), log `ON_CHAIN_NO_CONFIG`, exit; send no alert.
 
 ## Sandbox note
 

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -137,6 +137,17 @@ Reviewed N, skipped K (drafts: x, bots: y, dup-SHA: z, bot-reviewed-recently: w)
 - owner/repo#123: [verdict] — N critical, M issues
 ```
 
+**Interactive controls (Telegram).** When the run was scoped to a **single repo** (`${var}=owner/repo`), attach a Re-review + Open-PRs row so the operator can re-run after a fix lands or jump straight to the queue (see [`docs/telegram-commands.md`](../../docs/telegram-commands.md)):
+
+```bash
+REPO="owner/repo"     # the single-repo scope this run reviewed
+./notify -f review.md --buttons "[[
+  {\"text\":\"Re-review\",\"callback_data\":\"run:pr-review:${REPO}\"},
+  {\"text\":\"Open PRs\",\"url\":\"https://github.com/${REPO}/pulls\"}]]"
+```
+
+Omit the buttons on an all-repos run — a single Re-review button can't name which repo. Keep `callback_data` ≤64 bytes (a repo slug is well within budget).
+
 If every PR was skipped, do not notify — just log.
 
 Log to `memory/logs/${today}.md` under the shared `### pr-review` heading with a mode discriminator:
@@ -383,6 +394,19 @@ Full digest: articles/pr-merge-${today}.md
 Keep under 900 chars. Drop any bucket row whose count is zero. Drop the "oldest in queue" line if `open_count == 0`. The `⚠️ HIGH security finding` / `⚠️ touches aeon.yml` annotations are appended only to PRs the operator has not been notified about on this head SHA — repeat-rendering them would dilute the alert signal.
 
 Send via `./notify "$MSG"` (single positional argument — the heredoc-built message; aeon's `./notify` accepts a positional argument or `-f file`, this branch uses positional to keep the message inline with the other locals computed in this step, and keeps it under 900 chars).
+
+**Interactive controls (Telegram).** Attach Snooze/Mute + Open-queue buttons so the operator can quiet this repo's morning digest once triaged, and jump to the PR list in one tap (see [`docs/telegram-commands.md`](../../docs/telegram-commands.md)):
+
+```bash
+KEY="pr-review:${TARGET_REPO}"
+./notify "$MSG" \
+  ${MUTEABLE:+--mute-key "$KEY"} \
+  --buttons "[[{\"text\":\"Snooze 24h\",\"callback_data\":\"snooze:${KEY}:86400\"},
+               {\"text\":\"Mute\",\"callback_data\":\"mute:${KEY}\"},
+               {\"text\":\"Open queue\",\"url\":\"https://github.com/${TARGET_REPO}/pulls\"}]]"
+```
+
+Pass **`--mute-key`** only when the body carries **no** SKILL_WARN_OR_BLOCK / CORE_REVIEW escalation (set `MUTEABLE=1` in that case, empty otherwise): a security finding or an executor-blast-radius PR must still reach the operator even on a muted repo, and `notify` would otherwise swallow it. Routine FAST_TRACK/INFRA digests honour the mute. Snooze is time-boxed (auto-expires), so it's always safe to offer. Keep `callback_data` ≤64 bytes — for an unusually long repo slug, drop the Snooze/Mute row (keep Open queue) rather than truncate the key.
 
 ### 10. Log (SURVEY branch)
 

--- a/skills/price-alert/SKILL.md
+++ b/skills/price-alert/SKILL.md
@@ -5,7 +5,7 @@ description: Fire when the tracked token does something — new ATH, sharp 1h mo
 var: ""
 tags: [crypto]
 ---
-> **${var}** — Optional. Pass one or more `target_price` levels (comma-separated USD numbers, scientific notation allowed) to fire a one-time alert when the price crosses any of them. Empty = only ATH and sharp-move gates run. Pass `dry-run` to skip notify (state still updates).
+> **${var}** — Optional. Pass one or more `target_price` levels (comma-separated USD numbers, scientific notation allowed) to fire a one-time alert when the price crosses any of them. Empty = only ATH and sharp-move gates run. Pass `dry-run` to skip notify (state still updates). Pass `set-target:<price>` — the shape the Telegram force-reply sends (step 7) — to register a target and get a one-line confirmation.
 
 Today is ${today}. `repo-pulse` reports star/fork deltas once a day, and the other scheduled digests run at fixed hours. None of them tell the operator "the price just hit a new high" or "the token moved 28% in the last hour" — both are events that warrant attention the moment they happen, not 14 hours later in a daily digest. This skill closes that window.
 
@@ -68,11 +68,12 @@ Key invariants:
 
 ### 1. Parse var
 
-- If `${var}` matches `^dry-run` → `MODE=dry-run`. Strip the prefix; remainder (if any) is treated as targets.
+- If `${var}` starts with `set-target:` → set `FROM_REPLY=1`, `MODE=execute`. Strip the `set-target:` prefix (`${var#set-target:}`); the remainder is the target(s) list, parsed exactly like the comma-split below. This is the shape `scripts/telegram-route.sh` sends when the operator replies to the step-7 force-reply prompt. The run proceeds normally (register the target, don't fire on first observation) and closes the loop with a confirmation in step 7.
+- Else if `${var}` matches `^dry-run` → `MODE=dry-run`. Strip the prefix; remainder (if any) is treated as targets.
 - Otherwise `MODE=execute`.
 - Split the remainder on `,` (commas) and strip whitespace.
 - For each token: if it parses as a positive float (scientific notation OK, e.g. `5e-6`), include it. Reject zero / negative / non-numeric tokens and log `PRICE_ALERT_BAD_TARGET: ${token}` — continue with the surviving targets.
-- If after filtering the remainder was non-empty but yielded zero valid targets → log `PRICE_ALERT_BAD_VAR: ${var}` and exit (no notify).
+- If after filtering the remainder was non-empty but yielded zero valid targets → log `PRICE_ALERT_BAD_VAR: ${var}` and exit. Normally no notify — **but if `FROM_REPLY=1`**, first close the loop with `./notify "Couldn't read \"${var#set-target:}\" as a price. Reply with a number like 0.000005."` (a force-reply always deserves an acknowledgement).
 - If the remainder was empty, `TARGETS=()` is fine — ATH and sharp-move gates still run.
 
 ### 2. Resolve tracked token
@@ -193,6 +194,48 @@ Chart: ${POOL_URL}
 If `MODE == dry-run`: build the messages, log the planned notifications, but skip `./notify`. State still updates so dedup clocks advance correctly.
 
 Cap each message at ~2500 chars; price-alert messages are short by nature and shouldn't approach this.
+
+#### Interactive controls (Telegram)
+
+Every alert notification carries snooze/mute controls plus a one-tap deep report, so a chatty
+token can be quieted without a config edit (see [`docs/telegram-commands.md`](../../docs/telegram-commands.md)).
+Pass **`--mute-key "price-alert:$SYMBOL"`** so a tapped Snooze/Mute actually suppresses future
+alerts — `notify` skips the send when that key is muted or snoozed into the future, no skill-side
+logic required. Build each gate's message to a file and send it like this:
+
+```bash
+KEY="price-alert:$SYMBOL"          # $SYMBOL resolved from the tracked token (a bare ticker)
+./notify -f alert.md \
+  --mute-key "$KEY" \
+  --buttons "[[{\"text\":\"Snooze 24h\",\"callback_data\":\"snooze:${KEY}:86400\"},
+               {\"text\":\"Mute\",\"callback_data\":\"mute:${KEY}\"},
+               {\"text\":\"Deep report\",\"callback_data\":\"run:token-movers:${SYMBOL}\"}]]"
+```
+
+- The **Deep report** button re-dispatches `token-movers` in single-token mode on the same symbol
+  (`run:token-movers:$SYMBOL`) — one tap from "it moved" to a full report.
+- The mute-key is shared across all three gates, so muting a token silences its ATH, sharp-move,
+  and target pings together — the intended "quiet this token" behaviour. State still advances, so
+  the moment the operator unmutes, dedup clocks are already correct.
+- Keep `callback_data` ≤64 bytes: `$SYMBOL` is a bare ticker, never a name with spaces.
+
+#### Set-a-target follow-up (force-reply)
+
+Buttons and force_reply can't share one message, so this is a **separate** send. After a genuine
+**ATH** alert (post-baseline, not a deduped repeat), and only when no un-hit operator target
+currently sits above `CURRENT_PRICE` (don't nag operators who already queued one), offer to capture
+the next level:
+
+```bash
+./notify "New high — want an alert when $SYMBOL clears a level above this? Reply with a price." \
+  --force-reply --placeholder "e.g. 0.000005" \
+  --context "price-alert::set-target"
+```
+
+The reply routes back as `var=set-target:<price>` (handled in step 1). On that run, once the target
+is registered (step 6, first-observation — no cross alert), close the loop with a one-line
+confirmation: `./notify "Target set: \$<price> for $SYMBOL — I'll alert you when it crosses."`
+(Send it only when a *new* target was actually registered this run.)
 
 ### 8. Persist state
 

--- a/skills/reg-monitor/SKILL.md
+++ b/skills/reg-monitor/SKILL.md
@@ -8,7 +8,7 @@ requires: [CONGRESS_GOV_API_KEY?]
 ---
 <!-- autoresearch: variation B — sharper output via stage×impact scoring, action-first triage, deadline-aware buckets, structured primary sources (Federal Register + SEC/CFTC RSS), persistent URL dedup, source-status observability -->
 
-> **${var}** — Specific regulatory topic to narrow focus (e.g. `prediction-markets`, `stablecoins`, `ai-agents`). If empty, scans all tracked domains.
+> **${var}** — Specific regulatory topic to narrow focus (e.g. `prediction-markets`, `stablecoins`, `ai-agents`). If empty, scans all tracked domains. A value starting with `add-topic:` (e.g. `add-topic:RWA tokenization`) is the Telegram force-reply shape — it appends `<topic>` to the tracked verticals and ends the run without scanning (see Step 0).
 
 Read `memory/MEMORY.md` for context on current positions and interests.
 Read the last 2 days of `memory/logs/` entries for this skill to avoid repeating items.
@@ -19,6 +19,25 @@ Read `memory/topics/reg-monitor-seen.md` (create if missing) for persistent URL 
 Original skill produced news-shaped output (HIGH PRIORITY / NOTABLE / WATCH LIST) with soft ranking and no deadlines. Reg-monitor's real value is **decisions** — file a comment, prepare for a ban, short a market, brief counsel. Rank items by **stage × impact**, surface deadlines, drop filler buckets, and distinguish "quiet week" from "monitor failure" via source-status observability.
 
 ## Steps
+
+### 0. Inbound reply + onboarding offer (Telegram force-reply wiring)
+
+**Handle a reply first — this branch takes priority over everything below.** If `${var}` starts with `add-topic:`, this run is the operator answering the "track a new vertical?" prompt, not a scheduled scan:
+
+1. Strip the prefix and trim: `topic="${var#add-topic:}"` then strip surrounding whitespace. The value is free text and may contain spaces (e.g. `RWA tokenization`, `stablecoin regulation`) — keep it whole.
+2. If `topic` is empty/blank after trimming, send a friendly re-ask (no force-reply loop) and END the run:
+   `./notify "No vertical received — reply to the prompt with a regulatory topic to track (for example: stablecoin regulation, or prediction markets), and I'll add it to reg-monitor's tracked list."`
+3. Otherwise append `topic` as a new line to `memory/topics/reg-monitor-topics.md` (operator-tracked extra verticals, one topic per line — create the file if missing). **Dedup:** skip the append if the topic already appears (case-insensitive).
+4. Confirm (keep it ≥120 chars so a topic containing a filtered word can't be dropped as a probe):
+   `./notify "Now tracking \"${topic}\" for reg-monitor. It's been added to memory/topics/reg-monitor-topics.md and will be folded into the regulatory searches on the next scheduled run."`
+5. Log under `### reg-monitor`: `- add-topic: "${topic}" → appended to memory/topics/reg-monitor-topics.md` and **END the run** (skip all steps below).
+
+**Onboarding offer (normal runs only, deduped).** If `${var}` did NOT start with `add-topic:` AND `memory/topics/reg-monitor-topics.md` is missing or empty AND the last 2 days of `memory/logs/` contain no `FORCE_REPLY_OFFERED: add-topic` marker for this skill, send one force-reply offer, then continue the normal flow below:
+```bash
+./notify "Want reg-monitor to track another regulatory vertical? Reply with one (e.g. RWA tokenization) and I'll fold it into the searches." \
+  --force-reply --placeholder "a topic to track" --context "reg-monitor::add-topic"
+```
+Then log a `FORCE_REPLY_OFFERED: add-topic` marker line under `### reg-monitor` so it doesn't re-offer next run. (Sending a force-reply is just a notify flag — the offer is separate from any digest, never combined with buttons.)
 
 ### 1. Load inputs (structured primary sources first, WebSearch as gap-filler)
 
@@ -51,7 +70,9 @@ Keep items on/after `${since}`. CFTC runs prediction-market rulemaking — all C
 - `"AI agent" (regulation OR liability OR legislation) ${year}`
 - `ESMA OR MiCA (enforcement OR guidance) ${year}`
 
-If `${var}` is set, replace the above with 3 targeted searches for that specific topic (include `${year}` and "bill OR ruling OR enforcement").
+Also read `memory/topics/reg-monitor-topics.md` (operator-tracked extra verticals, one topic per line — Step 0 maintains it; treat as empty if the file is absent). For each listed topic, add one WebSearch: `"<topic>" (bill OR legislation OR regulation OR enforcement OR ruling) ${year}`. These fold the operator's topics into the same scoring/triage as the built-in domains.
+
+If `${var}` is set (and is not an `add-topic:` reply — that's handled in Step 0), replace the above with 3 targeted searches for that specific topic (include `${year}` and "bill OR ruling OR enforcement").
 
 **E. Congress.gov (optional, skip if no API key)** — if `CONGRESS_GOV_API_KEY` env var is set, WebFetch bill search for crypto/prediction-market keywords. Otherwise skip silently and rely on Federal Register + WebSearch to catch bill activity.
 

--- a/skills/reply-maker/SKILL.md
+++ b/skills/reply-maker/SKILL.md
@@ -14,6 +14,7 @@ requires: [XAI_API_KEY?]
 > - **empty** → **Mode A (Reply Drafting):** auto-discover reply-worthy tweets across your areas of interest (from recent logs + memory) and draft two reply options for each.
 > - **`@handle` / numeric X list ID / topic** → **Mode A (Reply Drafting)** scoped to that handle, list, or topic.
 > - **`from-logs`** (or **`--from-logs`**, optionally followed by an `@handle` or project name to narrow the scan) → **Mode B (From-Logs Engagement):** scan recent logs for flagged engagement opportunities and turn them into copy-paste-ready responses.
+> - **`revise:<instruction>`** → **Revise branch:** reload the last drafted replies and refine them per the instruction (the Telegram force-reply shape, e.g. `revise:make them shorter`).
 
 ## Preamble (both modes)
 
@@ -24,6 +25,7 @@ Then read `memory/logs/` — the window depends on the mode:
 - **Mode B:** the last 7 days of `memory/logs/` for engagement opportunities flagged by other skills (`project-pulse`, `refresh-x`, `reply-maker`, `channel-recap`) or noted in MEMORY.md "Known Follow-ups".
 
 **Parse `${var}` to pick the branch** (trim whitespace, compare case-insensitively):
+- If `${var}` starts with `revise:` — run the **Revise branch** (below) and stop. This is the shape `scripts/telegram-route.sh` sends when the operator replies to a "refine these replies?" force-reply prompt; catch it before mode parsing.
 - If `${var}` is `from-logs` or `--from-logs` — optionally followed by a whitespace-separated `@handle` or project name — run **Mode B (From-Logs Engagement)**. Treat any trailing token as an optional filter that narrows the opportunity scan to that handle/project.
 - Otherwise run **Mode A (Reply Drafting)**, treating `${var}` as the scope: empty, `@handle`, numeric X list ID, or a topic string.
 
@@ -38,6 +40,25 @@ If no soul files exist (or the bodies are empty placeholders), write replies tha
 - The kind of reply that adds to the conversation, not noise
 
 Either way, when responding to someone who cosigned/mentioned/attributed the operator (Mode B): **acknowledge without groveling** — no "thanks so much for the kind words!", just the actual response.
+
+---
+
+# Revise branch (`revise:…` — Telegram force-reply)
+
+The operator tapped the "refine these replies?" prompt and sent a free-text revision instruction. Handle it before Mode A/B:
+
+1. **Strip the prefix.** The instruction is `${var#revise:}` (keep any inner colons). Trim whitespace — e.g. `make them shorter`, `less formal`, `drop reply B on #2`.
+2. **Load the last draft.** Read `memory/drafts/reply-maker-latest.md` — the stable path every normal run saves to (see the save steps in A4 / B6). If it's missing or empty, there's nothing to refine: send `./notify "Nothing to revise yet — run reply-maker first, then reply here to refine the drafts."` and **end the run**.
+3. **Apply the instruction.** Read `soul/` for voice, then regenerate the saved replies applying the operator's instruction. Keep the same set of target tweets and the same **A/B two-option** structure (Mode A) or ready-to-post list (Mode B) — you're refining wording, not re-discovering candidates. Re-enforce the hard reply rules: ≤280 chars for X replies, no sycophancy (see **Banned sycophancy phrases**), specifics not gestures.
+4. **Re-save** the revised drafts to `memory/drafts/reply-maker-latest.md` (overwrite), so a further `revise:` refines the newest version.
+5. **Re-send** via `./notify` in the same format the originating mode uses, with a first line flagging it as a revision, e.g. `revised (${var#revise:}):`. Use `./notify -f <file>` for multi-line output.
+6. **Re-offer** a further revision (the operator is actively iterating, so this is expected, not a nag — skip the daily dedup guard here):
+   ```bash
+   ./notify "Want another pass? Reply with a change and I'll revise again." \
+     --force-reply --placeholder "e.g. make them shorter" \
+     --context "reply-maker::revise"
+   ```
+7. **Log** under `### reply-maker` with `- **Mode:** revise` and the instruction (see **Log**), then **end the run** — do NOT run Mode A or B.
 
 ---
 
@@ -161,6 +182,8 @@ source-status: xai=ok|fail|skip, memory=N, websearch=ok|fail|skip
 
 If zero candidates survive the skip gate from any source, send a single `REPLY_MAKER_EMPTY — [one-line reason]` notification and stop.
 
+Otherwise, after notifying, **save the drafts and offer a revision** (see *Save drafts + offer revision*).
+
 ### A5. Log
 
 Append to `memory/logs/${today}.md` under the shared `### reply-maker` heading (see **Log** below), using the **Mode A** template.
@@ -227,11 +250,35 @@ some opps aging — act or drop
 
 Write this to `/tmp/reply-maker-from-logs.md` then run `./notify -f /tmp/reply-maker-from-logs.md`.
 
+After notifying, **save the drafts and offer a revision** (see *Save drafts + offer revision*).
+
 ### B7. Log
 
 Append to `memory/logs/${today}.md` under the shared `### reply-maker` heading (see **Log** below), using the **Mode B** template.
 
 ---
+
+## Save drafts + offer revision (both modes)
+
+After a normal run (Mode A or B) has drafted and notified replies, do two things so the operator can refine them from Telegram. **Skip both** when the run sent nothing (`REPLY_MAKER_EMPTY`, or Mode B's `ENGAGEMENT_ACT_SKIP`).
+
+1. **Persist the drafts** to a stable path a later `revise:` run can reload:
+   ```bash
+   mkdir -p memory/drafts
+   ```
+   Write the full draft body you just sent — all selected tweets with their A/B options (Mode A), or the ready-to-post list (Mode B) — to `memory/drafts/reply-maker-latest.md`, overwriting any previous file. Only the newest draft is revisable.
+2. **Offer a revision** — a **separate** `./notify` (force_reply can't share a message with inline buttons):
+   ```bash
+   ./notify "Want to refine these replies? Reply with a change and I'll revise them." \
+     --force-reply --placeholder "e.g. make them shorter" \
+     --context "reply-maker::revise"
+   ```
+   The reply routes back as `var="revise:<instruction>"` and re-dispatches this skill into the **Revise branch**.
+
+   **Dedup — once per produced draft.** Before offering, scan the last ~2 days of `memory/logs/` for a `FORCE_REPLY_OFFERED: revise` line dated `${today}`; if present, skip the offer. When you send it, append the marker under the run's `### reply-maker` entry:
+   ```
+   - FORCE_REPLY_OFFERED: revise
+   ```
 
 ## Banned sycophancy phrases
 
@@ -270,6 +317,15 @@ The `Tweet URLs` line is what tomorrow's run reads to avoid duplicate replies �
 - ENGAGEMENT_ACT_OK
 ```
 If skipped: `ENGAGEMENT_ACT_SKIP: <reason>` (still under `### reply-maker`).
+
+**Revise (Telegram force-reply):**
+```
+### reply-maker
+- **Mode:** revise
+- **Instruction:** [the operator's revision instruction]
+- **Base draft:** memory/drafts/reply-maker-latest.md (reloaded + re-saved)  (or: none — nothing to revise)
+- **Notification:** sent
+```
 
 ## Sandbox note
 

--- a/skills/repo-scanner/SKILL.md
+++ b/skills/repo-scanner/SKILL.md
@@ -484,6 +484,22 @@ Full details: https://github.com/${AEON_REPO}/blob/main/articles/repo-actions-${
 ```
 Where `AEON_REPO` = `git remote get-url origin` stripped to `owner/repo` (this is the Aeon repo, **not** `${TARGET}`).
 
+### B9a. Offer to ship one (Telegram force-reply)
+
+After the ideas article (and any Branch B notification), offer the operator a one-tap way to ship an opportunity: a Telegram force-reply whose answer routes to the `feature` skill, which opens the PR. This is a **separate** `./notify` call (force-reply and inline buttons can't share one Telegram message), sent only at this natural moment right after the ideas land.
+
+**Gate — offer only on real signal:**
+- Only when this run actually surfaced ≥1 opportunity — i.e. Branch B shipped ≥1 action idea (mode `REPO_ACTIONS_OK`, or `THIN` with ≥1 idea). Skip entirely on `NO_CHANGE`, `NO_CONFIG`, `ERROR`, or any zero-idea run.
+- **Dedup to once/day:** scan the last ~2 days of `memory/logs/` for a `FORCE_REPLY_OFFERED: build` marker. If one is present, skip the offer — you already asked recently. Don't nag every scheduled run.
+
+If both checks pass, send exactly one prompt:
+```bash
+./notify "Ship which opportunity? Reply with an owner/repo, an issue URL, or a one-line idea and I'll open a PR." \
+  --force-reply --context "feature::build" \
+  --placeholder "owner/repo or an idea"
+```
+The `--context "feature::build"` marker makes the operator's reply dispatch the **`feature`** skill with `var="build:<their reply>"`; feature's Selector intercepts the `build:` prefix and routes it into its external-enhancement branch. After sending, record the marker in the log (see B10) so the dedup holds. Keep the message free of `test`/`trace`/`ping`/`debug` (notify drops short diagnostic-looking probes).
+
 ### B10. Log (Branch B)
 Contribute to the consolidated `### repo-scanner` log block under an `actions:` sub-block:
 - Target: ${TARGET}
@@ -496,6 +512,7 @@ Contribute to the consolidated `### repo-scanner` log block under an `actions:` 
 - Dropped (novelty): [count]
 - Dropped (implementability → Monitor): [count]
 - Carried over to tomorrow: [titles of the top pick if not closed]
+- Force-reply offer: [sent → also append a discrete `FORCE_REPLY_OFFERED: build` line under this sub-block | skipped (deduped, offered ≤1d ago) | n/a (no ideas surfaced)]
 - Source status: gh=[...] code_search=[...] memory_topics=[...]
 
 ### Branch B guardrails

--- a/skills/send-email/SKILL.md
+++ b/skills/send-email/SKILL.md
@@ -6,7 +6,7 @@ var: ""
 requires: [RESEND_API_KEY?]
 tags: [productivity, email, outreach]
 ---
-> **${var}** — who to email and why, e.g. `to=jane@acme.com | subject=Intro | about=propose a 20-min call on X`. Freeform also works ("email jane@acme.com to follow up on yesterday's demo"). `cc=` is optional.
+> **${var}** — who to email and why, e.g. `to=jane@acme.com | subject=Intro | about=propose a 20-min call on X`. Freeform also works ("email jane@acme.com to follow up on yesterday's demo"). `cc=` is optional. The reply-shape `revise:<instruction>` (Telegram force-reply, e.g. `revise:make it warmer`) refines the **last composed draft for review only — it never sends**.
 
 Read `soul/` (for voice) and `memory/MEMORY.md` (for context) before composing.
 
@@ -17,6 +17,30 @@ Composes a single, purposeful email and queues it for sending. The send is an au
 This is **not** a bulk or cold-outreach tool. One deliberate recipient per run, with a genuine reason to write. If the request reads as mass-mailing, list-blasting, or spam, refuse and log `SEND_EMAIL_REFUSED: not a 1:1 purposeful email`.
 
 ## Steps
+
+### Revise intercept (Telegram force-reply — re-stage for review only, NEVER auto-send)
+
+**Before anything else**, if `${var}` starts with `revise:`, the operator replied to a "refine this email?" prompt. Handle it here and **end the run** — the normal compose/stage/send flow below does NOT run, and **no send is ever queued**:
+
+1. **Strip the prefix.** The instruction is `${var#revise:}` (keep any inner colons), e.g. `make it warmer`, `shorten to 3 lines`, `drop the meeting ask`.
+2. **Load the last draft** from `memory/drafts/send-email-latest.md` (the review copy the normal run saves in step 4). If it's missing or empty, there's nothing to refine: send `./notify "Nothing to revise yet — compose an email first, then reply here to refine it."` and end the run.
+3. **Regenerate** the email applying the instruction — re-read `soul/` for voice; keep the same recipient / cc / subject unless the instruction changes them; keep the body as the exact send-ready text (operator-only notes stay out).
+4. **Re-stage for REVIEW ONLY.** Overwrite `memory/drafts/send-email-latest.md` with the revised draft. **Do NOT write `.pending-email/` and do NOT queue the actual send.** A `revise:` reply never sends — the operator confirms a real send by invoking send-email normally (which re-composes and stages `.pending-email/`).
+5. **Notify** the operator with the full revised draft for review — multi-line ⇒ `./notify -f <file>`:
+   ```
+   revised draft (not sent) → <to>: <subject>
+
+   <body>
+   ```
+6. **Re-offer** a further revision (the operator is iterating — skip the daily dedup guard here):
+   ```bash
+   ./notify "Want another pass? Reply with a change and I'll revise the draft again (still won't send)." \
+     --force-reply --placeholder "e.g. make it warmer" \
+     --context "send-email::revise"
+   ```
+7. **Log** `- SEND_EMAIL_REVISED (draft re-staged for review, not sent)` under a `## Send Email` heading in `memory/logs/${today}.md`, then **end the run**.
+
+Otherwise (no `revise:` prefix), run the normal flow:
 
 1. **Parse the request** from `${var}`: `to` (required — one valid email address), optional `cc`, optional `subject`, and the `about` (the goal / what to say). If `to` or the purpose is missing, check `memory/outreach.md` for a queued request; if still nothing, log `SEND_EMAIL_SKIP: no recipient/purpose` and stop.
 
@@ -33,10 +57,23 @@ This is **not** a bulk or cold-outreach tool. One deliberate recipient per run, 
    ```
    The postprocess sender reads this and sends via Resend when `RESEND_API_KEY` + `RESEND_FROM` are set; otherwise the draft stays queued (nothing is lost). Per-run / per-day / cooldown caps and the operator audit CC are the shared settings below.
 
+   Then save a **review copy** of the composed email (human-readable: to / cc / subject / body) to `memory/drafts/send-email-latest.md` (overwrite):
+   ```bash
+   mkdir -p memory/drafts
+   ```
+   This is the stable path a later `revise:` reply reloads — kept **separate** from the `.pending-email/` send queue, so a revision refines a review copy and never touches what's already queued to send.
+
 5. **Notify** the operator (audit copy) via `./notify`:
    ```
    email queued → <to>: <subject>
    ```
+   Then **offer a revision** — a **separate** `./notify` (dedup: once per produced draft — scan the last ~2 days of `memory/logs/` for a `FORCE_REPLY_OFFERED: revise` line dated `${today}` and skip if present):
+   ```bash
+   ./notify "Want to refine this email? Reply with a change and I'll revise the draft (won't re-send)." \
+     --force-reply --placeholder "e.g. make it warmer" \
+     --context "send-email::revise"
+   ```
+   The reply routes back as `var="revise:<instruction>"` → the **Revise intercept** above, which re-stages the draft for review only and never sends. Note: the queued email is sent by `scripts/postprocess-email.sh` right after this run, so this offer refines a **review copy** for the operator — any real re-send is a fresh normal invocation, not a change to the message already going out.
 
 6. **Log** to `memory/logs/${today}.md`:
    ```
@@ -46,6 +83,7 @@ This is **not** a bulk or cold-outreach tool. One deliberate recipient per run, 
    - **Why:** <one line>
    - SEND_EMAIL_QUEUED
    ```
+   If you sent the revision offer, also append `- FORCE_REPLY_OFFERED: revise`.
 
 ## Sandbox Note
 - The send is an auth-required outbound call (`RESEND_API_KEY` in the header), blocked inside the sandbox. The skill only writes `.pending-email/<slug>.json`; `scripts/postprocess-email.sh` (post-run, full env) sends it. Pure local file write here — no network, no secrets.

--- a/skills/token-movers/SKILL.md
+++ b/skills/token-movers/SKILL.md
@@ -19,6 +19,7 @@ capabilities: [external_api, sends_notifications]
 > - **`<contract>`** or **`<contract>:<chain>`** (e.g. `0xabc…`, `0xabc…:base`) → single-token deep report on that contract.
 > - **`<SYMBOL>`** (e.g. `SOL`, `WIF`) → single-token deep report; resolve the symbol to its top contract first.
 > - **`token`** / **`single-token`** → single-token deep report on the token configured in `memory/token-report.md`.
+> - **`deep-dive:<symbol|contract>`** (e.g. `deep-dive:WIF`, `deep-dive:0xabc…:base`) → single-token deep report — the shape the Telegram force-reply sends. Strips the `deep-dive:` prefix and resolves the remainder exactly like a bare symbol/contract.
 >
 > Examples: `""` (global movers), `geckoterminal:base` (Base runners), `category:layer-2` (L2 movers), `0x4ed…:base` or `WIF` (single-token report).
 
@@ -28,6 +29,7 @@ capabilities: [external_api, sends_notifications]
 2. Read the last 2 days of `memory/logs/` to avoid repeating the same movers/trending/runner names unless the move is materially different — **repeat runners across days are the real signal**. (The single-token branch reads the last **30 days** for its `TOKEN_REPORT_STATE:` delta lines — see that branch.)
 3. **Parse `${var}` → `source` + `mode` (+ optional `token`/`chain`/`category`).** Trim whitespace; evaluate the rules top-to-bottom, first match wins (fully deterministic):
 
+   0. **Force-reply intercept (Telegram deep-dive).** starts with `deep-dive:` → strip the prefix (`${var#deep-dive:}`) and treat the remainder EXACTLY as a single-token target, resolving it contract-or-symbol just like rule 8 (`token:`) does → **single-token**. Single-token branch. This is the shape the Telegram force-reply sends; it reuses all existing single-token logic (no separate handler, no confirmation — the single-token report IS the response).
    1. empty → **mode=movers, source=coingecko** (global). Go to **Movers branch**.
    2. `coingecko` (case-insensitive) → **movers / coingecko** (global). Movers branch.
    3. `geckoterminal` → **movers / geckoterminal** (all major networks). Movers branch.
@@ -366,6 +368,34 @@ KEY="token-movers:all"     # or token-movers:<SYMBOL> when the run is scoped to 
 Keep `callback_data` short (≤64 bytes): use a bare symbol like `BTC`, never a name
 with spaces. For a single-token **[PUMP-RISK]** you may also send a dedicated alert
 keyed to that symbol (`--mute-key "token-movers:SYMBOL"`) so it can be muted on its own.
+
+### Deep-dive offer (force-reply — movers runs only)
+
+On a **movers** run that surfaced **notable** movers, follow the buttoned digest with a
+one-tap offer to get the single-token deep report on any name the operator names. "Notable"
+means: coingecko → at least one winner/loser or `Notable` signal was published; geckoterminal
+→ verdict is **not** SLEEPY and ≥1 pick cleared the gate. Skip the offer on a SLEEPY / all-sources-failed
+run, and **never** on a single-token run (that branch never reaches this section).
+
+Because `force_reply` and inline buttons can't share one Telegram message, this is a SEPARATE
+`./notify` sent AFTER the buttoned digest:
+
+```bash
+./notify "Want a deep-dive report on a mover? Reply with a ticker or contract." \
+  --force-reply --placeholder "e.g. WIF" \
+  --context "token-movers::deep-dive"
+```
+
+The operator's reply comes back as `var="deep-dive:<their text>"` and re-dispatches this skill,
+which rule 0 routes into the single-token branch.
+
+**Dedup — once per day.** Before offering, scan the last ~2 days of `memory/logs/` for a
+`FORCE_REPLY_OFFERED: deep-dive` line dated `${today}`; if present, skip the offer. When you do
+send it, append the marker to `memory/logs/${today}.md` under the run's `### token-movers` entry:
+
+```
+- FORCE_REPLY_OFFERED: deep-dive
+```
 
 ---
 

--- a/skills/token-pick/SKILL.md
+++ b/skills/token-pick/SKILL.md
@@ -134,6 +134,20 @@ sources: cg=ok|fail, dex=ok|fail, poly=ok|fail
 
 If all sources failed, send `TOKEN_PICK_NO_DATA` with the source-status line — do not invent picks from cached intuition.
 
+### 6c. Offer a deep-dive (force-reply — normal-day only)
+
+Only after a **normal-day** send (6a) — never on the skip-day (6b) or the no-data path (weak signals → no pick, so no offer). This skill is `read-only`, so it can't run the deep report itself; instead it offers to hand off to **token-movers** (write mode), which owns the single-token deep report and the `deep-dive:` handler. Because `force_reply` and inline buttons can't share one message, send this as a SEPARATE `./notify` AFTER the 6a pick:
+
+```bash
+./notify "Want a deeper report on a token? Reply with a ticker or contract." \
+  --force-reply --placeholder "e.g. WIF" \
+  --context "token-movers::deep-dive"
+```
+
+The `token-movers::deep-dive` marker routes the operator's reply to **token-movers** as `var="deep-dive:<their text>"`; token-movers strips the `deep-dive:` prefix and produces the single-token deep report.
+
+**Dedup.** token-pick runs once daily, so one offer per run is already once-per-day. Being `read-only`, it can't write a `FORCE_REPLY_OFFERED` marker — but it already reads recent logs, so if today's log already carries a `FORCE_REPLY_OFFERED: deep-dive` line (e.g. token-movers offered earlier today), SKIP this offer to avoid double-nagging.
+
 ### 7. Log to `memory/logs/${today}.md`
 
 ```

--- a/skills/write-tweet/SKILL.md
+++ b/skills/write-tweet/SKILL.md
@@ -6,13 +6,15 @@ var: ""
 tags: [social, content]
 requires: [XAI_API_KEY?]
 ---
-> **${var}** — `[format] [argument]`. Pick one of three formats, then pass its argument. Empty ⇒ **drafts** (standalone tweet drafts). `thread …` ⇒ a multi-tweet **thread**. `remix …` ⇒ **remix** of your past tweets. See Selector below.
+> **${var}** — `[format] [argument]`. Pick one of three formats, then pass its argument. Empty ⇒ **drafts** (standalone tweet drafts). `thread …` ⇒ a multi-tweet **thread**. `remix …` ⇒ **remix** of your past tweets. `revise:<instruction>` ⇒ **revise** the last saved draft (the Telegram force-reply shape, e.g. `revise:make it punchier`). See Selector below.
 
 Read `memory/MEMORY.md` for context on recent articles, digests, topics being tracked, and the operator's tracked handles/token. Each branch then reads its own `memory/logs/` window (drafts: 3 days, thread: 7 days, remix: 14 days) — see the branch.
 
 ## Selector
 
-Parse `${var}` once, before doing anything else:
+**Revise intercept first (Telegram force-reply).** If `${var}` starts with `revise:` → jump straight to **Branch: REVISE** (below) and stop; do **not** token-parse. This is the shape `scripts/telegram-route.sh` sends when the operator replies to a "refine this draft?" prompt — the `revise:` prefix would otherwise fall through to the drafts branch.
+
+Otherwise, parse `${var}` once, before doing anything else:
 
 1. Trim whitespace. Take the **first token** (everything up to the first space **or** the first `:`), lowercased.
 2. If that token is one of `drafts`, `thread`, `remix` → that's the **format**. The **argument** is the remainder of `${var}` after stripping the keyword and one optional following `:` and surrounding whitespace.
@@ -31,6 +33,25 @@ Parse `${var}` once, before doing anything else:
 | `remix 2025-01-01:2025-03-01` | remix | `2025-01-01:2025-03-01` | Remix, explicit date range |
 
 Then dispatch to the matching branch below. Only run the selected branch.
+
+---
+
+# Branch: REVISE (`revise:…` — Telegram force-reply)
+
+The operator tapped the "refine this draft?" prompt and sent a free-text revision instruction. Handle it before any normal generation:
+
+1. **Strip the prefix.** The instruction is `${var#revise:}` (the remainder may itself contain colons — keep them). Trim surrounding whitespace. Example values: `make it punchier`, `drop the emoji`, `lead with the number`.
+2. **Load the last draft.** Read `memory/drafts/write-tweet-latest.md` — the stable path every normal run saves to (see **Save draft + offer revision**). If it's missing or empty, there's nothing to refine yet: send `./notify "Nothing to revise yet — run a tweet draft first, then reply here to refine it."` and **end the run**.
+3. **Apply the instruction.** Re-read `soul/` (`SOUL.md`, `STYLE.md`, examples) for voice, then regenerate the saved draft applying the operator's instruction. Keep the **same format** (drafts / thread / remix) and structure as the saved draft — you're refining it, not starting over — and respect the same character limits and anti-patterns as the originating branch (no hashtags, no emojis unless the draft had them, per-tier/thread length caps).
+4. **Re-save.** Overwrite `memory/drafts/write-tweet-latest.md` with the revised draft, so a further `revise:` refines the newest version.
+5. **Re-send** via `./notify` in the same shape the originating branch uses for its draft, with a first line that flags it as a revision, e.g. `revised (${var#revise:}):` followed by the refreshed draft body. (For multi-line output use `./notify -f <file>`.)
+6. **Re-offer** a further revision (the operator is actively iterating, so this is expected, not a nag — skip the daily dedup guard here):
+   ```bash
+   ./notify "Want another pass? Reply with a change and I'll revise again." \
+     --force-reply --placeholder "e.g. cut the last line" \
+     --context "write-tweet::revise"
+   ```
+7. **Log** under `### write-tweet` with `- **Format:** revise` and the instruction (see **Log**), then **end the run** — do NOT run drafts / thread / remix.
 
 ---
 
@@ -194,7 +215,7 @@ tweet drafts: [topic]
 best: #[n] — [reason]
 ```
 
-Then log (see **Log**, format `drafts`).
+Then **save the draft and offer a revision** (see *Save draft + offer revision*), and log (see **Log**, format `drafts`).
 
 ---
 
@@ -345,7 +366,7 @@ thread: [topic — 3-5 words]
 n/ [tweet n]
 ```
 
-Then log (see **Log**, format `thread`). On a quiet day (top candidate < 3, or empty log), send nothing — just log the no-op.
+Then **save the draft and offer a revision** (see *Save draft + offer revision*), and log (see **Log**, format `thread`). On a quiet day (top candidate < 3, or empty log), send nothing — no draft, no save, no offer — just log the no-op.
 
 ---
 
@@ -506,6 +527,8 @@ source: cache=hit|miss, xai=ok|partial|fail, fetched=N, kept=N, drops=N
 - `REMIX_TWEETS_EMPTY` — XAI returned no usable tweets in the window. Notify once with cause and stop.
 - `REMIX_TWEETS_ERROR` — no handle configured, no `XAI_API_KEY`, OR both XAI queries failed AND WebFetch fallback failed. Notify cause and stop.
 
+On a successful (`OK`/`DEGRADED`) run, after notifying, **save the draft and offer a revision** (see *Save draft + offer revision*) — persist the remix batch to `memory/drafts/write-tweet-latest.md`. Skip the save+offer on `EMPTY`/`ERROR` (nothing was produced).
+
 ### 7. Log (remix)
 
 Append to `memory/logs/${today}.md` under the shared `### write-tweet` heading (see **Log**, format `remix`).
@@ -525,6 +548,28 @@ Save the fetched originals (even the filtered-out ones) to `memory/topics/tweet-
 - `X_HANDLE` (optional) — X handle to search. Falls back to `soul/SOUL.md` Identity section if unset.
 
 ---
+
+## Save draft + offer revision (all branches)
+
+After a normal run (drafts / thread / remix) has produced and notified a draft, do two things so the operator can refine it from Telegram. **Skip both on a no-op** (e.g. a quiet-day thread that produced nothing) — there's nothing to save or offer.
+
+1. **Persist the draft** to a stable path a later `revise:` run can reload:
+   ```bash
+   mkdir -p memory/drafts
+   ```
+   Write the full draft you just sent — the same content as the notification body (all tiers / the whole thread / all remixes) — to `memory/drafts/write-tweet-latest.md`, overwriting any previous file. Only the newest draft is revisable.
+2. **Offer a revision.** Because `force_reply` and inline buttons can't share one Telegram message, send this as a **separate** `./notify` after the draft:
+   ```bash
+   ./notify "Want to refine this draft? Reply with a change and I'll revise it." \
+     --force-reply --placeholder "e.g. make it punchier" \
+     --context "write-tweet::revise"
+   ```
+   The reply routes back as `var="revise:<instruction>"` and re-dispatches this skill into **Branch: REVISE**.
+
+   **Dedup — once per produced draft.** Before offering, scan the last ~2 days of `memory/logs/` for a `FORCE_REPLY_OFFERED: revise` line dated `${today}`; if present, skip the offer. When you send it, append the marker under the run's `### write-tweet` entry:
+   ```
+   - FORCE_REPLY_OFFERED: revise
+   ```
 
 ## Log
 
@@ -549,6 +594,15 @@ Append **one** entry to `memory/logs/${today}.md` under a single `### write-twee
 - **Length:** [n] tweets
 - **Hook:** [first 60 chars of tweet 1]
 - **Notification sent:** yes | no (quiet day)
+```
+
+**Format `revise`:**
+```
+### write-tweet
+- **Format:** revise
+- **Instruction:** [the operator's revision instruction]
+- **Base draft:** memory/drafts/write-tweet-latest.md (reloaded + re-saved)  (or: none — nothing to revise)
+- **Notification sent:** yes
 ```
 
 **Format `remix`:**

--- a/skills/x402-monitor/SKILL.md
+++ b/skills/x402-monitor/SKILL.md
@@ -8,7 +8,7 @@ commits: true
 permissions:
   - contents:write
 ---
-> **${var}** — vertical selector. **Empty** → the default protocol (x402) via `memory/topics/tracked-protocol.md`. A **reserved preset keyword** selects a specialized vertical: `rwa` | `compute` | `mcp` | `agent-displacement` (aliases: `agents`, `displacement`). **Any other value** is treated as a protocol name and must match a stanza in `memory/topics/tracked-protocol.md` (runs the generic Protocol Monitor branch on that protocol).
+> **${var}** — vertical selector. **Empty** → the default protocol (x402) via `memory/topics/tracked-protocol.md`. A **reserved preset keyword** selects a specialized vertical: `rwa` | `compute` | `mcp` | `agent-displacement` (aliases: `agents`, `displacement`). A value starting with `add-topic:` (e.g. `add-topic:RWA tokenization`) is the Telegram force-reply shape — it appends a new protocol stanza to the registry and ends the run without tracking (see **Inbound reply handler** below). **Any other value** is treated as a protocol name and must match a stanza in `memory/topics/tracked-protocol.md` (runs the generic Protocol Monitor branch on that protocol).
 
 Today is ${today}. Read `memory/MEMORY.md` before starting, and scan the last ~3 days of `memory/logs/` — drop anything already reported so you don't re-emit the same signal.
 
@@ -29,6 +29,39 @@ Several fast-moving verticals each need a recurring weekly "is this still spread
 Each vertical keeps its own sources, signal definitions, scoring, output format, and state file. Only the memory read, voice, and selector are shared.
 
 **Original cadences** (wired in `aeon.yml`, not here): Protocol Monitor/x402 = Tue 12:00 UTC; `rwa` = Mon 12:00; `compute` = Sat 11:00; `mcp` = Fri 10:00; `agent-displacement` = Sun 11:00. One invocation runs exactly one vertical, chosen by `${var}`.
+
+## Inbound reply handler + onboarding offer (Telegram force-reply wiring)
+
+**Check this BEFORE the selector.** If `${var}` starts with `add-topic:`, this run is the operator answering the "track a new vertical?" prompt — do NOT run any tracker branch:
+
+1. Strip the prefix and trim: `topic="${var#add-topic:}"` then strip surrounding whitespace. The value is free text and may contain spaces (e.g. `RWA tokenization`, `stablecoin infra`) — keep it whole. Derive `slug` = `topic` lowercased with spaces → hyphens (this is what the selector will normalize `${var}` to when the operator later runs the vertical).
+2. If `topic` is empty/blank after trimming, send a friendly re-ask (no force-reply loop) and END the run:
+   `./notify "No vertical received — reply to the prompt with a protocol or ecosystem to track (for example: RWA tokenization, or stablecoin infra), and I'll add it to the tracked-protocol registry."`
+3. If `slug` collides with a **reserved preset keyword** (`rwa`, `compute`, `mcp`, `agent-displacement`, or their aliases `agents`/`displacement`/`real-world-assets`/`tokenization`/`gpu`/`depin-compute`/`model-context-protocol`/`jobs`), it's already tracked — skip the append and confirm that (see step 6), then END.
+4. Ensure `memory/topics/tracked-protocol.md` exists (create the seed from the **Config** section if missing). **Dedup:** if a `### ${slug}` stanza already exists under `## Verticals`, skip the append. Otherwise append a new protocol-monitor stanza, matching the registry's documented format:
+   ```markdown
+   ### ${slug}   (preset: protocol-monitor)
+   - **Search queries (GitHub):**
+     - `${topic}`
+     - `"${topic}"`
+   - **npm packages to watch:**
+     - `${slug}`
+   - **WebSearch queries:**
+     - `${topic} site:github.com OR site:npmjs.com`
+     - `"${topic}" launch OR integration OR announcement`
+   - **One-line context:** Operator-added vertical (via Telegram force-reply). Tracks ${topic} ecosystem velocity.
+   ```
+   (All three of Search queries / npm packages / WebSearch queries are populated so the stanza is complete and won't trip `PROTOCOL_MONITOR_NO_CONFIG`. If the guessed npm package 404s, Branch A skips it gracefully.)
+5. Log under `### x402-monitor`: `- add-topic: "${topic}" → appended stanza ### ${slug} to memory/topics/tracked-protocol.md`.
+6. Confirm (keep it ≥120 chars so a topic containing a filtered word can't be dropped as a probe) and **END the run**:
+   `./notify "Now tracking \"${topic}\" as a Protocol Monitor vertical — a stanza was added to memory/topics/tracked-protocol.md. Run it any time with var=${slug}, or add a cron for it in aeon.yml."`
+
+**Onboarding offer (normal runs only, deduped).** If `${var}` did NOT start with `add-topic:` AND `memory/topics/tracked-protocol.md` did not exist before this run (i.e. you're about to create the seed) AND the last 3 days of `memory/logs/` contain no `FORCE_REPLY_OFFERED: add-topic` marker for this skill, send one force-reply offer, then continue into the selector below:
+```bash
+./notify "Want the Protocol Monitor to track another vertical beyond x402? Reply with a protocol or ecosystem (e.g. RWA tokenization) and I'll add it to the registry." \
+  --force-reply --placeholder "a topic to track" --context "x402-monitor::add-topic"
+```
+Then log a `FORCE_REPLY_OFFERED: add-topic` marker line under `### x402-monitor` so it doesn't re-offer next run. (The force-reply is a standalone notify, never combined with a digest.)
 
 ## Selector — resolve `${var}` to a branch
 


### PR DESCRIPTION
Both Telegram interactivity layers already existed (router-side is universal; docs + one reference impl) but were barely used — buttons only on `token-movers`, force-reply on **zero** skills. This wires them into the 16 skills where they earn their keep.

## Buttons (snooze / mute / run / url)
- **price-alert** — Snooze/Mute per token (`--mute-key`) + a "Deep report" `run:token-movers:$SYM` button on every alert
- **pr-review** — REVIEW: Re-review + Open-PRs (single-repo scope); SURVEY: Snooze/Mute + Open-queue, with `--mute-key` withheld when a SKILL_WARN_OR_BLOCK/CORE_REVIEW escalation is present
- **onchain-monitor** — per-watch Mute/Snooze buttons + in-skill per-watch mute/snooze filtering (a single `--mute-key` can't do per-item)

## Force-reply (offer + `var=intent:reply` handler)
- **github-monitor** `add-repo`, **onchain-monitor** `add-address` — append to watchlist (offered on empty config)
- **price-alert** `set-target` — register a target from an ATH follow-up
- **token-movers** `deep-dive` — single-token report; **token-pick** (read-only) asks and routes the reply to token-movers
- **repo-scanner → feature** `build` — ship an opportunity via the feature skill
- **idea-forge / idea-pipeline** `pick` — mark an idea chosen-to-build in the shared backlog
- **reg-monitor / deal-flow / x402-monitor** `add-topic` — append a tracked vertical
- **write-tweet / reply-maker / send-email** `revise` — refine the last draft (persisted to `memory/drafts/*-latest.md`); **send-email's revise re-stages a review copy and NEVER auto-sends**

## Gotchas respected
notify.sh drops <120-char messages containing `test/trace/ping/debug`; inline buttons and force_reply can't share one message (offers are separate sends); offers deduped via `FORCE_REPLY_OFFERED` log markers; `callback_data` ≤64 bytes.

## Tests
Router contract (`test_telegram_route.sh`, incl. `reply marker → var=intent:input`), notify-format, skill-category, and capabilities-parity all pass.