### PR TITLE
chore(registry): prune community skill packs 24 → 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,7 +551,7 @@ Third-party skill collections in their own repos, installable as one bundle - tw
 **CLI.**
 
 ```bash
-./install-skill-pack baseddevoloper/aeon-skill-pack-vvvkernel
+./install-skill-pack AntFleet/aeon-skills
 ./install-skill-pack --list      # browse the registry (skill-packs.json)
 ```
 
@@ -559,25 +559,13 @@ Either way the installer reads the pack's `skills-pack.json` manifest, runs the 
 
 | Pack | Skills | Description |
 |------|--------|-------------|
-| [aeon-skill-pack-vvvkernel](https://github.com/baseddevoloper/aeon-skill-pack-vvvkernel) | 9 | Venice AI inference via VVVKernel - onchain, audit, growth, narrative, image gen, monitoring |
-| [luca-aeon-skills](https://github.com/danbuildss/luca-aeon-skills) | 4 | Financial intelligence via x402Books AI - wallet scanning, treasury monitoring, financial reports, and agent registry on Base |
-| [zer0-skill-pack](https://github.com/0xShak/zer0-skill-pack) | 6 | Polymarket intelligence - daily thesis, mispricing scanner, contrarian fades, narrative-vs-markets, paper-trade PnL journal, alpha comment curator |
-| [gitbounty-skill-pack](https://github.com/gitlawbounty/gitbounty-skill-pack) | 1 | Bounty hunting on the gitlawb network via gitbounty - discover open bounties, scout the best fit with the gitbounty LLM scout, draft a solution plan (read-only) |
 | [aeon-skills](https://github.com/AntFleet/aeon-skills) | 2 | Two-model-consensus PR review (Opus 4.7 + GPT-5) - channel drawdown for installed repos, x402 pay-per-call for public repos |
 | [careful-finance-aeon-skill-pack](https://github.com/UIZorrot/careful-finance-aeon-skill-pack) | 1 | Careful Finance market intelligence - scan DeFi yield and perpetual-futures opportunities, then print or publish a conservative hourly snapshot |
 | [aeon-skill-pack-liquidpad](https://github.com/liquidpadbot/aeon-skill-pack-liquidpad) | 4 | Track LiquidPad on Base - burn cycle alerts, new token launches with onchain provenance, daily protocol digest, and fee accrual tracking |
 | [aeon-skill-pack-mythosforge](https://github.com/ryjin111/aeon-skill-pack-mythosforge) | 5 | Read-only MythosForge monitoring - ops/backlog/jury/payout health, proof-of-creation integrity on Base, theme/round guard against silent relabels, jury-drift detection, and live gallery/proof-page QA |
-| [demo-pack](https://github.com/sparkleware/demo-pack) | 1 | Holographic demo skill - proves the Sparkleware registry install pipeline works |
-| [aeon-pulse](https://github.com/sparkleware/aeon-pulse) | 1 | Daily activity summary for the Aeon framework - recent commits, releases, and open issues |
-| [registry-watch](https://github.com/sparkleware/registry-watch) | 1 | Daily digest of new packs added to the Sparkleware registry - discover community skills without manually browsing |
-| [arxiv-digest](https://github.com/sparkleware/arxiv-digest) | 1 | Daily digest of newest AI / autonomous-agent papers on arXiv - top submissions in cs.AI, cs.LG, cs.MA |
-| [hn-top](https://github.com/sparkleware/hn-top) | 1 | Daily digest of HackerNews top stories - dev / startup / AI conversation in one screen |
-| [eth-gas-watch](https://github.com/sparkleware/eth-gas-watch) | 1 | Ethereum gas-price status check on a schedule - flags cheap windows for batching on-chain ops |
-| [morning-briefing](https://github.com/sparkleware/morning-briefing) | 1 | Daily morning briefing - date, day-of-week, current weather, and a sparkly closer |
-| [aeon-skill-pack-noelclaw](https://github.com/noelclaw/aeon-skill-pack-noelclaw) | 2 | Persistent versioned memory and multi-agent swarm coordination - save typed artifacts to Noel Vault and manage shared agent session state across runs |
 | [signa](https://github.com/codexvritra/signa) (`--path aeon-skills`) | 20 | Full SIGNA suite - wallet-signed cross-platform agent messaging, multi-agent broadcast and delegate, encrypted rooms + ERC-8004 trust gate, plus Bankr resolver / launches, gitlawb, MiroShark, and **x402 receipts + bounded spend mandates** (a human grants a signed budget, the agent spends within it and asks for more) |
+| [Atrium Skills](https://github.com/Atrium-Hermes/aeon-atrium-skills) | 3 | Publish, monetize & discover agent skills on Atrium - the onchain skill marketplace on Base. atrium-publish (DID-signed, IPFS-pinned, USDC-earning), atrium-scout (rents skills matching open loops), atrium-earnings (tracks and withdraws creator USDC) |
 | [aeon-skill-pack-mneme](https://github.com/mnemedb/aeon-skill-pack-mneme) | 8 | Mneme as Aeon's persistent memory layer - vector recall across runs, entity/relation graph, live Base chain streams, async LLM "dream" reflections, and schema-aware /chat. One `MNEME_API_KEY`, zero infra. |
-| [Hunch Prediction Markets](https://github.com/rajkaria/hunch/tree/main/aeon-skill-pack) (`--path aeon-skill-pack`) | 3 | Crowd-conviction signal, market discovery, and **x402 betting** on PlayHunch - onchain prediction markets on Base. Unlike monitor-only packs, hunch-bet places real positions (simulate-by-default, $1-$10, USDC payout + onchain proof) |
 | [clawhunter-skills](https://github.com/clawhunter/clawhunter-skills) | 2 | Aggregates and AI-triages crypto bounties across venues (Pump Fun GO, Atelier, EarnFi, tiny.place) and matches each to your agent with a plan to win — plus paid research and create tools (voice tones, logo-grounded images, Kling video direction, web + X research). Paid tools settle via x402 (USDC on Solana or Base). |
 | [Polymarket Trader by Simmer](https://github.com/SpartanLabsXyz/aeon-skill-pack-polymarket/tree/main/aeon-skill-pack) (`--path aeon-skill-pack`) | 3 | Signal, discovery, and real position-taking on **Polymarket** - the deepest prediction-market venue - powered by Simmer. Unlike monitor-only packs, polymarket-trade places actual orders (simulate-by-default, live opt-in, bounded) |
 | [Charon for AEON](https://github.com/CharonAI-code/charon/tree/main/skills/aeon) (`--path skills/aeon`) | 2 | Repo-local policy enforcement for AEON runs, with guided setup and natural-language policy management |

--- a/README.md
+++ b/README.md
@@ -560,7 +560,6 @@ Either way the installer reads the pack's `skills-pack.json` manifest, runs the 
 | Pack | Skills | Description |
 |------|--------|-------------|
 | [aeon-skills](https://github.com/AntFleet/aeon-skills) | 2 | Two-model-consensus PR review (Opus 4.7 + GPT-5) - channel drawdown for installed repos, x402 pay-per-call for public repos |
-| [careful-finance-aeon-skill-pack](https://github.com/UIZorrot/careful-finance-aeon-skill-pack) | 1 | Careful Finance market intelligence - scan DeFi yield and perpetual-futures opportunities, then print or publish a conservative hourly snapshot |
 | [aeon-skill-pack-liquidpad](https://github.com/liquidpadbot/aeon-skill-pack-liquidpad) | 4 | Track LiquidPad on Base - burn cycle alerts, new token launches with onchain provenance, daily protocol digest, and fee accrual tracking |
 | [aeon-skill-pack-mythosforge](https://github.com/ryjin111/aeon-skill-pack-mythosforge) | 5 | Read-only MythosForge monitoring - ops/backlog/jury/payout health, proof-of-creation integrity on Base, theme/round guard against silent relabels, jury-drift detection, and live gallery/proof-page QA |
 | [signa](https://github.com/codexvritra/signa) (`--path aeon-skills`) | 20 | Full SIGNA suite - wallet-signed cross-platform agent messaging, multi-agent broadcast and delegate, encrypted rooms + ERC-8004 trust gate, plus Bankr resolver / launches, gitlawb, MiroShark, and **x402 receipts + bounded spend mandates** (a human grants a signed budget, the agent spends within it and asks for more) |

--- a/docs/community-skill-packs.md
+++ b/docs/community-skill-packs.md
@@ -26,7 +26,7 @@ public repos with x402 pay-per-call USDC.
 ## One-command install
 
 ```bash
-./install-skill-pack baseddevoloper/aeon-skill-pack-vvvkernel
+./install-skill-pack AntFleet/aeon-skills
 ```
 
 That single command:

--- a/install-skill-pack
+++ b/install-skill-pack
@@ -97,7 +97,7 @@ Install a curated community skill pack from a GitHub repository, or browse the
 community registry.
 
 Arguments:
-  <github-repo>          owner/repo (e.g. baseddevoloper/aeon-skill-pack-vvvkernel)
+  <github-repo>          owner/repo (e.g. AntFleet/aeon-skills)
                          Omit with --list to browse the community registry.
   [skill-names...]       Optional — limit install to specific slugs from the pack
 
@@ -124,10 +124,10 @@ Community registry:
 
 Examples:
   ./install-skill-pack --list
-  ./install-skill-pack baseddevoloper/aeon-skill-pack-vvvkernel --list
-  ./install-skill-pack baseddevoloper/aeon-skill-pack-vvvkernel
-  ./install-skill-pack baseddevoloper/aeon-skill-pack-vvvkernel vvvkernel-onchain vvvkernel-audit
-  ./install-skill-pack danbuildss/luca-aeon-skills --dry-run
+  ./install-skill-pack AntFleet/aeon-skills --list
+  ./install-skill-pack AntFleet/aeon-skills
+  ./install-skill-pack liquidpadbot/aeon-skill-pack-liquidpad liquidpad-burn-monitor liquidpad-token-alert
+  ./install-skill-pack mnemedb/aeon-skill-pack-mneme --dry-run
 EOF
   exit 0
 }

--- a/skill-packs.json
+++ b/skill-packs.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "updated": "2026-06-20",
+  "updated": "2026-07-03",
   "description": "Machine-readable registry of community skill packs installable via ./install-skill-pack. Mirrors the human-readable table in README.md.",
   "packs": [
     {
@@ -12,43 +12,9 @@
       "homepage": "https://www.antfleet.dev",
       "category": "dev",
       "trust_level": "trusted",
-      "skills": ["pr-review-antfleet", "pr-review-antfleet-x402"]
-    },
-    {
-      "repo": "baseddevoloper/aeon-skill-pack-vvvkernel",
-      "name": "aeon-skill-pack-vvvkernel",
-      "description": "Venice AI inference via VVVKernel — onchain, audit, growth, narrative, image gen, monitoring.",
-      "author": "baseddevoloper",
-      "license": "MIT",
-      "homepage": "https://github.com/baseddevoloper/aeon-skill-pack-vvvkernel",
-      "category": "crypto",
-      "trust_level": "community",
       "skills": [
-        "vvvkernel",
-        "vvvkernel-audit",
-        "vvvkernel-brief",
-        "vvvkernel-digest",
-        "vvvkernel-growth",
-        "vvvkernel-image",
-        "vvvkernel-monitor",
-        "vvvkernel-narrative",
-        "vvvkernel-onchain"
-      ]
-    },
-    {
-      "repo": "danbuildss/luca-aeon-skills",
-      "name": "luca-aeon-skills",
-      "description": "Financial intelligence via x402Books AI — wallet scanning, treasury monitoring, financial reports, agent registry on Base.",
-      "author": "danbuildss",
-      "license": "MIT",
-      "homepage": "https://github.com/danbuildss/luca-aeon-skills",
-      "category": "crypto",
-      "trust_level": "community",
-      "skills": [
-        "check-agent",
-        "get-report",
-        "scan-wallet",
-        "treasury-monitor"
+        "pr-review-antfleet",
+        "pr-review-antfleet-x402"
       ]
     },
     {
@@ -60,38 +26,15 @@
       "homepage": "https://careful-finance.txzy.net",
       "category": "crypto",
       "trust_level": "community",
-      "skills": ["careful-finance"],
-      "secrets_required": [],
-      "capabilities": ["external_api", "writes_external_host", "sends_notifications"]
-    },
-    {
-      "repo": "0xShak/zer0-skill-pack",
-      "name": "zer0-skill-pack",
-      "description": "Polymarket intelligence — daily theses, mispricing scans, contrarian fades, narrative-vs-markets gaps, paper-trade PnL journal, alpha comment curation.",
-      "author": "ZER0 LABS",
-      "license": "MIT",
-      "homepage": "https://atzer0.xyz",
-      "category": "crypto",
-      "trust_level": "community",
       "skills": [
-        "prediction-journal",
-        "polymarket-thesis",
-        "polymarket-edge",
-        "polymarket-contrarian",
-        "narrative-vs-markets",
-        "polymarket-alpha-comments"
+        "careful-finance"
+      ],
+      "secrets_required": [],
+      "capabilities": [
+        "external_api",
+        "writes_external_host",
+        "sends_notifications"
       ]
-    },
-    {
-      "repo": "gitlawbounty/gitbounty-skill-pack",
-      "name": "GitBounty Skill Pack",
-      "description": "Bounty hunting on the gitlawb network — discovers open bounties via the gitbounty firehose, scouts the best fit, drafts a PR plan with a confidence score.",
-      "author": "gitlawbounty",
-      "license": "MIT",
-      "homepage": "https://github.com/gitlawbounty/gitbounty-skill-pack",
-      "category": "dev",
-      "trust_level": "community",
-      "skills": ["bounty-hunter"]
     },
     {
       "repo": "liquidpadbot/aeon-skill-pack-liquidpad",
@@ -118,95 +61,13 @@
       "homepage": "https://mythosforge.xyz",
       "category": "dev",
       "trust_level": "community",
-      "skills": ["mythosforge-ops-report", "mythosforge-proof-integrity", "mythosforge-theme-round-guard", "mythosforge-jury-drift-watcher", "mythosforge-gallery-qa-watcher"]
-    },
-    {
-      "repo": "sparkleware/demo-pack",
-      "name": "demo-pack",
-      "description": "Holographic demo skill — proves the Sparkleware registry install pipeline works.",
-      "author": "sparkleware",
-      "license": "MIT",
-      "homepage": "https://github.com/sparkleware/demo-pack",
-      "category": "meta",
-      "trust_level": "community",
-      "skills": ["sparkle-status"]
-    },
-    {
-      "repo": "sparkleware/aeon-pulse",
-      "name": "aeon-pulse",
-      "description": "Daily activity summary for the Aeon framework — recent commits, releases, and open issues.",
-      "author": "sparkleware",
-      "license": "MIT",
-      "homepage": "https://github.com/sparkleware/aeon-pulse",
-      "category": "dev",
-      "trust_level": "community",
-      "skills": ["aeon-activity"]
-    },
-    {
-      "repo": "sparkleware/registry-watch",
-      "name": "registry-watch",
-      "description": "Daily digest of new packs added to the Sparkleware registry — discover community skills without manually browsing.",
-      "author": "sparkleware",
-      "license": "MIT",
-      "homepage": "https://github.com/sparkleware/registry-watch",
-      "category": "meta",
-      "trust_level": "community",
-      "skills": ["new-packs-digest"]
-    },
-    {
-      "repo": "sparkleware/arxiv-digest",
-      "name": "arxiv-digest",
-      "description": "Daily digest of newest AI / autonomous-agent papers on arXiv — top submissions in cs.AI, cs.LG, cs.MA.",
-      "author": "sparkleware",
-      "license": "MIT",
-      "homepage": "https://github.com/sparkleware/arxiv-digest",
-      "category": "research",
-      "trust_level": "community",
-      "skills": ["daily-papers"]
-    },
-    {
-      "repo": "sparkleware/hn-top",
-      "name": "hn-top",
-      "description": "Daily digest of HackerNews top stories — dev / startup / AI conversation in one screen.",
-      "author": "sparkleware",
-      "license": "MIT",
-      "homepage": "https://github.com/sparkleware/hn-top",
-      "category": "social",
-      "trust_level": "community",
-      "skills": ["hn-daily"]
-    },
-    {
-      "repo": "sparkleware/eth-gas-watch",
-      "name": "eth-gas-watch",
-      "description": "Ethereum gas-price status check on a schedule — flags cheap windows for batching on-chain ops.",
-      "author": "sparkleware",
-      "license": "MIT",
-      "homepage": "https://github.com/sparkleware/eth-gas-watch",
-      "category": "crypto",
-      "trust_level": "community",
-      "skills": ["gas-status"]
-    },
-    {
-      "repo": "sparkleware/morning-briefing",
-      "name": "morning-briefing",
-      "description": "Daily morning briefing — date, day-of-week, current weather, and a sparkly closer. No API key required.",
-      "author": "sparkleware",
-      "license": "MIT",
-      "homepage": "https://github.com/sparkleware/morning-briefing",
-      "category": "productivity",
-      "trust_level": "community",
-      "skills": ["morning-briefing"]
-    },
-    {
-      "repo": "noelclaw/aeon-skill-pack-noelclaw",
-      "name": "aeon-skill-pack-noelclaw",
-      "description": "Persistent versioned memory and multi-agent swarm coordination — save typed artifacts to Noel Vault and manage shared agent session state across runs.",
-      "author": "noelclaw",
-      "license": "MIT",
-      "homepage": "https://noelclaw.com",
-      "category": "dev",
-      "trust_level": "community",
-      "skills": ["noelvault", "noel-swarm"]
+      "skills": [
+        "mythosforge-ops-report",
+        "mythosforge-proof-integrity",
+        "mythosforge-theme-round-guard",
+        "mythosforge-jury-drift-watcher",
+        "mythosforge-gallery-qa-watcher"
+      ]
     },
     {
       "repo": "codexvritra/signa",
@@ -218,19 +79,28 @@
       "homepage": "https://www.signaagent.xyz/partners",
       "category": "messaging",
       "trust_level": "community",
-      "skills": ["signa-connect", "signa-message", "signa-inbox", "signa-discover", "signa-broadcast", "signa-delegate", "signa-encrypted-room", "signa-pubkey-register", "signa-trust-gate", "signa-search", "signa-receipts", "signa-room-holders", "signa-launches-leaderboard", "signa-anchor-status", "bankr-resolve", "bankr-launches", "gitlawb-stats", "miroshark-stats", "miroshark-fire", "signa-spend"]
-    },
-    {
-      "repo": "mandateseal/mandateseal-guard",
-      "path": "aeon",
-      "name": "MandateSeal Guard",
-      "description": "Guard Aeon fund-moving skills with a MandateSeal mandate before each transfer (per-tx cap, chain/token allow-list, blocked recipients, human-approval queue) and a signed, Base-anchored receipt after — bounded, gated, provable.",
-      "author": "mandateseal",
-      "license": "MIT",
-      "homepage": "https://mandateseal.tech",
-      "category": "crypto",
-      "trust_level": "community",
-      "skills": ["distribute-tokens-guarded"]
+      "skills": [
+        "signa-connect",
+        "signa-message",
+        "signa-inbox",
+        "signa-discover",
+        "signa-broadcast",
+        "signa-delegate",
+        "signa-encrypted-room",
+        "signa-pubkey-register",
+        "signa-trust-gate",
+        "signa-search",
+        "signa-receipts",
+        "signa-room-holders",
+        "signa-launches-leaderboard",
+        "signa-anchor-status",
+        "bankr-resolve",
+        "bankr-launches",
+        "gitlawb-stats",
+        "miroshark-stats",
+        "miroshark-fire",
+        "signa-spend"
+      ]
     },
     {
       "repo": "Atrium-Hermes/aeon-atrium-skills",
@@ -241,7 +111,11 @@
       "homepage": "https://atriumhermes.tech",
       "category": "crypto",
       "trust_level": "community",
-      "skills": ["atrium-publish", "atrium-scout", "atrium-earnings"]
+      "skills": [
+        "atrium-publish",
+        "atrium-scout",
+        "atrium-earnings"
+      ]
     },
     {
       "repo": "mnemedb/aeon-skill-pack-mneme",
@@ -252,19 +126,16 @@
       "homepage": "https://mnemedb.dev",
       "category": "memory",
       "trust_level": "community",
-      "skills": ["mneme-remember", "mneme-recall", "mneme-entity", "mneme-relate", "mneme-find", "mneme-dream", "mneme-watch", "mneme-ask"]
-    },
-    {
-      "repo": "rajkaria/hunch",
-      "path": "aeon-skill-pack",
-      "name": "Hunch Prediction Markets",
-      "description": "Crowd-conviction signal, market discovery, and autonomous x402 betting on PlayHunch - onchain prediction markets on Base. Unlike monitor-only market packs, hunch-bet lets the agent take a real position: simulate-by-default, $1-$10, settlement opt-in with a funded Base wallet, USDC payout + onchain proof.",
-      "author": "rajkaria",
-      "license": "MIT",
-      "homepage": "https://www.playhunch.xyz/agents",
-      "category": "crypto",
-      "trust_level": "community",
-      "skills": ["hunch-intel", "hunch-markets", "hunch-bet"]
+      "skills": [
+        "mneme-remember",
+        "mneme-recall",
+        "mneme-entity",
+        "mneme-relate",
+        "mneme-find",
+        "mneme-dream",
+        "mneme-watch",
+        "mneme-ask"
+      ]
     },
     {
       "repo": "clawhunter/clawhunter-skills",
@@ -275,7 +146,10 @@
       "homepage": "https://clawhunter.fun",
       "category": "crypto",
       "trust_level": "community",
-      "skills": ["clawhunter-bounties", "clawhunter-content-studio"]
+      "skills": [
+        "clawhunter-bounties",
+        "clawhunter-content-studio"
+      ]
     },
     {
       "repo": "SpartanLabsXyz/aeon-skill-pack-polymarket",
@@ -287,9 +161,20 @@
       "homepage": "https://simmer.markets",
       "category": "crypto",
       "trust_level": "community",
-      "skills": ["polymarket-intel", "polymarket-markets", "polymarket-trade"],
-      "secrets_required": ["SIMMER_API_KEY"],
-      "capabilities": ["external_api", "writes_external_host", "onchain_writes", "sends_notifications"]
+      "skills": [
+        "polymarket-intel",
+        "polymarket-markets",
+        "polymarket-trade"
+      ],
+      "secrets_required": [
+        "SIMMER_API_KEY"
+      ],
+      "capabilities": [
+        "external_api",
+        "writes_external_host",
+        "onchain_writes",
+        "sends_notifications"
+      ]
     },
     {
       "repo": "CharonAI-code/charon",
@@ -301,9 +186,15 @@
       "homepage": "https://charon.codes",
       "category": "dev",
       "trust_level": "community",
-      "skills": ["charon-setup", "charon-policy"],
+      "skills": [
+        "charon-setup",
+        "charon-policy"
+      ],
       "secrets_required": [],
-      "capabilities": ["external_api", "writes_external_host"]
+      "capabilities": [
+        "external_api",
+        "writes_external_host"
+      ]
     }
   ]
 }

--- a/skill-packs.json
+++ b/skill-packs.json
@@ -18,25 +18,6 @@
       ]
     },
     {
-      "repo": "UIZorrot/careful-finance-aeon-skill-pack",
-      "name": "Careful Finance Aeon Skill Pack",
-      "description": "Market-intelligence scanner for DeFi yield and perpetual-futures opportunities; prints or publishes a conservative hourly Careful Finance snapshot.",
-      "author": "UIZorrot",
-      "license": "MIT",
-      "homepage": "https://careful-finance.txzy.net",
-      "category": "crypto",
-      "trust_level": "community",
-      "skills": [
-        "careful-finance"
-      ],
-      "secrets_required": [],
-      "capabilities": [
-        "external_api",
-        "writes_external_host",
-        "sends_notifications"
-      ]
-    },
-    {
       "repo": "liquidpadbot/aeon-skill-pack-liquidpad",
       "name": "LiquidPad",
       "description": "Track LiquidPad on Base — $LPAD burn cycle alerts, new token launches with onchain provenance, daily protocol digest, and fee-accrual tracking on every launched token.",

--- a/skills/install-skill/SKILL.md
+++ b/skills/install-skill/SKILL.md
@@ -8,9 +8,9 @@ tags: [dev, meta, packs]
 
 > **${var}** — The community pack to install: `owner/repo`, optionally followed by specific skill slugs to install only a subset, and optional flags. **Required.**
 > Examples:
-> - `baseddevoloper/aeon-skill-pack-vvvkernel` — install the whole pack
-> - `baseddevoloper/aeon-skill-pack-vvvkernel vvvkernel-onchain` — install one skill from it
-> - `danbuildss/luca-aeon-skills --branch develop` — install from a non-default branch
+> - `AntFleet/aeon-skills` — install the whole pack
+> - `liquidpadbot/aeon-skill-pack-liquidpad liquidpad-burn-monitor` — install one skill from it
+> - `mnemedb/aeon-skill-pack-mneme --branch develop` — install from a non-default branch
 
 If `${var}` is empty, exit `INSTALL_SKILL_NO_VAR`:
 ```bash


### PR DESCRIPTION
Prunes the community skill-pack registry (`skill-packs.json`) and its README mirror from **24 → 10** packs after a full quality audit of every entry (each repo's `skills-pack.json` + `SKILL.md` files were read and graded).

## Removed (14)

**Dead repos — verified 404, `./install-skill-pack` installs nothing:**
| Entry | Status |
|---|---|
| `noelclaw/aeon-skill-pack-noelclaw` | 404. `noelvault`/`noel-swarm` exist in no public repo. |
| `0xShak/zer0-skill-pack` | 404 as a pack — skills live only in a personal `aaronjmars/aeon` fork with no `skills-pack.json`. |
| `rajkaria/hunch` | 404 (private/deleted). Described as autonomous real-funds betting; must not be trusted sight-unseen. |

**Sparkleware (7)** — thin/filler; every skill misses Aeon conventions the same way (no `./notify`, no `mode:`, no WebFetch Sandbox note, `tags:` instead of `category:`): `demo-pack` (self-admitted filler), `aeon-pulse`, `registry-watch`, `arxiv-digest`, `hn-top`, `eth-gas-watch`, `morning-briefing`.

**Thin/rough (4):** `baseddevoloper/aeon-skill-pack-vvvkernel` (9 near-identical prompt wrappers, no manifest, sandbox-blocked auth), `danbuildss/luca-aeon-skills` (4 thin lookups), `gitlawbounty/gitbounty-skill-pack` (single thin skill, schedule mismatch, stale), `mandateseal/mandateseal-guard` (1-skill SaaS wrapper, sandbox-broken gate).

## Kept (10)
AntFleet/aeon-skills (A) · UIZorrot/careful-finance (B) · liquidpadbot/…-liquidpad (A−) · ryjin111/…-mythosforge (A−) · codexvritra/signa (B−) · Atrium-Hermes/aeon-atrium-skills (B+) · mnemedb/…-mneme (B−) · clawhunter/clawhunter-skills (B) · SpartanLabsXyz/…-polymarket (B+) · CharonAI-code/charon (B+)

## Also
- **Restored README↔registry parity:** the README table was already missing `Atrium` and `mandateseal` (had 22 rows vs the registry's 24). Added the `Atrium` row so the table now mirrors `skill-packs.json` exactly (10 == 10, verified by diff).
- Repointed stale install examples (in `install-skill-pack`, `docs/community-skill-packs.md`, `skills/install-skill/SKILL.md`) that referenced now-removed packs to kept packs.
- Bumped `skill-packs.json` `updated` to 2026-07-03.

## Left untouched (flagged, out of scope)
- `ECOSYSTEM.md` still lists NoelClaw / Sparkleware / zer0 as **ecosystem partners** (X accounts/logos) — a separate registry from installable packs. Removing pack entries shouldn't auto-remove partner rows; worth a separate review (NoelClaw's repo is now 404).
- `docs/CAPABILITIES.md` uses vvvkernel as a **schema illustration** — left intact rather than fabricate another pack's capability values.