### PR TITLE
ci(tests): gate skill-pack manifest validation test

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -40,6 +40,8 @@ jobs:
         run: python3 scripts/tests/test_prune_skills.py
       - name: capability mode tests
         run: bash scripts/tests/test_skill_mode.sh
+      - name: skill-pack manifest validation tests
+        run: bash scripts/tests/test_validate_pack.sh
       - name: grok harness runner tests
         run: bash scripts/tests/test_run_grok.sh
       - name: state reducer tests


### PR DESCRIPTION
## What

Wires `scripts/tests/test_validate_pack.sh` into `ci-tests.yml` as a named step, next to the other skill-related bash tests.

## Why

`test_validate_pack.sh` was added in #630 (reject duplicate slugs in the skill-pack manifest) but was never referenced by any workflow, so CI never executed it — the green `test` check on #630 didn't actually cover the new validator. This one-line follow-up closes that gap.

## Verification

Ran locally against `main`:

```
ok   - duplicate slug detected with correct message
ok   - clean pack passes validation
ok   - triple duplicate detected
All validate-pack tests passed.
```

Since this PR touches `.github/workflows/ci-tests.yml` (a watched path), the workflow runs on this PR and will exercise the newly-added step itself.

🤖 Follow-up to #630.