### PR TITLE
test(verdikta): add 9 safety tests + 11 real-world gotchas

### DIFF
--- a/scripts/tests/test_verdikta_postprocess.py
+++ b/scripts/tests/test_verdikta_postprocess.py
@@ -137,6 +137,109 @@ def make_request(dry_run=False):
 
 
 class VerdiktaGuardTests(unittest.TestCase):
+
+    # ── balance & gas cap tests ────────────────────────────────────────
+
+    def test_insufficient_balance_refused(self):
+        """sign_and_send must refuse when balance < value + gas."""
+        be = self._install(FakeBackend())
+        _orig_rpc = be.rpc
+        def _low_balance_rpc(method, params):
+            if method == "eth_getBalance":
+                return hex(10_000_000_000_000)  # 0.00001 ETH
+            return _orig_rpc(method, params)
+        helper.api, helper.rpc = be.api, _low_balance_rpc
+        with self.assertRaises(RuntimeError) as cm:
+            helper.do_submit(make_request(), self.acct, Path(".pending-verdikta"))
+        self.assertIn("insufficient balance", str(cm.exception))
+        self.assertEqual(len(be.sent_raw), 0)
+
+    def test_gas_price_capped_at_max_gas_gwei(self):
+        """Gas price must not exceed VERDIKTA_MAX_GAS_GWEI even when chain is higher."""
+        be = self._install(FakeBackend())
+        _orig_rpc = be.rpc
+        def _high_gas_rpc(method, params):
+            if method == "eth_gasPrice":
+                return hex(50_000_000_000)
+            if method == "eth_getBalance":
+                return hex(50_000_000_000_000_000)  # 0.05 ETH
+            return _orig_rpc(method, params)
+        helper.api, helper.rpc = be.api, _high_gas_rpc
+        helper.do_submit(make_request(), self.acct, Path(".pending-verdikta"))
+        start = be.signed_tx(1)
+        gas_price = int(start["maxFeePerGas"])
+        self.assertLessEqual(gas_price, 3_000_000_000)
+
+    def test_tx_revert_detected(self):
+        """A reverted TX must raise RuntimeError, not silently succeed."""
+        be = self._install(FakeBackend())
+        _orig_rpc = be.rpc
+        def _revert_rpc(method, params):
+            if method == "eth_getTransactionReceipt":
+                return {"status": "0x0"}
+            return _orig_rpc(method, params)
+        helper.api, helper.rpc = be.api, _revert_rpc
+        with self.assertRaises(RuntimeError) as cm:
+            helper.do_submit(make_request(), self.acct, Path(".pending-verdikta"))
+        self.assertIn("REVERTED", str(cm.exception))
+
+    def test_api_error_response_raises(self):
+        """Non-200 API responses must raise RuntimeError."""
+        be = self._install(FakeBackend())
+        _orig_api = be.api
+        def _bad_api(method, path, **kw):
+            if path.endswith("/submit/bundle"):
+                raise RuntimeError(f"POST {path} -> HTTP 500: Internal Server Error")
+            return _orig_api(method, path, **kw)
+        helper.api, helper.rpc = _bad_api, be.rpc
+        with self.assertRaises(RuntimeError) as cm:
+            helper.do_submit(make_request(), self.acct, Path(".pending-verdikta"))
+        self.assertIn("HTTP 500", str(cm.exception))
+
+    def test_daily_cap_enforced_by_shell(self):
+        """do_submit increments daily count for shell cap enforcement."""
+        be = self._install(FakeBackend())
+        helper.do_submit(make_request(), self.acct, Path(".pending-verdikta"))
+        state = self._state()
+        today = __import__("datetime").datetime.now(
+            __import__("datetime").timezone.utc
+        ).strftime("%Y-%m-%d")
+        self.assertEqual(state["daily"].get(today, 0), 1)
+
+    def test_missing_state_file_handled(self):
+        """load_state must bootstrap cleanly when no state file exists."""
+        state = helper.load_state()
+        self.assertEqual(state, {"submissions": {}, "daily": {}})
+
+    def test_corrupt_state_file_raises(self):
+        """Corrupt JSON in state file must raise, not silently overwrite."""
+        Path("memory/state").mkdir(parents=True, exist_ok=True)
+        Path("memory/state/verdikta-hunter.json").write_text("{invalid json")
+        with self.assertRaises(json.JSONDecodeError):
+            helper.load_state()
+
+    def test_missing_file_raises(self):
+        """do_submit must raise when listed file doesn't exist."""
+        be = self._install(FakeBackend())
+        req = make_request()
+        req["files"] = ["nonexistent.md"]
+        with self.assertRaises(FileNotFoundError):
+            helper.do_submit(req, self.acct, Path(".pending-verdikta"))
+
+    def test_finalize_updates_state_to_finalized(self):
+        """Finalize must update state entry to FINALIZED with tx hash."""
+        be = self._install(FakeBackend())
+        helper.do_submit(make_request(), self.acct, Path(".pending-verdikta"))
+        state = self._state()
+        sub_key = [k for k in state["submissions"] if k.startswith("97:")][0]
+        sub_id = int(sub_key.split(":")[1])
+        helper.do_finalize(
+            {"action": "finalize", "jobId": 97, "submissionId": sub_id},
+            self.acct,
+        )
+        state = self._state()
+        self.assertEqual(state["submissions"][f"97:{sub_id}"]["status"], "FINALIZED")
+        self.assertIsNotNone(state["submissions"][f"97:{sub_id}"]["finalizeTx"])
     def setUp(self):
         self._old_cwd = os.getcwd()
         self._tmp = tempfile.TemporaryDirectory()

--- a/skills/verdikta-hunter/SKILL.md
+++ b/skills/verdikta-hunter/SKILL.md
@@ -130,6 +130,17 @@ Append to `memory/logs/YYYY-MM-DD.md`:
 5. **Two-model jury.** Independent AI models score and their weighted results are combined — write for a careful, literal reader, not for keyword-matching.
 6. **The confirm call matters.** `POST /api/jobs/:id/submissions/confirm` (between prepare and start) registers the submission for backend tracking; the postprocess script does it — if you ever drive the flow manually, don't skip it.
 7. **API statuses lag chain state** by a sync cycle. `GET /api/jobs/:id/onchain-status` is the ground truth when they disagree.
+8. **Images cause ORACLE_TIMEOUT — every time.** Verified on multiple bounties: including `.jpg`, `.png`, or `.webp` files causes the oracle to timeout with score 0. Submit only text/markdown/PDF/code. Embed screenshots as base64 in markdown or convert to PDF if needed.
+9. **`.json` files also cause issues.** The oracle treats `.json` as binary data. Embed raw data inline using fenced code blocks. Verified: submission with separate `.json` file scored 0.
+10. **`ethMaxBudget` is a STRING, not an integer.** The API returns it as a decimal string (e.g. `"240000000000000"`). Always `int()` it before comparison.
+11. **Windowed (creator-approval) bounties are out of scope for v1.** These have `creatorAssessmentWindowSize > 0`. The discover filter drops them automatically.
+12. **`alpha` parameter tuning.** Default 200 favours quality (range 0–1000; lower = quality-weighted). For competitive bounties, try 100–150. For time-sensitive, try 400–500.
+13. **Gas price spikes on Base can stall TXs.** The postprocess script caps gas at `VERDIKTA_MAX_GAS_GWEI` (default 3). If Base gas spikes above this, TXs may be stuck until gas drops.
+14. **PREPARED_INCOMPLETE recovery.** If prepare TX succeeds but a later stage fails, the state entry stays `PREPARED_INCOMPLETE`. The next run sees this and skips the bounty. To recover: check on-chain submission ID via event log, update state, and finalize.
+15. **Multiple submitted files become separate evaluation units.** Each file is forwarded to jurors individually. Prefer a single markdown file with inline data.
+16. **Oracle intermittency is real.** The same report can score differently on retry due to different oracle node assignments. Retry before rewriting content.
+17. **`finalizeSubmission` timing.** For `EVALUATED_PASSED` submissions, finalize can fail if called before the oracle commits on-chain. Retry after a few minutes. Check if already `WINNER` — winners are auto-paid.
+18. **Claude model name bug.** Some creators set `claude-opus-4.6` (dot) but Anthropic expects `claude-opus-4-6` (dash). This causes 404 — only GPT evaluates. Creator config issue, not fixable by hunters.
 
 ## Sandbox note
 


### PR DESCRIPTION
## Summary

Adds 9 new safety tests and 11 real-world gotchas to the verdikta-hunter skill module.

### Tests (8 existing → 17 total, all passing)

| New Test | What it pins |
|----------|-------------|
| test_insufficient_balance_refused | `sign_and_send` refuses when balance < value + gas |
| test_gas_price_capped_at_max_gas_gwei | Gas price capped at `VERDIKTA_MAX_GAS_GWEI` even when chain is higher |
| test_tx_revert_detected | Reverted TX raises `RuntimeError`, not silent success |
| test_api_error_response_raises | Non-200 API responses raise `RuntimeError` |
| test_daily_cap_enforced_by_shell | `do_submit` increments daily count for shell cap enforcement |
| test_missing_state_file_handled | `load_state` bootstraps cleanly when no state file exists |
| test_corrupt_state_file_raises | Corrupt JSON in state file raises, not silently overwritten |
| test_missing_file_raises | `FileNotFoundError` on missing report file |
| test_finalize_updates_state_to_finalized | Finalize updates state entry to `FINALIZED` with tx hash |

```bash
python3 scripts/tests/test_verdikta_postprocess.py
# Ran 17 tests in 0.074s — OK
```

### Gotchas (7 existing → 18 total)

All from real-world bounty hunting experience (15+ submissions, bounties #50–#121):

| # | Gotcha |
|---|--------|
| 8 | Images cause `ORACLE_TIMEOUT` — every time. Submit only text/markdown/PDF/code. |
| 9 | `.json` files also cause issues — oracle treats as binary. Embed inline. |
| 10 | `ethMaxBudget` is a STRING, not int. Always `int()` before comparison. |
| 11 | Windowed (creator-approval) bounties out of scope for v1. |
| 12 | `alpha` parameter tuning: 100–150 for competitive, 400–500 for time-sensitive. |
| 13 | Gas price spikes on Base can stall TXs when capped below market. |
| 14 | `PREPARED_INCOMPLETE` recovery: check on-chain event log, update state, finalize. |
| 15 | Multiple files become separate evaluation units. Prefer single markdown. |
| 16 | Oracle intermittency — same report scores differently on retry. |
| 17 | `finalizeSubmission` timing — retry after oracle commits, check for `WINNER`. |
| 18 | Claude model name bug: `claude-opus-4.6` (dot) vs `claude-opus-4-6` (dash). |

## What this doesn't change

- No architectural changes — same prompt-based skill, same scripts
- No new dependencies
- No changes to the fund safety envelope
- Only adds tests and documentation

## Verification

```bash
python3 scripts/tests/test_verdikta_postprocess.py
# 17 tests, all OK
```