### PR TITLE
feat(dashboard): Langfuse region dropdown + Core secret reorder

### DIFF
--- a/apps/dashboard/app/api/observability/route.ts
+++ b/apps/dashboard/app/api/observability/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from 'next/server'
+import { execFileSync } from 'child_process'
+import { ghAvailable, ghArgsRepo } from '@/lib/gh'
+import { errorResponse } from '@/lib/http'
+
+// Langfuse region → OTLP host. The shim (scripts/langfuse-otel.sh) reads the
+// LANGFUSE_HOST repo VARIABLE and defaults to EU cloud when it's unset, so EU is
+// the default here too. A self-hosted / non-cloud URL surfaces as `custom` and
+// is left untouched unless the operator explicitly picks EU or US.
+const LANGFUSE_HOSTS = {
+  eu: 'https://cloud.langfuse.com',
+  us: 'https://us.cloud.langfuse.com',
+} as const
+type Region = keyof typeof LANGFUSE_HOSTS
+
+function regionOf(host: string | null): Region | 'custom' {
+  if (!host) return 'eu'
+  const h = host.replace(/\/+$/, '')
+  if (h === LANGFUSE_HOSTS.eu) return 'eu'
+  if (h === LANGFUSE_HOSTS.us) return 'us'
+  return 'custom'
+}
+
+function readVar(name: string): string | null {
+  try {
+    const out = execFileSync(
+      'gh',
+      ['variable', 'list', ...ghArgsRepo(), '--json', 'name,value', '-q', `.[] | select(.name=="${name}") | .value`],
+      { stdio: 'pipe', cwd: process.cwd() },
+    ).toString().trim()
+    return out || null
+  } catch {
+    return null
+  }
+}
+
+export async function GET() {
+  if (!ghAvailable()) {
+    return NextResponse.json({ error: 'GitHub CLI not authenticated. Run: gh auth login', ghReady: false }, { status: 503 })
+  }
+  const host = readVar('LANGFUSE_HOST')
+  return NextResponse.json({ ghReady: true, host, region: regionOf(host) })
+}
+
+export async function POST(request: Request) {
+  if (!ghAvailable()) {
+    return NextResponse.json({ error: 'GitHub CLI not authenticated' }, { status: 503 })
+  }
+  const body = await request.json().catch(() => ({})) as { region?: string }
+  const region: Region | null = body.region === 'us' ? 'us' : body.region === 'eu' ? 'eu' : null
+  if (!region) {
+    return NextResponse.json({ error: "region must be 'eu' or 'us'" }, { status: 400 })
+  }
+  const host = LANGFUSE_HOSTS[region]
+  try {
+    execFileSync('gh', ['variable', 'set', 'LANGFUSE_HOST', ...ghArgsRepo(), '--body', host], {
+      stdio: 'pipe',
+      cwd: process.cwd(),
+    })
+    return NextResponse.json({ ok: true, host, region })
+  } catch (error: unknown) {
+    return errorResponse(error, 'Failed to set LANGFUSE_HOST')
+  }
+}

--- a/apps/dashboard/app/api/secrets/route.ts
+++ b/apps/dashboard/app/api/secrets/route.ts
@@ -8,13 +8,13 @@ import type { Secret } from '@/lib/types'
 
 const BUILTIN_SECRETS: Omit<Secret, 'isSet'>[] = [
   { name: 'CLAUDE_CODE_OAUTH_TOKEN', group: 'Core', description: 'How Claude Code signs in - option 1 of 2. Runs Aeon on your Claude Pro/Max subscription (no per-token billing). Easiest: click AUTH above; or run claude setup-token locally and paste the token here.', either: 'auth' },
+  { name: 'GROK_CREDENTIALS', group: 'Core', description: 'Grok Build (grok CLI) X-account OAuth session - base64 of your ~/.grok login, captured by "Connect X account" in AUTH. Lets the grok harness (harness: grok) run in CI on your SuperGrok / X Premium+ entitlement. Alternative: set XAI_API_KEY instead.' },
   { name: 'ANTHROPIC_API_KEY', group: 'Core', description: 'How Claude Code signs in - option 2 of 2. A pay-as-you-go Anthropic API key (sk-ant-...) billed via the Console, or any Anthropic-compatible key for a proxy. Create one at console.anthropic.com.', either: 'auth' },
   { name: 'BANKR_LLM_KEY', group: 'Core', description: 'Bankr Gateway API key (bk_...) - enable at bankr.bot/api-keys' },
   { name: 'OPENROUTER_API_KEY', group: 'Core', description: 'OpenRouter API key (sk-or-...) - routes Claude through openrouter.ai. Create at openrouter.ai/keys' },
   { name: 'USEPOD_TOKEN', group: 'Core', description: "UsePod proxy token - routes Claude through UsePod's gateway (token embedded in the base URL). Get one at usepod.ai" },
   { name: 'VENICE_API_KEY', group: 'Core', description: 'Venice API key - routes Claude through api.venice.ai via a local translator. Create at venice.ai/settings/api' },
   { name: 'SURPLUS_API_KEY', group: 'Core', description: 'Surplus Intelligence API key (inf_...) - routes Claude through surplusintelligence.ai via a local translator' },
-  { name: 'GROK_CREDENTIALS', group: 'Core', description: 'Grok Build (grok CLI) X-account OAuth session - base64 of your ~/.grok login, captured by "Connect X account" in AUTH. Lets the grok harness (harness: grok) run in CI on your SuperGrok / X Premium+ entitlement. Alternative: set XAI_API_KEY instead.' },
   { name: 'TELEGRAM_BOT_TOKEN', group: 'Telegram', description: 'Bot token from @BotFather' },
   { name: 'TELEGRAM_CHAT_ID', group: 'Telegram', description: 'Your chat ID' },
   { name: 'DISCORD_BOT_TOKEN', group: 'Discord', description: 'Discord bot token' },
@@ -30,7 +30,7 @@ const BUILTIN_SECRETS: Omit<Secret, 'isSet'>[] = [
   // OpenTelemetry. No-op when unset. Region/host + toggles are repo VARIABLES:
   // LANGFUSE_HOST (default https://cloud.langfuse.com), LANGFUSE_TRACING (0 to
   // disable), LANGFUSE_LOG_CONTENT (0 = metadata only, all = incl. tool bodies).
-  { name: 'LANGFUSE_PUBLIC_KEY', group: 'Observability', description: 'Langfuse public key (pk-lf-...) - pairs with LANGFUSE_SECRET_KEY to trace every run to Langfuse. Set the region via the LANGFUSE_HOST repo variable (default EU cloud; US = https://us.cloud.langfuse.com). Keys in Langfuse → Settings → API Keys.' },
+  { name: 'LANGFUSE_PUBLIC_KEY', group: 'Observability', description: 'Langfuse public key (pk-lf-...) - pairs with LANGFUSE_SECRET_KEY to trace every run to Langfuse. Pick EU or US cloud with the region dropdown below (default EU). Keys in Langfuse → Settings → API Keys.' },
   { name: 'LANGFUSE_SECRET_KEY', group: 'Observability', description: 'Langfuse secret key (sk-lf-...) - the other half of the Langfuse trace-ingestion credential. Both keys must be set for tracing to activate.' },
   // Skill Keys - third-party API keys individual skills call. Each is opt-in:
   // unset means the skills that need it skip rather than fail. Names below are

--- a/apps/dashboard/components/LangfuseRegionCard.tsx
+++ b/apps/dashboard/components/LangfuseRegionCard.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+
+interface LangfuseRegionCardProps {
+  // Whether both Langfuse keys are set — drives the "activate the keys" hint.
+  keysSet: boolean
+}
+
+type Region = 'eu' | 'us' | 'custom'
+
+const REGION_LABEL: Record<Region, string> = {
+  eu: 'EU · cloud.langfuse.com',
+  us: 'US · us.cloud.langfuse.com',
+  custom: 'Custom (self-hosted)',
+}
+
+// Rendered as a row inside the Observability credentials list: a dropdown that
+// writes the LANGFUSE_HOST repo variable (EU or US Langfuse cloud). Defaults to
+// EU — the same default the shim (scripts/langfuse-otel.sh) uses when unset.
+export function LangfuseRegionCard({ keysSet }: LangfuseRegionCardProps) {
+  const [region, setRegion] = useState<Region>('eu')
+  const [host, setHost] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [saved, setSaved] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let alive = true
+    fetch('/api/observability')
+      .then(r => r.json())
+      .then((d: { region?: Region; host?: string | null }) => {
+        if (!alive) return
+        if (d.region) setRegion(d.region)
+        setHost(d.host ?? null)
+      })
+      .catch(() => { /* leave EU default */ })
+      .finally(() => { if (alive) setLoading(false) })
+    return () => { alive = false }
+  }, [])
+
+  const choose = async (next: Region) => {
+    if (next === 'custom' || next === region) return
+    setSaving(true); setSaved(false); setError(null)
+    const prev = region
+    setRegion(next)
+    try {
+      const res = await fetch('/api/observability', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ region: next }),
+      })
+      const data = await res.json() as { ok?: boolean; host?: string; error?: string }
+      if (!res.ok || !data.ok) throw new Error(data.error || 'Failed to save region')
+      setHost(data.host ?? null)
+      setSaved(true)
+      setTimeout(() => setSaved(false), 1600)
+    } catch (e) {
+      setRegion(prev)
+      setError(e instanceof Error ? e.message : 'Failed to save region')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="px-[var(--space-md)] py-[var(--space-sm)]">
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="font-mono text-xs">🌍 Langfuse region</span>
+            <span className="text-[10px] font-mono uppercase tracking-[0.14em] text-primary-35">LANGFUSE_HOST</span>
+          </div>
+          <div className="text-[11px] text-primary-40 font-mono">
+            {loading
+              ? 'Loading…'
+              : region === 'custom'
+                ? `Self-hosted: ${host}. Pick EU/US to switch to Langfuse cloud.`
+                : keysSet
+                  ? 'Where your traces are sent. Default is EU cloud.'
+                  : 'Where traces will be sent once the keys above are set. Default is EU cloud.'}
+          </div>
+          {error && <div className="text-[11px] text-eva-orange font-mono mt-1">{error}</div>}
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          {saving && <span className="text-[10px] font-mono text-primary-35">saving…</span>}
+          {saved && <span className="text-[10px] font-mono text-eva-green">saved ✓</span>}
+          <select
+            value={region}
+            onChange={(e) => choose(e.target.value as Region)}
+            disabled={loading || saving}
+            title="Langfuse region"
+            className="bg-aeon-panel text-primary-70 text-[11px] font-mono uppercase tracking-[0.14em] px-3 h-[32px] border border-[rgba(250,250,250,0.10)] outline-none cursor-pointer hover:border-[rgba(250,250,250,0.22)] transition-colors disabled:opacity-50"
+          >
+            <option value="eu">{REGION_LABEL.eu}</option>
+            <option value="us">{REGION_LABEL.us}</option>
+            {region === 'custom' && <option value="custom">{REGION_LABEL.custom}</option>}
+          </select>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/dashboard/components/SecretsPanel.tsx
+++ b/apps/dashboard/components/SecretsPanel.tsx
@@ -7,6 +7,7 @@ import { Scramble } from './ui/Animated'
 import { ServiceIcon } from './ui/ServiceIcon'
 import { linkify } from './ui/Linkify'
 import { InstantModeCard } from './InstantModeCard'
+import { LangfuseRegionCard } from './LangfuseRegionCard'
 import { TelegramCommandsCard } from './TelegramCommandsCard'
 import { TelegramChatIdHelper } from './TelegramChatIdHelper'
 
@@ -183,6 +184,7 @@ export function SecretsPanel({ secrets, skills, busy, repo, focusKey, onFocusHan
               ))}
               {group === 'Telegram' && <TelegramCommandsCard tokenSet={secrets.some(s => s.name === 'TELEGRAM_BOT_TOKEN' && s.isSet)} />}
               {group === 'Telegram' && <InstantModeCard repo={repo} sessionBotToken={sessionBotToken} />}
+              {group === 'Observability' && <LangfuseRegionCard keysSet={secrets.some(s => s.name === 'LANGFUSE_PUBLIC_KEY' && s.isSet) && secrets.some(s => s.name === 'LANGFUSE_SECRET_KEY' && s.isSet)} />}
             </div>
           </section>
         )

--- a/docs/langfuse.md
+++ b/docs/langfuse.md
@@ -51,12 +51,14 @@ scorer, the json-render feed convert, and the conversational-reply poller
    gh secret set LANGFUSE_SECRET_KEY   # sk-lf-...
    ```
 
-3. If you're **not** on Langfuse EU cloud, set the host as a **repo variable**:
+3. Pick your region. In the dashboard, the **Observability** group has an
+   **EU / US** dropdown (🌍 Langfuse region) that writes the `LANGFUSE_HOST`
+   variable for you — **default is EU**. Or set it by hand:
 
    ```bash
    # US cloud:
    gh variable set LANGFUSE_HOST --body 'https://us.cloud.langfuse.com'
-   # or a self-hosted instance:
+   # or a self-hosted instance (shows as "Custom" in the dropdown, left untouched):
    gh variable set LANGFUSE_HOST --body 'https://langfuse.internal.example.com'
    ```
 


### PR DESCRIPTION
Two dashboard-UX tweaks requested after the Langfuse observability landing (#636).

## 1. Core secrets: GROK_CREDENTIALS below CLAUDE_CODE_OAUTH_TOKEN

Reorders the `BUILTIN_SECRETS` array so the *01 / Core* section lists the two sign-in credentials together:

`CLAUDE_CODE_OAUTH_TOKEN → GROK_CREDENTIALS → ANTHROPIC_API_KEY → …`

(The group renders in array order via `.filter`, so this is a pure reorder — no logic change.)

## 2. Observability: EU / US region dropdown

Adds a 🌍 **Langfuse region** dropdown to the *Observability* group that writes the `LANGFUSE_HOST` repo **variable** — no more hand-running `gh variable set`.

- **New route** `app/api/observability/route.ts` — `GET` reads the current `LANGFUSE_HOST` (via `gh variable list --json`), `POST {region}` sets it (via `gh variable set`, same pattern as the auth route's `ANTHROPIC_BASE_URL`).
- **New component** `LangfuseRegionCard.tsx` — rendered as a row in the Observability list (same pattern as `InstantModeCard`). EU / US options; optimistic update with a *saved ✓* tick and rollback on error.
- **Default = EU** (`https://cloud.langfuse.com`), matching `scripts/langfuse-otel.sh` and the Langfuse SDK default.
- A **self-hosted** host surfaces as a read-only **Custom** option and is left untouched unless you explicitly pick EU/US.

Docs + the `LANGFUSE_PUBLIC_KEY` description updated to point at the dropdown.

## What's the default config? (answered inline)

- **Region:** EU cloud (`https://cloud.langfuse.com`).
- **Tracing:** on whenever both keys are set (`LANGFUSE_TRACING=1`).
- **Content:** captured by default (`LANGFUSE_LOG_CONTENT=1` → prompts + responses + tool params; tool I/O bodies stay off unless `all`).

## Validation

- OKF validation passes. Diffs follow existing route/component conventions exactly (imports resolve to existing `errorResponse` / `ghAvailable` / `ghArgsRepo`). Dashboard deps aren't installed locally, so the Next build/lint runs in CI.

Follow-up to #636.