### PR TITLE
feat(verdikta): reconcile #633 — API reference, on-chain flow, +13 gotchas (no content dropped)

### DIFF
--- a/skills/verdikta-hunter/SKILL.md
+++ b/skills/verdikta-hunter/SKILL.md
@@ -130,17 +130,110 @@ Append to `memory/logs/YYYY-MM-DD.md`:
 5. **Two-model jury.** Independent AI models score and their weighted results are combined — write for a careful, literal reader, not for keyword-matching.
 6. **The confirm call matters.** `POST /api/jobs/:id/submissions/confirm` (between prepare and start) registers the submission for backend tracking; the postprocess script does it — if you ever drive the flow manually, don't skip it.
 7. **API statuses lag chain state** by a sync cycle. `GET /api/jobs/:id/onchain-status` is the ground truth when they disagree.
-8. **Images cause ORACLE_TIMEOUT — every time.** Verified on multiple bounties: including `.jpg`, `.png`, or `.webp` files causes the oracle to timeout with score 0. Submit only text/markdown/PDF/code. Embed screenshots as base64 in markdown or convert to PDF if needed.
-9. **`.json` files also cause issues.** The oracle treats `.json` as binary data. Embed raw data inline using fenced code blocks. Verified: submission with separate `.json` file scored 0.
+8. **Images cause ORACLE_TIMEOUT — every time.** Including `.jpg`, `.png`, or `.webp` files causes the oracle to time out with score 0 — it cannot process them. Submit only text/markdown/PDF/code. Embed screenshots as base64 in markdown or convert to PDF if needed. Verified: 3 consecutive timeouts with images, immediate success with markdown-only.
+9. **Separate `.json` files also cause issues.** The oracle treats `.json` as binary data (same as images). Embed raw data inline using fenced code blocks within the markdown report. Verified: submission with `report.md` + a separate `raw_data.json` scored 0.
 10. **`ethMaxBudget` is a STRING, not an integer.** The API returns it as a decimal string (e.g. `"240000000000000"`). Always `int()` it before comparison.
-11. **Windowed (creator-approval) bounties are out of scope for v1.** These have `creatorAssessmentWindowSize > 0`. The discover filter drops them automatically.
+11. **Windowed (creator-approval) bounties are out of scope for v1.** These have `creatorAssessmentWindowSize > 0` (`creatorApproval: true`) and use direct creator review instead of oracle consensus — they skip the oracle prepay but can take longer to settle. The discover filter drops them automatically.
 12. **`alpha` parameter tuning.** Default 200 favours quality (range 0–1000; lower = quality-weighted). For competitive bounties, try 100–150. For time-sensitive, try 400–500.
 13. **Gas price spikes on Base can stall TXs.** The postprocess script caps gas at `VERDIKTA_MAX_GAS_GWEI` (default 3). If Base gas spikes above this, TXs may be stuck until gas drops.
 14. **PREPARED_INCOMPLETE recovery.** If prepare TX succeeds but a later stage fails, the state entry stays `PREPARED_INCOMPLETE`. The next run sees this and skips the bounty. To recover: check on-chain submission ID via event log, update state, and finalize.
 15. **Multiple submitted files become separate evaluation units.** Each file is forwarded to jurors individually. Prefer a single markdown file with inline data.
-16. **Oracle intermittency is real.** The same report can score differently on retry due to different oracle node assignments. Retry before rewriting content.
+16. **Oracle intermittency is real.** The same report can score differently on retry due to different oracle node assignments. If a submission times out with **no images included**, the fix is retry, not rewrite. Check `GET /api/jobs/admin/stuck` (oracle health) before submitting.
 17. **`finalizeSubmission` timing.** For `EVALUATED_PASSED` submissions, finalize can fail if called before the oracle commits on-chain. Retry after a few minutes. Check if already `WINNER` — winners are auto-paid.
-18. **Claude model name bug.** Some creators set `claude-opus-4.6` (dot) but Anthropic expects `claude-opus-4-6` (dash). This causes 404 — only GPT evaluates. Creator config issue, not fixable by hunters.
+18. **Claude model name bug.** Some creators set `claude-opus-4.6` (dot) but Anthropic expects `claude-opus-4-6` (dash). This causes a 404 "model not found" — only GPT evaluates. Creator config issue, not fixable by hunters.
+19. **Gas limits per TX type.** `prepareSubmission`: 1M / 5 gwei. `startPreparedSubmission`: 4M / 0.5–5 gwei. `finalizeSubmission`: 300K / 5 gwei. `failTimedOutSubmission`: 2M / **10 gwei minimum** (5 gwei reverts — verified 3 consecutive failures at 5 gwei, immediate success at 10). Note the manual-timeout floor sits above `VERDIKTA_MAX_GAS_GWEI` (#13), so timeout recovery is an operator action, not an automated one.
+20. **Balance preflight is mandatory.** `balance >= ethMaxBudget + (gas_limit * gas_price)`. If tight, reduce gas price — 0.5 gwei succeeded where 5 gwei tripped insufficient-funds.
+21. **Never finalize an already-finalized submission.** Check `GET /api/jobs/:id/submissions` status *before* sending a finalize TX — a redundant finalize just reverts and burns gas.
+22. **On-chain finalize can fail repeatedly.** The website's "Claim" button can succeed when on-chain `finalizeSubmission` keeps reverting (verified: 3 failed on-chain attempts, then 1 manual website claim = WINNER). Fall back to the website claim before writing off a passed submission.
+23. **`status=WINNER` means the bounty is already awarded.** When `GET /submissions` shows `WINNER`, the payout was processed — no finalize needed; `awardTxHash` is the payment proof.
+24. **Never send a timeout TX without on-chain verification.** The API's `canTimeout` can return `true` while the contract rejects. Simulate with `eth_call` first, wait 15+ minutes, then send at 10 gwei (see #19).
+25. **API calldata encoding bug (intermittent).** The `/submit/bundle` endpoint occasionally returns calldata with incorrect ABI encoding (extra bytes). Compare API calldata length against a manual encoding; if they differ, use the manual `eth_abi.encode()` output.
+26. **`hashlib.sha3_256` is NOT `keccak256`.** Python's `hashlib.sha3_256` is NIST SHA3-256 and produces different output than Ethereum's keccak256. Use `from Crypto.Hash import keccak` for function selectors.
+27. **The evaluation endpoint can return binary data.** On some submissions `GET /submissions/:subId/evaluation` returns a Buffer (byte array starting with `PK`) instead of JSON. Fall back to the submissions-list endpoint for scores.
+28. **Base L2 RPC limitations.** `base.publicnode.com` — no archive requests. `1rpc.io/base` — caps `eth_getLogs` at 50 blocks. Use the `base.blockscout.com` API for transaction history.
+29. **GPT scores lower than Claude** (~5–10% gap), with Novel Research its biggest weakness — anonymous/unverifiable sources are penalized. Named, verifiable sources are critical when a GPT model is on the jury.
+30. **Be exact for `no_fabrication` bounties.** When breaking down categories, precision is graded: "87 solo bounties" is wrong if 10 have zero submissions and 77 have one hunter — write "10 zero-submission + 77 one-hunter = 87 non-competitive."
+31. **No "meta" sections in submission files.** The oracle reads *everything* as deliverable content, so a "Requirement Checklist" or "Proof Note" section counts against you — and words like "error" or "failed" inside them can drag the quality score down.
+
+## API Reference
+
+All endpoints at `https://bounties.verdikta.org/api` with header `X-Bot-API-Key: <key>`. These are the authed calls `scripts/prefetch-verdikta.sh` / `scripts/postprocess-verdikta.sh` make on the skill's behalf (the skill itself never calls them — see Sandbox note); documented here for reference and manual recovery.
+
+### Bounty Discovery
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/jobs?status=OPEN&limit=30` | GET | List open bounties with submission counts |
+| `/jobs/<jobId>` | GET | Single bounty detail — includes `awardTxHash` |
+| `/jobs/<jobId>/rubric` | GET | Rubric with weighted criteria + must-pass flags |
+| `/jobs/<jobId>/evaluation-package` | GET | Full evaluation prompt sent to arbiters |
+| `/jobs/admin/stuck` | GET | Submissions stuck in `PENDING_EVALUATION` (oracle health) |
+
+### Submission Flow
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/jobs/<jobId>/submit/bundle` | POST | Upload files + get step-1 calldata |
+| `/jobs/<jobId>/submit/bundle/complete` | POST | After step-1 TX — returns `ethMaxBudget` + step 2/3 calldata |
+| `/jobs/<jobId>/submissions/confirm` | POST | **Required** between prepare and start |
+| `/jobs/<jobId>/submissions` | GET | Status array per bounty |
+| `/jobs/<jobId>/submissions/<subId>/evaluation` | GET | Per-model scores + justification |
+
+### Response Shapes
+
+```json
+GET  /jobs                  -> {success, jobs[], total, limit, offset}
+GET  /jobs/:id              -> {success, job{...fields, submissions[{...}]}}
+POST /submit/bundle         -> {success, hunterCid, transactions[{to, data, value, chainId, gasLimit}]}
+POST /submit/bundle/complete-> {success, parsed:{submissionId, evalWallet, ethMaxBudget}, transactions:[3]}
+```
+
+## On-Chain Submission Flow
+
+Reference for the three transactions `scripts/postprocess-verdikta.sh` signs and broadcasts (cap-checked against `VERDIKTA_MAX_SPEND_ETH`, pinned to the BountyEscrow contract on Base, chainId 8453). The skill never signs — this documents the flow for review and manual recovery only.
+
+### Step 1: `prepareSubmission` (gas only, no value)
+
+```
+Selector: 0xfae4a73d | Gas: 1M / 5 gwei
+```
+
+Creates the submission record. Parse the `SubmissionPrepared` event: `topics[1]`=bountyId, `topics[2]`=submissionId, `topics[3]`=hunter. (Read `ethMaxBudget` from the API's `parsed.ethMaxBudget`, never from a partial-ABI decode of this event — see gotcha #2.)
+
+### Step 2: `startPreparedSubmission` (value = ethMaxBudget)
+
+```
+Selector: 0xcb493514 | Gas: 4M / 0.5–5 gwei
+```
+
+Triggers the oracle. Value comes from the API's `parsed.ethMaxBudget` (wei). Balance check: `balance >= ethMaxBudget + (gas * gasPrice)`.
+
+### Step 3: `finalizeSubmission` (gas only, no value)
+
+```
+Selector: 0x1485eb7a | Gas: 300K / 5 gwei
+```
+
+Claims the reward or refunds the escrow. **Mandatory** — the escrow stays locked without it.
+
+### Signing Pattern
+
+```python
+from eth_account import Account
+from eth_abi import encode
+from Crypto.Hash import keccak
+
+k = keccak.new(digest_bits=256)
+k.update(b"prepareSubmission(uint256,string,string,string,uint256,uint256,uint256,uint256)")
+selector = bytes.fromhex(k.hexdigest()[:8])
+encoded = encode(
+    ['uint256', 'string', 'string', 'string', 'uint256', 'uint256', 'uint256', 'uint256'],
+    [bounty_id, eval_cid, hunter_cid, addendum, alpha, max_oracle_fee, est_base_cost, max_fee_scaling]
+)
+calldata = selector + encoded
+```
+
+**Pitfall**: `hashlib.sha3_256` is NOT `keccak256` — always use `from Crypto.Hash import keccak` (see gotcha #26).
 
 ## Sandbox note
 


### PR DESCRIPTION
Supersedes #633. Same valuable additions, merged into main's current `skills/verdikta-hunter/SKILL.md` instead of replacing it.

## Why a new PR

#633 branched **before** `SKILL.md` existed on `main`, so both sides created the file independently — a whole-file conflict (`CONFLICTING`/`DIRTY`). Taken as-is, #633 would have **silently dropped five gotchas** `main` has since gained:

- `ethMaxBudget` is a STRING, `int()` before compare
- `alpha` parameter tuning
- `VERDIKTA_MAX_GAS_GWEI` gas-price cap / stuck-TX behavior
- `PREPARED_INCOMPLETE` recovery
- multiple files → separate evaluation units

This PR is the hand-merge that keeps everything from both sides.

## What's in it

- **Kept all 18 existing gotchas.** Enriched 3 overlapping ones (images, `.json`, oracle intermittency) with #633's verified evidence, and folded #633's windowed-bounty explanation into the existing #11 rather than duplicating it.
- **Appended #633's 13 new gotchas** (19–31): per-TX gas limits, balance preflight, re-finalize guard, website-Claim fallback, `status=WINNER` means paid, timeout `eth_call` guard, calldata-encoding bug, `sha3_256 ≠ keccak256`, binary evaluation endpoint, Base RPC limits, GPT scoring, `no_fabrication` precision, no-meta-sections.
- **Added #633's two reference sections** (API Reference, On-Chain Submission Flow) — framed as `scripts/postprocess-verdikta.sh` / manual-recovery reference so they stay consistent with the skill's "never sign in-skill" sandbox design, and cross-linked to the relevant gotchas.

## Result

251 lines · 31 gotchas · no information lost from either side · `node scripts/okf-validate.mjs` passes · diff vs main is +98/−5.

Credit to @s97472091-pixel — all the new content originates from #633 (preserved via `Co-authored-by`). Closing #633 in favor of this.