### PR TITLE
fix(dashboard): silence npm allow-scripts warning on ./aeon

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -30,5 +30,10 @@
   },
   "overrides": {
     "postcss": "^8.5.10"
+  },
+  "allowScripts": {
+    "esbuild": true,
+    "fsevents": true,
+    "sharp": true
   }
 }


### PR DESCRIPTION
## Problem
Running `./aeon` (which does `npm install` in `apps/dashboard`) prints:

```
npm warn allow-scripts 3 packages have install scripts not yet covered by allowScripts:
npm warn allow-scripts   esbuild@0.28.1 (postinstall: node install.js)
npm warn allow-scripts   fsevents@2.3.3 (install: (install scripts present))
npm warn allow-scripts   sharp@0.34.5 (install: node install/check.js || npm run build)
```

npm 11.6+ gates dependency lifecycle scripts behind an `allowScripts` allow-list and warns about any package with install scripts that isn't listed.

## Fix
Pre-approve the three packages in `apps/dashboard/package.json` (written by `npm approve-scripts esbuild fsevents sharp --no-allow-scripts-pin` — unpinned so it survives version bumps):

```json
"allowScripts": {
  "esbuild": true,
  "fsevents": true,
  "sharp": true
}
```

All three **legitimately need** their install scripts — esbuild fetches its platform binary, sharp builds/loads libvips, fsevents builds the macOS native file-watcher — so approving (not denying) is the correct call.

## Verification
- Clean `rm -rf node_modules && npm install` → **no allow-scripts warning**
- `require('esbuild').version` → 0.28.1, `require('sharp')` → OK (scripts ran)
- Only `package.json` changed; `package-lock.json` untouched