### PR TITLE
fix(dashboard): auth CTA per-harness + Sonnet 4.6 default + Anthropic modal tidy

### DIFF
--- a/apps/dashboard/app/page.tsx
+++ b/apps/dashboard/app/page.tsx
@@ -8,7 +8,7 @@ import type {
   UploadResponse, ErrorResponse, PacksResponse, McpServers,
 } from '../lib/types'
 import { postJson, putJson, patchJson, del, scheduleRunRefresh } from '../lib/api-client'
-import { MODELS, AUTH_SECRETS, GROK_AUTH_SECRETS, PACK_BY_KEY, FIRST_PARTY_KEYS, HARNESSES, modelsForHarness } from '../lib/constants'
+import { MODELS, authSecretsForHarness, PACK_BY_KEY, FIRST_PARTY_KEYS, HARNESSES, modelsForHarness } from '../lib/constants'
 import { displayName } from '../lib/utils'
 import TargetCursor from '../components/ui/TargetCursor'
 import { LoadingScreen } from '../components/LoadingScreen'
@@ -136,7 +136,7 @@ export default function Dashboard() {
   useEffect(() => { mainScrollRef.current?.scrollTo({ top: 0 }) }, [view, selectedSkill])
 
   const toggleSkill = async (n: string, en: boolean) => { setBusy(b => ({ ...b, [n]: true })); try { const { ok, data } = await patchJson<SyncResult>('/api/skills', { name: n, enabled: en }); if (ok) { setSkills(s => s.map(sk => sk.name === n ? { ...sk, enabled: en } : sk)); flashSynced(`${displayName(n)} ${en ? 'on duty' : 'off duty'}`, data) } else { flash(`${displayName(n)} update failed`) } } catch { flash('Network error') } finally { setBusy(b => ({ ...b, [n]: false })) } }
-  const runSkill = async (n: string, v?: string, sm?: string) => { if (!secrets.some(s => s.isSet && AUTH_SECRETS.includes(s.name))) { flash('No provider key set - add one in Settings before running skills'); return } setBusy(b => ({ ...b, [`r-${n}`]: true })); try { const { ok, data } = await postJson<ErrorResponse>(`/api/skills/${n}/run`, { var: v || '', model: sm || model }); if (ok) { flash(`${displayName(n)} started`); scheduleRunRefresh(refreshRuns) } else { flash(data.error || 'Failed') } } finally { setBusy(b => ({ ...b, [`r-${n}`]: false })) } }
+  const runSkill = async (n: string, v?: string, sm?: string) => { if (!secrets.some(s => s.isSet && authSecretsForHarness(harness).includes(s.name))) { flash('No provider key set - add one in Settings before running skills'); return } setBusy(b => ({ ...b, [`r-${n}`]: true })); try { const { ok, data } = await postJson<ErrorResponse>(`/api/skills/${n}/run`, { var: v || '', model: sm || model }); if (ok) { flash(`${displayName(n)} started`); scheduleRunRefresh(refreshRuns) } else { flash(data.error || 'Failed') } } finally { setBusy(b => ({ ...b, [`r-${n}`]: false })) } }
   const updateSchedule = async (n: string, s: string) => { try { const { ok, data } = await patchJson<SyncResult>('/api/skills', { name: n, schedule: s }); if (ok) { setSkills(sk => sk.map(x => x.name === n ? { ...x, schedule: s } : x)); flashSynced('Shift updated', data) } } catch { flash('Network error') } }
   const updateVar = async (n: string, v: string) => { try { const { ok, data } = await patchJson<SyncResult>('/api/skills', { name: n, var: v }); if (ok) { setSkills(s => s.map(x => x.name === n ? { ...x, var: v } : x)); flashSynced('Brief updated', data) } } catch { flash('Network error') } }
   const updateSkillModel = async (n: string, m: string) => { try { const { ok, data } = await patchJson<SyncResult>('/api/skills', { name: n, skillModel: m }); if (ok) { setSkills(s => s.map(x => x.name === n ? { ...x, model: m } : x)); flashSynced('Capability updated', data) } } catch { flash('Network error') } }
@@ -189,7 +189,7 @@ export default function Dashboard() {
   // Harness-aware: the grok harness needs its OWN auth (X-account session or an
   // xAI key), so a Claude token doesn't count when grok is selected — that's what
   // surfaces the Auth CTA → "Connect X account". Derived from live `secrets`.
-  const hasModelKey = secrets.some(s => s.isSet && (harness === 'grok' ? GROK_AUTH_SECRETS : AUTH_SECRETS).includes(s.name))
+  const hasModelKey = secrets.some(s => s.isSet && authSecretsForHarness(harness).includes(s.name))
   // Skills visible across the dashboard = first-party skills whose pack is
   // enabled (Core always on), PLUS every community skill — anything in a pack
   // that isn't first-party was installed from another repo on purpose, so it's

--- a/apps/dashboard/components/AuthModal.tsx
+++ b/apps/dashboard/components/AuthModal.tsx
@@ -3,11 +3,13 @@
 import { useState } from 'react'
 import { inputCls } from '../lib/utils'
 
-// Claude Code auth: a Claude subscription token (one-click), or a gateway/
-// Anthropic-compatible key. Anthropic submits no provider, so the backend still
-// prefix-detects (Anthropic-compatible keys, OAuth tokens); every gateway is
-// selected explicitly. `grok` here is the GATEWAY path (Claude Code → xAI); the
-// grok CLI *harness* has its own modal (GrokAuthModal → "Connect X account").
+// Anthropic (Claude Code) auth: a Claude subscription token (one-click), or a
+// gateway/Anthropic-compatible key. Anthropic submits no provider, so the backend
+// still prefix-detects (Anthropic-compatible keys, OAuth tokens); every gateway is
+// selected explicitly. The grok gateway (Claude Code → xAI) is intentionally NOT a
+// menu option — the grok CLI has its own harness + modal (GrokAuthModal → "Connect
+// X account"); an `xai-`-prefixed key pasted under "Anthropic (or compatible)" is
+// still prefix-detected and routed to the xAI gateway.
 const PROVIDER_OPTIONS = [
   { value: '', label: 'Anthropic (or compatible)' },
   { value: 'bankr', label: 'Bankr' },
@@ -15,7 +17,6 @@ const PROVIDER_OPTIONS = [
   { value: 'usepod', label: 'UsePod' },
   { value: 'venice', label: 'Venice' },
   { value: 'surplus', label: 'Surplus Intelligence' },
-  { value: 'grok', label: 'Grok (xAI) — gateway' },
 ]
 
 interface AuthModalProps {
@@ -33,7 +34,7 @@ export function AuthModal({ loading, onClose, onAuth }: AuthModalProps) {
     <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/30 backdrop-blur-sm">
       <div className="bg-aeon-panel border border-[rgba(250,250,250,0.10)] w-full max-w-sm mx-4 p-[var(--space-lg)] shadow-2xl">
         <div className="flex items-center justify-between mb-[var(--space-sm)]">
-          <h2 className="font-display text-xl">Claude Code</h2>
+          <h2 className="font-display text-xl">Anthropic</h2>
           <button onClick={onClose} className="text-primary-35 hover:text-primary-100 text-lg">&times;</button>
         </div>
         <p className="text-xs text-primary-50 font-mono mb-[var(--space-md)]">Connect a Claude subscription token, or pick your key&apos;s provider and paste it below. Routing is automatic - at run time Aeon uses whichever provider keys are set, in priority order.</p>

--- a/apps/dashboard/components/GrokAuthModal.tsx
+++ b/apps/dashboard/components/GrokAuthModal.tsx
@@ -23,7 +23,7 @@ export function GrokAuthModal({ loading, onClose, onGrokAuth }: GrokAuthModalPro
     <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/30 backdrop-blur-sm">
       <div className="bg-aeon-panel border border-[rgba(250,250,250,0.10)] w-full max-w-sm mx-4 p-[var(--space-lg)] shadow-2xl">
         <div className="flex items-center justify-between mb-[var(--space-sm)]">
-          <h2 className="font-display text-xl">Grok Build</h2>
+          <h2 className="font-display text-xl">xAI</h2>
           <button onClick={onClose} className="text-primary-35 hover:text-primary-100 text-lg">&times;</button>
         </div>
         <p className="text-xs text-primary-50 font-mono mb-[var(--space-md)]">Run skills with the grok CLI on your X account. Click below: a browser tab opens to approve on <code className="text-primary-70">accounts.x.ai</code>, and the session is stored for CI. Needs SuperGrok / X Premium+ and the <code className="text-primary-70">grok</code> CLI installed.</p>

--- a/apps/dashboard/lib/constants.ts
+++ b/apps/dashboard/lib/constants.ts
@@ -32,18 +32,30 @@ export function modelsForHarness(harness: string) {
   return harness === 'grok' ? GROK_MODELS : MODELS
 }
 
-// Secret names that authenticate Aeon's model access: Claude's own credentials
-// (OAuth token or Anthropic key), the gateway-provider keys that route Claude
-// through a third party (incl. XAI_API_KEY via the grok gateway), and the grok
-// harness's X-account OAuth session (GROK_CREDENTIALS). Setting any one means the
-// agent can run, so the top-bar "Auth" call-to-action hides once at least one is
-// present. The client derives auth state from /api/secrets by testing membership.
-export const AUTH_SECRETS = ['CLAUDE_CODE_OAUTH_TOKEN', 'ANTHROPIC_API_KEY', 'GROK_CREDENTIALS', ...GATEWAY_SECRET_NAMES]
+// Secret names that authenticate the CLAUDE harness (Claude Code): its own
+// credentials (OAuth token or Anthropic key) or any gateway-provider key that
+// routes Claude through a third party (incl. XAI_API_KEY via the grok gateway).
+// A grok X-account OAuth session (GROK_CREDENTIALS) does NOT authenticate Claude
+// Code, so it is deliberately excluded here.
+export const CLAUDE_AUTH_SECRETS = ['CLAUDE_CODE_OAUTH_TOKEN', 'ANTHROPIC_API_KEY', ...GATEWAY_SECRET_NAMES]
 
 // Auth secrets that specifically authenticate the GROK harness (X-account OAuth
-// session or an xAI key). A Claude token does NOT authenticate grok, so the Auth
-// CTA must key off these when the grok harness is selected.
+// session or an xAI key). A Claude token does NOT authenticate grok, and vice
+// versa — so the top-bar "Auth" CTA and the run-gate must key off the set for the
+// SELECTED harness (see authSecretsForHarness), never the union below.
 export const GROK_AUTH_SECRETS = ['GROK_CREDENTIALS', 'XAI_API_KEY']
+
+// Union of everything that authenticates ANY harness — for coarse "is the repo
+// authed at all" checks only. Harness-specific UI must use authSecretsForHarness()
+// so switching harness re-evaluates against that harness's own credentials.
+export const AUTH_SECRETS = [...CLAUDE_AUTH_SECRETS, 'GROK_CREDENTIALS']
+
+// The auth-secret set that authenticates the given harness. The client derives
+// auth state from /api/secrets by testing membership against this — so the Auth
+// CTA reappears when you switch to a harness whose own auth isn't set yet.
+export function authSecretsForHarness(harness: string): string[] {
+  return harness === 'grok' ? GROK_AUTH_SECRETS : CLAUDE_AUTH_SECRETS
+}
 
 export const DAYS = [
   { label: 'All', value: -1 }, { label: 'Mon', value: 1 }, { label: 'Tue', value: 2 },

--- a/apps/dashboard/lib/constants.ts
+++ b/apps/dashboard/lib/constants.ts
@@ -19,16 +19,16 @@ export const MODELS = [
 // CI), so selecting it would be a footgun. Grok still accepts custom model ids
 // via ~/.grok/config.toml for anyone who needs one.
 export const GROK_MODELS = [
-  { id: 'grok-composer-2.5-fast', label: 'Composer 2.5 Fast' },
+  { id: 'grok-composer-2.5-fast', label: 'Composer 2.5' },
 ]
 
 // Harnesses (agent CLIs). `claude` = Claude Code (default, uses the AI Gateway),
 // labelled "Anthropic" in the UI; `grok` = Grok Build (own X-account/API-key
-// auth, own model list above), labelled "Grok". The `id`s are the on-disk
+// auth, own model list above), labelled "xAI". The `id`s are the on-disk
 // harness values (aeon.yml `harness:`) and never change — only the labels do.
 export const HARNESSES = [
   { id: 'claude', label: 'Anthropic' },
-  { id: 'grok', label: 'Grok' },
+  { id: 'grok', label: 'xAI' },
 ] as const
 
 export function modelsForHarness(harness: string) {

--- a/apps/dashboard/lib/constants.ts
+++ b/apps/dashboard/lib/constants.ts
@@ -1,11 +1,14 @@
 import { GATEWAY_SECRET_NAMES } from './gateway-registry'
 
+// First entry is the default: it's the top of the model picker AND the fallback the
+// harness-switch snap uses (modelsForHarness(...)[0] in app/page.tsx). Keep it in
+// sync with the config default in lib/config.ts and aeon.yml `model:`.
 export const MODELS = [
+  { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
   { id: 'claude-opus-4-8', label: 'Opus 4.8' },
   { id: 'claude-fable-5', label: 'Fable 5' },
   { id: 'claude-opus-4-7', label: 'Opus 4.7' },
   { id: 'claude-sonnet-5', label: 'Sonnet 5' },
-  { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
   { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5' },
 ]
 


### PR DESCRIPTION
A batch of dashboard fixes around the harness/auth UI.

### 1. Auth CTA respects the selected harness (bug fix)
`hasModelKey` (top-bar Auth button) and `runSkill`'s gate tested the **claude** harness against `AUTH_SECRETS`, which includes `GROK_CREDENTIALS`. So with only a grok X-account session set, switching to the Anthropic harness left the Auth button hidden even though a grok session can't authenticate Claude Code. Added `CLAUDE_AUTH_SECRETS` (excludes `GROK_CREDENTIALS`) + `authSecretsForHarness(harness)`, used by both the CTA and the run-gate; `AUTH_SECRETS` stays as the union.

### 2. Default model → Sonnet 4.6
`MODELS` now lists Sonnet 4.6 first, so it's the picker default and the harness-switch-snap fallback (`modelsForHarness()[0]`). Already matched by `lib/config.ts` default and `aeon.yml model:`.

### 3. Anthropic auth modal tidy
- Removed the **Grok (xAI) — gateway** provider option (the grok CLI has its own harness + modal; an `xai-` key pasted under "Anthropic (or compatible)" is still prefix-detected and routed to the xAI gateway — no functionality lost).
- Renamed the modal title **Claude Code → Anthropic** to match the top-bar harness label.

### Verified
Auth-CTA logic simulated across 7 harness/secret scenarios (bug case now shows the CTA; all others unchanged). Model/modal changes are a list reorder + one option removal + a title string. `config.test.ts:72` already asserts the sonnet-4-6 default. Dashboard deps aren't installed locally, so no `tsc`/test run.