### PR TITLE
feat(okf): make all knowledge+operational markdown OKF-conformant in place

### DIFF
--- a/.github/workflows/ci-okf.yml
+++ b/.github/workflows/ci-okf.yml
@@ -15,16 +15,24 @@ name: ci-okf
 on:
   pull_request:
     paths:
-      - 'memory/topics/**'
+      - 'memory/**'
+      - 'output/articles/**'
+      - 'skills/**'
+      - 'docs/**'
       - 'scripts/okf-validate.mjs'
       - 'scripts/okf-index.mjs'
+      - 'scripts/okf-config.json'
       - '.github/workflows/ci-okf.yml'
   push:
     branches: [main]
     paths:
-      - 'memory/topics/**'
+      - 'memory/**'
+      - 'output/articles/**'
+      - 'skills/**'
+      - 'docs/**'
       - 'scripts/okf-validate.mjs'
       - 'scripts/okf-index.mjs'
+      - 'scripts/okf-config.json'
   workflow_dispatch:
 
 permissions:
@@ -35,5 +43,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - name: Validate OKF conformance of memory/topics/
-        run: node scripts/okf-validate.mjs memory/topics
+      - name: Validate OKF conformance (roots in scripts/okf-config.json)
+        run: node scripts/okf-validate.mjs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,27 +53,29 @@ When consolidating memory (reflect), move detail into topic files rather than cr
 
 ## Publishing knowledge (OKF)
 
-Aeon's `memory/topics/` directory **is** a native [OKF](docs/OKF.md) (Open Knowledge Format) knowledge bundle — a portable, self-describing corpus other tools and agents can read. This is not a separate export; the topic files *are* the bundle. So when you write a durable, shareable **concept** to `memory/topics/` (a tracked token, a protocol, a narrative, a watched repo, a runbook), write it as an OKF concept:
+Aeon's real files **are** a native [OKF](docs/OKF.md) (Open Knowledge Format) bundle — self-describing in place, not a separate export or duplicated copy. Every markdown file in the OKF scope (the roots in `scripts/okf-config.json`: `memory/`, `output/articles/`, `skills/`, `docs/`) carries a non-empty `type:` frontmatter field. **So any markdown file you create in that scope must start with a `type:`.** If you forget, `node scripts/okf-backfill.mjs` stamps the right one; the `ci-okf` check gates it.
 
-- **One concept = one markdown file at a stable path** under `memory/topics/`. The path is its identity; `memory/topics/` is the bundle root (a link `/tokens/ethereum.md` resolves there). Subfolders (`tokens/`, `repos/`) are fine.
-- **Start every concept file with YAML frontmatter carrying a non-empty `type:`** from the vocabulary below. Add `title`, `description`, `tags`, `resource` (canonical URL), and `timestamp` (ISO 8601) whenever you can — they power the index and previews.
-- **Ownership is last-writer-wins.** Any skill may create or rewrite any concept. **Always set/bump `timestamp:` on every write** — the newest timestamp is the source of truth. Edit the existing file in place rather than duplicating it.
-- **Cross-link** related concepts with bundle-relative markdown links (`See [Solana](/tokens/solana.md)`). **Cite** external sources under a `# Citations` heading. Favor structure (headings, tables) over prose.
+`memory/topics/` is the primary **living-knowledge** store — durable, shareable concepts (a token, a protocol, a narrative, a watched repo, a runbook). Write those with care:
 
-`type:` vocabulary — reuse these exact words across the fleet (the list is additive; new descriptive types are fine, but check here first):
+- **One concept = one markdown file at a stable path** under `memory/topics/` (the bundle root; a link `/tokens/ethereum.md` resolves there). Subfolders are fine.
+- **Frontmatter:** a `type:` from the vocabulary below, plus `title`, `description`, `tags`, `resource` (canonical URL), and `timestamp` (ISO 8601) whenever you can.
+- **Ownership is last-writer-wins.** Any skill may create or rewrite any concept. **Set/bump `timestamp:` on every write** — the newest wins. Edit in place; never duplicate.
+- **Cross-link** with bundle-relative links (`See [Solana](/tokens/solana.md)`); **cite** under a `# Citations` heading. Favor structure over prose.
+
+Everything else in scope is *operational* OKF — give it the right `type:` and otherwise leave its body/shape alone (don't reformat, don't rename). `type:` vocabulary (additive — new descriptive types are fine, but reuse these):
 
 | `type:` | Use for |
 |---|---|
-| `Token` | A tracked crypto asset |
-| `Protocol` | A DeFi / onchain protocol |
-| `Narrative` | A market or tech narrative being tracked |
-| `Repo` | A watched GitHub repository |
+| `Token` `Protocol` `Narrative` `Repo` `Metric` | Living `memory/topics/` concepts (asset / protocol / narrative / repo / KPI) |
 | `Playbook` | A reusable procedure / runbook |
-| `Metric` | A tracked number / KPI |
-| `Reference` | Mirrored external source material or config |
-| `Skill` | An Aeon skill (served from the catalog; you don't hand-write these) |
+| `Reference` | Mirrored source material, config, docs, skill-internal notes |
+| `Skill` | A `SKILL.md` (you rarely hand-edit this line) |
+| `Article` | A published piece under `output/articles/` |
+| `Log` | A daily `memory/logs/*.md` |
+| `Index` | `MEMORY.md`, `memory/issues/INDEX.md` |
+| `Issue` | A `memory/issues/` tracker entry |
 
-Do **not** OKF-ify the rest of `memory/`: `MEMORY.md` (the human index) and `memory/logs/` (the daily log) already play OKF's index/log roles in their existing Aeon shapes — never add `type:` frontmatter to a log file or reformat `MEMORY.md`. `memory/issues/` and `memory/skill-health/` are internal and out of scope. Validate the bundle with `node scripts/okf-validate.mjs`; the `ci-okf` check gates any PR touching `memory/topics/`.
+Two exemptions: **reserved `index.md`/`log.md`** stay untyped (OKF §6/§7), and **out-of-scope files** — root instruction files (`CLAUDE.md`, `STRATEGY.md`, `README.md`), generated files (`AGENTS.md`), and illustrative examples (`docs/examples/`, `soul/`) — carry no `type:`. Validate everything with `node scripts/okf-validate.mjs`.
 
 ## Tools
 

--- a/apps/mcp-server/src/okf.ts
+++ b/apps/mcp-server/src/okf.ts
@@ -36,8 +36,14 @@ interface Concept {
   description: string;
 }
 
-function topicsRoot(repoRoot: string): string {
-  return join(repoRoot, "memory", "topics");
+// Concept roots served over MCP. Knowledge surfaces here; operational OKF files
+// (logs, issues, docs) are conformant but intentionally not published in the
+// index — serving every log would defeat progressive disclosure (§6).
+function conceptRoots(repoRoot: string): { dir: string; prefix: string }[] {
+  return [
+    { dir: join(repoRoot, "memory", "topics"), prefix: "" },
+    { dir: join(repoRoot, "output", "articles"), prefix: "articles/" },
+  ];
 }
 
 function walkMd(dir: string): string[] {
@@ -71,20 +77,21 @@ function parseFrontmatter(content: string): Record<string, string> {
 
 /** Load every OKF concept from memory/topics/ (reserved files excluded). */
 export function loadConcepts(repoRoot: string): Concept[] {
-  const root = topicsRoot(repoRoot);
   const concepts: Concept[] = [];
-  for (const file of walkMd(root)) {
-    const base = file.slice(file.lastIndexOf("/") + 1);
-    if (RESERVED.has(base)) continue;
-    const fm = parseFrontmatter(readFileSync(file, "utf-8"));
-    const rel = relative(root, file).split("\\").join("/");
-    concepts.push({
-      id: rel.replace(/\.md$/, ""),
-      file,
-      type: fm.type || "Untyped",
-      title: fm.title || rel.replace(/\.md$/, ""),
-      description: fm.description || "",
-    });
+  for (const { dir, prefix } of conceptRoots(repoRoot)) {
+    for (const file of walkMd(dir)) {
+      const base = file.slice(file.lastIndexOf("/") + 1);
+      if (RESERVED.has(base)) continue;
+      const fm = parseFrontmatter(readFileSync(file, "utf-8"));
+      const rel = relative(dir, file).split("\\").join("/");
+      concepts.push({
+        id: prefix + rel.replace(/\.md$/, ""),
+        file,
+        type: fm.type || "Untyped",
+        title: fm.title || rel.replace(/\.md$/, ""),
+        description: fm.description || "",
+      });
+    }
   }
   return concepts.sort((a, b) => a.id.localeCompare(b.id));
 }

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -1,4 +1,5 @@
 ---
+type: Reference
 layout: default
 title: Skill Capabilities Taxonomy
 ---

--- a/docs/CORE.md
+++ b/docs/CORE.md
@@ -1,4 +1,5 @@
 ---
+type: Reference
 layout: default
 title: The Core
 ---

--- a/docs/ECOSYSTEM.md
+++ b/docs/ECOSYSTEM.md
@@ -1,3 +1,7 @@
+---
+type: Reference
+---
+
 <p align="center">
   <img src="assets/aeon.jpg" alt="Aeon" width="80" />
 </p>

--- a/docs/OKF.md
+++ b/docs/OKF.md
@@ -1,26 +1,32 @@
 ---
+type: Reference
 layout: default
 title: OKF — Open Knowledge Format
 ---
 
 # OKF — the native knowledge bundle
 
-Aeon speaks [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf) (Open Knowledge Format) v0.1 **natively**. There is no separate `knowledge/` export directory — `memory/topics/` *is* the bundle. Any tool or agent that understands OKF can read Aeon's curated knowledge directly from the repo.
+Aeon speaks [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf) (Open Knowledge Format) v0.1 **natively and in place**. There is no separate `knowledge/` directory and no duplicated copy — the real files *are* the bundle. Any tool or agent that understands OKF can read Aeon directly from the repo.
 
-OKF is not a technology, it's an agreement: a directory of markdown files where **every concept file carries a non-empty `type:` frontmatter field**, with `index.md`/`log.md` playing reserved roles. That one rule (`type:`) is the whole hard requirement (OKF §9); everything else is soft.
+OKF is not a technology, it's an agreement: markdown files where **every non-reserved file carries a non-empty `type:` frontmatter field**, with `index.md`/`log.md` playing reserved roles. That one rule (`type:`) is the whole hard requirement (OKF §9); everything else is soft.
 
-## The native mapping
+## Scope — one file, self-describing
 
-Rather than bolt on a parallel directory, OKF's roles map onto structures Aeon already has:
+Conformance covers the "knowledge + operational" roots declared in [`scripts/okf-config.json`](../scripts/okf-config.json): `memory/`, `output/articles/`, `skills/`, `docs/`. Every markdown file under them carries a `type:` **in place** — a leading frontmatter block is *additive*, so the parsers that key off these files (the LLM-read logs, the filename-based `compact_logs.py`, the field-based issue/skills readers) are unaffected.
 
-| OKF role | Aeon-native home | Notes |
+| Family | `type:` | Note |
 |---|---|---|
-| **Concept store** (the bundle root) | `memory/topics/` | Each concept = one `.md` with `type:` frontmatter |
-| **Index** (§6) | `MEMORY.md` (human) + generated `memory/topics/index.md` (machine) | `MEMORY.md` keeps its Aeon shape; `index.md` is regenerable |
-| **Log** (§7) | `memory/logs/YYYY-MM-DD.md` | Unchanged — the `skill-health` loop parses this shape |
-| Out of scope | `memory/issues/`, `memory/skill-health/` | Internal; the validator never looks here |
+| `memory/topics/**` | `Token` `Protocol` `Narrative` `Repo` `Metric` `Playbook` `Reference` | Living, updated-in-place concepts (last-writer-wins) |
+| `output/articles/*.md` | `Article` | Dated, write-once publications |
+| `skills/*/SKILL.md` | `Skill` | Skill-internal notes/docs → `Reference` |
+| `docs/*.md` | `Reference` | `docs/examples/` excluded (illustrative) |
+| `memory/logs/*.md` | `Log` | Body untouched — health loop still parses `### skill` bullets |
+| `MEMORY.md`, `memory/issues/INDEX.md` | `Index` | Not renamed to reserved `index.md` (that would break parsers) |
+| `memory/issues/*.md` | `Issue` | Added to the existing frontmatter |
 
-Conformance is deliberately scoped to `memory/topics/` **only**. `MEMORY.md`, the daily logs, and the issue tracker keep their existing formats, so nothing that parses them (the health loop, memory-flush) is at risk. **Do not** add `type:` frontmatter to a log file or reformat `MEMORY.md`.
+**Two exemptions.** Reserved `index.md`/`log.md` stay untyped (OKF §6/§7 structural files). And these stay out of scope entirely — no `type:`: root instruction files (`CLAUDE.md`, `STRATEGY.md`, `README.md`), generated files (`AGENTS.md`), and illustrative examples (`docs/examples/`, `soul/`).
+
+> **Why type in place instead of renaming to `index.md`/`log.md`?** Aeon's index/log files (`MEMORY.md`, `memory/logs/YYYY-MM-DD.md`) are load-bearing under those exact names — `skill-health` and `memory-flush` parse them. Renaming to OKF's reserved names would break that for no gain, so they become normal typed concepts (`type: Index` / `type: Log`) instead. Consumers tolerate that (reserved files are optional; an index can be synthesized at read time).
 
 ## Writing a concept
 
@@ -59,10 +65,11 @@ Any skill may create or rewrite any concept. **Always set/bump `timestamp:` on e
 
 | Command | What it does |
 |---|---|
-| `node scripts/okf-validate.mjs [root]` | Assert OKF §9 conformance (non-empty `type:` on every concept). `--stale N` also warns on concepts older than N days. Exits non-zero on violation. |
+| `node scripts/okf-validate.mjs` | Assert OKF §9 conformance across all `okf-config.json` roots (non-empty `type:` on every non-reserved file). Pass an explicit `<root>` to check one tree (used by `okf-ingest`). `--stale N` warns on concepts older than N days. Exits non-zero on violation. |
+| `node scripts/okf-backfill.mjs` | Stamp the right `type:` onto every in-scope file that lacks one, per the `backfill_rules` in `okf-config.json`. Idempotent; `--dry` previews. Run it after adding files, or when CI flags a missing `type:`. |
 | `node scripts/okf-index.mjs [root]` | Regenerate `memory/topics/index.md` from concept frontmatter (idempotent). `--check` verifies it's current. |
 
-The validator holds the spec's bar and **no stricter** — it never rejects unknown `type:` values, missing optional fields, or broken links (over-conformance would fight Aeon's own non-deterministic agents). The `ci-okf` workflow runs it on every PR touching `memory/topics/`.
+The scope (roots + exclusions + per-family types) lives in one place: [`scripts/okf-config.json`](../scripts/okf-config.json). The validator holds the spec's bar and **no stricter** — it never rejects unknown `type:` values, missing optional fields, or broken links (over-conformance would fight Aeon's own non-deterministic agents). The `ci-okf` workflow runs it on every PR touching an OKF root.
 
 The index regenerator is **not scheduled and not CI-gated** — Aeon's OKF setup is passive. Knowledge accrues as skills naturally emit concepts; refresh the index on demand (or wire it into `memory-flush` later). The MCP server also synthesizes an index at read time (§6), so a stored `index.md` is a convenience snapshot.
 
@@ -73,10 +80,10 @@ The Aeon MCP server (`apps/mcp-server`) exposes the bundle as read-only resource
 | Resource URI | Content |
 |---|---|
 | `okf://index` | Synthesized bundle index (concepts + skills) |
-| `okf://concept/{id}` | One topic concept's raw markdown (`id` = path under `topics/`) |
+| `okf://concept/{id}` | One knowledge concept's raw markdown (`id` = path under `memory/topics/`, or `articles/<name>` for `output/articles/`) |
 | `okf://skill/{slug}` | One Aeon skill rendered as a `type: Skill` concept |
 
-Every `SKILL.md` is already a frontmatter concept doc, so the whole catalog is published "as OKF" nearly for free. The git repo itself is also a valid distribution — anyone can `git clone` and read `memory/topics/`.
+The served index surfaces **knowledge** (topics + articles + skills). Operational OKF files (logs, issues, docs) are conformant but intentionally not published in the index — serving every log would defeat progressive disclosure (§6). Every `SKILL.md` is already a frontmatter concept doc, so the whole catalog is published "as OKF" nearly for free, and the git repo itself is a valid distribution — anyone can `git clone` and read it.
 
 ## Producing & consuming (optional skills, default-off)
 

--- a/docs/SHOWCASE.md
+++ b/docs/SHOWCASE.md
@@ -1,3 +1,7 @@
+---
+type: Reference
+---
+
 <p align="center">
   <img src="assets/aeon.jpg" alt="Aeon" width="80" />
 </p>

--- a/docs/community-skill-packs.md
+++ b/docs/community-skill-packs.md
@@ -1,4 +1,5 @@
 ---
+type: Reference
 layout: default
 title: Community Skill Packs
 ---

--- a/docs/help.md
+++ b/docs/help.md
@@ -1,3 +1,7 @@
+---
+type: Reference
+---
+
 Aeon — how to use me over Telegram
 
 • Type / to see every skill you have enabled, then tap one to run it.

--- a/docs/skill-packs.md
+++ b/docs/skill-packs.md
@@ -1,3 +1,7 @@
+---
+type: Reference
+---
+
 # Skill packs
 
 Aeon ships **68 skills**, but most forks only ever run a handful. Packs make

--- a/docs/smithery-submission.md
+++ b/docs/smithery-submission.md
@@ -1,3 +1,7 @@
+---
+type: Reference
+---
+
 # Aeon — Smithery / MCP Registry Submission
 *Generated from `skills.json` (the `smithery-manifest` skill was retired in #566). Regenerate by re-deriving from `skills.json` when the skill catalog changes.*
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,4 +1,5 @@
 ---
+type: Reference
 layout: default
 title: "Status"
 permalink: /status/

--- a/docs/telegram-commands.md
+++ b/docs/telegram-commands.md
@@ -1,3 +1,7 @@
+---
+type: Reference
+---
+
 # Telegram commands, buttons & deep links
 
 Beyond plain-text chat, Aeon's Telegram integration supports slash commands,

--- a/docs/telegram-instant.md
+++ b/docs/telegram-instant.md
@@ -1,3 +1,7 @@
+---
+type: Reference
+---
+
 # Telegram Instant Mode
 
 Default polling checks for messages every 5 minutes. For ~1s response time, deploy

--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -1,3 +1,7 @@
+---
+type: Index
+---
+
 # Long-term Memory
 *Last consolidated: never*
 

--- a/memory/issues/INDEX.md
+++ b/memory/issues/INDEX.md
@@ -1,3 +1,7 @@
+---
+type: Index
+---
+
 # Issues
 
 ## Open

--- a/memory/logs/2026-06-15.md
+++ b/memory/logs/2026-06-15.md
@@ -1,3 +1,7 @@
+---
+type: Log
+---
+
 # Log — 2026-06-15
 
 ## Skill prune (chore/prune-redundant-skills)

--- a/memory/products.md
+++ b/memory/products.md
@@ -1,3 +1,7 @@
+---
+type: Reference
+---
+
 # Products
 
 Config for the product-aware skills: `bd-radar` and `product-pulse`.

--- a/memory/watched-repos.md
+++ b/memory/watched-repos.md
@@ -1,2 +1,6 @@
+---
+type: Reference
+---
+
 # Watched Repos
 - aaronjmars/aeon

--- a/output/articles/changelog-2026-03-19.md
+++ b/output/articles/changelog-2026-03-19.md
@@ -1,3 +1,7 @@
+---
+type: Article
+---
+
 # Changelog — Week of 2026-03-19
 
 ## aaronjmars/aeon

--- a/output/articles/workflow-audit-2026-04-11.md
+++ b/output/articles/workflow-audit-2026-04-11.md
@@ -1,3 +1,7 @@
+---
+type: Article
+---
+
 # Workflow Security Audit — 2026-04-11
 
 **Repo:** [aaronjmars/aeon](https://github.com/aaronjmars/aeon)

--- a/scripts/okf-backfill.mjs
+++ b/scripts/okf-backfill.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+// okf-backfill.mjs — stamp a `type:` onto every in-scope markdown file that lacks
+// one, so Aeon's real files are OKF v0.1 conformant IN PLACE (no duplicate copy).
+//
+// Type per file family comes from scripts/okf-config.json → backfill_rules (first
+// match wins). Idempotent: a file that already has a non-empty `type:` is left
+// untouched, as are reserved index.md/log.md and anything under `exclude`.
+//
+// For a file that already has frontmatter (SKILL.md, Jekyll docs), `type:` is
+// inserted as the first field. For a file with none, a minimal `--- type: X ---`
+// block is prepended — nothing else is disturbed.
+//
+// Usage:
+//   node scripts/okf-backfill.mjs          # apply
+//   node scripts/okf-backfill.mjs --dry     # preview only
+
+import { readFileSync, writeFileSync, readdirSync } from 'node:fs'
+import { join, relative, basename, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const RESERVED = new Set(['index.md', 'log.md'])
+const CONFIG_PATH = join(dirname(fileURLToPath(import.meta.url)), 'okf-config.json')
+const dry = process.argv.includes('--dry')
+
+const cfg = JSON.parse(readFileSync(CONFIG_PATH, 'utf-8'))
+const roots = cfg.roots ?? []
+const exclude = cfg.exclude ?? []
+const rules = cfg.backfill_rules ?? []
+
+const isExcluded = (p) => exclude.some((ex) => p === ex || p.startsWith(ex + '/'))
+
+// forward-slash relative path from repo root, for rule matching
+const relPath = (p) => relative(process.cwd(), p).split('\\').join('/')
+
+function ruleType(rel) {
+  for (const r of rules) {
+    const pathMatch = r.match.endsWith('/') ? rel.startsWith(r.match) : rel === r.match
+    if (!pathMatch) continue
+    if (r.name && basename(rel) !== r.name) continue // optional basename constraint
+    return r.type
+  }
+  return null
+}
+
+function walk(dir) {
+  let out = []
+  let entries
+  try {
+    entries = readdirSync(dir, { withFileTypes: true })
+  } catch {
+    return out
+  }
+  for (const e of entries) {
+    const p = join(dir, e.name)
+    if (isExcluded(p)) continue
+    if (e.isDirectory()) out = out.concat(walk(p))
+    else if (e.isFile() && e.name.endsWith('.md')) out.push(p)
+  }
+  return out
+}
+
+const FM_OPEN = /^﻿?(---[ \t]*\r?\n)/
+function hasType(content) {
+  const m = content.replace(/^﻿/, '').match(/^---[ \t]*\r?\n([\s\S]*?)\r?\n---/)
+  return m ? /^type:\s*\S/m.test(m[1]) : false
+}
+
+const changed = []
+const seen = new Set()
+for (const root of roots) {
+  for (const file of walk(root)) {
+    if (seen.has(file)) continue
+    seen.add(file)
+    if (RESERVED.has(basename(file))) continue
+    const rel = relPath(file)
+    const type = ruleType(rel)
+    if (!type) continue // no rule → not our concern (e.g. memory/topics handled elsewhere)
+
+    const content = readFileSync(file, 'utf-8')
+    if (hasType(content)) continue // idempotent
+
+    let next
+    if (FM_OPEN.test(content)) {
+      // existing frontmatter → insert type: as the first field
+      next = content.replace(FM_OPEN, `$1type: ${type}\n`)
+    } else {
+      // no frontmatter → prepend a minimal block
+      next = `---\ntype: ${type}\n---\n\n${content.replace(/^﻿/, '')}`
+    }
+    changed.push({ rel, type })
+    if (!dry) writeFileSync(file, next)
+  }
+}
+
+if (!changed.length) {
+  console.log('okf-backfill: nothing to do — every in-scope file already carries a type:')
+} else {
+  for (const c of changed) console.log(`okf-backfill: ${dry ? 'would set' : 'set'} type: ${c.type.padEnd(9)} ${c.rel}`)
+  console.log(`\nokf-backfill: ${dry ? 'would update' : 'updated'} ${changed.length} file(s)`)
+}

--- a/scripts/okf-config.json
+++ b/scripts/okf-config.json
@@ -1,0 +1,17 @@
+{
+  "_comment": "Which markdown OKF conformance applies to (scope: knowledge + operational). Every non-reserved .md under a root must carry a non-empty type: (OKF v0.1 §9). Reserved index.md/log.md are exempt. Read by scripts/okf-validate.mjs and scripts/okf-backfill.mjs. Left OUT by design: root instruction files (CLAUDE.md, STRATEGY.md, README.md), generated files (AGENTS.md), and illustrative examples (docs/examples/, soul/).",
+  "roots": ["memory", "output/articles", "skills", "docs"],
+  "exclude": ["docs/examples", "memory/skill-health"],
+  "backfill_rules": [
+    { "match": "skills/", "name": "SKILL.md", "type": "Skill" },
+    { "match": "skills/", "type": "Reference" },
+    { "match": "docs/", "type": "Reference" },
+    { "match": "memory/logs/", "type": "Log" },
+    { "match": "memory/issues/INDEX.md", "type": "Index" },
+    { "match": "memory/issues/", "type": "Issue" },
+    { "match": "memory/MEMORY.md", "type": "Index" },
+    { "match": "memory/products.md", "type": "Reference" },
+    { "match": "memory/watched-repos.md", "type": "Reference" },
+    { "match": "output/articles/", "type": "Article" }
+  ]
+}

--- a/scripts/okf-validate.mjs
+++ b/scripts/okf-validate.mjs
@@ -1,35 +1,37 @@
 #!/usr/bin/env node
-// okf-validate.mjs — conformance checker for Aeon's OKF-native knowledge bundle.
+// okf-validate.mjs — conformance checker for Aeon's OKF-native knowledge.
 //
-// Aeon speaks the Open Knowledge Format (OKF v0.1) *natively*: memory/topics/ IS
-// the bundle (no separate knowledge/ dir). This validator enforces the ONE hard
-// requirement of the spec (§9) and nothing stricter:
+// Aeon speaks the Open Knowledge Format (OKF v0.1) *natively* and in place: the
+// real files ARE the bundle (no separate/duplicated copy). Scope is "knowledge +
+// operational" — see scripts/okf-config.json for the exact roots. This validator
+// enforces the ONE hard requirement of the spec (§9) and nothing stricter:
 //
-//   1. Every non-reserved .md file has a parseable YAML frontmatter block.
+//   1. Every non-reserved .md file (under a configured root) has a parseable YAML
+//      frontmatter block.
 //   2. Every frontmatter block has a non-empty `type:` field.
 //   3. Reserved files (index.md, log.md) follow their §6/§7 shape *when present*.
 //
 // Deliberately NOT enforced (the spec forbids over-conformance — a stricter bar
 // would fight Aeon's own non-deterministic agents): unknown `type:` values,
-// missing optional fields (title/description/timestamp/…), broken cross-links.
-// Those are soft guidance, surfaced at most as warnings.
+// missing optional fields, broken cross-links. Those are soft, at most warnings.
 //
 // Usage:
-//   node scripts/okf-validate.mjs [root]            # default root: memory/topics
-//   node scripts/okf-validate.mjs [root] --stale N  # also WARN on concepts whose
-//                                                     # timestamp: is older than N days
+//   node scripts/okf-validate.mjs                 # validate all roots in okf-config.json
+//   node scripts/okf-validate.mjs <root> [root…]  # validate explicit root(s), no config excludes
+//   node scripts/okf-validate.mjs … --stale N      # also WARN on concepts older than N days
 //
 // Exit 1 on any §9 hard violation; exit 0 (with `okf-validate: OK`) otherwise.
-// Warnings never change the exit code.
 
-import { readFileSync, readdirSync, statSync } from 'node:fs'
-import { join, relative, basename } from 'node:path'
+import { readFileSync, readdirSync } from 'node:fs'
+import { join, relative, basename, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 const RESERVED = new Set(['index.md', 'log.md'])
+const CONFIG_PATH = join(dirname(fileURLToPath(import.meta.url)), 'okf-config.json')
 
 // ---- args ----
 const rawArgs = process.argv.slice(2)
-let root = 'memory/topics'
+let explicitRoots = []
 let staleDays = null
 for (let i = 0; i < rawArgs.length; i++) {
   const a = rawArgs[i]
@@ -40,9 +42,28 @@ for (let i = 0; i < rawArgs.length; i++) {
       process.exit(2)
     }
   } else if (!a.startsWith('--')) {
-    root = a
+    explicitRoots.push(a)
   }
 }
+
+// Explicit roots → validate exactly those (no config excludes; used by okf-ingest
+// against a fetched .okf-cache/ tree). No args → the whole configured scope.
+let roots
+let exclude = []
+if (explicitRoots.length) {
+  roots = explicitRoots
+} else {
+  let cfg = { roots: ['memory/topics'], exclude: [] }
+  try {
+    cfg = JSON.parse(readFileSync(CONFIG_PATH, 'utf-8'))
+  } catch {
+    /* no config → fall back to the original single root */
+  }
+  roots = cfg.roots ?? ['memory/topics']
+  exclude = cfg.exclude ?? []
+}
+
+const isExcluded = (p) => exclude.some((ex) => p === ex || p.startsWith(ex + '/'))
 
 // ---- fs walk ----
 function walk(dir) {
@@ -55,88 +76,73 @@ function walk(dir) {
   }
   for (const e of entries) {
     const p = join(dir, e.name)
+    if (isExcluded(p)) continue
     if (e.isDirectory()) out = out.concat(walk(p))
     else if (e.isFile() && e.name.endsWith('.md')) out.push(p)
   }
   return out
 }
 
-// ---- frontmatter ----
-// Strip a leading BOM, then match a leading `--- ... ---` block per OKF §4.1
-// (frontmatter is delimited by `---` on its own line at the START of the file).
+// ---- frontmatter (§4.1: a leading `--- … ---` block; tolerate a BOM) ----
 function parseFrontmatter(content) {
   const text = content.replace(/^﻿/, '')
   const m = text.match(/^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/)
   if (!m) return null
-  const block = m[1]
   const fields = {}
-  for (const line of block.split(/\r?\n/)) {
+  for (const line of m[1].split(/\r?\n/)) {
     const km = line.match(/^([A-Za-z_][A-Za-z0-9_]*):\s*(.*)$/)
-    if (km) fields[km[1]] = unquote(km[2])
+    if (km) fields[km[1]] = (km[2] ?? '').trim().replace(/^['"]|['"]$/g, '').trim()
   }
-  return { block, fields }
+  return { fields }
 }
 
-function unquote(v) {
-  return (v ?? '').trim().replace(/^['"]|['"]$/g, '').trim()
-}
-
-// ---- validation ----
+// ---- validate ----
 const errors = []
 const warnings = []
-const files = walk(root).sort()
 let conceptCount = 0
+const seen = new Set()
+const staleCutoff = staleDays != null ? Date.now() - staleDays * 864e5 : null
 
-const staleCutoff =
-  staleDays != null ? Date.now() - staleDays * 24 * 60 * 60 * 1000 : null
+for (const root of roots) {
+  for (const file of walk(root)) {
+    if (seen.has(file)) continue // roots may nest; validate each file once
+    seen.add(file)
+    const rel = relative(process.cwd(), file)
+    const name = basename(file)
+    const content = readFileSync(file, 'utf-8')
+    const fm = parseFrontmatter(content)
 
-for (const file of files) {
-  const rel = relative(process.cwd(), file)
-  const name = basename(file)
-  const content = readFileSync(file, 'utf-8')
-  const fm = parseFrontmatter(content)
-
-  if (RESERVED.has(name)) {
-    // §6 / §7 structure — soft. index.md carries no frontmatter except the
-    // bundle-root, which MAY declare only `okf_version` (§11).
-    if (name === 'index.md' && fm) {
-      const isBundleRoot = rel === join(root, 'index.md') || file === join(root, 'index.md')
-      const keys = Object.keys(fm.fields)
-      const onlyOkfVersion = keys.length === 1 && keys[0] === 'okf_version'
-      if (!isBundleRoot || !onlyOkfVersion) {
-        warnings.push(
-          `${rel}: index.md should carry no frontmatter (only the bundle-root index.md may declare okf_version). Found: [${keys.join(', ') || 'empty'}]`
-        )
+    if (RESERVED.has(name)) {
+      // §6/§7 — soft. An index.md carries no frontmatter except the bundle-root's,
+      // which MAY declare only `okf_version` (§11). Warn (never fail) on extras.
+      if (name === 'index.md' && fm) {
+        const keys = Object.keys(fm.fields)
+        if (!(keys.length === 1 && keys[0] === 'okf_version')) {
+          warnings.push(`${rel}: index.md should carry no frontmatter except a bundle-root okf_version. Found: [${keys.join(', ') || 'empty'}]`)
+        }
       }
-    }
-    if (name === 'log.md') {
-      const badHeading = content
-        .split(/\r?\n/)
-        .filter(l => /^##\s+/.test(l))
-        .find(l => !/^##\s+\d{4}-\d{2}-\d{2}\s*$/.test(l))
-      if (badHeading) {
-        warnings.push(`${rel}: log.md date headings should be ISO '## YYYY-MM-DD' (found "${badHeading.trim()}")`)
+      if (name === 'log.md') {
+        const bad = content.split(/\r?\n/).filter((l) => /^##\s+/.test(l)).find((l) => !/^##\s+\d{4}-\d{2}-\d{2}\s*$/.test(l))
+        if (bad) warnings.push(`${rel}: log.md date headings should be ISO '## YYYY-MM-DD' (found "${bad.trim()}")`)
       }
+      continue
     }
-    continue
-  }
 
-  // Non-reserved .md = a concept. HARD requirements (§9.1, §9.2).
-  conceptCount++
-  if (!fm) {
-    errors.push(`${rel}: missing or unparseable YAML frontmatter block (§9.1)`)
-    continue
-  }
-  if (!fm.fields.type) {
-    errors.push(`${rel}: frontmatter has no non-empty \`type:\` field (§9.2)`)
-    continue
-  }
-
-  // Staleness — soft, opt-in via --stale.
-  if (staleCutoff != null && fm.fields.timestamp) {
-    const t = Date.parse(fm.fields.timestamp)
-    if (Number.isFinite(t) && t < staleCutoff) {
-      warnings.push(`${rel}: stale — timestamp ${fm.fields.timestamp} is older than ${staleDays}d`)
+    // Non-reserved .md = a concept. HARD requirements (§9.1, §9.2).
+    conceptCount++
+    if (!fm) {
+      errors.push(`${rel}: missing or unparseable YAML frontmatter block (§9.1)`)
+      continue
+    }
+    if (!fm.fields.type) {
+      errors.push(`${rel}: frontmatter has no non-empty \`type:\` field (§9.2)`)
+      continue
+    }
+    if (staleCutoff != null && fm.fields.timestamp) {
+      const t = Date.parse(fm.fields.timestamp)
+      if (Number.isFinite(t) && t < staleCutoff) {
+        warnings.push(`${rel}: stale — timestamp ${fm.fields.timestamp} is older than ${staleDays}d`)
+      }
     }
   }
 }
@@ -146,11 +152,11 @@ for (const w of warnings) console.warn(`okf-validate: WARN ${w}`)
 
 if (errors.length) {
   for (const e of errors) console.error(`okf-validate: ERROR ${e}`)
-  console.error(`\nokf-validate: FAIL — ${errors.length} violation(s) across ${conceptCount} concept(s) in ${root}/`)
+  console.error(`\nokf-validate: FAIL — ${errors.length} violation(s) across ${conceptCount} concept(s) in [${roots.join(', ')}]`)
   process.exit(1)
 }
 
 console.log(
-  `okf-validate: OK — ${conceptCount} concept(s) in ${root}/ conform to OKF v0.1 §9` +
+  `okf-validate: OK — ${conceptCount} concept(s) across [${roots.join(', ')}] conform to OKF v0.1 §9` +
     (warnings.length ? ` (${warnings.length} warning(s))` : '')
 )

--- a/skills/action-converter/SKILL.md
+++ b/skills/action-converter/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Action Converter
 category: productivity
 description: 5 concrete real-life actions, leverage-scored against open loops with specificity and anti-fluff gates

--- a/skills/article/SKILL.md
+++ b/skills/article/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Article
 category: research
 description: Write a publication-ready article in one of three angles — a general trending long-form piece (or a single-mechanism technical explainer), a thesis-driven article about a watched repo, or a project-through-a-lens essay. Optionally generate a Replicate hero image with --visual.

--- a/skills/auto-merge/SKILL.md
+++ b/skills/auto-merge/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Auto Merge
 category: dev
 description: Automatically merge open PRs that have passing CI, no blocking reviews, and no conflicts

--- a/skills/auto-workflow/SKILL.md
+++ b/skills/auto-workflow/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Auto-Workflow Builder
 category: dev
 description: Two-mode aeon.yml workflow builder — (analyze) inspect one or more URLs and emit a tiered, signal-verified skill-enablement plan plus an aeon.yml diff, or (enable) flip enabled:false→true for a slug list, validating against skills/ and opening a PR. The analyze mode recommends what to turn on; the enable mode turns it on.

--- a/skills/autoresearch/SKILL.md
+++ b/skills/autoresearch/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Autoresearch
 category: core
 description: Evolve a skill by generating variations, evaluating them, and updating the best version

--- a/skills/base-mcp/README.md
+++ b/skills/base-mcp/README.md
@@ -1,4 +1,5 @@
 ---
+type: Reference
 title: "Base MCP Skill — Disclaimer"
 description: "Terms, risks, and limitations for using the Base MCP skill with AI agents."
 ---

--- a/skills/base-mcp/SKILL.md
+++ b/skills/base-mcp/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 mode: read-only
 name: Base MCP
 category: crypto

--- a/skills/base-mcp/plugins/aerodrome.md
+++ b/skills/base-mcp/plugins/aerodrome.md
@@ -1,4 +1,5 @@
 ---
+type: Reference
 title: "Aerodrome Plugin"
 description: "Skill plugin reference for building unsigned Aerodrome calldata with the Sugar SDK CLI and submitting it through Base MCP send_calls."
 ---

--- a/skills/base-mcp/plugins/avantis.md
+++ b/skills/base-mcp/plugins/avantis.md
@@ -1,4 +1,5 @@
 ---
+type: Reference
 title: "Avantis Plugin"
 description: "Skill plugin reference for reading Avantis market data and positions on any surface, and building perpetual-futures transactions from CLI harnesses (with an Avantis UI fallback on chat-only surfaces). Aligned with the canonical Avantis-Labs/avantis-trading-skill spec."
 ---

--- a/skills/base-mcp/plugins/bankr.md
+++ b/skills/base-mcp/plugins/bankr.md
@@ -1,4 +1,5 @@
 ---
+type: Reference
 title: "Bankr Plugin"
 description: "Skill plugin reference for discovering the latest token launches on Base via the Bankr API and buying them with Base MCP's swap tool."
 ---

--- a/skills/base-mcp/plugins/moonwell.md
+++ b/skills/base-mcp/plugins/moonwell.md
@@ -1,4 +1,5 @@
 ---
+type: Reference
 title: "Moonwell Plugin"
 description: "Skill plugin reference for lending on Moonwell through Base MCP."
 ---

--- a/skills/base-mcp/plugins/morpho.md
+++ b/skills/base-mcp/plugins/morpho.md
@@ -1,4 +1,5 @@
 ---
+type: Reference
 title: "Morpho Plugin"
 description: "Skill plugin reference for lending on Morpho with Morpho CLI when available, or Morpho MCP on chat-only surfaces."
 ---

--- a/skills/base-mcp/plugins/uniswap.md
+++ b/skills/base-mcp/plugins/uniswap.md
@@ -1,4 +1,5 @@
 ---
+type: Reference
 title: "Uniswap Plugin"
 description: "Skill plugin reference for swapping and LPing on Uniswap through Base MCP."
 ---

--- a/skills/base-mcp/plugins/virtuals.md
+++ b/skills/base-mcp/plugins/virtuals.md
@@ -1,4 +1,5 @@
 ---
+type: Reference
 title: "Virtuals Plugin"
 description: "Skill plugin reference for creating and operating Virtuals (ACP) AI agents through the Virtuals MCP, signed in via Base MCP."
 ---

--- a/skills/base-mcp/references/approval-mode.md
+++ b/skills/base-mcp/references/approval-mode.md
@@ -1,4 +1,5 @@
 ---
+type: Reference
 title: "Approval Mode"
 description: "Skill reference for how Base MCP returns approval URLs and request IDs for every write call."
 ---

--- a/skills/base-mcp/references/batch-calls.md
+++ b/skills/base-mcp/references/batch-calls.md
@@ -1,4 +1,5 @@
 ---
+type: Reference
 title: "Batched Contract Calls"
 description: "Skill reference for Base MCP's EIP-5792 batched contract calls."
 ---

--- a/skills/base-mcp/references/custom-plugins.md
+++ b/skills/base-mcp/references/custom-plugins.md
@@ -1,4 +1,5 @@
 ---
+type: Reference
 title: "Custom Plugins and the web_request Allowlist"
 description: "Skill reference for how Base MCP routes plugin HTTP calls and which surfaces are allowlisted."
 ---

--- a/skills/base-mcp/references/install.md
+++ b/skills/base-mcp/references/install.md
@@ -1,4 +1,5 @@
 ---
+type: Reference
 title: "Installing Base MCP"
 description: "Skill reference for installing the Base MCP server in Claude, ChatGPT, Cursor, Codex, and other surfaces."
 ---

--- a/skills/base-mcp/references/tone.md
+++ b/skills/base-mcp/references/tone.md
@@ -1,4 +1,5 @@
 ---
+type: Reference
 title: "Tone"
 description: "Skill reference for the language and tone rules an agent should follow when using Base MCP."
 ---

--- a/skills/bd-radar/SKILL.md
+++ b/skills/bd-radar/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: BD Radar
 category: research
 description: Business-development radar across your product family — find who's building, forking, integrating, and mentioning your products, then rank them into a who-to-talk-to-this-week lead list with a suggested next move per lead

--- a/skills/changelog/SKILL.md
+++ b/skills/changelog/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Changelog
 category: dev
 description: Generate a user-facing changelog from recent commits/PRs across watched repos — write it in-repo (Keep a Changelog format), or with push-to open a cross-repo changelog PR on a marketing/docs website repo

--- a/skills/code-health/SKILL.md
+++ b/skills/code-health/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Code Health
 category: dev
 description: Report on TODOs, dead code, and test coverage gaps

--- a/skills/cost-report/SKILL.md
+++ b/skills/cost-report/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: cost-report
 category: meta
 description: API cost intelligence — the full weekly report (dollar costs from token usage, anomaly flags, burn forecast, concrete optimizations) plus a `watch` budget watchdog that checks running weekly spend against a cap and alerts on WATCH/WARN/ALERT tiers

--- a/skills/create-skill/SKILL.md
+++ b/skills/create-skill/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Create Skill
 category: core
 description: Generate a complete new skill from a one-line prompt and ship it as a PR

--- a/skills/ctrl/SKILL.md
+++ b/skills/ctrl/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: CTRL
 category: crypto
 description: Build on-chain automation workflows on Base via CTRL. Use for recurring or triggered actions — DCA, price-gated swaps, launchpad sniping, whale-follow — that should run autonomously after a single wallet signature. The wallet signs once (EIP-5792 batch), and the CTRL keeper executes every trigger after, bounded by per-swap and per-day caps the user pre-authorized.

--- a/skills/defi-overview/SKILL.md
+++ b/skills/defi-overview/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: DeFi Overview
 category: crypto
 description: One-pass crypto read — tracked-protocol positions/health plus macro context. Regime Take + DeFi verdict, biggest movers with "why it matters", sustainable-vs-incentive yields, fees fundamentals, breadth, Fear & Greed, prediction markets; refreshes memory/topics/market-context.md.

--- a/skills/deploy-prototype/SKILL.md
+++ b/skills/deploy-prototype/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Deploy Prototype
 category: core
 description: Generate a small app or tool and deploy it live to Vercel via API

--- a/skills/digest/SKILL.md
+++ b/skills/digest/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 mode: write
 name: Digest
 category: research

--- a/skills/distribute-tokens/SKILL.md
+++ b/skills/distribute-tokens/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Distribute Tokens
 category: core
 description: Two-phase contributor rewards — computes a tier-priced reward plan from the repo's merged-PR contributor ranking (plan phase) and executes the on-chain send via Bankr Wallet API with per-recipient idempotency, resolve→execute, dry-run, and partial-run recovery (send phase). Run either phase alone or both back-to-back.

--- a/skills/ecosystem-pulse/SKILL.md
+++ b/skills/ecosystem-pulse/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: ecosystem-pulse
 category: dev
 description: One weekly pass over ECOSYSTEM.md covering both project liveness (stars / forks / last-push recency + new releases for any project that resolves to a GitHub repo) AND link-health (URL audit of every link in every row — archived/disabled GitHub repos, HTTP 4xx/5xx dead links, cross-host redirects). Runs both branches by default; scope with var=liveness|links.

--- a/skills/fear-divergence/SKILL.md
+++ b/skills/fear-divergence/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Fear Divergence
 category: crypto
 description: Conditional scan — fires only when Fear & Greed < 25. Identifies assets outperforming during broad market fear, synthesizes narrative catalysts from memory, and delivers a terse conviction setup brief. Skips silently when market conditions don't qualify.

--- a/skills/feature/SKILL.md
+++ b/skills/feature/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Feature
 category: dev
 description: Build, enhance, or revive GitHub repos — sweep every watched repo and ship one feature PR each (watched), make the best single enhancement on one external repo or issue (external), or reactivate the highest-scoring dormant repo (dormant); optional --fix-issues bias

--- a/skills/fetch-tweets/SKILL.md
+++ b/skills/fetch-tweets/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Fetch Tweets
 category: research
 description: Search and curate X/Twitter behind one selector — by keyword/query, topic roundup, a single account or a tracked-account digest, an X list, or the AI-agent "buzz" preset — clustered into sub-narratives with signal-scored, insight-per-item output.

--- a/skills/fleet-control/SKILL.md
+++ b/skills/fleet-control/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Fleet Control
 category: core
 description: Operate managed Aeon instances registered in memory/instances.json — health-check, dispatch skills, and full status snapshots (control view), plus a fleet-wide scorecard of runs, tokens (OpenRouter shape), est. cost and reliability with day-over-day deltas and alerts (scorecard view)

--- a/skills/fork-fleet/SKILL.md
+++ b/skills/fork-fleet/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: fork-fleet
 category: dev
 description: Fork divergence monitor — tracks where the fleet's active forks diverge in CODE (unique commits, new/modified skills, upstream-contribution candidates) and in CONFIG (enable/disable/var/model/schedule decisions vs upstream defaults), and gates notifications on real change

--- a/skills/github-monitor/SKILL.md
+++ b/skills/github-monitor/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: GitHub Monitor
 category: dev
 description: Watch your GitHub repos across four selectable views — a combined urgency monitor (stale PRs, new issues, new releases), a ranked new-issue triage queue, a release upgrade-triage digest, and a tracker for PRs this aeon instance opened. Empty var = combined monitor; issues|releases|prs select a focused view.

--- a/skills/github-trending/SKILL.md
+++ b/skills/github-trending/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 mode: read-only
 name: GitHub Trending
 category: dev

--- a/skills/heartbeat/SKILL.md
+++ b/skills/heartbeat/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Heartbeat
 category: meta
 description: Ambient fleet-health check that surfaces anything worth attention (default), or an on-demand priority brief — the 3 things to focus on, why now, and what moved (var=brief)

--- a/skills/idea-forge/SKILL.md
+++ b/skills/idea-forge/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Idea Forge
 category: research
 description: Three-mode idea engine. generate — collide the week's zeitgeist with what the operator can ship now into 3-5 wedges scored by timing-window/fit/edge, appended to the shared backlog. validate — viability-screen and score the startup-idea backlog (competition, funding, timing, operator-fit, market size). memo — 2 evidence-backed startup memos with ICP, wedge, monetization, cited pain, and numeric kill criteria.

--- a/skills/idea-pipeline/SKILL.md
+++ b/skills/idea-pipeline/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: idea-pipeline
 category: productivity
 description: Execution-gap audit — cross-references the startup idea backlog against shipped skills, prototypes, and cross-repo PRs. Surfaces the top 3 ideas to build next based on narrative fit and operator fit.

--- a/skills/inbox-triage/SKILL.md
+++ b/skills/inbox-triage/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Inbox Triage
 category: dev
 description: Daily GitHub notification inbox triage — surfaces aging vuln PR replies, security advisories, review requests, and mentions that need action

--- a/skills/install-skill/SKILL.md
+++ b/skills/install-skill/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Install Skill
 category: core
 description: Install a community skill pack into this fork from a GitHub repo and ship it as an auto-merged PR

--- a/skills/investigation-report/SKILL.md
+++ b/skills/investigation-report/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 mode: read-only
 name: Investigation Report
 category: onchain-security

--- a/skills/issue-triage/SKILL.md
+++ b/skills/issue-triage/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Issue Triage
 category: dev
 description: Decision-ready triage — classify, dedupe, and emit a verdict + next action per new GitHub issue

--- a/skills/last30/SKILL.md
+++ b/skills/last30/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Last 30 Days
 category: research
 description: Cross-platform social research — narrative-first intelligence on what people are saying about a topic across Reddit, X, HN, Polymarket, and the web over the last 30 days

--- a/skills/memory-flush/SKILL.md
+++ b/skills/memory-flush/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Memory Flush
 category: meta
 description: Promote important recent log entries into MEMORY.md and prune stale ones

--- a/skills/mention-radar/SKILL.md
+++ b/skills/mention-radar/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Mention Radar
 category: social
 description: Monitor external web and social mentions of the operator's active projects — surface what people are discovering, where they're confused, and where to engage

--- a/skills/monitor-polymarket/SKILL.md
+++ b/skills/monitor-polymarket/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 mode: read-only
 name: Monitor Prediction Markets
 category: crypto

--- a/skills/monitor-polymarket/watchlist-kalshi.md
+++ b/skills/monitor-polymarket/watchlist-kalshi.md
@@ -1,3 +1,7 @@
+---
+type: Reference
+---
+
 # Kalshi Watchlist
 # One event ticker per line. Find tickers at kalshi.com/markets or via the API.
 # Examples: KXGDP-26Q2, KXFED-26JUN, KXINFLATION-26MAR

--- a/skills/monitor-polymarket/watchlist-polymarket.md
+++ b/skills/monitor-polymarket/watchlist-polymarket.md
@@ -1,3 +1,7 @@
+---
+type: Reference
+---
+
 # Polymarket Watchlist
 # One event slug per line. Find slugs at polymarket.com/event/{slug}
 

--- a/skills/narrative-convergence/SKILL.md
+++ b/skills/narrative-convergence/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: narrative-convergence
 category: research
 description: Cross-skill signal detector — finds entities or themes surfaced independently by 3+ different skill categories within 48h and surfaces them as high-confidence write opportunities

--- a/skills/narrative-tracker/SKILL.md
+++ b/skills/narrative-tracker/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 mode: read-only
 name: Narrative Tracker
 category: crypto

--- a/skills/okf-export/SKILL.md
+++ b/skills/okf-export/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: OKF Export
 category: meta
 description: Backfill memory/topics into an OKF-conformant bundle by adding type frontmatter, then open a PR

--- a/skills/okf-ingest/SKILL.md
+++ b/skills/okf-ingest/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: OKF Ingest
 category: meta
 description: Fetch, validate, and quarantine an EXTERNAL OKF knowledge bundle into memory/topics/ingested, then open a PR

--- a/skills/onchain-monitor/SKILL.md
+++ b/skills/onchain-monitor/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Onchain Monitor
 category: crypto
 description: Monitor blockchain addresses and contracts for notable activity

--- a/skills/operator-scorecard/SKILL.md
+++ b/skills/operator-scorecard/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: operator-scorecard
 category: meta
 description: Three recap modes behind one selector — (default) a plain-language operator scorecard synthesizing agent health + community growth + economic activity into a was-it-worth-it verdict; `ops` an operational day-recap of what Aeon shipped, what failed, and what needs a human call; `push` a diff-reading deep-dive that ranks push impact and separates user-visible shipments from internal work.

--- a/skills/picks-tracker/SKILL.md
+++ b/skills/picks-tracker/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Picks Tracker
 category: crypto
 description: Retrospective on past token and prediction market picks — what hit, what flopped, what the score is

--- a/skills/pm-manipulation/SKILL.md
+++ b/skills/pm-manipulation/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: PM Manipulation
 category: crypto
 description: Detect suspected manipulation on prediction markets over the past 3 days by cross-referencing price/volume/comment anomalies with multilingual local-press coverage

--- a/skills/pm-pulse/SKILL.md
+++ b/skills/pm-pulse/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: pm-pulse
 category: crypto
 description: Prediction-market & coordination-market tracker — volume, new mechanism designs, regulatory moves, plus competitive intel on what platforms ship and who's entering

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: PR Review
 category: dev
 description: Review open PRs two ways — default is a per-PR deep review with severity-tagged findings, inline comments, and a one-line verdict; `--survey` runs a risk-tiered triage digest that buckets every open PR by touched-file blast radius (FAST_TRACK / INFRA_REVIEW / SKILL_PASS / SKILL_WARN_OR_BLOCK / CORE_REVIEW), runs skill-scan on every changed SKILL.md, and emits one operator digest of what's safe to merge first

--- a/skills/pr-triage/SKILL.md
+++ b/skills/pr-triage/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: PR Triage
 category: dev
 description: First-touch triage for external pull requests — verdict + label + welcoming comment within minutes of open

--- a/skills/price-alert/SKILL.md
+++ b/skills/price-alert/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Price Alert
 category: crypto
 description: Fire when the tracked token does something — new ATH, sharp 1h move, or operator-set target crossed. Silent on normal days.

--- a/skills/reply-maker/SKILL.md
+++ b/skills/reply-maker/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Reply Maker
 category: social
 description: Draft copy-paste-ready X replies — either two reply options per reply-worthy tweet from tracked accounts/topics/lists (default), or (from-logs mode) ready-to-post responses to engagement opportunities flagged in recent logs

--- a/skills/repo-scanner/SKILL.md
+++ b/skills/repo-scanner/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Repo Scanner
 category: dev
 description: Unified GitHub fleet intelligence — catalog repos into a prioritized report with concrete coded opportunities (that downstream skills consume directly), generate anchored, implementable per-repo action ideas, and map who's building on the fleet (forks, third-party ecosystem repos, builder announcements). One scan, three facets, selected via a var scope keyword.

--- a/skills/schedule-ads/SKILL.md
+++ b/skills/schedule-ads/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Schedule Ads
 category: social
 description: Manage paid ads on AdManage.ai from declarative config. Default branch schedules ad launches across Meta/TikTok/Snapchat/Pinterest/LinkedIn (PAUSED by default, never auto-activates live spend); `create` branch provisions Meta campaigns + ad sets (created PAUSED, IDs written back to state so the schedule branch can launch into them).

--- a/skills/search-skill/SKILL.md
+++ b/skills/search-skill/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Search Skills
 category: dev
 description: Search the open agent skills ecosystem for skills that fill a real gap and install them via the native add-skill path

--- a/skills/self-improve/SKILL.md
+++ b/skills/self-improve/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: self-improve
 category: core
 description: Improve the agent itself, or audit its recent performance — better skills, prompts, workflows, and config, plus a quality/reliability/memory-hygiene review of what the agent did and what failed

--- a/skills/send-email/SKILL.md
+++ b/skills/send-email/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Send Email
 category: productivity
 description: Compose and send a one-off email to a named recipient via Resend — written in the operator's voice, staged locally, then sent in postprocess with caps and an operator audit copy

--- a/skills/shiplog/SKILL.md
+++ b/skills/shiplog/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Shiplog
 category: productivity
 description: Recap of everything shipped since the last run — cross-repo PRs and commits, security fixes merged into other people's repos, star deltas, and X + ecosystem traction — synthesized into a digest article AND a ready-to-post shiplog in the operator's voice. Cadence-agnostic: schedule it daily, weekly, or on-demand.

--- a/skills/skill-health/SKILL.md
+++ b/skills/skill-health/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Skill Health
 category: core
 description: Fleet skill observability with two views. Health view audits per-skill metrics, files/resolves issues in memory/issues/, and notifies on state change only. Analytics view ranks the fleet by 7d run count, surfaces success rates, exit-taxonomy distribution, and anomaly flags (significance-gated). The selector picks the view.

--- a/skills/skill-repair/SKILL.md
+++ b/skills/skill-repair/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Skill Repair
 category: core
 description: Diagnose and fix failing or degraded skills automatically — systemic-first triage, per-category playbooks, verification plan

--- a/skills/soul-builder/SKILL.md
+++ b/skills/soul-builder/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: soul-builder
 category: social
 description: Build a SOUL from an X handle — read a wide sample of someone's public X account, then draft soul/SOUL.md (identity, worldview, opinions, influences), soul/STYLE.md (voice), and soul/examples/good-outputs.md so every content skill can speak in that voice.

--- a/skills/spawn-instance/SKILL.md
+++ b/skills/spawn-instance/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Spawn Instance
 category: core
 description: Clone this Aeon agent into a new GitHub repo — fork, configure skills, validate, register in fleet

--- a/skills/star-milestone/SKILL.md
+++ b/skills/star-milestone/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: star-milestone
 category: dev
 description: Two complementary star-growth jobs for watched repos in one pass. (1) CROSSING — announces when a repo crosses a star-count milestone (25, 50, 100, 150, 175, 200, 250, 500, 1000, ...) with a velocity-shaped narrative (time-to-milestone, growth shape, projection, tight highlight reel) and optionally auto-dispatches downstream skills (e.g. the `product-hunt` Show HN post via `product-hunt:showhn` at 500⭐) per the rule map in `memory/topics/milestone-dispatch.json`. (2) MOMENTUM — projects the date the next un-crossed milestone will be hit from the 7-day star growth-rate and fires a Show HN launch-timing alert only when that date lands in the dispatch window (7-14 days out, landing Tue/Wed/Thu). A default run reports crossings + momentum + next-milestone projection together.

--- a/skills/strategy-builder/SKILL.md
+++ b/skills/strategy-builder/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: strategy-builder
 category: productivity
 description: Draft STRATEGY.md from a goal — read the operator's brief (goal text, repo, links) plus the repo README + memory, then write a tight north-star/priorities/audience/constraints strategy that every skill reads on every run.

--- a/skills/token-movers/SKILL.md
+++ b/skills/token-movers/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Token Movers
 category: crypto
 description: Crypto market scanner + single-token analyst. Movers mode scans top winners/losers/trending (CoinGecko) or on-chain "runners" (GeckoTerminal) with signal enrichment and pump-risk flags; single-token mode produces a verdict-first deep report (price, volume, liquidity, treasury, social) for one address or symbol.

--- a/skills/token-pick/SKILL.md
+++ b/skills/token-pick/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 mode: read-only
 name: Token Pick
 category: crypto

--- a/skills/treasury-info/SKILL.md
+++ b/skills/treasury-info/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Treasury Info
 category: crypto
 description: Decision-ready treasury overview — verdict, concentration, depegs, significant changes

--- a/skills/tx-explain/SKILL.md
+++ b/skills/tx-explain/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 mode: read-only
 name: Tx Explain
 category: onchain-security

--- a/skills/unlock-monitor/SKILL.md
+++ b/skills/unlock-monitor/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Unlock Monitor
 category: crypto
 description: Token unlock and vesting tracker — quantify supply pressure via absorption ratio, classify cliff vs linear, deliver one-line market reads

--- a/skills/verdikta-hunter/SKILL.md
+++ b/skills/verdikta-hunter/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Verdikta Hunter
 category: crypto
 description: Hunt Verdikta AI-judged bounties on Base — discover open bounties, write rubric-targeted reports, and queue hard-capped on-chain submissions (signing happens post-run via scripts/postprocess-verdikta.sh, never in-skill)

--- a/skills/vuln-scanner/SKILL.md
+++ b/skills/vuln-scanner/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Vuln Scanner
 category: core
 description: Audit trending repos for real security vulnerabilities and disclose responsibly — scan and route findings (PVR / dependency PR), re-submit queued advisories when a watched repo enables private reporting, and auto-send armed out-of-band email disclosures via Resend

--- a/skills/vuln-tracker/SKILL.md
+++ b/skills/vuln-tracker/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Vuln Tracker
 category: dev
 description: One lifecycle poll over everything vuln-scanner produces — PR & advisory status (merges, stale opens, maintainer replies needing an answer, queued-too-long carve-outs), PVR triage-state transitions on submitted advisories, and pending-disclosure queue aging — with a stars-secured impact headline and a single operator-action queue.

--- a/skills/workflow-audit/SKILL.md
+++ b/skills/workflow-audit/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Workflow Audit
 category: dev
 description: Audit .github/workflows and composite actions with zizmor + actionlint, classify findings against the prior audit, auto-fix Critical/High regressions, and open a PR only when something actually changed.

--- a/skills/write-tweet/SKILL.md
+++ b/skills/write-tweet/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Write Tweet
 category: social
 description: Multi-format tweet studio — standalone drafts (10 across 5 size tiers), a 5–10 tweet thread, or 10 remixes of past tweets, selected via ${var}

--- a/skills/x402-monitor/SKILL.md
+++ b/skills/x402-monitor/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: Skill
 name: Protocol Monitor (x402 default)
 category: crypto
 description: Configurable weekly vertical/ecosystem tracker. Defaults to x402 (agent micropayments); preset selectors track RWA tokenization, the AI compute market, the MCP ecosystem, or AI agent job-displacement — each with its own sources, scoring, and output format. Repoint the default protocol via memory/topics/tracked-protocol.md.


### PR DESCRIPTION
Builds on #627 (merged). Widens OKF v0.1 conformance from `memory/topics/` to the full **knowledge + operational** scope, so Aeon's **real files are self-describing in place** — one file, no duplicated OKF copy.

## What & why
Per the follow-up decision: scope = "knowledge + operational" (`memory/`, `output/articles/`, `skills/`, `docs/`), shipped as a separate PR on top of the foundation. Every non-reserved `.md` under those roots now carries a non-empty `type:` (OKF §9).

**Verified additive-safe** before doing it: a leading frontmatter block doesn't disturb the load-bearing parsers — daily logs are LLM-read (health loop greps `### skill`), `compact_logs.py` matches on *filename*, issues/skills readers are *field*-based. No parser assumes a file starts with a heading.

## Type by family (105 files backfilled)
| Family | `type:` |
|---|---|
| `skills/*/SKILL.md` (71) | `Skill` (skill-internal notes → `Reference`) |
| `docs/*.md` (12) | `Reference` (`docs/examples/` excluded) |
| `output/articles/` (2) | `Article` |
| `memory/logs/` | `Log` |
| `MEMORY.md`, `memory/issues/INDEX.md` | `Index` |
| `memory/issues/` | `Issue` |
| `memory/products.md`, `watched-repos.md` | `Reference` |

## Tooling
- **`scripts/okf-config.json`** — single source for roots, exclusions, and per-family backfill types.
- **`scripts/okf-backfill.mjs`** — idempotent `type:` stamper (`--dry` preview).
- **`scripts/okf-validate.mjs`** — now multi-root from config (explicit `<root>` still works for `okf-ingest`); refined reserved-index handling.
- **`ci-okf.yml`** — gate widened to `memory/**`, `output/articles/**`, `skills/**`, `docs/**`.
- **`apps/mcp-server`** — `okf://` surface now also serves `output/articles` as `Article` concepts (logs/issues/docs stay conformant but out of the served index, to preserve progressive disclosure §6).
- **`CLAUDE.md` + `docs/OKF.md`** — convention + scope documented.

## Exemptions (no `type:`)
Reserved `index.md`/`log.md`; and out-of-scope: root instruction files (`CLAUDE.md`, `STRATEGY.md`, `README.md`), generated `AGENTS.md`, illustrative examples (`docs/examples/`, `soul/`). We do **not** rename `MEMORY.md`/logs to reserved OKF names — that would break the health loop; they become typed concepts instead.

## Verification (all green locally)
- `node scripts/okf-validate.mjs` → OK, **106 concepts** across all roots; `okf-backfill --dry` → no-op (idempotent).
- `apps/mcp-server` `tsc` build clean; smoke test serves `okf://concept/articles/...`.
- `skills.json` **semantically identical** (`type:` not read by the generator) → `ci-skills-json` passes; `check-skill-categories`, `check-capabilities-parity`, `validate-config`, `gen-agents-md --check` all pass.
- `ci-tests` suite (notify_format, notify, telegram_route, compact_logs, prune_skills, skill_mode) all pass.

## Notes
- No skill enabled; purely additive metadata + tooling.
- `apps/mcp-server/package-lock.json` left uncommitted (mcp-server tracks no lockfile).