### PR TITLE
fix: reject duplicate slugs in skill-pack manifest

### DIFF
--- a/bin/install-skill-pack
+++ b/bin/install-skill-pack
@@ -345,6 +345,7 @@ if [[ -f "$MANIFEST_PATH" ]]; then
     exit 1
   fi
 
+  seen_slugs=""
   for i in $(seq 0 $((skill_count - 1))); do
     slug=$(jq -r ".skills[$i].slug // empty" "$MANIFEST_PATH")
     if [[ -z "$slug" ]]; then
@@ -356,6 +357,13 @@ if [[ -f "$MANIFEST_PATH" ]]; then
       echo "Invalid slug in manifest: $slug" >&2
       exit 1
     fi
+    # Reject duplicate slugs — a second declaration would silently overwrite the
+    # first skill's install, leaving the author confused about which config won.
+    # Space-delimited string check (no associative arrays — macOS bash 3 compat).
+    case " $seen_slugs " in
+      *" $slug "*) echo "Duplicate slug in manifest: '$slug' is declared more than once — aborting." >&2; exit 1 ;;
+    esac
+    seen_slugs="$seen_slugs $slug"
     rel_path=$(jq -r ".skills[$i].path // empty" "$MANIFEST_PATH")
     [[ -z "$rel_path" ]] && rel_path="skills/$slug"
     rel_path="${rel_path#/}"

--- a/scripts/tests/test_validate_pack.sh
+++ b/scripts/tests/test_validate_pack.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Unit test for scripts/validate-pack.sh — duplicate-slug detection and clean-pack pass.
+# No network, no GitHub auth required. Creates throwaway pack dirs under /tmp.
+set -uo pipefail
+cd "$(dirname "$0")/../.." || exit 1
+
+V="scripts/validate-pack.sh"
+fail=0
+pass(){ echo "ok   - $1"; }
+bad(){ echo "FAIL - $1"; fail=1; }
+
+# ── Setup: a minimal pack with two skills ────────────────────────────────────
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p "$TMP/skills/foo" "$TMP/skills/bar"
+cat > "$TMP/skills/foo/SKILL.md" <<'EOF'
+---
+name: foo
+description: Test skill foo
+---
+# Foo
+EOF
+cat > "$TMP/skills/bar/SKILL.md" <<'EOF'
+---
+name: bar
+description: Test skill bar
+---
+# Bar
+EOF
+
+# ── Test 1: duplicate slugs → ERROR, exit 1 ──────────────────────────────────
+cat > "$TMP/skills-pack.json" <<'EOF'
+{
+  "name": "test-pack",
+  "version": "1.0",
+  "skills": [
+    { "slug": "foo", "path": "skills/foo" },
+    { "slug": "foo", "path": "skills/bar" }
+  ]
+}
+EOF
+
+out=$(bash "$V" "$TMP" 2>&1)
+rc=$?
+if [[ "$rc" -ne 1 ]]; then
+  bad "duplicate slug should exit 1 (got $rc)"
+else
+  if echo "$out" | grep -q "duplicate slug 'foo'"; then
+    pass "duplicate slug detected with correct message"
+  else
+    bad "duplicate slug not mentioned in output: $out"
+  fi
+fi
+
+# ── Test 2: unique slugs → pass, exit 0 ──────────────────────────────────────
+cat > "$TMP/skills-pack.json" <<'EOF'
+{
+  "name": "test-pack",
+  "version": "1.0",
+  "description": "Test pack",
+  "author": "test",
+  "license": "MIT",
+  "skills": [
+    { "slug": "foo", "path": "skills/foo" },
+    { "slug": "bar", "path": "skills/bar" }
+  ]
+}
+EOF
+
+out=$(bash "$V" "$TMP" 2>&1)
+rc=$?
+if [[ "$rc" -ne 0 ]]; then
+  bad "clean pack should exit 0 (got $rc): $out"
+else
+  if echo "$out" | grep -q "pack is valid"; then
+    pass "clean pack passes validation"
+  else
+    bad "clean pack did not report valid: $out"
+  fi
+fi
+
+# ── Test 3: triple duplicate → ERROR, reports the slug ───────────────────────
+cat > "$TMP/skills-pack.json" <<'EOF'
+{
+  "name": "test-pack",
+  "version": "1.0",
+  "skills": [
+    { "slug": "foo", "path": "skills/foo" },
+    { "slug": "bar", "path": "skills/bar" },
+    { "slug": "foo", "path": "skills/foo" }
+  ]
+}
+EOF
+
+out=$(bash "$V" "$TMP" 2>&1)
+rc=$?
+if [[ "$rc" -ne 1 ]]; then
+  bad "triple duplicate should exit 1 (got $rc)"
+else
+  if echo "$out" | grep -q "duplicate slug 'foo'"; then
+    pass "triple duplicate detected"
+  else
+    bad "triple duplicate not reported: $out"
+  fi
+fi
+
+if [[ "$fail" -eq 0 ]]; then
+  echo ""
+  echo "All validate-pack tests passed."
+else
+  echo ""
+  echo "SOME TESTS FAILED."
+fi
+exit "$fail"

--- a/scripts/validate-pack.sh
+++ b/scripts/validate-pack.sh
@@ -181,6 +181,8 @@ fi
 
 # Track the manifest-declared paths so we can flag on-disk skills that aren't listed.
 declared_paths=""
+# Track slugs already seen so a duplicate declaration is caught before install.
+seen_slugs=""
 
 for i in $(seq 0 $((skill_count - 1))); do
   slug=$(jq -r ".skills[$i].slug // empty" "$MANIFEST_PATH")
@@ -194,6 +196,14 @@ for i in $(seq 0 $((skill_count - 1))); do
     err "skill '$slug' has an invalid slug (allowed: A-Z a-z 0-9 _ -)"
     continue
   fi
+
+  # Reject duplicate slugs — a second declaration silently overwrites the first
+  # at install time. Catching it here gives the author an actionable message.
+  # Space-delimited string check (portable, no associative arrays).
+  case " $seen_slugs " in
+    *" $slug "*) err "duplicate slug '$slug' — declared more than once in the manifest"; continue ;;
+  esac
+  seen_slugs="$seen_slugs $slug"
 
   rel_path=$(jq -r ".skills[$i].path // empty" "$MANIFEST_PATH")
   [[ -z "$rel_path" ]] && rel_path="skills/$slug"


### PR DESCRIPTION
## Problem

`install-skill-pack` and `validate-pack.sh` both iterated `skills[]` without checking for repeated slug declarations. A manifest that accidentally listed the same slug twice would silently overwrite the first skill's install — the author gets no signal until the wrong skill config shows up at runtime.

## Fix

Add a space-delimited seen-slug check to both scripts:
- `install-skill-pack`: exits 1 on the first duplicate (fail-fast at install time)
- `validate-pack.sh`: reports it as an ERROR and keeps going so the author sees all problems in one pass

Uses a space-delimited string pattern (`case " $seen_slugs " in`) instead of associative arrays for macOS bash 3 compatibility — matching the existing convention noted at line 304 of `install-skill-pack`.

## Tests

New `scripts/tests/test_validate_pack.sh` covers three cases:
1. Duplicate slug → ERROR, exit 1
2. Clean pack (unique slugs) → passes, exit 0
3. Triple duplicate → ERROR, reports the slug

All tests pass:
```
ok   - duplicate slug detected with correct message
ok   - clean pack passes validation
ok   - triple duplicate detected

All validate-pack tests passed.
```