### PR TITLE
feat(observability): optional Langfuse tracing for Claude Code runs

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -489,6 +489,12 @@ effort: high       # low|medium|high|xhigh|max → --effort  (grok-build only)
 
 Two surfaces stay Claude-only **by design**: the **AI gateway** (`scripts/llm-gateway.sh`) only reshapes the model behind Claude Code — grok has its own auth and bypasses it — and the **json-render feed** (`notify-jsonrender`) renders via `claude -p` and is skipped on grok (the feed is a display nicety; skill output, memory, and notifications are unaffected).
 
+### Observability (Langfuse)
+
+Optional, opt-in tracing. Set the repo secrets `LANGFUSE_PUBLIC_KEY` + `LANGFUSE_SECRET_KEY` (dashboard → Secrets → *Observability*) and every Claude Code run streams to your [Langfuse](https://langfuse.com) project as a trace — LLM calls (model, tokens, cost, latency), tool calls, and (by default) the prompts and responses. It's a pure no-op when the keys are unset.
+
+Under the hood `scripts/langfuse-otel.sh` exports Claude Code's OpenTelemetry env so its span tree ships to Langfuse's OTLP endpoint — out of band, so a Langfuse outage never affects a run. Region/toggles are repo **variables**: `LANGFUSE_HOST` (default EU cloud; US = `https://us.cloud.langfuse.com`), `LANGFUSE_TRACING=0` to disable, `LANGFUSE_LOG_CONTENT=0` for metadata-only (no prompt/response text). Covers the skill run, scorer, feed, and message poller; the grok harness is not traced. Full guide: [docs/langfuse.md](../docs/langfuse.md).
+
 ### Strategy
 
 `STRATEGY.md` is Aeon's north-star - your overarching goal, top priorities, audience, and hard constraints. It's imported into `CLAUDE.md`, so it rides along in the context of **every** skill run: when a choice isn't otherwise determined, the strategy breaks the tie ("showcase real output over new features", "depth over breadth"). Keep it tight (it costs tokens every run) and specific (a vague strategy can't break a tie).

--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -306,6 +306,13 @@ jobs:
           VENICE_CLEANCACHE: ${{ vars.VENICE_CLEANCACHE }}
           SURPLUS_MODEL: ${{ vars.SURPLUS_MODEL }}
           CCR_LOG: ${{ vars.CCR_LOG }}
+          # Optional Langfuse observability — set both keys to stream Claude Code's
+          # run to Langfuse as a trace (scripts/langfuse-otel.sh; no-op when unset).
+          LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
+          LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
+          LANGFUSE_HOST: ${{ vars.LANGFUSE_HOST }}
+          LANGFUSE_TRACING: ${{ vars.LANGFUSE_TRACING }}
+          LANGFUSE_LOG_CONTENT: ${{ vars.LANGFUSE_LOG_CONTENT }}
           GITHUB_TOKEN: ${{ secrets.GH_GLOBAL || secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GH_GLOBAL || secrets.GITHUB_TOKEN }}
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
@@ -383,6 +390,9 @@ jobs:
           # The Grok Build harness has its own auth and does NOT use the gateway.
           BASE_MODEL="$MODEL"
           GW="${GITHUB_WORKSPACE}/scripts/llm-gateway.sh"
+          # Optional Langfuse OTEL tracing — sourced after the gateway in each
+          # claude attempt below. Self-gates on LANGFUSE_* and never fails the run.
+          LF="${GITHUB_WORKSPACE}/scripts/langfuse-otel.sh"
           if [ "$HARNESS" = "grok" ]; then
             # Set the post-run scorer's routing hint: route its `claude -p` scoring
             # call to xAI (Anthropic-compatible) when an API key is present, else
@@ -524,6 +534,7 @@ jobs:
                 GATEWAY="$cand"
                 MODEL="$BASE_MODEL"
                 source "$GW" >&2
+                source "$LF" >&2   # optional Langfuse tracing (no-op unless LANGFUSE_* set)
                 echo "$PROMPT" | claude -p - --model "$MODEL" --allowedTools "$ALLOWED" "${MCP_FLAGS[@]}" --output-format json 2>&1
               ); then
                 USED_GATEWAY="$cand"; CLAUDE_OK=1; break
@@ -676,6 +687,11 @@ jobs:
           VENICE_CLEANCACHE: ${{ vars.VENICE_CLEANCACHE }}
           SURPLUS_MODEL: ${{ vars.SURPLUS_MODEL }}
           CCR_LOG: ${{ vars.CCR_LOG }}
+          LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
+          LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
+          LANGFUSE_HOST: ${{ vars.LANGFUSE_HOST }}
+          LANGFUSE_TRACING: ${{ vars.LANGFUSE_TRACING }}
+          LANGFUSE_LOG_CONTENT: ${{ vars.LANGFUSE_LOG_CONTENT }}
         run: |
           SKILL="${{ steps.skill.outputs.name }}"
 
@@ -690,6 +706,7 @@ jobs:
           if [ "$HARNESS" != "grok" ]; then
             GATEWAY="${{ steps.run.outputs.GATEWAY }}"
             source "${GITHUB_WORKSPACE}/scripts/llm-gateway.sh"
+            AEON_OTEL_COMPONENT=scorer source "${GITHUB_WORKSPACE}/scripts/langfuse-otel.sh"
           fi
 
           # Read and truncate skill output for analysis
@@ -828,11 +845,17 @@ jobs:
           VENICE_CLEANCACHE: ${{ vars.VENICE_CLEANCACHE }}
           SURPLUS_MODEL: ${{ vars.SURPLUS_MODEL }}
           CCR_LOG: ${{ vars.CCR_LOG }}
+          LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
+          LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
+          LANGFUSE_HOST: ${{ vars.LANGFUSE_HOST }}
+          LANGFUSE_TRACING: ${{ vars.LANGFUSE_TRACING }}
+          LANGFUSE_LOG_CONTENT: ${{ vars.LANGFUSE_LOG_CONTENT }}
         run: |
           # GATEWAY may be empty when the Run step failed early — the script
           # treats that as `direct`, matching the old inline behavior.
           GATEWAY="${{ steps.run.outputs.GATEWAY }}"
           source "${GITHUB_WORKSPACE}/scripts/llm-gateway.sh"
+          AEON_OTEL_COMPONENT=feed source "${GITHUB_WORKSPACE}/scripts/langfuse-otel.sh"
           for pending in apps/dashboard/outputs/.pending-*.md; do
             [ -f "$pending" ] || continue
             SKILL=$(basename "$pending" .md | sed 's/^\.pending-//')

--- a/.github/workflows/messages.yml
+++ b/.github/workflows/messages.yml
@@ -820,6 +820,13 @@ jobs:
           VENICE_CLEANCACHE: ${{ vars.VENICE_CLEANCACHE }}
           SURPLUS_MODEL: ${{ vars.SURPLUS_MODEL }}
           CCR_LOG: ${{ vars.CCR_LOG }}
+          # Optional Langfuse observability — traces the conversational-reply run
+          # (scripts/langfuse-otel.sh; no-op unless both LANGFUSE_* keys are set).
+          LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
+          LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
+          LANGFUSE_HOST: ${{ vars.LANGFUSE_HOST }}
+          LANGFUSE_TRACING: ${{ vars.LANGFUSE_TRACING }}
+          LANGFUSE_LOG_CONTENT: ${{ vars.LANGFUSE_LOG_CONTENT }}
           GITHUB_TOKEN: ${{ secrets.GH_GLOBAL || secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GH_GLOBAL || secrets.GITHUB_TOKEN }}
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
@@ -860,6 +867,7 @@ jobs:
             GATEWAY=$(grep -A1 '^gateway:' aeon.yml | grep 'provider:' | sed 's/.*provider:[[:space:]]*//' | sed "s/[\"' ]//g" || true)
             GATEWAY="${GATEWAY:-auto}"
             source "${GITHUB_WORKSPACE}/scripts/llm-gateway.sh"
+            AEON_OTEL_COMPONENT=message source "${GITHUB_WORKSPACE}/scripts/langfuse-otel.sh"
           fi
 
           cat > ./notify << 'NOTIFY_SCRIPT'

--- a/aeon.yml
+++ b/aeon.yml
@@ -229,3 +229,10 @@ channels:
 # Polls for messages every 5 minutes on Telegram/Discord/Slack.
 telegram:
   enabled: true
+
+# Observability (optional) — no config lives here; it's credential-driven.
+# Set the repo secrets LANGFUSE_PUBLIC_KEY + LANGFUSE_SECRET_KEY and every
+# Claude Code run streams to your Langfuse project as a trace (LLM calls,
+# tokens, cost, prompts/responses). Region/toggles are repo variables:
+# LANGFUSE_HOST (default EU cloud), LANGFUSE_TRACING (0 to disable),
+# LANGFUSE_LOG_CONTENT (0 = metadata only). See docs/langfuse.md.

--- a/apps/dashboard/app/api/secrets/route.ts
+++ b/apps/dashboard/app/api/secrets/route.ts
@@ -25,6 +25,13 @@ const BUILTIN_SECRETS: Omit<Secret, 'isSet'>[] = [
   { name: 'SLACK_WEBHOOK_URL', group: 'Slack', description: 'Webhook URL for notifications' },
   { name: 'SENDGRID_API_KEY', group: 'Email', description: 'SendGrid API key (SendGrid is a Twilio product) - keys & API reference at www.twilio.com/docs/sendgrid/api-reference' },
   { name: 'NOTIFY_EMAIL_TO', group: 'Email', description: 'Recipient email address for skill notifications' },
+  // Observability - optional. Set both keys to stream every Claude Code run to a
+  // Langfuse project as a trace (LLM calls, tokens, cost, prompts/responses) via
+  // OpenTelemetry. No-op when unset. Region/host + toggles are repo VARIABLES:
+  // LANGFUSE_HOST (default https://cloud.langfuse.com), LANGFUSE_TRACING (0 to
+  // disable), LANGFUSE_LOG_CONTENT (0 = metadata only, all = incl. tool bodies).
+  { name: 'LANGFUSE_PUBLIC_KEY', group: 'Observability', description: 'Langfuse public key (pk-lf-...) - pairs with LANGFUSE_SECRET_KEY to trace every run to Langfuse. Set the region via the LANGFUSE_HOST repo variable (default EU cloud; US = https://us.cloud.langfuse.com). Keys in Langfuse → Settings → API Keys.' },
+  { name: 'LANGFUSE_SECRET_KEY', group: 'Observability', description: 'Langfuse secret key (sk-lf-...) - the other half of the Langfuse trace-ingestion credential. Both keys must be set for tracing to activate.' },
   // Skill Keys - third-party API keys individual skills call. Each is opt-in:
   // unset means the skills that need it skip rather than fail. Names below are
   // the exact env vars referenced across skills/ (verified by global scan).

--- a/apps/dashboard/components/SecretsPanel.tsx
+++ b/apps/dashboard/components/SecretsPanel.tsx
@@ -18,6 +18,7 @@ const GROUP_ICON: Record<string, { domain?: string; glyph?: 'mail' | 'key' }> = 
   Discord: { domain: 'discord.com' },
   Slack: { domain: 'slack.com' },
   Email: { glyph: 'mail' },
+  Observability: { domain: 'langfuse.com' },
   'Skill Keys': { glyph: 'key' },
 }
 
@@ -105,7 +106,7 @@ export function SecretsPanel({ secrets, skills, busy, repo, focusKey, onFocusHan
         </div>
       </section>
 
-      {['Core', 'Telegram', 'Discord', 'Slack', 'Email', 'Skill Keys'].map((group, gi) => {
+      {['Core', 'Telegram', 'Discord', 'Slack', 'Email', 'Observability', 'Skill Keys'].map((group, gi) => {
         const gs = secrets.filter(s => s.group === group); if (!gs.length) return null
         return (
           <section key={group} className="border-t border-[rgba(250,250,250,0.10)] pt-6">

--- a/docs/langfuse.md
+++ b/docs/langfuse.md
@@ -1,0 +1,107 @@
+---
+type: Reference
+layout: default
+title: Langfuse Observability
+---
+
+# Langfuse Observability (optional)
+
+Aeon can stream every Claude Code run to a [Langfuse](https://langfuse.com) project
+as a **trace** — the LLM requests (model, tokens, cost, latency), the tool calls,
+and, when content logging is on, the prompts and responses themselves. It is
+**opt-in and no-op**: set two secrets and traces start appearing; leave them unset
+and nothing changes.
+
+## How it works
+
+`claude -p` (the default harness) has native OpenTelemetry support. When the
+`LANGFUSE_*` credentials are present, `scripts/llm-gateway.sh` is followed by
+`scripts/langfuse-otel.sh`, which exports the OTEL env vars that point Claude
+Code's span exporter at Langfuse's OTLP endpoint (`<host>/api/public/otel`).
+
+- **Traces only.** Langfuse's OTLP endpoint ingests spans, not OTEL metrics/logs.
+  Claude Code's span tree — `claude_code.interaction → claude_code.llm_request →
+  claude_code.tool` — carries `gen_ai.*` attributes that map directly onto
+  Langfuse's LLM data model. The shim leaves the metrics/logs signals disabled so
+  nothing is sent to an endpoint that would reject it.
+- **HTTP, not gRPC.** Langfuse only accepts OTLP over HTTP, so the shim pins
+  `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`.
+- **Out of band.** Telemetry export is decoupled from the model call — if Langfuse
+  is slow or down, the skill run is unaffected. The shim never `exit`s or fails
+  the run.
+- **Span export is a Claude Code beta** (`CLAUDE_CODE_ENHANCED_TELEMETRY_BETA`).
+  It ships with the pinned Claude Code version; if you pin an older CLI that
+  predates span tracing, no traces are produced (still a clean no-op).
+
+Coverage: the main skill run (all gateway fallback attempts), the post-run quality
+scorer, the json-render feed convert, and the conversational-reply poller
+(`messages.yml`). Each is tagged with an `aeon.component` resource attribute
+(`skill-run` / `scorer` / `feed` / `message`). The **Grok Build harness**
+(`harness: grok`) is not traced — the grok CLI has no equivalent OTEL export.
+
+## Setup
+
+1. Create a Langfuse project and copy its API keys (Langfuse → **Settings → API
+   Keys**).
+2. Add two **repo secrets** — in the dashboard (Secrets → *Observability*) or with
+   the `gh` CLI:
+
+   ```bash
+   gh secret set LANGFUSE_PUBLIC_KEY   # pk-lf-...
+   gh secret set LANGFUSE_SECRET_KEY   # sk-lf-...
+   ```
+
+3. If you're **not** on Langfuse EU cloud, set the host as a **repo variable**:
+
+   ```bash
+   # US cloud:
+   gh variable set LANGFUSE_HOST --body 'https://us.cloud.langfuse.com'
+   # or a self-hosted instance:
+   gh variable set LANGFUSE_HOST --body 'https://langfuse.internal.example.com'
+   ```
+
+That's it — the next run appears in Langfuse. One `claude -p` run maps to one
+Langfuse **session** (Claude Code stamps `session.id` per run).
+
+## Configuration reference
+
+| Name | Kind | Default | Purpose |
+|---|---|---|---|
+| `LANGFUSE_PUBLIC_KEY` | secret | — | Langfuse public key (`pk-lf-…`). **Required** to activate. |
+| `LANGFUSE_SECRET_KEY` | secret | — | Langfuse secret key (`sk-lf-…`). **Required** to activate. |
+| `LANGFUSE_HOST` | variable | `https://cloud.langfuse.com` | Langfuse base URL / region. `LANGFUSE_BASE_URL` is accepted as an alias. |
+| `LANGFUSE_TRACING` | variable | `1` | Set to `0`/`false`/`off` to force-disable even with keys set. |
+| `LANGFUSE_LOG_CONTENT` | variable | `1` | `1` = capture prompts + responses + tool params; `0` = metadata only (redact all content); `all` = also capture tool input/output bodies. |
+
+## Privacy
+
+By default (`LANGFUSE_LOG_CONTENT=1`) prompts, responses, and tool **parameters**
+are sent to your Langfuse project — that's the point of tracing the inference.
+Tool input/output **bodies** (which can include command output) stay off unless
+you set `LANGFUSE_LOG_CONTENT=all`. Set `LANGFUSE_LOG_CONTENT=0` for
+metadata-only traces (tokens, cost, latency, structure — no text). All data goes
+only to the Langfuse instance you configure; nothing is sent to Anthropic beyond
+the normal model call.
+
+## Sandbox note
+
+No sandbox workaround is needed. The OTEL exporter runs **inside** the `claude`
+process (the same process that already reaches the model API / gateways), not
+through Claude Code's Bash tool, so its egress to Langfuse is not subject to the
+bash network restrictions described in the README. No prefetch/postprocess hook is
+involved; export is inline and out of band.
+
+## Verifying
+
+`scripts/tests/test_langfuse_otel.sh` covers the gating and env-export behavior
+(no-op without keys, endpoint/auth/protocol construction, content toggles,
+force-disable, `bash -e` safety). Run it with:
+
+```bash
+bash scripts/tests/test_langfuse_otel.sh
+```
+
+# Citations
+
+- Langfuse OpenTelemetry ingestion: <https://langfuse.com/integrations/native/opentelemetry>
+- Claude Code monitoring & telemetry: <https://code.claude.com/docs/en/monitoring-usage>

--- a/scripts/langfuse-otel.sh
+++ b/scripts/langfuse-otel.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# langfuse-otel.sh — optional Langfuse observability for the Claude Code harness.
+#
+# SOURCED (not executed) right after scripts/llm-gateway.sh at every `claude -p`
+# call site (aeon.yml Run cascade / scorer / feed-convert, messages.yml Run). It
+# exports the OpenTelemetry env vars that make Claude Code stream the run as a
+# trace to a Langfuse project: LLM requests (model, tokens, cost, latency), tool
+# calls, and — when content logging is on — the prompts and responses themselves.
+#
+# OPT-IN + NO-OP. Does nothing unless BOTH LANGFUSE_PUBLIC_KEY and
+# LANGFUSE_SECRET_KEY are set, i.e. "set a Langfuse token → traces just appear."
+# It must NEVER `exit` or fail the caller — it only ever `return`s, so a bad
+# config degrades to "no tracing", never a broken skill run.
+#
+# WHY TRACES (not metrics/logs): Langfuse's OTLP endpoint ingests spans only.
+# Claude Code's span tree (claude_code.interaction → llm_request → tool) carries
+# gen_ai.* semantic attributes that map cleanly onto Langfuse's LLM data model.
+# Span export is a Claude Code beta (CLAUDE_CODE_ENHANCED_TELEMETRY_BETA); the
+# metrics/logs signals are left disabled so nothing is shipped to an endpoint
+# that would reject it. Langfuse takes OTLP over HTTP only — no gRPC.
+#
+# INPUTS (all optional except the two keys):
+#   LANGFUSE_PUBLIC_KEY   pk-lf-...   required to activate
+#   LANGFUSE_SECRET_KEY   sk-lf-...   required to activate
+#   LANGFUSE_HOST         Langfuse base URL. Default https://cloud.langfuse.com
+#                         (EU cloud). US cloud: https://us.cloud.langfuse.com.
+#                         Self-hosted URLs work too. LANGFUSE_BASE_URL is an alias.
+#   LANGFUSE_TRACING      set to 0/false/off/no to force-disable even with keys set.
+#   LANGFUSE_LOG_CONTENT  1 (default) = capture prompts + responses + tool params.
+#                         0 = metadata only (redact all content).
+#                         all = additionally capture tool input/output bodies.
+#   AEON_OTEL_COMPONENT   label for this call site (skill-run|scorer|feed|message);
+#                         recorded in resource attributes. Default skill-run.
+#
+# NOTE: no `set -e/-u` here (sourced file — must not change the caller's shell
+# opts), and the host step runs under `bash -e`, so use `if`, never a bare
+# `[ … ] && …` as a trailing command. Mirrors scripts/llm-gateway.sh conventions.
+
+# --- gate: both keys present, and not explicitly disabled -------------------
+if [ -z "${LANGFUSE_PUBLIC_KEY:-}" ] || [ -z "${LANGFUSE_SECRET_KEY:-}" ]; then
+  return 0 2>/dev/null || exit 0
+fi
+case "${LANGFUSE_TRACING:-}" in
+  0|false|off|no|False|FALSE|Off|OFF|No|NO)
+    echo "::notice::Langfuse tracing disabled via LANGFUSE_TRACING" >&2
+    return 0 2>/dev/null || exit 0 ;;
+esac
+
+# --- resolve host + build Basic auth (base64 of public:secret) --------------
+_lf_host="${LANGFUSE_HOST:-${LANGFUSE_BASE_URL:-https://cloud.langfuse.com}}"
+_lf_host="${_lf_host%/}"
+# tr -d '\n' keeps the header single-line across GNU (wraps at 76 cols) and BSD base64.
+_lf_auth=$(printf '%s:%s' "$LANGFUSE_PUBLIC_KEY" "$LANGFUSE_SECRET_KEY" | base64 | tr -d '\n')
+
+# --- Claude Code OpenTelemetry → Langfuse OTLP (traces only, HTTP) ----------
+export CLAUDE_CODE_ENABLE_TELEMETRY=1
+export CLAUDE_CODE_ENHANCED_TELEMETRY_BETA=1        # required for span/trace export
+export OTEL_TRACES_EXPORTER=otlp
+# Langfuse ingests OTLP over HTTP at <host>/api/public/otel; the OTEL SDK appends
+# /v1/traces to this generic endpoint for the traces signal. Protobuf over HTTP —
+# gRPC is unsupported by Langfuse, so pin the protocol explicitly.
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+export OTEL_EXPORTER_OTLP_ENDPOINT="${_lf_host}/api/public/otel"
+export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic ${_lf_auth},x-langfuse-ingestion-version=4"
+# Short flush interval — headless `-p` runs are brief; batch export on a long
+# interval could drop the final spans when the process exits.
+export OTEL_TRACES_EXPORT_INTERVAL="${OTEL_TRACES_EXPORT_INTERVAL:-1000}"
+# Keep metrics/logs off: Langfuse's OTLP endpoint rejects those signals.
+export OTEL_METRICS_EXPORTER="${OTEL_METRICS_EXPORTER:-none}"
+export OTEL_LOGS_EXPORTER="${OTEL_LOGS_EXPORTER:-none}"
+
+# --- content capture (prompts / responses / tool details) -------------------
+# Default ON — the whole point is to see the inference. `0` redacts everything;
+# `all` also records full tool input/output bodies (can include command output,
+# so it's opt-in). Tool *content* stays off by default even when content is on.
+case "${LANGFUSE_LOG_CONTENT:-1}" in
+  0|false|off|no|False|FALSE|Off|OFF|No|NO)
+    : ;;  # metadata only — leave every OTEL_LOG_* unset (Claude Code redacts by default)
+  all|full|ALL|FULL)
+    export OTEL_LOG_USER_PROMPTS=1
+    export OTEL_LOG_ASSISTANT_RESPONSES=1
+    export OTEL_LOG_TOOL_DETAILS=1
+    export OTEL_LOG_TOOL_CONTENT=1 ;;
+  *)
+    export OTEL_LOG_USER_PROMPTS=1
+    export OTEL_LOG_ASSISTANT_RESPONSES=1
+    export OTEL_LOG_TOOL_DETAILS=1 ;;
+esac
+
+# --- identity / grouping ----------------------------------------------------
+# Resource attributes land in Langfuse trace metadata.resourceAttributes. Claude
+# Code already stamps session.id per run, so one `claude -p` run groups into one
+# Langfuse session automatically; these add the Aeon-side context on top.
+export OTEL_SERVICE_NAME="${OTEL_SERVICE_NAME:-aeon}"
+_lf_attrs="service.name=aeon,deployment.environment=github-actions"
+_lf_attrs="${_lf_attrs},aeon.component=${AEON_OTEL_COMPONENT:-skill-run}"
+if [ -n "${SKILL_NAME:-}" ];        then _lf_attrs="${_lf_attrs},aeon.skill=${SKILL_NAME}"; fi
+if [ -n "${GITHUB_REPOSITORY:-}" ]; then _lf_attrs="${_lf_attrs},aeon.repo=${GITHUB_REPOSITORY}"; fi
+if [ -n "${GITHUB_RUN_ID:-}" ];     then _lf_attrs="${_lf_attrs},aeon.run_id=${GITHUB_RUN_ID}"; fi
+if [ -n "${GITHUB_RUN_ATTEMPT:-}" ];then _lf_attrs="${_lf_attrs},aeon.run_attempt=${GITHUB_RUN_ATTEMPT}"; fi
+export OTEL_RESOURCE_ATTRIBUTES="$_lf_attrs"
+
+echo "::notice::Langfuse tracing on → ${_lf_host} (component=${AEON_OTEL_COMPONENT:-skill-run}, content=${LANGFUSE_LOG_CONTENT:-1})" >&2
+unset _lf_host _lf_auth _lf_attrs
+return 0 2>/dev/null || exit 0

--- a/scripts/tests/test_langfuse_otel.sh
+++ b/scripts/tests/test_langfuse_otel.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Tests for scripts/langfuse-otel.sh. Run: bash scripts/tests/test_langfuse_otel.sh
+#
+# The shim is SOURCED by the workflow, so these tests source it too — each case
+# in a subshell (parentheses) so exported OTEL_* vars don't leak between cases.
+set -uo pipefail
+# shellcheck disable=SC1090  # LF is a fixed path; dynamic-source is intentional here.
+cd "$(dirname "$0")/../.." || exit 1
+LF="scripts/langfuse-otel.sh"
+fail=0
+pass() { echo "ok   - $1"; }
+bad()  { echo "FAIL - $1"; fail=1; }
+
+# Guarantee a clean slate for the vars we assert on (inherited env would lie).
+unset LANGFUSE_PUBLIC_KEY LANGFUSE_SECRET_KEY LANGFUSE_HOST LANGFUSE_BASE_URL \
+      LANGFUSE_TRACING LANGFUSE_LOG_CONTENT AEON_OTEL_COMPONENT SKILL_NAME \
+      CLAUDE_CODE_ENABLE_TELEMETRY OTEL_TRACES_EXPORTER OTEL_EXPORTER_OTLP_ENDPOINT \
+      OTEL_EXPORTER_OTLP_HEADERS OTEL_LOG_USER_PROMPTS OTEL_LOG_TOOL_CONTENT \
+      OTEL_RESOURCE_ATTRIBUTES 2>/dev/null || true
+
+# 1. No keys → complete no-op (nothing exported), and returns success under -e.
+( set -e
+  source "$LF" 2>/dev/null
+  [ -z "${CLAUDE_CODE_ENABLE_TELEMETRY:-}" ] && [ -z "${OTEL_TRACES_EXPORTER:-}" ]
+) && pass "no keys → no-op, no OTEL vars exported" || bad "no keys → no-op, no OTEL vars exported"
+
+# 2. Only one key → still a no-op (both are required).
+( set -e
+  export LANGFUSE_PUBLIC_KEY=pk-lf-x
+  source "$LF" 2>/dev/null
+  [ -z "${CLAUDE_CODE_ENABLE_TELEMETRY:-}" ]
+) && pass "one key only → no-op" || bad "one key only → no-op"
+
+# 3. Both keys → telemetry + traces exporter turned on.
+( export LANGFUSE_PUBLIC_KEY=pk-lf-abc LANGFUSE_SECRET_KEY=sk-lf-def
+  source "$LF" 2>/dev/null
+  [ "${CLAUDE_CODE_ENABLE_TELEMETRY:-}" = "1" ] \
+    && [ "${CLAUDE_CODE_ENHANCED_TELEMETRY_BETA:-}" = "1" ] \
+    && [ "${OTEL_TRACES_EXPORTER:-}" = "otlp" ]
+) && pass "both keys → tracing enabled" || bad "both keys → tracing enabled"
+
+# 4. Endpoint defaults to EU cloud and targets the OTLP path.
+( export LANGFUSE_PUBLIC_KEY=pk LANGFUSE_SECRET_KEY=sk
+  source "$LF" 2>/dev/null
+  [ "${OTEL_EXPORTER_OTLP_ENDPOINT:-}" = "https://cloud.langfuse.com/api/public/otel" ]
+) && pass "default host → EU cloud OTLP endpoint" || bad "default host → EU cloud OTLP endpoint"
+
+# 5. LANGFUSE_HOST override + trailing slash stripped; protocol is HTTP (no gRPC).
+( export LANGFUSE_PUBLIC_KEY=pk LANGFUSE_SECRET_KEY=sk LANGFUSE_HOST=https://us.cloud.langfuse.com/
+  source "$LF" 2>/dev/null
+  [ "${OTEL_EXPORTER_OTLP_ENDPOINT:-}" = "https://us.cloud.langfuse.com/api/public/otel" ] \
+    && [ "${OTEL_EXPORTER_OTLP_PROTOCOL:-}" = "http/protobuf" ]
+) && pass "host override + slash strip + http protocol" || bad "host override + slash strip + http protocol"
+
+# 6. Auth header is Basic <base64(public:secret)> — verify the encoding.
+( export LANGFUSE_PUBLIC_KEY=pk-lf-1 LANGFUSE_SECRET_KEY=sk-lf-2
+  source "$LF" 2>/dev/null
+  want=$(printf '%s:%s' pk-lf-1 sk-lf-2 | base64 | tr -d '\n')
+  case "${OTEL_EXPORTER_OTLP_HEADERS:-}" in
+    "Authorization=Basic ${want},x-langfuse-ingestion-version=4") exit 0 ;;
+    *) exit 1 ;;
+  esac
+) && pass "Basic auth header encodes public:secret" || bad "Basic auth header encodes public:secret"
+
+# 7. Content ON by default → prompts/responses captured, tool bodies NOT.
+( export LANGFUSE_PUBLIC_KEY=pk LANGFUSE_SECRET_KEY=sk
+  source "$LF" 2>/dev/null
+  [ "${OTEL_LOG_USER_PROMPTS:-}" = "1" ] && [ "${OTEL_LOG_ASSISTANT_RESPONSES:-}" = "1" ] \
+    && [ -z "${OTEL_LOG_TOOL_CONTENT:-}" ]
+) && pass "default content → prompts on, tool bodies off" || bad "default content → prompts on, tool bodies off"
+
+# 8. LANGFUSE_LOG_CONTENT=0 → redact everything (no OTEL_LOG_* set).
+( export LANGFUSE_PUBLIC_KEY=pk LANGFUSE_SECRET_KEY=sk LANGFUSE_LOG_CONTENT=0
+  source "$LF" 2>/dev/null
+  [ -z "${OTEL_LOG_USER_PROMPTS:-}" ] && [ -z "${OTEL_LOG_ASSISTANT_RESPONSES:-}" ]
+) && pass "LANGFUSE_LOG_CONTENT=0 → content redacted" || bad "LANGFUSE_LOG_CONTENT=0 → content redacted"
+
+# 9. LANGFUSE_LOG_CONTENT=all → also capture tool input/output bodies.
+( export LANGFUSE_PUBLIC_KEY=pk LANGFUSE_SECRET_KEY=sk LANGFUSE_LOG_CONTENT=all
+  source "$LF" 2>/dev/null
+  [ "${OTEL_LOG_TOOL_CONTENT:-}" = "1" ]
+) && pass "LANGFUSE_LOG_CONTENT=all → tool bodies captured" || bad "LANGFUSE_LOG_CONTENT=all → tool bodies captured"
+
+# 10. LANGFUSE_TRACING=0 → force-disabled even with both keys present.
+( export LANGFUSE_PUBLIC_KEY=pk LANGFUSE_SECRET_KEY=sk LANGFUSE_TRACING=0
+  source "$LF" 2>/dev/null
+  [ -z "${CLAUDE_CODE_ENABLE_TELEMETRY:-}" ]
+) && pass "LANGFUSE_TRACING=0 → force-disabled" || bad "LANGFUSE_TRACING=0 → force-disabled"
+
+# 11. Component + skill land in resource attributes for Langfuse-side context.
+( export LANGFUSE_PUBLIC_KEY=pk LANGFUSE_SECRET_KEY=sk AEON_OTEL_COMPONENT=scorer SKILL_NAME=my-skill
+  source "$LF" 2>/dev/null
+  case "${OTEL_RESOURCE_ATTRIBUTES:-}" in
+    *aeon.component=scorer*) : ;; *) exit 1 ;;
+  esac
+  case "${OTEL_RESOURCE_ATTRIBUTES:-}" in
+    *aeon.skill=my-skill*) exit 0 ;; *) exit 1 ;;
+  esac
+) && pass "resource attrs include component + skill" || bad "resource attrs include component + skill"
+
+# 12. Sourcing under `bash -e` (Actions default) never fails the caller.
+( set -e
+  export LANGFUSE_PUBLIC_KEY=pk LANGFUSE_SECRET_KEY=sk
+  source "$LF" >/dev/null 2>&1
+  echo "still-running" >/dev/null
+) && pass "sourcing under bash -e does not abort caller" || bad "sourcing under bash -e does not abort caller"
+
+echo
+if [ "$fail" -eq 0 ]; then echo "All langfuse-otel tests passed."; else echo "Some tests FAILED."; fi
+exit "$fail"


### PR DESCRIPTION
## What

Optional, **opt-in** observability: set `LANGFUSE_PUBLIC_KEY` + `LANGFUSE_SECRET_KEY` and every Claude Code run streams to a [Langfuse](https://langfuse.com) project as a **trace** — LLM calls (model, tokens, cost, latency), tool calls, and (by default) the prompts/responses. **Pure no-op when the keys are unset** — "set a Langfuse token → traces just appear."

## How it works

Aeon already sources `scripts/llm-gateway.sh` right before every `claude -p` call to own `ANTHROPIC_BASE_URL`/auth. This adds a parallel self-gating shim, `scripts/langfuse-otel.sh`, sourced at the same spots. It exports Claude Code's native **OpenTelemetry** env so the CLI's span tree (`claude_code.interaction → llm_request → tool`, with `gen_ai.*` attrs) ships to Langfuse's OTLP endpoint.

Design decisions grounded in the docs:
- **Traces only.** Langfuse's OTLP endpoint ingests spans, not OTEL metrics/logs — so the shim enables only the traces exporter and leaves metrics/logs off (nothing hits an endpoint that would reject it).
- **HTTP, not gRPC.** Langfuse doesn't support gRPC → `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`.
- **Span export is a Claude Code beta** (`CLAUDE_CODE_ENHANCED_TELEMETRY_BETA`) — ships with the pinned CLI; older pins just no-op.
- **Out of band + fail-safe.** Export is decoupled from the model call; the shim never `exit`s or fails a run (returns only). A Langfuse outage can't break a skill.

## Coverage

Sourced after the gateway in: main run (all cascade fallback attempts), post-run **scorer**, json-render **feed** convert, and the conversational **message** poller (`messages.yml`) — each tagged with an `aeon.component` resource attribute. The **grok harness is not traced** (the grok CLI has no equivalent OTEL export), documented as such.

## Config

| Name | Kind | Default | Purpose |
|---|---|---|---|
| `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` | secret | — | Required to activate. |
| `LANGFUSE_HOST` | variable | `https://cloud.langfuse.com` | Region / self-hosted URL (US = `https://us.cloud.langfuse.com`). |
| `LANGFUSE_TRACING` | variable | `1` | `0` to force-disable even with keys set. |
| `LANGFUSE_LOG_CONTENT` | variable | `1` | `0` = metadata-only (no text); `all` = also tool I/O bodies. |

Registered `LANGFUSE_*` in the dashboard under a new **Observability** secrets group.

## Tests / validation

- `scripts/tests/test_langfuse_otel.sh` — **12 cases**, all passing (no-op without keys, one-key no-op, endpoint/auth/protocol construction, host override + slash-strip, content on/off/all, `LANGFUSE_TRACING=0`, resource attrs, `bash -e` safety).
- Both workflows + root `aeon.yml` parse; OKF validation passes (`docs/langfuse.md` typed `Reference`); shim is shellcheck-clean.

## Files

- **New:** `scripts/langfuse-otel.sh`, `scripts/tests/test_langfuse_otel.sh`, `docs/langfuse.md`
- **Wiring:** `.github/workflows/aeon.yml`, `.github/workflows/messages.yml`
- **Config/UI:** `aeon.yml` (pointer comment), `apps/dashboard/app/api/secrets/route.ts`, `apps/dashboard/components/SecretsPanel.tsx`
- **Docs:** `.github/README.md`

## Notes for review

- No new telemetry infra existed to conflict with (zero prior OTEL wiring).
- Requires no sandbox workaround: the OTEL exporter runs inside the `claude` process (same egress as the model call), not through the Bash-tool sandbox.