### PR TITLE
chore: add FUNDING.yml (Sponsor button)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,7 @@
+# These are supported funding model platforms
+
+custom:
+  - "https://bankr.bot/terminal/agents/aeon"
+  - "https://www.aeon.fun/"
+  - "https://dexscreener.com/base/0x4a9b9e13975d26f4e3e17c655593bb82145dd4452aedafb826d856b817c9cfd4"
+  - "https://basescan.org/token/0xBf8E8f0e8866a7052F948C16508644347c57aba3"


### PR DESCRIPTION
Adds `.github/FUNDING.yml` with 4 custom funding links (Bankr terminal, aeon.fun, DexScreener pool, BaseScan token) so aeon shows a Sponsor button.