### PR TITLE
feat(observability): group a whole Aeon run into one Langfuse session

### DIFF
--- a/docs/langfuse.md
+++ b/docs/langfuse.md
@@ -62,8 +62,10 @@ scorer, the json-render feed convert, and the conversational-reply poller
    gh variable set LANGFUSE_HOST --body 'https://langfuse.internal.example.com'
    ```
 
-That's it — the next run appears in Langfuse. One `claude -p` run maps to one
-Langfuse **session** (Claude Code stamps `session.id` per run).
+That's it — the next run appears in Langfuse. Every `claude -p` in one Aeon run
+(the skill-run, the post-run scorer, the feed convert) is grouped into a single
+Langfuse **session** keyed by the GitHub run id (`langfuse.session.id`), so you
+see the whole run in one place rather than one session per process.
 
 ## Configuration reference
 

--- a/scripts/langfuse-otel.sh
+++ b/scripts/langfuse-otel.sh
@@ -88,15 +88,23 @@ case "${LANGFUSE_LOG_CONTENT:-1}" in
 esac
 
 # --- identity / grouping ----------------------------------------------------
-# Resource attributes land in Langfuse trace metadata.resourceAttributes. Claude
-# Code already stamps session.id per run, so one `claude -p` run groups into one
-# Langfuse session automatically; these add the Aeon-side context on top.
+# Resource attributes land in Langfuse (and are flattened onto each span, so the
+# langfuse.* ones below take effect). Each `claude -p` process gets its OWN
+# session.id (a per-process UUID), so a single Aeon run — the skill-run, the
+# post-run scorer, and the feed convert — would otherwise fragment into separate
+# Langfuse sessions. Pin langfuse.session.id to the GitHub run id so all of one
+# run's components collapse into ONE session; langfuse.trace.name gives the trace
+# a readable name instead of a blank one.
 export OTEL_SERVICE_NAME="${OTEL_SERVICE_NAME:-aeon}"
 _lf_attrs="service.name=aeon,deployment.environment=github-actions"
 _lf_attrs="${_lf_attrs},aeon.component=${AEON_OTEL_COMPONENT:-skill-run}"
-if [ -n "${SKILL_NAME:-}" ];        then _lf_attrs="${_lf_attrs},aeon.skill=${SKILL_NAME}"; fi
+if [ -n "${GITHUB_RUN_ID:-}" ]; then
+  _lf_attrs="${_lf_attrs},langfuse.session.id=${GITHUB_RUN_ID},aeon.run_id=${GITHUB_RUN_ID}"
+fi
+if [ -n "${SKILL_NAME:-}" ]; then
+  _lf_attrs="${_lf_attrs},aeon.skill=${SKILL_NAME},langfuse.trace.name=aeon:${AEON_OTEL_COMPONENT:-skill-run}:${SKILL_NAME}"
+fi
 if [ -n "${GITHUB_REPOSITORY:-}" ]; then _lf_attrs="${_lf_attrs},aeon.repo=${GITHUB_REPOSITORY}"; fi
-if [ -n "${GITHUB_RUN_ID:-}" ];     then _lf_attrs="${_lf_attrs},aeon.run_id=${GITHUB_RUN_ID}"; fi
 if [ -n "${GITHUB_RUN_ATTEMPT:-}" ];then _lf_attrs="${_lf_attrs},aeon.run_attempt=${GITHUB_RUN_ATTEMPT}"; fi
 export OTEL_RESOURCE_ATTRIBUTES="$_lf_attrs"
 

--- a/scripts/tests/test_langfuse_otel.sh
+++ b/scripts/tests/test_langfuse_otel.sh
@@ -98,7 +98,16 @@ unset LANGFUSE_PUBLIC_KEY LANGFUSE_SECRET_KEY LANGFUSE_HOST LANGFUSE_BASE_URL \
   esac
 ) && pass "resource attrs include component + skill" || bad "resource attrs include component + skill"
 
-# 12. Sourcing under `bash -e` (Actions default) never fails the caller.
+# 12. GITHUB_RUN_ID → langfuse.session.id, so a whole Aeon run groups into one
+#     Langfuse session (skill-run + scorer + feed share the run id).
+( export LANGFUSE_PUBLIC_KEY=pk LANGFUSE_SECRET_KEY=sk GITHUB_RUN_ID=123456789
+  source "$LF" 2>/dev/null
+  case "${OTEL_RESOURCE_ATTRIBUTES:-}" in
+    *langfuse.session.id=123456789*) exit 0 ;; *) exit 1 ;;
+  esac
+) && pass "GITHUB_RUN_ID → langfuse.session.id" || bad "GITHUB_RUN_ID → langfuse.session.id"
+
+# 13. Sourcing under `bash -e` (Actions default) never fails the caller.
 ( set -e
   export LANGFUSE_PUBLIC_KEY=pk LANGFUSE_SECRET_KEY=sk
   source "$LF" >/dev/null 2>&1


### PR DESCRIPTION
From analyzing a live test-run trace export (thanks @aaronjmars): the wiring works end-to-end and **confirms Claude Code 2.1.168 emits the beta trace spans**. But one run fragmented into 3 traces across 2 Langfuse sessions, because each `claude -p` process stamps its own per-process `session.id`:

- skill-run session → the interaction trace **+** an orphan `standalone` haiku trace (Claude's internal title-gen)
- scorer session → a separate trace

## Fix

Pin `langfuse.session.id` to `GITHUB_RUN_ID` in `OTEL_RESOURCE_ATTRIBUTES`, so all `claude -p` calls of one Aeon run (skill-run + scorer + feed) collapse into **one Langfuse session**. The export confirmed resource attributes flatten onto spans (`attributes.aeon.skill` was present), so `langfuse.session.id` takes effect. Also adds `langfuse.trace.name` (`aeon:<component>:<skill>`) so traces get a readable name instead of a blank one.

One-line-ish change in `scripts/langfuse-otel.sh` + a test case (13/13 pass) + doc note.

## Not addressed here (separate decision — see PR discussion)

Langfuse's `usageDetails`/`costDetails`/`totalCost`/`input`/`output` are all empty because Claude Code emits **bare** `input_tokens` / `user_prompt` rather than Langfuse's expected `gen_ai.usage.*` / `gen_ai.prompt`; assistant response text is on the OTEL *logs* signal (which Langfuse's OTLP endpoint doesn't ingest). Fixing cost/usage would need an OTEL-collector sidecar that renames attributes — proposed as an optional follow-up.

Follow-up to #636.