### PR TITLE
feat(dashboard): auto-register Telegram commands on token save + re-register button

### DIFF
--- a/.github/workflows/setup-commands.yml
+++ b/.github/workflows/setup-commands.yml
@@ -3,9 +3,15 @@ name: Setup Telegram Commands
 # Pushes the bot's slash-command list (the `/` autocomplete menu) to Telegram and
 # points the message-field menu button at it. Idempotent — safe to re-run anytime.
 #
-# Runs on demand (Actions tab → Run workflow) and automatically whenever aeon.yml
-# changes on main, so the menu never drifts from the set of enabled skills.
-# No-ops silently on forks without TELEGRAM_BOT_TOKEN configured.
+# Triggers:
+#   • automatically the moment TELEGRAM_BOT_TOKEN is saved in the dashboard
+#     (apps/dashboard → POST /api/secrets dispatches this workflow), so first-time
+#     setup needs no manual step;
+#   • the dashboard's "Re-register commands" button (POST /api/telegram/commands);
+#   • whenever aeon.yml changes on main, so the menu never drifts from the enabled set;
+#   • on demand from the Actions tab → Run workflow.
+# All paths read TELEGRAM_BOT_TOKEN server-side (no token pasting). No-ops silently on
+# forks without TELEGRAM_BOT_TOKEN configured.
 
 on:
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Set the secret → channel activates. No code changes needed.
 | Slack | `SLACK_WEBHOOK_URL` | `SLACK_BOT_TOKEN` + `SLACK_CHANNEL_ID` |
 | Email | `SENDGRID_API_KEY` + `NOTIFY_EMAIL_TO` | - |
 
-**Telegram:** Create a bot with @BotFather → get token + chat ID. Then run the **Setup Telegram Commands** workflow (Actions tab) to get slash-command autocomplete (`/skillname` dispatches instantly, no LLM), inline snooze/mute/re-run buttons on notifications, deep links, and stateless follow-up questions. Full guide: [docs/telegram-commands.md](docs/telegram-commands.md).
+**Telegram:** Create a bot with @BotFather → get token + chat ID. Saving the bot token in the dashboard **auto-registers** the slash-command menu (`/skillname` dispatches instantly, no LLM) — no manual step; a **Re-register commands** button re-syncs it after you toggle skills, and every notification carries **Run again / Schedule weekly** quick-action buttons, deep links, and stateless follow-up questions. Full guide: [docs/telegram-commands.md](docs/telegram-commands.md).
 **Discord:** Outbound: Channel → Integrations → Webhooks → Create. Inbound: discord.com/developers → bot → add `channels:history` scope → copy token + channel ID.
 **Slack:** api.slack.com → Create App → Incoming Webhooks → install → copy URL. Inbound: add `channels:history`, `reactions:write` scopes → copy bot token + channel ID.
 **Email:** sendgrid.com/settings/api_keys → Create API Key (Mail Send permission) → add as `SENDGRID_API_KEY`, set `NOTIFY_EMAIL_TO`. Optional repo variables: `NOTIFY_EMAIL_FROM` (default `aeon@notifications.aeon.bot`), `NOTIFY_EMAIL_SUBJECT_PREFIX` (default `[Aeon]`).

--- a/apps/dashboard/app/api/secrets/route.ts
+++ b/apps/dashboard/app/api/secrets/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 import { execFileSync } from 'child_process'
-import { ghAvailable, ghArgsRepo } from '@/lib/gh'
+import { ghAvailable, ghArgsRepo, dispatchCommandsWorkflow } from '@/lib/gh'
 import { syncGatewayProvider } from '@/lib/gateway'
 import { errorResponse } from '@/lib/http'
 import { GATEWAY_SECRET_NAMES } from '@/lib/gateway-registry'
@@ -114,6 +114,13 @@ export async function POST(request: Request) {
     // Keep routing on `auto` so the workflow resolves the provider at run time
     // from whichever keys are set (scripts/llm-gateway.sh) - no per-key pinning.
     if (GATEWAY_SECRET_NAMES.includes(name)) await syncGatewayProvider()
+    // Auto-register the Telegram slash-command menu the moment the bot token lands,
+    // so the operator never has to run the workflow by hand for the first setup.
+    // Best-effort: a dispatch hiccup must not fail the secret save (the manual
+    // "Re-register" button and the aeon.yml push trigger are the fallbacks).
+    if (name === 'TELEGRAM_BOT_TOKEN') {
+      try { dispatchCommandsWorkflow() } catch { /* non-fatal — token is still saved */ }
+    }
     return NextResponse.json({ ok: true })
   } catch (error: unknown) {
     return errorResponse(error, 'Failed to set secret')

--- a/apps/dashboard/app/api/telegram/commands/route.ts
+++ b/apps/dashboard/app/api/telegram/commands/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server'
+import { ghAvailable, dispatchCommandsWorkflow } from '@/lib/gh'
+import { errorResponse } from '@/lib/http'
+
+// Re-register the Telegram slash-command menu. Dispatches the Setup Telegram
+// Commands workflow, which reads TELEGRAM_BOT_TOKEN server-side and calls
+// setMyCommands + setChatMenuButton — no token pasting from the browser. Commands
+// also auto-register the moment the bot token is saved (see /api/secrets); this
+// route is the manual "re-sync after toggling skills" path behind the dashboard button.
+export async function POST() {
+  if (!ghAvailable()) {
+    return NextResponse.json({ error: 'GitHub CLI not authenticated' }, { status: 503 })
+  }
+  try {
+    dispatchCommandsWorkflow()
+    return NextResponse.json({ ok: true })
+  } catch (error: unknown) {
+    return errorResponse(error, 'Failed to start the command-registration workflow')
+  }
+}

--- a/apps/dashboard/components/SecretsPanel.tsx
+++ b/apps/dashboard/components/SecretsPanel.tsx
@@ -180,7 +180,7 @@ export function SecretsPanel({ secrets, skills, busy, repo, focusKey, onFocusHan
                   )}
                 </div>
               ))}
-              {group === 'Telegram' && <TelegramCommandsCard sessionBotToken={sessionBotToken} />}
+              {group === 'Telegram' && <TelegramCommandsCard tokenSet={secrets.some(s => s.name === 'TELEGRAM_BOT_TOKEN' && s.isSet)} />}
               {group === 'Telegram' && <InstantModeCard repo={repo} sessionBotToken={sessionBotToken} />}
             </div>
           </section>

--- a/apps/dashboard/components/TelegramCommandsCard.tsx
+++ b/apps/dashboard/components/TelegramCommandsCard.tsx
@@ -1,77 +1,38 @@
 'use client'
 
-import { useState, useEffect } from 'react'
-import { inputCls } from '../lib/utils'
+import { useState } from 'react'
 import type { TelegramStatus } from '../lib/types'
 
 interface TelegramCommandsCardProps {
-  // Bot token saved earlier in this session - secrets are write-only on GitHub,
-  // so this pre-fills the token for the one-click register.
-  sessionBotToken?: string
+  // Whether TELEGRAM_BOT_TOKEN is set. The workflow reads the token server-side, so
+  // re-registering only makes sense once it exists — the button is disabled until then.
+  tokenSet: boolean
 }
 
-// Telegram command names: 1-32 chars, lowercase a-z / 0-9 / _. Mirrors the mapping
-// in .github/workflows/setup-commands.yml so the button and the workflow agree.
-function cmdName(slug: string): string {
-  return slug.toLowerCase().replace(/-/g, '_').replace(/[^a-z0-9_]/g, '').slice(0, 32)
-}
-
-// A row inside the Telegram credentials list: pushes the enabled skills to
-// Telegram's `/` autocomplete menu in one click, calling setMyCommands straight
-// from the browser (Telegram allows CORS - same trick as the webhook helper).
-// The token never leaves the page except to api.telegram.org.
-export function TelegramCommandsCard({ sessionBotToken }: TelegramCommandsCardProps) {
-  const [botToken, setBotToken] = useState('')
+// A row inside the Telegram credentials list. Slash commands register automatically
+// the moment the bot token is saved (POST /api/secrets dispatches the workflow), and
+// again whenever aeon.yml changes on main — so this is just a manual "re-sync after
+// toggling skills" button. It POSTs to /api/telegram/commands, which dispatches the
+// Setup Telegram Commands workflow (reads the stored TELEGRAM_BOT_TOKEN server-side and
+// calls setMyCommands + setChatMenuButton). No token pasting.
+export function TelegramCommandsCard({ tokenSet }: TelegramCommandsCardProps) {
   const [busy, setBusy] = useState(false)
   const [status, setStatus] = useState<TelegramStatus | null>(null)
 
-  useEffect(() => { if (sessionBotToken) setBotToken(sessionBotToken) }, [sessionBotToken])
-
   const register = async () => {
-    const token = botToken.trim()
-    if (!token) return
+    if (!tokenSet || busy) return
     setBusy(true)
     setStatus(null)
     try {
-      // Pull enabled skills + descriptions from the dashboard's own catalog.
-      const res = await fetch('/api/skills')
-      if (!res.ok) throw new Error('skills')
-      const data = await res.json() as { skills?: Array<{ name: string; description?: string; enabled?: boolean }> }
-
-      const reserved = new Set(['start', 'help', 'settings'])
-      const commands: Array<{ command: string; description: string }> = [
-        { command: 'start', description: 'Introduction and how to run skills' },
-        { command: 'help', description: 'How to use Aeon over Telegram' },
-        { command: 'settings', description: 'List currently enabled skills' },
-      ]
-      for (const s of data.skills ?? []) {
-        if (!s.enabled) continue
-        const c = cmdName(s.name)
-        if (!c || reserved.has(c)) continue
-        reserved.add(c)
-        commands.push({ command: c, description: (s.description || s.name).slice(0, 256) })
-      }
-      // Telegram caps the list at 100.
-      const capped = commands.slice(0, 100)
-
-      // GET with a JSON-encoded query param avoids a CORS preflight (same as the
-      // webhook helper's setWebhook GET).
-      const setRes = await fetch(
-        `https://api.telegram.org/bot${token}/setMyCommands?commands=${encodeURIComponent(JSON.stringify(capped))}`,
-      )
-      const setData = await setRes.json() as { ok: boolean; description?: string }
-      if (!setData.ok) {
-        setStatus({ ok: false, msg: setData.description ?? 'Telegram rejected the request - double-check the token.' })
+      const res = await fetch('/api/telegram/commands', { method: 'POST' })
+      const data = (await res.json().catch(() => ({}))) as { ok?: boolean; error?: string }
+      if (!res.ok || !data.ok) {
+        setStatus({ ok: false, msg: data.error || 'Could not start the registration workflow.' })
         return
       }
-      // Point the message-field menu button at the command list (default type).
-      await fetch(
-        `https://api.telegram.org/bot${token}/setChatMenuButton?menu_button=${encodeURIComponent(JSON.stringify({ type: 'commands' }))}`,
-      )
-      const n = capped.length - 3
-      setStatus({ ok: true, msg: `Registered ${n} skill command${n === 1 ? '' : 's'} + start/help/settings. Type / in Telegram to see them.` })
+      setStatus({ ok: true, msg: 'Registering… the workflow is running in GitHub Actions; your / menu updates in ~30s.' })
     } catch {
-      setStatus({ ok: false, msg: 'Could not reach the skills API or api.telegram.org from the browser - run the Setup Telegram Commands workflow instead.' })
+      setStatus({ ok: false, msg: 'Could not reach the dashboard API.' })
     } finally {
       setBusy(false)
     }
@@ -81,32 +42,28 @@ export function TelegramCommandsCard({ sessionBotToken }: TelegramCommandsCardPr
     <div className="px-[var(--space-md)] py-[var(--space-sm)]">
       <div className="flex items-center gap-2">
         <span className="font-mono text-xs">⌘ Slash commands</span>
-        <span className="text-[10px] font-mono uppercase tracking-[0.14em] text-primary-35">optional</span>
+        <span className="text-[10px] font-mono uppercase tracking-[0.14em] text-primary-35">auto</span>
       </div>
       <div className="text-[11px] text-primary-40 font-mono mb-2">
-        Push enabled skills to Telegram&apos;s <span className="text-primary-70">/</span> autocomplete menu — then{' '}
-        <span className="text-primary-70">/skillname</span> runs instantly, no LLM call.
+        Enabled skills become Telegram <span className="text-primary-70">/</span> commands — then{' '}
+        <span className="text-primary-70">/skillname</span> runs instantly, no LLM call. They register
+        automatically when you save the bot token; use this to re-sync after toggling skills.
       </div>
-      <div className="flex flex-col sm:flex-row gap-2">
-        <input
-          type="password"
-          value={botToken}
-          onChange={(e) => setBotToken(e.target.value)}
-          onKeyDown={(e) => e.key === 'Enter' && register()}
-          placeholder="bot token..."
-          className={inputCls}
-        />
-        <button
-          onClick={register}
-          disabled={!botToken.trim() || busy}
-          className="bg-eva-green text-white text-[11px] px-4 py-2 font-mono hover:opacity-90 transition-opacity disabled:opacity-50 shrink-0"
-        >
-          {busy ? 'Registering…' : 'Register'}
-        </button>
-      </div>
-      <p className="text-[11px] text-primary-35 mt-2">
-        Reads your enabled skills; the token only goes to api.telegram.org, nothing is stored. Re-run after toggling skills.
-      </p>
+      <button
+        onClick={register}
+        disabled={!tokenSet || busy}
+        title={tokenSet
+          ? 'Runs the Setup Telegram Commands workflow — reuses the stored bot token server-side, no pasting.'
+          : 'Set TELEGRAM_BOT_TOKEN first; commands register automatically once it is saved.'}
+        className="bg-eva-green text-white text-[11px] px-4 py-2 font-mono hover:opacity-90 transition-opacity disabled:opacity-50 shrink-0"
+      >
+        {busy ? 'Registering…' : 'Re-register commands'}
+      </button>
+      {!tokenSet && (
+        <p className="text-[11px] text-primary-35 mt-2">
+          Set the bot token above first — commands register automatically once it&apos;s saved.
+        </p>
+      )}
       {status && (
         <p className={`text-[11px] font-mono mt-2 ${status.ok ? 'text-eva-green' : 'text-eva-red/80'}`}>{status.msg}</p>
       )}

--- a/apps/dashboard/lib/gh.ts
+++ b/apps/dashboard/lib/gh.ts
@@ -60,3 +60,14 @@ export function ensureActionsCanOpenPRs(): void {
       { stdio: 'pipe', cwd: REPO_ROOT })
   } catch { /* auto-merge unavailable (e.g. private free repo) — skill falls back to direct merge */ }
 }
+
+// Dispatch the "Setup Telegram Commands" workflow (.github/workflows/setup-commands.yml).
+// It reads TELEGRAM_BOT_TOKEN server-side (where secrets are readable) and pushes the
+// bot's `/` command menu via setMyCommands + setChatMenuButton — no token pasting. Used
+// both by the manual "Re-register" button and automatically right after the bot token is
+// saved. Throws on failure so the API route can surface it; wrap in try/catch for the
+// best-effort auto-register path.
+export function dispatchCommandsWorkflow(): void {
+  execFileSync('gh', ['workflow', 'run', 'setup-commands.yml', ...ghArgsRepo()],
+    { stdio: 'pipe', cwd: REPO_ROOT })
+}

--- a/docs/telegram-commands.md
+++ b/docs/telegram-commands.md
@@ -18,12 +18,20 @@ loop for commands, buttons, or replies.
 
 ## 1. Slash commands & the `/` menu
 
-Push your enabled skills to Telegram as slash commands so the `/` autocomplete
-menu populates and the message-field menu button points at it:
+Your enabled skills become Telegram slash commands so the `/` autocomplete menu
+populates and the message-field menu button points at it. Registration is automatic:
 
-1. Actions tab → **Setup Telegram Commands** → **Run workflow**
+1. **On first setup** — saving `TELEGRAM_BOT_TOKEN` in the dashboard dispatches the
+   registration workflow for you (POST `/api/secrets` → `setup-commands.yml`). No manual step.
+2. **Re-sync after toggling skills** — the dashboard's **Re-register commands** button
+   (Credentials → Telegram) POSTs to `/api/telegram/commands`, which re-runs the same
+   workflow. It reuses the stored token server-side — nothing to paste.
+3. It also re-runs automatically on any push to `aeon.yml`, and can be run by hand from
+   the Actions tab → **Setup Telegram Commands** → **Run workflow**
    (`.github/workflows/setup-commands.yml`).
-2. It also re-runs automatically on any push to `aeon.yml`, so the menu never drifts.
+
+Every path reads `TELEGRAM_BOT_TOKEN` server-side (where secrets are readable) and calls
+`setMyCommands` + `setChatMenuButton` — identical result, no browser token handling.
 
 Command names can only use `a-z`, `0-9`, `_` — so a skill dir `deep-research`
 becomes `/deep_research`. The router inverts `_`→`-` when it dispatches.


### PR DESCRIPTION
## What

Reworks slash-command registration into a **server-side, no-paste** flow, as requested:

1. **Removed the field** — the bot-token input + browser `setMyCommands` are gone from `TelegramCommandsCard`. It's now a single **Re-register commands** button.
2. **Auto-init on first setup** — saving `TELEGRAM_BOT_TOKEN` in the dashboard now dispatches the *Setup Telegram Commands* workflow automatically, so commands register the moment the token lands. No manual step.
3. **Re-register system + button** — a new `POST /api/telegram/commands` dispatches the same workflow (the "Option A" path: reuses the stored secret server-side, no pasting). The settings button calls it; it's disabled until the token is set.

## How

- **`lib/gh.ts`** — `dispatchCommandsWorkflow()` runs `gh workflow run setup-commands.yml`. Shared by both entry points.
- **`app/api/secrets/route.ts`** — after `gh secret set`, if `name === 'TELEGRAM_BOT_TOKEN'`, dispatch the workflow. **Best-effort** (wrapped in try/catch) so a dispatch hiccup never fails the secret save — the button + the `aeon.yml`-push trigger are fallbacks.
- **`app/api/telegram/commands/route.ts`** *(new)* — `POST` → `dispatchCommandsWorkflow()`; 503 if `gh` isn't authed, surfaces dispatch errors.
- **`components/TelegramCommandsCard.tsx`** — token field → single button that POSTs to the new route; shows "running in Actions, updates in ~30s". Takes a `tokenSet` prop (disabled until the token exists).
- **`components/SecretsPanel.tsx`** — passes `tokenSet` (derived from `secrets`) instead of `sessionBotToken`. `sessionBotToken` is still used by the chat-ID helper + Instant Mode card, so it's untouched.

Every path reads `TELEGRAM_BOT_TOKEN` server-side and calls `setMyCommands` + `setChatMenuButton` — identical result to the old browser register, just no token handling in the page.

## Verification

- Import/export parity checked by hand (`dispatchCommandsWorkflow`/`ghAvailable` exported; `errorResponse(error, fallback)` signature; `@/*` alias; route mirrors `soul/build`). Dashboard `node_modules` isn't installed locally so `tsc` wasn't run — please let CI typecheck confirm.
- `saveSecret` optimistically flips `isSet: true`, so the button enables immediately after the token is saved.
- Workflow only adds trigger paths (comment + existing `workflow_dispatch`); `setMyCommands` logic unchanged.

Docs: `setup-commands.yml` header, `README.md`, and `docs/telegram-commands.md` §1 updated to describe the auto-init + button.