### PR TITLE
feat(verdikta-hunter): add Python helpers for API client and on-chain interaction

### DIFF
--- a/skills/verdikta-hunter/SKILL.md
+++ b/skills/verdikta-hunter/SKILL.md
@@ -1,0 +1,147 @@
+---
+type: Skill
+name: Verdikta Hunter
+category: crypto
+description: Hunt Verdikta AI-judged bounties on Base — discover open bounties, write rubric-targeted reports, and queue hard-capped on-chain submissions (signing happens post-run via scripts/postprocess-verdikta.sh, never in-skill)
+var: ""
+tags: [crypto, bounties, base, verdikta, web3]
+requires: [VERDIKTA_API_KEY, VERDIKTA_WALLET_KEY?]
+capabilities: [external_api, writes_external_host, onchain_writes, sends_notifications]
+---
+
+> **${var}** — Mode selector.
+> - `` (empty) → **discover + settle**: rank open bounties, notify a shortlist, and queue finalize for any prior submissions ready to claim. Never queues a new submission — zero new spend. *[default]*
+> - `hunt` / `hunt:<jobId>` → discover + settle, then pick the best-fit bounty (or the given `<jobId>`), write the report, and queue one on-chain submission for post-run execution.
+> - `dry-run` / `dry-run:<jobId>` → same as `hunt` but the queued request is validation-only: the postprocess script calls the API's `/submit/dry-run` and sends **no transactions**.
+
+## Goal
+
+Earn ETH from [Verdikta](https://bounties.verdikta.org) bounties on Base: open bounties carry an escrowed ETH reward and a public rubric; two independent AI models score each submission against the rubric, and a submission at or above the bounty's threshold wins the escrow. This skill does the judgment work — choosing bounties worth attempting and writing reports that score well — while all authed API calls and transaction signing happen outside the sandbox in `scripts/prefetch-verdikta.sh` (before the run) and `scripts/postprocess-verdikta.sh` (after the run).
+
+## Config
+
+| Name | Kind | Default | Purpose |
+|------|------|---------|---------|
+| `VERDIKTA_API_KEY` | secret | required | Bot API key (`X-Bot-API-Key`) from `POST https://bounties.verdikta.org/api/bots/register` |
+| `VERDIKTA_WALLET_KEY` | secret | — | Private key of a **dedicated** Base hot wallet. Only needed to submit (`hunt`); discover/settle-only and `dry-run` work without it |
+| `VERDIKTA_MAX_SPEND_ETH` | repo var | `0.0005` | **Hard client-side cap** on the ETH value of any single transaction the postprocess script will sign, regardless of what the API returns |
+| `VERDIKTA_MAX_SUBMISSIONS_PER_DAY` | repo var | `5` | Daily cap on new submissions (tracked in `memory/state/verdikta-hunter.json`) |
+| `VERDIKTA_RPC_URL` | repo var | `https://mainnet.base.org` | Base JSON-RPC endpoint |
+
+### Fund safety — read before enabling
+
+This skill can spend real ETH. The safety envelope, enforced by `scripts/postprocess-verdikta.sh` (not by the model, and not by the remote API):
+
+- **Dedicated wallet only.** Fund a fresh wallet with a small working balance (~0.005 ETH covers gas plus several oracle prepays) and use its key as `VERDIKTA_WALLET_KEY`. Never reuse a wallet that holds anything you can't lose.
+- **Hard spend cap.** The oracle prepay (`ethMaxBudget`) comes from the API response, so the script treats it as untrusted: any transaction whose value exceeds `VERDIKTA_MAX_SPEND_ETH` is refused and logged, never signed. The real-world worst-case prepay is ~0.00024 ETH, so the 0.0005 default has headroom without meaningful blast radius. The prepay is escrow, not a fee — the unspent portion is refunded at finalize.
+- **Pinned destination.** Transactions are only signed if `to` equals the known BountyEscrow contract `0x2Ae271f5E86bee449a36B943414b7C1a7b39772D` and `chainId` is 8453 (Base). A compromised API response cannot redirect funds elsewhere.
+- **Rate limits.** At most one new submission per run, at most `VERDIKTA_MAX_SUBMISSIONS_PER_DAY` per UTC day, and a balance preflight before every transaction.
+- **Deferred execution.** The skill itself only writes request files under `.pending-verdikta/`; if the run errors, the workflow drops the queue and nothing is sent. Start with `dry-run` until you trust the loop.
+
+## Steps
+
+### 0. Parse `${var}` and load context
+
+- Parse the mode: empty → `MODE=discover`; `hunt[:<jobId>]` → `MODE=hunt`; `dry-run[:<jobId>]` → `MODE=hunt` with `DRY_RUN=true`. A trailing `<jobId>` pins the target bounty.
+- Read `memory/MEMORY.md` and the last ~3 days of `memory/logs/` (don't re-report signals already sent).
+- Read `memory/state/verdikta-hunter.json` if present — it tracks prior submissions (`jobId`, `submissionId`, tx hashes, status, spend) and the daily submission count. Bootstrap mentally with `{"submissions": {}, "daily": {}}` if absent; the postprocess script owns writes to this file.
+- Read the prefetched cache: `.verdikta-cache/bounties.json` (open bounties), `.verdikta-cache/rubric-<jobId>.json` (per-bounty rubrics), `.verdikta-cache/submissions-<jobId>.json` (status of bounties we've submitted to). If `.verdikta-cache/` is missing or empty, `VERDIKTA_API_KEY` isn't configured or the prefetch failed — notify `VERDIKTA_HUNTER_ERROR — no cache; check VERDIKTA_API_KEY and prefetch logs`, log, and stop.
+
+### 1. Settle prior submissions (every mode)
+
+For each tracked submission in state, check its current status in `.verdikta-cache/submissions-<jobId>.json`:
+
+- `ACCEPTED_PENDING_CLAIM` or `REJECTED_PENDING_FINALIZATION` → queue a finalize: write `.pending-verdikta/finalize-<jobId>-<subId>.json` containing `{"action": "finalize", "jobId": <n>, "submissionId": <n>}`. Finalize is **mandatory even after a pass** — payment is not automatic, and it's what refunds the unspent oracle prepay after a fail.
+- `PENDING_EVALUATION` for more than ~30 minutes (compare state's `submittedAt` to now) → the oracle may be stuck; note it in the report and log. Timeout recovery is intentionally not automated — flag it for the operator with the manual command: `POST /api/jobs/<jobId>/submissions/<subId>/timeout`.
+- `APPROVED` (paid) or `REJECTED` (settled) since last run → include the outcome in the notification: score vs threshold, and the payout tx if won.
+
+### 2. Discover and rank open bounties
+
+From `.verdikta-cache/bounties.json`, drop bounties that are: already submitted to by our wallet (in state), past or within ~24h of their `submissionDeadline`, targeted at another hunter (`targetHunter` set and not us), or in a creator-approval window flow (`creatorAssessmentWindowSize > 0`) — windowed bounties are out of scope for v1.
+
+Score the rest on: reward (`payoutWei`) vs. effort implied by the rubric, threshold attainability (lower threshold = easier), competition (`submissions` count), and fit with `STRATEGY.md` priorities and our actual capabilities — **skip bounties requiring work we can't genuinely deliver** (e.g. deliverables needing binary assets, human accounts, or off-repo actions). For each surviving candidate read `.verdikta-cache/rubric-<jobId>.json`: `must: true` criteria are binary gates (fail one = score 0); weighted criteria sum to 1.0.
+
+- `MODE=discover`: notify the top 3–5 as a shortlist (jobId, reward in ETH, threshold, submissions count, one-line rubric summary, deadline), log, and stop. If nothing is worth attempting and nothing settled, stay silent — no empty reports.
+- `MODE=hunt`: pick the single best candidate (or the pinned `<jobId>` — but still refuse it if it fails the drop-filters above, and say why). If the daily count in state already meets `VERDIKTA_MAX_SUBMISSIONS_PER_DAY`, fall back to discover behaviour and note the cap in the notification.
+
+### 3. Write the report
+
+Write the deliverable to `.pending-verdikta/files/<jobId>/report.md` (plus extra files alongside it only if the rubric explicitly demands separate deliverables).
+
+- Address **every** rubric criterion, in rubric order, under explicit headings — the AI jurors score criterion-by-criterion. Treat `must: true` criteria as pass/fail gates and satisfy them beyond doubt.
+- Embed all evidence inline in markdown: fenced code blocks for data/commands, full URLs for sources, tx hashes where relevant. Verifiable beats voluminous.
+- **Never** produce archives (`.zip`/`.tar`/`.gz`/`.rar`) — the oracle drops them as binary and the models see nothing. Prefer markdown; each uploaded file is forwarded to the jurors individually.
+- No placeholders, no "TODO", no fabricated claims — an unverified claim that fails a must-pass gate burns the prepay and the reputation.
+
+### 4. Queue the submission
+
+Write `.pending-verdikta/submit-<jobId>.json`:
+
+```json
+{
+  "action": "submit",
+  "jobId": 97,
+  "files": ["report.md"],
+  "addendum": "",
+  "alpha": 200,
+  "maxOracleFee": "0.00002",
+  "estimatedBaseCost": "0.00001",
+  "maxFeeBasedScaling": 3,
+  "dryRun": false
+}
+```
+
+- `files` are names under `.pending-verdikta/files/<jobId>/`.
+- `alpha` 200 favours quality over timeliness (range 0–1000; lower = quality-weighted).
+- Keep the fee parameters at these defaults — they bound the oracle prepay by construction; raising them raises `ethMaxBudget`.
+- Set `"dryRun": true` when `DRY_RUN` — the postprocess script then only calls `/submit/dry-run` (file readability + rubric shape validation, no gas, no transactions).
+
+The postprocess script executes this after the run: upload → `prepareSubmission` tx (value 0) → confirm → cap-check → `startPreparedSubmission` tx (value = `ethMaxBudget`), then records tx hashes, `submissionId`, and spend into `memory/state/verdikta-hunter.json` and appends a `### verdikta-hunter (postprocess)` entry to today's log. **This run cannot see those results** — the next run reports them (step 1).
+
+### 5. Notify
+
+One `./notify -f` message per run with real signal, following soul/ voice if present. Write the message body to `.verdikta-cache/notify.md` (gitignored and regenerated each run — the harness can't `rm`, so scratch files anywhere else end up auto-committed):
+
+- Settlements first: won (score, payout), lost (score vs threshold, one-line diagnosis from `.verdikta-cache/` evaluation data if available), finalizes queued.
+- Then the action taken: shortlist (discover), or "queued submission to #<jobId> (<reward> ETH, threshold <t>%) — pending postprocess" (hunt), or dry-run verdict.
+- Severity: `success` for a win, `warn` for a stuck/failed submission or refused cap, `info` otherwise.
+- Nothing settled and nothing worth attempting → no notification.
+
+### 6. Log
+
+Append to `memory/logs/YYYY-MM-DD.md`:
+
+```
+### verdikta-hunter
+- Mode: discover | hunt | dry-run
+- Open bounties: N (M viable after filters)
+- Settled: #97/0 finalize queued | #95/1 WON 0.002 ETH | none
+- Queued: submit-97 (0.0015 ETH reward, threshold 80) | none
+- Skipped: #98 (deadline <24h), #99 (windowed) — one line, only when relevant
+- Notification sent: yes/no
+```
+
+## Key gotchas
+
+1. **Always finalize.** Without `finalizeSubmission` the oracle prepay stays escrowed forever — even a winning submission isn't paid until finalize.
+2. **`ethMaxBudget` is wei and comes from the API** (`/submit/bundle/complete` → `parsed.ethMaxBudget`). Never hand-decode the `SubmissionPrepared` event with a partial ABI — the budget is the *last* field after a dynamic string, and a truncated ABI reads the string-offset word (96) instead.
+3. **must-pass criteria are binary.** `must: true` always has weight 0; failing any one scores the whole submission 0.
+4. **Archives are invisible.** `.zip` and friends are dropped by the oracle pipeline; submit individual readable files.
+5. **Two-model jury.** Independent AI models score and their weighted results are combined — write for a careful, literal reader, not for keyword-matching.
+6. **The confirm call matters.** `POST /api/jobs/:id/submissions/confirm` (between prepare and start) registers the submission for backend tracking; the postprocess script does it — if you ever drive the flow manually, don't skip it.
+7. **API statuses lag chain state** by a sync cycle. `GET /api/jobs/:id/onchain-status` is the ground truth when they disagree.
+
+## Sandbox note
+
+The GitHub Actions sandbox blocks secret-bearing outbound calls from the skill itself, so this skill never talks to `bounties.verdikta.org` or signs anything directly:
+
+- **Pre-fetch:** `scripts/prefetch-verdikta.sh` runs before the skill with full env access and caches open bounties, rubrics, and tracked-submission statuses into `.verdikta-cache/`.
+- **Post-process:** the skill queues requests in `.pending-verdikta/`; `scripts/postprocess-verdikta.sh` runs after a **successful** run and performs the authed uploads plus the cap-checked signing/broadcast. A failed run drops the queue.
+- Public reads that need no auth (e.g. spot-checking a bounty page) may use WebFetch, which bypasses the sandbox. Don't use curl for them.
+
+## Exit codes
+
+- `VERDIKTA_HUNTER_OK` — ran clean (shortlist, queue written, or silent no-op)
+- `VERDIKTA_HUNTER_DRY_RUN` — dry-run queued, no transactions will be sent
+- `VERDIKTA_HUNTER_CAPPED` — daily submission cap reached; fell back to discover
+- `VERDIKTA_HUNTER_ERROR` — missing cache/key or malformed state; notified

--- a/skills/verdikta-hunter/helpers/README.md
+++ b/skills/verdikta-hunter/helpers/README.md
@@ -1,0 +1,119 @@
+# Verdikta Hunter Helpers
+
+Python utilities for autonomous Verdikta bounty hunting on Base L2.
+
+## Modules
+
+### `verdikta_api.py` — API Client
+
+Wraps `bounties.verdikta.org` REST API with auth, filtering, and submission flow.
+
+```python
+from helpers.verdikta_api import VerdiktaClient
+
+client = VerdiktaClient(api_key="your-key")
+
+# Discovery
+bounties = client.list_open_bounties()
+filtered = client.filter_bounties(
+    bounties,
+    min_bounty_eth=0.001,
+    max_threshold=85,
+    min_deadline_hours=48,
+    keywords=["math", "graph"],
+)
+ranked = client.rank_bounties(filtered)
+
+# Rubric
+rubric = client.get_rubric(job_id=121)
+for criterion in rubric["criteria"]:
+    print(f"  {'⚠️ MUST' if criterion['must'] else f'weight {criterion[\"weight\"]}'}: "
+          f"{criterion['description'][:80]}")
+```
+
+**Key features:**
+- `filter_bounties()` — filter by reward, threshold, deadline, keywords, competition
+- `_is_windowed_bounty()` — detect creator-approval vs oracle-evaluated bounties
+- `rank_bounties()` — score by reward-to-difficulty ratio
+- `bundle_upload()` / `bundle_complete()` / `confirm_submission()` — full submit flow
+
+### `verdikta_onchain.py` — On-Chain Interaction
+
+Handles the 5-step submission flow on Base L2 (chainId 8453).
+
+```python
+from helpers.verdikta_onchain import VerdiktaOnchain
+
+chain = VerdiktaOnchain(
+    rpc_url="https://mainnet.base.org",
+    private_key="0x...",
+)
+
+# Balance check
+print(f"Balance: {chain.get_balance_eth():.6f} ETH")
+
+# Step 1: prepareSubmission (uses API-returned calldata)
+result = chain.prepare_submission(
+    job_id=97,
+    calldata=api_calldata,  # From /submit/bundle
+    dry_run=True,  # Always simulate first!
+)
+
+# Step 2: startPreparedSubmission (triggers oracle)
+result = chain.start_submission(
+    job_id=97,
+    calldata=step2_calldata,  # From /bundle/complete
+    eth_max_budget_wei=3600000000000000,  # From API
+)
+
+# Step 3: finalizeSubmission (claim refund/reward)
+result = chain.finalize_submission(
+    job_id=97,
+    submission_id=5,
+    calldata=step3_calldata,  # From /bundle/complete or cached
+)
+```
+
+**Key features:**
+- All RPC calls use standard `eth_` method names (`eth_getBalance`, `eth_gasPrice`, etc.)
+- Prefers API-returned calldata over manual encoding
+- Balance verification before every TX
+- `dry_run` mode — simulates with `eth_call` before sending
+- Automatic timeout simulation check (prevents wasted gas)
+- Step 3 calldata caching from bundle/complete response
+- Event log parsing for SubmissionPrepared
+
+### `example_usage.py` — CLI
+
+```bash
+# Discover bounties
+python -m helpers.example_usage discover --top 5 --max-threshold 85
+
+# Check rubric
+python -m helpers.example_usage rubric 121
+
+# Submit (dry run first!)
+python -m helpers.example_usage submit 121 --file report.md --dry-run
+
+# Monitor evaluation
+python -m helpers.example_usage monitor 121 5
+
+# Finalize
+python -m helpers.example_usage finalize 121 5 --dry-run
+```
+
+## Dependencies
+
+```
+requests>=2.28
+web3>=6.0
+eth-account>=0.10
+eth-abi>=4.0
+```
+
+## Safety Notes
+
+- **Always use `dry_run=True` first** — catches calldata errors, balance issues, and simulation failures before committing gas
+- **Never hardcode private keys** — use `VERDIKTA_WALLET_KEY` env var
+- **Balance formula**: `balance >= ethMaxBudget + (gas_limit × gas_price)` — check before every TX
+- **Gas limits**: prepare=1M, start=4M, finalize=300K, timeout=2M+10gwei minimum

--- a/skills/verdikta-hunter/helpers/__init__.py
+++ b/skills/verdikta-hunter/helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Verdikta Hunter helpers — API client and on-chain interaction."""

--- a/skills/verdikta-hunter/helpers/example_usage.py
+++ b/skills/verdikta-hunter/helpers/example_usage.py
@@ -1,0 +1,254 @@
+"""Example CLI usage for Verdikta bounty hunting helpers.
+
+Demonstrates the complete workflow: discover → filter → rank → submit.
+
+Usage:
+    python -m helpers.example_usage discover
+    python -m helpers.example_usage rubric 121
+    python -m helpers.example_usage submit 121 --dry-run
+    python -m helpers.example_usage monitor 121 5
+"""
+
+import argparse
+import json
+import os
+import sys
+
+from helpers.verdikta_api import VerdiktaClient
+from helpers.verdikta_onchain import VerdiktaOnchain
+
+
+def cmd_discover(args):
+    """Discover and rank open bounties."""
+    client = VerdiktaClient()
+    bounties = client.list_open_bounties()
+    print(f"\n📋 Found {len(bounties)} open bounties\n")
+
+    filtered = client.filter_bounties(
+        bounties,
+        hunter_address=args.hunter,
+        min_bounty_eth=args.min_reward,
+        max_threshold=args.max_threshold,
+        min_deadline_hours=args.min_hours,
+        keywords=args.keywords.split(",") if args.keywords else None,
+    )
+    print(f"🔍 After filters: {len(filtered)} bounties\n")
+
+    ranked = client.rank_bounties(filtered)
+
+    for i, b in enumerate(ranked[:args.top], 1):
+        hours = b.get("_hours_until_deadline", "?")
+        score = b.get("_opportunity_score", 0)
+        windowed = "📌 windowed" if client._is_windowed_bounty(b) else ""
+        print(f"  {i}. #{b['jobId']} — {b.get('bountyAmount', 0)} ETH "
+              f"(threshold {b.get('threshold', '?')}%) "
+              f"— {hours}h left — score: {score} {windowed}")
+        print(f"     {b.get('title', 'No title')[:80]}")
+        print()
+
+
+def cmd_rubric(args):
+    """Show rubric for a specific bounty."""
+    client = VerdiktaClient()
+    rubric = client.get_rubric(args.job_id)
+    bounty = client.get_bounty(args.job_id)
+
+    print(f"\n📝 Bounty #{args.job_id}: {bounty.get('title', 'N/A')}")
+    print(f"   Reward: {bounty.get('bountyAmount', 0)} ETH")
+    print(f"   Threshold: {bounty.get('threshold', '?')}%")
+    print(f"   Windowed: {VerdiktaClient._is_windowed_bounty(bounty)}")
+    print(f"\n   Rubric:")
+
+    for c in rubric.get("criteria", []):
+        must = "⚠️ MUST-PASS" if c.get("must") else f"weight {c.get('weight', 0)}"
+        print(f"   - [{must}] {c.get('description', '')[:100]}")
+
+
+def cmd_submit(args):
+    """Submit to a bounty (or dry-run)."""
+    client = VerdiktaClient()
+    chain = VerdiktaOnchain()
+
+    if not chain.address:
+        print("❌ No wallet configured (set VERDIKTA_WALLET_KEY)")
+        sys.exit(1)
+
+    bounty = client.get_bounty(args.job_id)
+    print(f"\n🎯 Submitting to #{args.job_id}: {bounty.get('title', 'N/A')}")
+    print(f"   Reward: {bounty.get('bountyAmount', 0)} ETH")
+    print(f"   Threshold: {bounty.get('threshold', '?')}%")
+
+    # Check if windowed
+    if VerdiktaClient._is_windowed_bounty(bounty):
+        print("   ⚠️  This is a windowed (creator-approval) bounty")
+        print("   Oracle prepay not required, but approval may take longer")
+
+    # Check balance
+    balance = chain.get_balance_eth()
+    print(f"\n   💰 Balance: {balance:.6f} ETH")
+
+    if args.dry_run:
+        print("   🔍 DRY RUN — no transactions will be sent\n")
+
+    # Step 1: Upload and get calldata
+    if not os.path.exists(args.file):
+        print(f"❌ File not found: {args.file}")
+        sys.exit(1)
+
+    print("   📤 Uploading files...")
+    bundle = client.bundle_upload(
+        job_id=args.job_id,
+        files=[args.file],
+        hunter_address=chain.address,
+        alpha=args.alpha,
+    )
+
+    step1_data = bundle.get("transactions", [{}])[0].get("data", "")
+    hunter_cid = bundle.get("hunterCid", "")
+    print(f"   ✅ Upload complete, hunterCid: {hunter_cid[:20]}...")
+
+    # Step 2: prepareSubmission
+    print("   📝 Step 1: prepareSubmission...")
+    result = chain.prepare_submission(
+        job_id=args.job_id,
+        calldata=step1_data,
+        dry_run=args.dry_run,
+    )
+    if not result.get("success"):
+        print(f"   ❌ Failed: {result.get('error')}")
+        sys.exit(1)
+
+    if args.dry_run:
+        print("   ✅ Simulation passed — ready for real submission")
+        return
+
+    step1_tx = result["tx_hash"]
+    print(f"   ✅ TX: {step1_tx}")
+
+    # Parse receipt for submissionId
+    receipt = chain.w3.eth.get_receipt(step1_tx)
+    parsed = chain.parse_submission_prepared(receipt)
+    if parsed:
+        submission_id = parsed["submission_id"]
+        eval_wallet = parsed["eval_wallet"]
+        print(f"   📋 Submission ID: {submission_id}")
+
+    print("\n   ⏸️  Submission queued. Complete the flow with:")
+    print(f"   1. POST /api/jobs/{args.job_id}/submissions/confirm")
+    print(f"   2. bundle_complete with step1 tx hash")
+    print(f"   3. startPreparedSubmission with ethMaxBudget")
+    print(f"   4. Poll until evaluated")
+    print(f"   5. finalizeSubmission to claim")
+
+
+def cmd_monitor(args):
+    """Monitor a submission until evaluated."""
+    client = VerdiktaClient()
+    chain = VerdiktaOnchain()
+
+    print(f"\n⏳ Monitoring bounty #{args.job_id}, submission #{args.submission_id}")
+    result = chain.poll_until_evaluated(
+        api_client=client,
+        job_id=args.job_id,
+        submission_id=args.submission_id,
+        timeout_minutes=args.timeout,
+    )
+
+    status = result.get("status", "UNKNOWN")
+    score = result.get("score", "N/A")
+    print(f"\n📊 Final status: {status}")
+    if score:
+        print(f"   Score: {score}")
+
+    if status in ("EVALUATED_PASSED", "WINNER", "ACCEPTED"):
+        print("   🎉 Ready to finalize!")
+    elif status == "EVALUATED_FAILED":
+        print("   💀 Failed — finalize to reclaim escrow")
+
+
+def cmd_finalize(args):
+    """Finalize a submission to claim refund/reward."""
+    chain = VerdiktaOnchain()
+
+    print(f"\n🏁 Finalizing bounty #{args.job_id}, submission #{args.submission_id}")
+
+    if args.dry_run:
+        print("   🔍 DRY RUN — simulating only\n")
+
+    result = chain.finalize_submission(
+        job_id=args.job_id,
+        submission_id=args.submission_id,
+        calldata=args.calldata,
+        dry_run=args.dry_run,
+    )
+
+    if result.get("success"):
+        if args.dry_run:
+            print("   ✅ Simulation passed")
+        else:
+            print(f"   ✅ TX: {result['tx_hash']}")
+    else:
+        print(f"   ❌ Failed: {result.get('error')}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Verdikta Bounty Hunter CLI",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  python -m helpers.example_usage discover --top 5
+  python -m helpers.example_usage rubric 121
+  python -m helpers.example_usage submit 121 --file report.md --dry-run
+  python -m helpers.example_usage monitor 121 5
+  python -m helpers.example_usage finalize 121 5 --dry-run
+        """,
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # discover
+    p = sub.add_parser("discover", help="Find and rank open bounties")
+    p.add_argument("--hunter", default="", help="Our wallet address")
+    p.add_argument("--min-reward", type=float, default=0.001, help="Min reward ETH")
+    p.add_argument("--max-threshold", type=int, default=90, help="Max threshold %")
+    p.add_argument("--min-hours", type=float, default=24, help="Min hours to deadline")
+    p.add_argument("--keywords", default="", help="Comma-separated keywords")
+    p.add_argument("--top", type=int, default=10, help="Show top N results")
+
+    # rubric
+    p = sub.add_parser("rubric", help="Show bounty rubric")
+    p.add_argument("job_id", type=int, help="Bounty ID")
+
+    # submit
+    p = sub.add_parser("submit", help="Submit to a bounty")
+    p.add_argument("job_id", type=int, help="Bounty ID")
+    p.add_argument("--file", required=True, help="Report file to submit")
+    p.add_argument("--alpha", type=int, default=200, help="Quality weight (0-1000)")
+    p.add_argument("--dry-run", action="store_true", help="Simulate only")
+
+    # monitor
+    p = sub.add_parser("monitor", help="Monitor submission status")
+    p.add_argument("job_id", type=int, help="Bounty ID")
+    p.add_argument("submission_id", type=int, help="Submission ID")
+    p.add_argument("--timeout", type=int, default=30, help="Timeout minutes")
+
+    # finalize
+    p = sub.add_parser("finalize", help="Finalize a submission")
+    p.add_argument("job_id", type=int, help="Bounty ID")
+    p.add_argument("submission_id", type=int, help="Submission ID")
+    p.add_argument("--calldata", default=None, help="Step 3 calldata (optional)")
+    p.add_argument("--dry-run", action="store_true", help="Simulate only")
+
+    args = parser.parse_args()
+    cmd_map = {
+        "discover": cmd_discover,
+        "rubric": cmd_rubric,
+        "submit": cmd_submit,
+        "monitor": cmd_monitor,
+        "finalize": cmd_finalize,
+    }
+    cmd_map[args.command](args)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/verdikta-hunter/helpers/verdikta_api.py
+++ b/skills/verdikta-hunter/helpers/verdikta_api.py
@@ -1,0 +1,350 @@
+"""Verdikta API client for bounty discovery, filtering, and submission flow.
+
+Wraps the bounties.verdikta.org REST API with proper auth, error handling,
+and structured responses. Designed to complement the SKILL.md workflow.
+
+Usage:
+    from helpers.verdikta_api import VerdiktaClient
+
+    client = VerdiktaClient(api_key="your-key")
+    bounties = client.list_open_bounties()
+    filtered = client.filter_bounties(bounties, min_threshold=75, min_deadline_hours=48)
+"""
+
+import os
+import json
+import time
+from datetime import datetime, timezone
+from typing import Optional
+
+import requests
+
+BASE_URL = "https://bounties.verdikta.org/api"
+
+
+class VerdiktaClient:
+    """API client for Verdikta bounty platform."""
+
+    def __init__(self, api_key: Optional[str] = None, base_url: str = BASE_URL):
+        self.api_key = api_key or os.environ.get("VERDIKTA_API_KEY", "")
+        self.base_url = base_url.rstrip("/")
+        self.session = requests.Session()
+        if self.api_key:
+            self.session.headers["X-Bot-API-Key"] = self.api_key
+
+    def _get(self, path: str, params: Optional[dict] = None) -> dict:
+        """GET request with error handling."""
+        url = f"{self.base_url}{path}"
+        resp = self.session.get(url, params=params, timeout=30)
+        resp.raise_for_status()
+        data = resp.json()
+        if not data.get("success", True):
+            raise VerdiktaAPIError(data.get("error", "Unknown error"), data)
+        return data
+
+    def _post(self, path: str, json_data: Optional[dict] = None) -> dict:
+        """POST request with error handling."""
+        url = f"{self.base_url}{path}"
+        resp = self.session.post(url, json=json_data, timeout=60)
+        resp.raise_for_status()
+        data = resp.json()
+        if not data.get("success", True):
+            raise VerdiktaAPIError(data.get("error", "Unknown error"), data)
+        return data
+
+    # ── Bounty Discovery ──────────────────────────────────────────────
+
+    def list_bounties(self, status: str = "OPEN", limit: int = 100) -> list[dict]:
+        """List bounties filtered by status.
+
+        Args:
+            status: OPEN, CLOSED, EVALUATING, etc.
+            limit: Max bounties to return (default 100).
+
+        Returns:
+            List of bounty dicts with embedded submissions.
+        """
+        data = self._get("/jobs", {"status": status, "limit": limit})
+        return data.get("jobs", [])
+
+    def list_open_bounties(self, limit: int = 100) -> list[dict]:
+        """Shortcut for OPEN bounties."""
+        return self.list_bounties(status="OPEN", limit=limit)
+
+    def get_bounty(self, job_id: int) -> dict:
+        """Get full bounty details including submissions.
+
+        Args:
+            job_id: The bounty ID.
+
+        Returns:
+            Bounty dict with submissions[], rubricContent, etc.
+        """
+        data = self._get(f"/jobs/{job_id}")
+        return data.get("job", {})
+
+    def get_rubric(self, job_id: int) -> dict:
+        """Fetch the evaluation rubric for a bounty.
+
+        Args:
+            job_id: The bounty ID.
+
+        Returns:
+            Rubric dict with criteria[], weights, and must-pass flags.
+        """
+        data = self._get(f"/jobs/{job_id}/rubric")
+        return data.get("rubric", {})
+
+    def get_submissions(self, job_id: int) -> list[dict]:
+        """Get all submissions for a bounty.
+
+        Args:
+            job_id: The bounty ID.
+
+        Returns:
+            List of submission dicts with status, score, etc.
+        """
+        data = self._get(f"/jobs/{job_id}/submissions")
+        return data.get("submissions", [])
+
+    def get_evaluation(self, job_id: int, submission_id: int) -> dict:
+        """Fetch the evaluation report for a specific submission.
+
+        Args:
+            job_id: The bounty ID.
+            submission_id: The submission ID.
+
+        Returns:
+            Evaluation dict with scores, justifications per model.
+        """
+        return self._get(f"/jobs/{job_id}/submissions/{submission_id}/evaluation")
+
+    def get_onchain_status(self, job_id: int) -> dict:
+        """Get on-chain status (ground truth when API lags).
+
+        Args:
+            job_id: The bounty ID.
+
+        Returns:
+            On-chain status dict with payoutWei, finalized, etc.
+        """
+        return self._get(f"/jobs/{job_id}/onchain-status")
+
+    # ── Filtering ─────────────────────────────────────────────────────
+
+    def filter_bounties(
+        self,
+        bounties: list[dict],
+        hunter_address: Optional[str] = None,
+        min_bounty_eth: float = 0,
+        max_threshold: int = 100,
+        min_threshold: int = 0,
+        min_deadline_hours: float = 24,
+        keywords: Optional[list[str]] = None,
+        exclude_submitted: bool = True,
+        exclude_windowed: bool = True,
+    ) -> list[dict]:
+        """Filter bounties by multiple criteria.
+
+        Args:
+            bounties: List of bounty dicts from list_bounties().
+            hunter_address: Our wallet address (to exclude already-submitted).
+            min_bounty_eth: Minimum bounty amount in ETH.
+            max_threshold: Maximum evaluation threshold (lower = easier).
+            min_threshold: Minimum evaluation threshold.
+            min_deadline_hours: Minimum hours until deadline (filters closing-soon).
+            keywords: Keywords that must appear in title or description.
+            exclude_submitted: Skip bounties we already submitted to.
+            exclude_windowed: Skip creator-approval (windowed) bounties.
+
+        Returns:
+            Filtered list with _hours_until_deadline added to each bounty.
+        """
+        now = time.time()
+        results = []
+
+        for b in bounties:
+            # Skip targeted bounties not for us
+            target = b.get("targetHunter")
+            if target and hunter_address and target.lower() != hunter_address.lower():
+                continue
+
+            # Skip already submitted
+            if exclude_submitted and hunter_address:
+                subs = b.get("submissions", [])
+                if any(s.get("hunter", "").lower() == hunter_address.lower() for s in subs):
+                    continue
+
+            # Skip windowed (creator-approval) bounties
+            if exclude_windowed and self._is_windowed_bounty(b):
+                continue
+
+            # Bounty amount filter
+            bounty_eth = float(b.get("bountyAmount", 0) or 0)
+            if bounty_eth < min_bounty_eth:
+                continue
+
+            # Threshold filter
+            threshold = b.get("threshold", 100) or 100
+            if threshold < min_threshold or threshold > max_threshold:
+                continue
+
+            # Deadline filter
+            close_time = b.get("submissionCloseTime", 0) or 0
+            if close_time:
+                hours_left = (close_time - now) / 3600
+                b["_hours_until_deadline"] = round(hours_left, 1)
+                if hours_left < min_deadline_hours:
+                    continue
+            else:
+                b["_hours_until_deadline"] = None
+
+            # Keyword filter
+            if keywords:
+                text = f"{b.get('title', '')} {b.get('description', '')}".lower()
+                if not any(kw.lower() in text for kw in keywords):
+                    continue
+
+            results.append(b)
+
+        # Sort by reward descending
+        results.sort(key=lambda x: float(x.get("bountyAmount", 0) or 0), reverse=True)
+        return results
+
+    @staticmethod
+    def _is_windowed_bounty(bounty: dict) -> bool:
+        """Check if a bounty uses creator-approval (windowed) flow.
+
+        Windowed bounties have creatorAssessmentWindowSize > 0,
+        meaning the creator reviews submissions directly instead of
+        the oracle evaluating them.
+        """
+        window = bounty.get("creatorAssessmentWindowSize", 0) or 0
+        return window > 0
+
+    # ── Submission Flow ───────────────────────────────────────────────
+
+    def bundle_upload(
+        self,
+        job_id: int,
+        files: list[str],
+        hunter_address: str,
+        addendum: str = "",
+        alpha: int = 200,
+        max_oracle_fee: str = "0.0003",
+        estimated_base_cost: str = "0.0001",
+        max_fee_scaling: int = 5,
+    ) -> dict:
+        """Upload files and prepare submission in one call (bundle method).
+
+        Args:
+            job_id: Target bounty ID.
+            files: List of file paths to upload.
+            hunter_address: Hunter's Base wallet address.
+            addendum: Optional addendum text.
+            alpha: Quality vs timeliness weight (0-1000, lower=quality).
+            max_oracle_fee: Max oracle fee in ETH.
+            estimated_base_cost: Estimated base cost in ETH.
+            max_fee_scaling: Max fee-based scaling factor.
+
+        Returns:
+            Bundle response with transactions[0].data (step 1 calldata).
+        """
+        import multipart
+
+        # Build multipart form
+        with open(files[0], "rb") as f:
+            file_data = f.read()
+
+        form_data = {
+            "hunterAddress": hunter_address,
+            "addendum": addendum,
+            "alpha": str(alpha),
+            "maxOracleFee": max_oracle_fee,
+            "estimatedBaseCost": estimated_base_cost,
+            "maxFeeBasedScaling": str(max_fee_scaling),
+        }
+
+        m = multipart.MultipartEncoder(
+            fields={
+                **form_data,
+                "files": (os.path.basename(files[0]), file_data, "text/markdown"),
+            }
+        )
+
+        resp = self.session.post(
+            f"{self.base_url}/jobs/{job_id}/submit/bundle",
+            data=m.to_string(),
+            headers={"Content-Type": m.content_type},
+            timeout=60,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def bundle_complete(self, job_id: int, step1_tx_hash: str) -> dict:
+        """Complete bundle submission with step 1 TX hash.
+
+        Returns step 2 calldata + ethMaxBudget + step 3 calldata.
+        """
+        return self._post(
+            f"/jobs/{job_id}/submit/bundle/complete",
+            {"step1TxHash": step1_tx_hash},
+        )
+
+    def confirm_submission(
+        self,
+        job_id: int,
+        submission_id: int,
+        hunter_address: str,
+        hunter_cid: str,
+        eval_wallet: str,
+    ) -> dict:
+        """Confirm submission between prepare and start steps.
+
+        This is REQUIRED — without it, the oracle won't pick up the submission.
+        """
+        return self._post(
+            f"/jobs/{job_id}/submissions/confirm",
+            {
+                "submissionId": submission_id,
+                "hunter": hunter_address,
+                "hunterCid": hunter_cid,
+                "evalWallet": eval_wallet,
+            },
+        )
+
+    # ── Utilities ─────────────────────────────────────────────────────
+
+    def rank_bounties(self, bounties: list[dict]) -> list[dict]:
+        """Rank bounties by reward-to-difficulty ratio.
+
+        Considers: bounty amount, threshold, competition (submission count),
+        and time remaining.
+        """
+        scored = []
+        for b in bounties:
+            reward = float(b.get("bountyAmount", 0) or 0)
+            threshold = b.get("threshold", 100) or 100
+            subs = b.get("submissionCount", 0) or 0
+            hours = b.get("_hours_until_deadline", 48) or 48
+
+            # Score: higher = better opportunity
+            reward_score = reward * 1000  # Normalize to ~1-10 range
+            difficulty_penalty = (100 - threshold) / 100  # Lower threshold = easier
+            competition_penalty = max(0, 1 - subs / 5)  # Fewer subs = less competition
+            time_bonus = min(1, hours / 72)  # More time = better
+
+            score = reward_score * difficulty_penalty * competition_penalty * time_bonus
+            b["_opportunity_score"] = round(score, 3)
+            scored.append(b)
+
+        scored.sort(key=lambda x: x["_opportunity_score"], reverse=True)
+        return scored
+
+
+class VerdiktaAPIError(Exception):
+    """API error with structured response."""
+
+    def __init__(self, message: str, response: dict = None):
+        super().__init__(message)
+        self.response = response or {}

--- a/skills/verdikta-hunter/helpers/verdikta_onchain.py
+++ b/skills/verdikta-hunter/helpers/verdikta_onchain.py
@@ -1,0 +1,494 @@
+"""Verdikta on-chain interaction for Base L2 (chainId 8453).
+
+Handles the full submission flow: prepare → confirm → start → poll → finalize.
+All RPC calls use standard eth_ method names. Prefers API-returned calldata
+over manual encoding. Includes dry_run mode and balance verification.
+
+Usage:
+    from helpers.verdikta_onchain import VerdiktaOnchain
+
+    chain = VerdiktaOnchain(rpc_url="https://mainnet.base.org", private_key="0x...")
+    result = chain.submit_bounty(job_id=97, step1_calldata="0x...", ...)
+    chain.finalize(job_id=97, submission_id=5, step3_calldata="0x...")
+"""
+
+import os
+import time
+import json
+from typing import Optional
+
+from web3 import Web3
+from eth_account import Account
+
+# Known contract address
+BOUNTY_CONTRACT = "0x2Ae271f5E86bee449a36B943414b7C1a7b39772D"
+CHAIN_ID = 8453  # Base L2
+
+
+class VerdiktaOnchain:
+    """On-chain interaction with Verdikta BountyEscrow contract on Base."""
+
+    def __init__(
+        self,
+        rpc_url: Optional[str] = None,
+        private_key: Optional[str] = None,
+        contract_address: str = BOUNTY_CONTRACT,
+        chain_id: int = CHAIN_ID,
+    ):
+        self.rpc_url = rpc_url or os.environ.get("VERDIKTA_RPC_URL", "https://mainnet.base.org")
+        self.private_key = private_key or os.environ.get("VERDIKTA_WALLET_KEY", "")
+        self.contract_address = Web3.to_checksum_address(contract_address)
+        self.chain_id = chain_id
+
+        self.w3 = Web3(Web3.HTTPProvider(self.rpc_url))
+        if self.private_key:
+            self.account = Account.from_key(self.private_key)
+            self.address = self.account.address
+        else:
+            self.account = None
+            self.address = None
+
+        # Cache for step3 calldata from bundle/complete
+        self._step3_calldata_cache: dict[tuple[int, int], str] = {}
+
+    # ── Balance & Gas ─────────────────────────────────────────────────
+
+    def get_balance(self, address: Optional[str] = None) -> int:
+        """Get ETH balance in wei using eth_getBalance.
+
+        Args:
+            address: Wallet address (defaults to our address).
+
+        Returns:
+            Balance in wei.
+        """
+        addr = address or self.address
+        if not addr:
+            raise ValueError("No address configured")
+        return self.w3.eth.get_balance(Web3.to_checksum_address(addr))
+
+    def get_balance_eth(self, address: Optional[str] = None) -> float:
+        """Get ETH balance as float."""
+        return Web3.from_wei(self.get_balance(address), "ether")
+
+    def get_gas_price(self) -> int:
+        """Get current gas price using eth_gasPrice."""
+        return self.w3.eth.gas_price
+
+    def get_nonce(self, address: Optional[str] = None) -> int:
+        """Get transaction count (nonce) using eth_getTransactionCount."""
+        addr = address or self.address
+        return self.w3.eth.get_transaction_count(
+            Web3.to_checksum_address(addr), "pending"
+        )
+
+    def estimate_gas(self, tx: dict) -> int:
+        """Estimate gas for a transaction using eth_estimateGas."""
+        return self.w3.eth.estimate_gas(tx)
+
+    def check_balance_for_tx(
+        self,
+        value_wei: int,
+        gas_limit: int,
+        gas_price_wei: int,
+    ) -> tuple[bool, str]:
+        """Verify sufficient balance for a transaction.
+
+        Args:
+            value_wei: Transaction value in wei.
+            gas_limit: Gas limit.
+            gas_price_wei: Gas price in wei.
+
+        Returns:
+            (is_sufficient, message) tuple.
+        """
+        balance = self.get_balance()
+        total_needed = value_wei + (gas_limit * gas_price_wei)
+        if balance < total_needed:
+            return False, (
+                f"Insufficient balance: have {Web3.from_wei(balance, 'ether'):.6f} ETH, "
+                f"need {Web3.from_wei(total_needed, 'ether'):.6f} ETH "
+                f"(value={Web3.from_wei(value_wei, 'ether'):.6f} + "
+                f"gas={Web3.from_wei(gas_limit * gas_price_wei, 'ether'):.6f})"
+            )
+        return True, f"Balance OK: {Web3.from_wei(balance, 'ether'):.6f} ETH"
+
+    # ── Transaction Helpers ───────────────────────────────────────────
+
+    def build_and_send_tx(
+        self,
+        to: str,
+        data: str,
+        value_wei: int = 0,
+        gas_limit: int = 300_000,
+        gas_price_gwei: float = 5.0,
+        dry_run: bool = False,
+    ) -> dict:
+        """Build, sign, and send a transaction.
+
+        Args:
+            to: Destination address.
+            data: Calldata (hex string starting with 0x).
+            value_wei: ETH value in wei.
+            gas_limit: Gas limit.
+            gas_price_gwei: Gas price in gwei.
+            dry_run: If True, simulate only (eth_call), don't send.
+
+        Returns:
+            Dict with tx_hash, receipt, or simulation result.
+        """
+        gas_price_wei = Web3.to_wei(gas_price_gwei, "gwei")
+
+        # Balance check
+        ok, msg = self.check_balance_for_tx(value_wei, gas_limit, gas_price_wei)
+        if not ok:
+            return {"success": False, "error": msg}
+
+        tx = {
+            "to": Web3.to_checksum_address(to),
+            "value": value_wei,
+            "data": bytes.fromhex(data.replace("0x", "")),
+            "chainId": self.chain_id,
+            "nonce": self.get_nonce(),
+            "gas": gas_limit,
+            "maxFeePerGas": gas_price_wei,
+            "maxPriorityFeePerGas": gas_price_wei,
+            "type": 2,  # EIP-1559
+        }
+
+        if dry_run:
+            # Simulate with eth_call
+            try:
+                result = self.w3.eth.call(tx)
+                return {
+                    "success": True,
+                    "dry_run": True,
+                    "simulation": "passed",
+                    "result": result.hex(),
+                }
+            except Exception as e:
+                return {"success": False, "dry_run": True, "error": str(e)}
+
+        # Sign and send
+        signed = Account.sign_transaction(tx, self.private_key)
+        tx_hash = self.w3.eth.send_raw_transaction(signed.raw_transaction)
+        receipt = self.w3.eth.wait_for_transaction_receipt(tx_hash, timeout=120)
+
+        return {
+            "success": receipt["status"] == 1,
+            "tx_hash": tx_hash.hex(),
+            "block_number": receipt["blockNumber"],
+            "gas_used": receipt["gasUsed"],
+            "status": receipt["status"],
+        }
+
+    # ── Submission Flow ───────────────────────────────────────────────
+
+    def prepare_submission(
+        self,
+        job_id: int,
+        calldata: str,
+        gas_limit: int = 1_000_000,
+        gas_price_gwei: float = 5.0,
+        dry_run: bool = False,
+    ) -> dict:
+        """Step 1: prepareSubmission — creates submission record on-chain.
+
+        Uses API-returned calldata from /submit/bundle or /submit/prepare.
+        Value is 0 (gas only).
+
+        Args:
+            job_id: Bounty ID.
+            calldata: API-returned calldata for prepareSubmission.
+            gas_limit: 1M recommended.
+            gas_price_gwei: 5 gwei recommended.
+            dry_run: Simulate only.
+
+        Returns:
+            TX result dict.
+        """
+        return self.build_and_send_tx(
+            to=self.contract_address,
+            data=calldata,
+            value_wei=0,
+            gas_limit=gas_limit,
+            gas_price_gwei=gas_price_gwei,
+            dry_run=dry_run,
+        )
+
+    def start_submission(
+        self,
+        job_id: int,
+        calldata: str,
+        eth_max_budget_wei: int,
+        gas_limit: int = 4_000_000,
+        gas_price_gwei: float = 1.0,
+        dry_run: bool = False,
+    ) -> dict:
+        """Step 2: startPreparedSubmission — triggers oracle evaluation.
+
+        Uses API-returned calldata from /bundle/complete.
+        Value = ethMaxBudget (from API, in wei).
+
+        Args:
+            job_id: Bounty ID.
+            calldata: API-returned calldata for startPreparedSubmission.
+            eth_max_budget_wei: Oracle prepay in wei (from API).
+            gas_limit: 4M recommended (lower causes out-of-gas).
+            gas_price_gwei: 0.5-1 gwei recommended for low balance.
+            dry_run: Simulate only.
+
+        Returns:
+            TX result dict.
+        """
+        return self.build_and_send_tx(
+            to=self.contract_address,
+            data=calldata,
+            value_wei=eth_max_budget_wei,
+            gas_limit=gas_limit,
+            gas_price_gwei=gas_price_gwei,
+            dry_run=dry_run,
+        )
+
+    def finalize_submission(
+        self,
+        job_id: int,
+        submission_id: int,
+        calldata: Optional[str] = None,
+        gas_limit: int = 300_000,
+        gas_price_gwei: float = 5.0,
+        dry_run: bool = False,
+    ) -> dict:
+        """Step 3: finalizeSubmission — claim refund/reward.
+
+        Uses cached calldata from bundle/complete if available,
+        falls back to manual encoding.
+
+        Args:
+            job_id: Bounty ID.
+            submission_id: Submission ID.
+            calldata: API-returned calldata (preferred). If None, uses cache.
+            gas_limit: 300K recommended.
+            gas_price_gwei: 5 gwei recommended.
+            dry_run: Simulate only.
+
+        Returns:
+            TX result dict.
+        """
+        # Priority: provided > cached > manual fallback
+        finalize_data = (
+            calldata
+            or self._step3_calldata_cache.get((job_id, submission_id))
+            or self._encode_finalize_fallback(job_id, submission_id)
+        )
+
+        return self.build_and_send_tx(
+            to=self.contract_address,
+            data=finalize_data,
+            value_wei=0,
+            gas_limit=gas_limit,
+            gas_price_gwei=gas_price_gwei,
+            dry_run=dry_run,
+        )
+
+    def timeout_submission(
+        self,
+        job_id: int,
+        submission_id: int,
+        gas_limit: int = 2_000_000,
+        gas_price_gwei: float = 10.0,
+        dry_run: bool = False,
+    ) -> dict:
+        """Fail a timed-out submission to reclaim escrow.
+
+        IMPORTANT: Always verify on-chain that the submission is actually
+        timed out before calling this. Use eth_call to simulate first.
+
+        Args:
+            job_id: Bounty ID.
+            submission_id: Submission ID.
+            gas_limit: 2M recommended.
+            gas_price_gwei: 10 gwei MINIMUM (5 gwei causes revert).
+            dry_run: Simulate only (ALWAYS simulate first!).
+
+        Returns:
+            TX result dict.
+        """
+        calldata = self._encode_timeout(job_id, submission_id)
+
+        # Always simulate first
+        sim = self.build_and_send_tx(
+            to=self.contract_address,
+            data=calldata,
+            value_wei=0,
+            gas_limit=gas_limit,
+            gas_price_gwei=gas_price_gwei,
+            dry_run=True,
+        )
+        if not sim.get("success"):
+            return {
+                "success": False,
+                "error": f"Simulation failed: {sim.get('error')}. "
+                         "Submission may not be timed out yet.",
+                "simulation": sim,
+            }
+
+        if dry_run:
+            return sim
+
+        return self.build_and_send_tx(
+            to=self.contract_address,
+            data=calldata,
+            value_wei=0,
+            gas_limit=gas_limit,
+            gas_price_gwei=gas_price_gwei,
+            dry_run=False,
+        )
+
+    # ── Calldata Encoding ─────────────────────────────────────────────
+
+    def _encode_finalize_fallback(self, job_id: int, submission_id: int) -> str:
+        """Manual calldata encoding for finalizeSubmission (fallback only).
+
+        Prefer API-returned calldata. This is a last resort when cache is empty.
+        """
+        from eth_abi import encode
+        from Crypto.Hash import keccak
+
+        k = keccak.new(digest_bits=256)
+        k.update(b"finalizeSubmission(uint256,uint256)")
+        selector = k.hexdigest()[:8]
+
+        encoded = encode(
+            ["uint256", "uint256"],
+            [job_id, submission_id],
+        )
+        return "0x" + selector + encoded.hex()
+
+    def _encode_timeout(self, job_id: int, submission_id: int) -> str:
+        """Calldata encoding for failTimedOutSubmission."""
+        from eth_abi import encode
+        from Crypto.Hash import keccak
+
+        k = keccak.new(digest_bits=256)
+        k.update(b"failTimedOutSubmission(uint256,uint256)")
+        selector = k.hexdigest()[:8]
+
+        encoded = encode(
+            ["uint256", "uint256"],
+            [job_id, submission_id],
+        )
+        return "0x" + selector + encoded.hex()
+
+    def cache_step3_calldata(
+        self, job_id: int, submission_id: int, calldata: str
+    ) -> None:
+        """Cache step 3 calldata from bundle/complete response.
+
+        Call this after bundle_complete returns step 3 calldata.
+        """
+        self._step3_calldata_cache[(job_id, submission_id)] = calldata
+
+    # ── Polling ───────────────────────────────────────────────────────
+
+    def poll_until_evaluated(
+        self,
+        api_client,
+        job_id: int,
+        submission_id: int,
+        timeout_minutes: int = 30,
+        poll_interval_seconds: int = 30,
+    ) -> dict:
+        """Poll submission status until evaluated or timed out.
+
+        Args:
+            api_client: VerdiktaClient instance.
+            job_id: Bounty ID.
+            submission_id: Submission ID.
+            timeout_minutes: Max wait time.
+            poll_interval_seconds: Poll interval.
+
+        Returns:
+            Final submission status dict.
+        """
+        deadline = time.time() + (timeout_minutes * 60)
+        terminal_statuses = {
+            "EVALUATED_PASSED",
+            "EVALUATED_FAILED",
+            "WINNER",
+            "ACCEPTED",
+            "REJECTED",
+        }
+
+        while time.time() < deadline:
+            subs = api_client.get_submissions(job_id)
+            for s in subs:
+                if s.get("submissionId") == submission_id:
+                    status = s.get("status", "")
+                    if status in terminal_statuses:
+                        return s
+                    print(f"  Status: {status} — waiting...")
+                    break
+
+            time.sleep(poll_interval_seconds)
+
+        return {"status": "TIMEOUT", "error": f"Polling timed out after {timeout_minutes} min"}
+
+    # ── Event Parsing ─────────────────────────────────────────────────
+
+    @staticmethod
+    def parse_submission_prepared(receipt: dict) -> Optional[dict]:
+        """Parse SubmissionPrepared event from TX receipt.
+
+        Args:
+            receipt: Transaction receipt from eth_getTransactionReceipt.
+
+        Returns:
+            Parsed event with bountyId, submissionId, evalWallet, ethMaxBudget.
+        """
+        event_sig = "0xdf7bc54a"  # SubmissionPrepared event signature
+
+        for log in receipt.get("logs", []):
+            topics = log.get("topics", [])
+            if not topics:
+                continue
+
+            # Handle both hex string and bytes
+            topic0 = topics[0]
+            topic0_hex = (
+                topic0.hex() if isinstance(topic0, bytes) else topic0.replace("0x", "")
+            )
+
+            if topic0_hex.startswith(event_sig[:8]):
+                # topics[1] = bountyId, topics[2] = submissionId
+                raw_bid = topics[1]
+                raw_sid = topics[2]
+
+                bounty_id = int(
+                    raw_bid if isinstance(raw_bid, str) else raw_bid.hex(), 16
+                )
+                submission_id = int(
+                    raw_sid if isinstance(raw_sid, str) else raw_sid.hex(), 16
+                )
+
+                # Parse data field for evalWallet and ethMaxBudget
+                data = log.get("data", "0x")
+                if isinstance(data, bytes):
+                    data = data.hex()
+                data = data.replace("0x", "")
+
+                # data[0:64] = evalWallet (padded address)
+                # data[64:128] = offset to string (usually 0x60)
+                # data[128:192] = ethMaxBudget (uint256 wei)
+                eval_wallet = "0x" + data[24:64]  # Last 40 chars of first word
+                eth_max_budget = int(data[128:192], 16) if len(data) >= 192 else 0
+
+                return {
+                    "bounty_id": bounty_id,
+                    "submission_id": submission_id,
+                    "eval_wallet": eval_wallet,
+                    "eth_max_budget_wei": eth_max_budget,
+                    "eth_max_budget_eth": float(Web3.from_wei(eth_max_budget, "ether")),
+                }
+
+        return None


### PR DESCRIPTION
## Summary

Adds Python helper modules to complement the existing `verdikta-hunter` SKILL.md:

### helpers/verdikta_api.py — API Client
- `VerdiktaClient` with full API coverage (bounties, rubrics, submissions, evaluations)
- `filter_bounties()` — filter by reward, threshold, deadline, keywords, windowed detection
- `rank_bounties()` — score by reward-to-difficulty ratio
- Submission flow: `bundle_upload`, `bundle_complete`, `confirm_submission`
- `_is_windowed_bounty()` — detect creator-approval vs oracle-evaluated bounties

### helpers/verdikta_onchain.py — On-Chain Interaction
- `VerdiktaOnchain` for Base L2 (chainId 8453)
- All RPC calls use standard `eth_` method names (`eth_getBalance`, `eth_gasPrice`, `eth_sendRawTransaction`, etc.)
- Balance verification before every TX: `balance >= ethMaxBudget + (gas_limit × gas_price)`
- `dry_run` mode — simulates with `eth_call` before sending real transactions
- API-returned calldata preferred over manual `eth_abi.encode()` (with fallback)
- Step 3 calldata caching from `/bundle/complete` response
- Timeout simulation check — always verifies via `eth_call` before `failTimedOutSubmission`
- `SubmissionPrepared` event log parsing

### helpers/example_usage.py — CLI
- Commands: `discover`, `rubric`, `submit`, `monitor`, `finalize`
- Demonstrates the complete bounty hunting workflow

## Key Improvements (from PR #582 review)

| Issue | PR #582 | This PR |
|-------|---------|--------|
| RPC method names | Missing `eth_` prefix | All use `eth_` prefix ✓ |
| Calldata source | Manual encoding preferred | API-returned preferred, manual fallback ✓ |
| Dry-run mode | Not supported | `eth_call` simulation ✓ |
| Balance check | Not verified | Formula check before every TX ✓ |
| Windowed bounties | Not detected | `creatorAssessmentWindowSize` check ✓ |
| Deadline filtering | Missing | `min_deadline_hours` parameter ✓ |
| Hardcoded tokens | Possible | Env vars only ✓ |
| Gas limits | Inconsistent | Documented: prepare=1M, start=4M, finalize=300K, timeout=2M+10gwei |

## Dependencies

```
requests>=2.28
web3>=6.0
eth-account>=0.10
eth-abi>=4.0
```

## Testing

```bash
# Discovery (no wallet needed)
python -m helpers.example_usage discover --top 5

# Rubric check
python -m helpers.example_usage rubric 121

# Submit (dry run — no TX sent)
python -m helpers.example_usage submit 121 --file report.md --dry-run
```