### PR TITLE
fix(scheduler): catch up missed skills (exact-slot debt model) + retry failed dispatches

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -52,3 +52,5 @@ jobs:
         run: python3 scripts/tests/test_verdikta_postprocess.py
       - name: validate-config unit tests
         run: node --test scripts/validate-config.test.js
+      - name: cron-due scheduler decision tests
+        run: bash scripts/tests/test_cron_due.sh

--- a/.github/workflows/messages.yml
+++ b/.github/workflows/messages.yml
@@ -56,57 +56,21 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_GLOBAL || secrets.GITHUB_TOKEN }}
         run: |
-          MINUTE=$(date -u +%-M)
-          HOUR=$(date -u +%-H)
-          DOM=$(date -u +%-d)
-          MONTH=$(date -u +%-m)
-          DOW=$(date -u +%w)
           NOW_ISO=$(date -u +%FT%TZ)
           NOW_EPOCH=$(date -u +%s)
 
-          # Previous two hours — used by the *chain* catch-up further below, which
-          # still uses the older hour-window heuristic. (The per-skill path no
-          # longer uses these; see CATCHUP_HOURS + scripts/cron-due.sh.)
-          PREV_HOUR=$(( (HOUR + 23) % 24 ))
-          PREV2_HOUR=$(( (HOUR + 22) % 24 ))
+          # Catch-up depth, in hours, for both skills and chains. GitHub delivers
+          # only ~10% of the */5 ticks, so gaps routinely exceed a 2h window and a
+          # due slot would age out and silently drop. scripts/cron-due.sh treats
+          # each skill/chain's last dispatch as a debt ledger and catches up any
+          # slot missed within this many hours. It is also the de-facto max
+          # lateness: a slot older than this is skipped rather than fired stale.
+          # 12h covers a bad half-day tick outage while staying same-day (a daily
+          # skill's slots are 24h apart, so this can never double-fire). Tune here.
+          CATCHUP_HOURS=12
 
-          # Per-skill catch-up depth, in hours. GitHub delivers only ~10% of the
-          # */5 ticks, so gaps routinely exceed a 2h window and a due slot would
-          # age out and silently drop. scripts/cron-due.sh treats each skill's
-          # last dispatch as a debt ledger and catches up any slot missed within
-          # this many hours. It is also the de-facto max lateness: a slot older
-          # than this is skipped rather than fired stale. Tune here.
-          CATCHUP_HOURS=6
-
-          # Cron field matcher — supports: *, N, N-M (ranges), N,M (lists), */N, N/step, N-M/step (steps)
-          cron_match() {
-            local field="$1" value="$2"
-            [ "$field" = "*" ] && return 0
-            # Step values: */5 or 1-10/2
-            if [[ "$field" == */* ]]; then
-              local base="${field%/*}" interval="${field#*/}"
-              if [ "$base" = "*" ]; then
-                [ $((value % interval)) -eq 0 ] && return 0
-              elif [[ "$base" == *-* ]]; then
-                local lo="${base%-*}" hi="${base#*-}"
-                [ "$value" -ge "$lo" ] && [ "$value" -le "$hi" ] && [ $(( (value - lo) % interval )) -eq 0 ] && return 0
-              else
-                [ "$value" -ge "$base" ] && [ $(( (value - base) % interval )) -eq 0 ] && return 0
-              fi
-              return 1
-            fi
-            # Comma-separated list (entries may be ranges or exact values)
-            IFS=',' read -ra VALS <<< "$field"
-            for v in "${VALS[@]}"; do
-              if [[ "$v" == *-* ]]; then
-                local lo="${v%-*}" hi="${v#*-}"
-                [ "$value" -ge "$lo" ] && [ "$value" -le "$hi" ] && return 0
-              else
-                [ "$v" = "$value" ] && return 0
-              fi
-            done
-            return 1
-          }
+          # (Cron matching + the due/skip decision live in scripts/cron-due.sh,
+          # called by both the per-skill and per-chain loops below.)
 
           # --- Load cron state ---
           STATE_FILE="memory/cron-state.json"
@@ -261,37 +225,12 @@ jobs:
             SCHED="${CHAIN_SCHEDULE[$CH]:-}"
             [ -z "$SCHED" ] && continue
 
-            IFS=' ' read -r C_MIN C_HOUR C_DOM C_MONTH C_DOW <<< "$SCHED"
-            cron_match "$C_DOM" "$DOM" || continue
-            cron_match "$C_MONTH" "$MONTH" || continue
-            cron_match "$C_DOW" "$DOW" || continue
-
             CHAIN_KEY="chain:$CH"
             LAST_DISPATCH=$(echo "$STATE" | jq -r --arg s "$CHAIN_KEY" '.[$s].last_dispatch // "1970-01-01T00:00:00Z"')
             LAST_DISPATCH_EPOCH=$(date -u -d "$LAST_DISPATCH" +%s 2>/dev/null || echo 0)
-            MINUTES_SINCE=$(( (NOW_EPOCH - LAST_DISPATCH_EPOCH) / 60 ))
 
-            SHOULD_RUN=false
-            if cron_match "$C_HOUR" "$HOUR"; then
-              if [ "$C_MIN" = "*" ] || [ "$C_MIN" -le "$MINUTE" ]; then
-                SHOULD_RUN=true
-              fi
-            fi
-            # Catch-up: only if last dispatch predates today's scheduled fire time
-            if [ "$SHOULD_RUN" = "false" ] && cron_match "$C_HOUR" "$PREV_HOUR"; then
-              if [[ "$C_MIN" =~ ^[0-9]+$ ]]; then
-                SCHED_EPOCH=$(date -u -d "$(date -u +%Y-%m-%d) ${PREV_HOUR}:$(printf '%02d' "$C_MIN"):00 UTC" +%s 2>/dev/null || echo 0)
-                [ "$LAST_DISPATCH_EPOCH" -lt "$SCHED_EPOCH" ] && SHOULD_RUN=true
-              else
-                SHOULD_RUN=true
-              fi
-            fi
-            [ "$SHOULD_RUN" = "false" ] && continue
-
-            if [ "$MINUTES_SINCE" -lt 90 ]; then
-              echo "Skipping chain $CH (dispatched ${MINUTES_SINCE}m ago)"
-              continue
-            fi
+            # Same exact-slot debt decision as the per-skill path (scripts/cron-due.sh).
+            bash scripts/cron-due.sh "$SCHED" "$NOW_EPOCH" "$LAST_DISPATCH_EPOCH" "$CATCHUP_HOURS" >/dev/null || continue
 
             MATCHED_CHAINS+=("$CH")
             IFS=',' read -ra CH_SKILLS <<< "${CHAIN_SKILLS[$CH]}"

--- a/.github/workflows/messages.yml
+++ b/.github/workflows/messages.yml
@@ -64,12 +64,19 @@ jobs:
           NOW_ISO=$(date -u +%FT%TZ)
           NOW_EPOCH=$(date -u +%s)
 
-          # Previous two hours for catch-up. GitHub Actions throttles the */5 tick
-          # to 71-97min gaps under load; a 1h lookback gives :40-:59 slots only
-          # ~65-80min of tolerance, so trailing-minute slots get dropped. A 2h
-          # lookback gives every slot >=120min of tolerance.
+          # Previous two hours — used by the *chain* catch-up further below, which
+          # still uses the older hour-window heuristic. (The per-skill path no
+          # longer uses these; see CATCHUP_HOURS + scripts/cron-due.sh.)
           PREV_HOUR=$(( (HOUR + 23) % 24 ))
           PREV2_HOUR=$(( (HOUR + 22) % 24 ))
+
+          # Per-skill catch-up depth, in hours. GitHub delivers only ~10% of the
+          # */5 ticks, so gaps routinely exceed a 2h window and a due slot would
+          # age out and silently drop. scripts/cron-due.sh treats each skill's
+          # last dispatch as a debt ledger and catches up any slot missed within
+          # this many hours. It is also the de-facto max lateness: a slot older
+          # than this is skipped rather than fired stale. Tune here.
+          CATCHUP_HOURS=6
 
           # Cron field matcher — supports: *, N, N-M (ranges), N,M (lists), */N, N/step, N-M/step (steps)
           cron_match() {
@@ -172,55 +179,19 @@ jobs:
               continue
             fi
 
-            # --- Normal cron matching ---
-            IFS=' ' read -r C_MIN C_HOUR C_DOM C_MONTH C_DOW <<< "$SCHED"
-
-            cron_match "$C_DOM" "$DOM" || continue
-            cron_match "$C_MONTH" "$MONTH" || continue
-            cron_match "$C_DOW" "$DOW" || continue
-
-            SHOULD_RUN=false
-            if cron_match "$C_HOUR" "$HOUR"; then
-              if [ "$C_MIN" = "*" ] || [ "$C_MIN" -le "$MINUTE" ]; then
-                SHOULD_RUN=true
-              fi
+            # --- Normal cron matching (exact-slot "debt" model) ---
+            # scripts/cron-due.sh decides due/skip by comparing the most recent
+            # scheduled slot (within CATCHUP_HOURS) against last dispatch. This
+            # replaces the old "first tick past the minute + 2h hour-window +
+            # flat 150m dedup" heuristic, which silently dropped any slot that
+            # aged out of the window before a (throttled) tick could see it.
+            # Anchoring on the exact slot means it can't double-fire, so no dedup
+            # window is needed; it also evaluates day-of-month/week against the
+            # slot's own date, fixing alternating-day catch-up across midnight.
+            if SLOT_ISO=$(bash scripts/cron-due.sh "$SCHED" "$NOW_EPOCH" "$LAST_DISPATCH_EPOCH" "$CATCHUP_HOURS"); then
+              MATCHED+=("$SKILL")
+              echo "Matched: $SKILL (schedule: $SCHED, slot: $SLOT_ISO)"
             fi
-            # Catch-up: schedule matched one of the previous two hours but was missed.
-            # Only catch up when last dispatch predates the scheduled fire time —
-            # prevents the same skill from firing twice when later ticks still match.
-            if [ "$SHOULD_RUN" = "false" ]; then
-              for CATCHUP_HOUR in "$PREV_HOUR" "$PREV2_HOUR"; do
-                cron_match "$C_HOUR" "$CATCHUP_HOUR" || continue
-                if [[ "$C_MIN" =~ ^[0-9]+$ ]]; then
-                  SCHED_EPOCH=$(date -u -d "$(date -u +%Y-%m-%d) ${CATCHUP_HOUR}:$(printf '%02d' "$C_MIN"):00 UTC" +%s 2>/dev/null || echo 0)
-                  # Lookback hour wrapped past midnight — scheduled fire was yesterday
-                  [ "$SCHED_EPOCH" -gt "$NOW_EPOCH" ] && SCHED_EPOCH=$((SCHED_EPOCH - 86400))
-                  [ "$LAST_DISPATCH_EPOCH" -lt "$SCHED_EPOCH" ] && SHOULD_RUN=true
-                else
-                  SHOULD_RUN=true
-                fi
-                [ "$SHOULD_RUN" = "true" ] && break
-              done
-            fi
-
-            [ "$SHOULD_RUN" = "false" ] && continue
-
-            # --- Dedup: skip if dispatched recently ---
-            # 150 (was 90): must exceed the 2h catch-up lookback so schedules with
-            # non-numeric minute fields can't re-fire on successive ticks.
-            DEDUP_WINDOW=150
-            if [[ "$C_MIN" == */* ]]; then
-              INTERVAL="${C_MIN#*/}"
-              DEDUP_WINDOW=$((INTERVAL * 2 + 5))
-            fi
-
-            if [ "$MINUTES_SINCE" -lt "$DEDUP_WINDOW" ]; then
-              echo "Skipping $SKILL (dispatched ${MINUTES_SINCE}m ago, window: ${DEDUP_WINDOW}m)"
-              continue
-            fi
-
-            MATCHED+=("$SKILL")
-            echo "Matched: $SKILL (schedule: $SCHED)"
           done
 
           if [ ${#MATCHED[@]} -eq 0 ]; then
@@ -428,6 +399,7 @@ jobs:
 
           # --- Dispatch ---
           DISPATCHED_DEPS=false
+          DISPATCHED=()   # skills whose dispatch GitHub accepted; state is stamped only for these
           for SKILL in "${ORDERED[@]}"; do
             if [ -n "${SKILL_DEPS[$SKILL]:-}" ] && [ "$DISPATCHED_DEPS" = "false" ]; then
               DISPATCHED_DEPS=true
@@ -436,16 +408,27 @@ jobs:
             fi
 
             VAR="${SKILL_VAR[$SKILL]:-}"
+            DISPATCH_OK=true
             if [ -n "$VAR" ]; then
               echo "Dispatching: $SKILL (var: $VAR)${SKILL_DEPS[$SKILL]:+ [depends_on: ${SKILL_DEPS[$SKILL]}]}"
-              gh workflow run aeon.yml -f skill="$SKILL" -f var="$VAR"
+              gh workflow run aeon.yml -f skill="$SKILL" -f var="$VAR" || DISPATCH_OK=false
             else
               echo "Dispatching: $SKILL${SKILL_DEPS[$SKILL]:+ [depends_on: ${SKILL_DEPS[$SKILL]}]}"
-              gh workflow run aeon.yml -f skill="$SKILL"
+              gh workflow run aeon.yml -f skill="$SKILL" || DISPATCH_OK=false
             fi
 
-            STATE=$(echo "$STATE" | jq --arg s "$SKILL" --arg ts "$NOW_ISO" \
-              '.[$s].last_dispatch = $ts | .[$s].last_status = "dispatched"')
+            # Stamp state ONLY for a dispatch GitHub actually accepted. A rejected
+            # one (e.g. secondary rate limit during a burst) leaves state untouched,
+            # so the next tick still sees the slot owed and retries — instead of the
+            # old behaviour that stamped "dispatched" regardless and let the dedup
+            # window bury a silent drop.
+            if [ "$DISPATCH_OK" = "true" ]; then
+              DISPATCHED+=("$SKILL")
+              STATE=$(echo "$STATE" | jq --arg s "$SKILL" --arg ts "$NOW_ISO" \
+                '.[$s].last_dispatch = $ts | .[$s].last_status = "dispatched"')
+            else
+              echo "::warning::dispatch failed for $SKILL — leaving cron state untouched so the next tick retries"
+            fi
 
             sleep 2
           done
@@ -474,7 +457,8 @@ jobs:
               else
                 MERGED='{}'
               fi
-              for SKILL in "${MATCHED[@]}"; do
+              for SKILL in "${DISPATCHED[@]}"; do
+                [ -n "$SKILL" ] || continue
                 MERGED=$(echo "$MERGED" | jq --arg s "$SKILL" --arg ts "$NOW_ISO" \
                   '.[$s].last_dispatch = $ts | .[$s].last_status = "dispatched"')
               done

--- a/scripts/cron-due.sh
+++ b/scripts/cron-due.sh
@@ -83,9 +83,17 @@ for (( h=0; h<=CATCHUP_HOURS; h++ )); do
   BUCKET_TOP=$(( HOUR_TOP - h * 3600 ))
   read -r B_HOUR B_DOM B_MON B_DOW <<< "$("$DATE" -u -d "@$BUCKET_TOP" +'%-H %-d %-m %w')"
   cron_match "$C_HOUR"  "$B_HOUR" || continue
-  cron_match "$C_DOM"   "$B_DOM"  || continue
   cron_match "$C_MONTH" "$B_MON"  || continue
-  cron_match "$C_DOW"   "$B_DOW"  || continue
+  # Standard cron day rule: when BOTH day-of-month and day-of-week are restricted
+  # (neither is "*"), the day matches if EITHER matches; otherwise it's a plain
+  # AND (the "*" field matches anything). NB: this is the POSIX/Vixie-cron rule —
+  # the old scheduler ANDed the two unconditionally.
+  if [ "$C_DOM" != "*" ] && [ "$C_DOW" != "*" ]; then
+    cron_match "$C_DOM" "$B_DOM" || cron_match "$C_DOW" "$B_DOW" || continue
+  else
+    cron_match "$C_DOM" "$B_DOM" || continue
+    cron_match "$C_DOW" "$B_DOW" || continue
+  fi
   for (( m=0; m<60; m++ )); do
     cron_match "$C_MIN" "$m" || continue
     SLOT=$(( BUCKET_TOP + m * 60 ))

--- a/scripts/cron-due.sh
+++ b/scripts/cron-due.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# cron-due.sh — decide whether a cron-scheduled skill is due to run *now*.
+#
+# Replaces the scheduler's old "fire on the first tick past the minute + a fixed
+# 2-hour catch-up + a flat dedup window" heuristic with one exact rule:
+#
+#     A skill is DUE  iff  its most recent scheduled fire time at-or-before now
+#     (within the last CATCHUP_HOURS) is NEWER than its last dispatch.
+#
+# This is the "debt ledger" model. A missed run stays owed until some tick —
+# however late — pays it, bounded by CATCHUP_HOURS so genuinely stale slots
+# (older than the cap) are skipped rather than fired hours late. Because the
+# decision is anchored to the *exact* scheduled slot (not wall-clock proximity),
+# it cannot double-fire and needs no separate dedup window.
+#
+# Why this exists: GitHub only delivers ~10% of the */5 scheduler ticks, so gaps
+# routinely exceed the old 2h catch-up window and a due slot would silently age
+# out and never run. See docs and the "Determine and dispatch" step in
+# .github/workflows/messages.yml.
+#
+# Usage:
+#   cron-due.sh "<min hour dom month dow>" <now_epoch> <last_dispatch_epoch> [catchup_hours]
+#
+# Exit 0 (DUE)  → prints the matched slot time (ISO 8601) to stdout.
+# Exit 1 (skip) → no output.
+#
+# Env: AEON_DATE overrides the `date` binary (set AEON_DATE=gdate to test on
+#      macOS/BSD; the workflow runner is GNU coreutils and needs no override).
+set -euo pipefail
+
+SCHED="${1:?schedule required (5 cron fields)}"
+NOW_EPOCH="${2:?now epoch required}"
+LAST_EPOCH="${3:-0}"
+CATCHUP_HOURS="${4:-6}"
+DATE="${AEON_DATE:-date}"
+
+IFS=' ' read -r C_MIN C_HOUR C_DOM C_MONTH C_DOW <<< "$SCHED"
+# Malformed / non-time schedule (e.g. "workflow_dispatch", "reactive", empty) → never due.
+[ -n "${C_DOW:-}" ] || exit 1
+case "$SCHED" in *workflow_dispatch*|*reactive*) exit 1 ;; esac
+
+# Cron field matcher — supports: *, N, N-M (ranges), N,M (lists), */N, N/step,
+# N-M/step (steps). Kept byte-for-byte in sync with the copy in messages.yml.
+cron_match() {
+  local field="$1" value="$2"
+  [ "$field" = "*" ] && return 0
+  if [[ "$field" == */* ]]; then
+    local base="${field%/*}" interval="${field#*/}"
+    if [ "$base" = "*" ]; then
+      [ $((value % interval)) -eq 0 ] && return 0
+    elif [[ "$base" == *-* ]]; then
+      local lo="${base%-*}" hi="${base#*-}"
+      [ "$value" -ge "$lo" ] && [ "$value" -le "$hi" ] && [ $(( (value - lo) % interval )) -eq 0 ] && return 0
+    else
+      [ "$value" -ge "$base" ] && [ $(( (value - base) % interval )) -eq 0 ] && return 0
+    fi
+    return 1
+  fi
+  local v lo hi
+  IFS=',' read -ra VALS <<< "$field"
+  for v in "${VALS[@]}"; do
+    if [[ "$v" == *-* ]]; then
+      lo="${v%-*}"; hi="${v#*-}"
+      [ "$value" -ge "$lo" ] && [ "$value" -le "$hi" ] && return 0
+    else
+      [ "$v" = "$value" ] && return 0
+    fi
+  done
+  return 1
+}
+
+# Top of the current UTC hour (UTC has no DST, so hour boundaries are exact).
+NOW_MIN_EPOCH=$(( NOW_EPOCH - (NOW_EPOCH % 60) ))
+HOUR_TOP=$(( NOW_EPOCH - (NOW_EPOCH % 3600) ))
+
+# Walk back hour-by-hour up to CATCHUP_HOURS. For each hour bucket, evaluate the
+# hour/day-of-month/month/day-of-week fields against THAT bucket's own date
+# (fixes the old bug where a pre-midnight slot was judged by today's date, which
+# broke alternating-day / weekly catch-up across midnight). Then enumerate the
+# minutes in the hour that match, and keep the most recent slot at-or-before now.
+DUE_SLOT=-1
+for (( h=0; h<=CATCHUP_HOURS; h++ )); do
+  BUCKET_TOP=$(( HOUR_TOP - h * 3600 ))
+  read -r B_HOUR B_DOM B_MON B_DOW <<< "$("$DATE" -u -d "@$BUCKET_TOP" +'%-H %-d %-m %w')"
+  cron_match "$C_HOUR"  "$B_HOUR" || continue
+  cron_match "$C_DOM"   "$B_DOM"  || continue
+  cron_match "$C_MONTH" "$B_MON"  || continue
+  cron_match "$C_DOW"   "$B_DOW"  || continue
+  for (( m=0; m<60; m++ )); do
+    cron_match "$C_MIN" "$m" || continue
+    SLOT=$(( BUCKET_TOP + m * 60 ))
+    [ "$SLOT" -gt "$NOW_MIN_EPOCH" ] && continue    # slot hasn't happened yet
+    [ "$SLOT" -gt "$DUE_SLOT" ] && DUE_SLOT=$SLOT    # keep the most recent
+  done
+  # The newest bucket with any past match holds the most-recent slot; stop.
+  [ "$DUE_SLOT" -ge 0 ] && break
+done
+
+# Due iff we haven't dispatched since that slot's scheduled time.
+if [ "$DUE_SLOT" -ge 0 ] && [ "$LAST_EPOCH" -lt "$DUE_SLOT" ]; then
+  "$DATE" -u -d "@$DUE_SLOT" +%FT%TZ
+  exit 0
+fi
+exit 1

--- a/scripts/tests/test_cron_due.sh
+++ b/scripts/tests/test_cron_due.sh
@@ -66,6 +66,29 @@ check "weekly-not-friday"              "5 10 * * 5"    2026-07-09T11:00:00Z 2026
 check "workflow_dispatch-never"        "workflow_dispatch" 2026-07-07T08:00:00Z never             6  skip
 check "reactive-never"                 "reactive"          2026-07-07T08:00:00Z never             6  skip
 
+# --- correct cron day semantics: DOM & DOW both restricted => OR (13th OR Fri) ---
+check "dom-or-dow friday (dow hit)"    "0 0 13 * 5"    2026-07-10T00:30:00Z never                1  due
+check "dom-or-dow 13th (dom hit)"      "0 0 13 * 5"    2026-07-13T00:30:00Z never                1  due
+check "dom-or-dow neither -> skip"     "0 0 13 * 5"    2026-07-14T00:30:00Z never                1  skip
+# single-restricted day field still behaves as plain AND
+check "dom-only on the 13th"           "0 0 13 * *"    2026-07-13T00:30:00Z never                1  due
+check "dom-only off the 13th"          "0 0 13 * *"    2026-07-14T00:30:00Z never                1  skip
+check "dom-31 in a 31-day month"       "0 0 31 * *"    2026-07-31T00:30:00Z never                1  due
+check "dom-31 off day -> skip"         "0 0 31 * *"    2026-07-30T00:30:00Z never                1  skip
+
+# --- hour ranges / steps / odd minute steps / every-minute ---
+check "hour-range inside window"       "0 9-17 * * *"   2026-07-07T13:30:00Z 2026-07-07T12:00:00Z 6 due
+check "hour-range before window"       "0 9-17 * * *"   2026-07-07T08:30:00Z 2026-07-06T17:00:00Z 6 skip
+check "hour step-range 9-17/2"         "0 9-17/2 * * *" 2026-07-07T12:30:00Z 2026-07-07T09:30:00Z 6 due
+check "minute step */7 latest slot"    "*/7 9 * * *"    2026-07-07T09:59:00Z 2026-07-07T09:00:00Z 6 due
+check "minute step */7 after run"      "*/7 9 * * *"    2026-07-07T09:03:00Z 2026-07-07T09:01:00Z 6 skip
+check "every-minute due"               "* 9 * * *"      2026-07-07T09:30:00Z 2026-07-07T09:29:00Z 6 due
+check "every-minute after run"         "* 9 * * *"      2026-07-07T09:30:00Z 2026-07-07T09:30:00Z 6 skip
+
+# --- hour-granular catch-up cap boundary ---
+check "cap boundary reachable"         "0 6 * * *"     2026-07-07T12:59:00Z 2026-07-06T06:00:00Z 6  due
+check "cap boundary just out"          "0 6 * * *"     2026-07-07T13:00:00Z 2026-07-06T06:00:00Z 6  skip
+
 echo "---"
 echo "PASS: $pass   FAIL: $fail"
 [ "$fail" -eq 0 ]

--- a/scripts/tests/test_cron_due.sh
+++ b/scripts/tests/test_cron_due.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Tests for scripts/cron-due.sh — the exact-slot "debt" scheduler decision.
+# Run:  bash scripts/tests/test_cron_due.sh
+# On macOS/BSD:  AEON_DATE=gdate bash scripts/tests/test_cron_due.sh
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/cron-due.sh"
+DATE="${AEON_DATE:-date}"
+[ -n "${AEON_DATE:-}" ] && export AEON_DATE
+
+pass=0; fail=0
+# check <desc> <schedule> <now-iso> <last-iso|never> <catchup_hours> <expect: due|skip>
+check() {
+  local desc="$1" sched="$2" now="$3" last="$4" catch="$5" expect="$6"
+  local now_e last_e out rc
+  now_e=$("$DATE" -u -d "$now" +%s)
+  if [ "$last" = "never" ]; then last_e=0; else last_e=$("$DATE" -u -d "$last" +%s); fi
+  if out=$(bash "$SCRIPT" "$sched" "$now_e" "$last_e" "$catch" 2>/dev/null); then rc=due; else rc=skip; fi
+  if [ "$rc" = "$expect" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1)); printf 'FAIL: %-38s got=%-4s want=%-4s (slot=%s)\n' "$desc" "$rc" "$expect" "${out:-none}"
+  fi
+}
+
+# Calendar context: 2026-07-06 = Mon (even DOM), 07 = Tue (odd), 10 = Fri.
+
+# --- the core bug: a missed daily run should catch up, not drop ---
+check "drop-recovery (2.6h late)"      "25 6 * * *"    2026-07-07T09:05:00Z 2026-07-06T06:25:00Z 6  due
+check "not-yet-due (before minute)"    "25 6 * * *"    2026-07-07T06:10:00Z 2026-07-06T06:25:00Z 6  skip
+check "already-ran-this-slot"          "25 6 * * *"    2026-07-07T06:50:00Z 2026-07-07T06:30:00Z 6  skip
+check "just-past-slot-not-run"         "25 6 * * *"    2026-07-07T06:50:00Z 2026-07-06T06:30:00Z 6  due
+check "exactly-at-slot-minute"         "0 8 * * *"     2026-07-07T08:00:00Z 2026-07-06T08:00:00Z 6  due
+check "one-min-before-slot"            "0 8 * * *"     2026-07-07T07:59:00Z 2026-07-06T08:00:00Z 6  skip
+check "never-dispatched"               "0 8 * * *"     2026-07-07T08:30:00Z never                6  due
+
+# --- lateness cap (CATCHUP_HOURS bounds how stale a fire can be) ---
+check "stale-beyond-6h-cap"            "25 6 * * *"    2026-07-07T14:00:00Z 2026-07-06T06:25:00Z 6  skip
+check "wide-12h-cap-catches"           "25 6 * * *"    2026-07-07T14:00:00Z 2026-07-06T06:25:00Z 12 due
+
+# --- twice-daily two-hour field (6,18) ---
+check "twice-daily-evening-slot"       "25 6,18 * * *" 2026-07-07T18:52:00Z 2026-07-07T06:30:00Z 6  due
+check "twice-daily-after-evening-run"  "25 6,18 * * *" 2026-07-07T20:00:00Z 2026-07-07T18:40:00Z 6  skip
+
+# --- cross-midnight + alternating-day (the day-eval fix) ---
+# Slot is yesterday 23:30 on an EVEN day; "now" is just after midnight on an ODD
+# day. Old code judged 2/2 against today (odd) and dropped it. Must be DUE.
+check "cross-midnight-altday-catchup"  "30 23 2/2 * *" 2026-07-07T00:20:00Z 2026-07-06T12:00:00Z 6  due
+# Even-day skill must NOT fire on an odd day with no in-window even-day slot.
+check "altday-no-slot-on-odd-day"      "0 6 2/2 * *"   2026-07-07T09:00:00Z 2026-07-05T06:00:00Z 6  skip
+
+# --- interval minutes (*/30): fire once, catch up to latest, no double-fire ---
+check "every30-due"                    "*/30 * * * *"  2026-07-07T09:47:00Z 2026-07-07T09:05:00Z 6  due
+check "every30-after-run"              "*/30 * * * *"  2026-07-07T09:50:00Z 2026-07-07T09:47:00Z 6  skip
+check "every30-missed-multi-fires-once" "*/30 * * * *" 2026-07-07T09:47:00Z 2026-07-07T08:00:00Z 6  due
+
+# --- minute lists ---
+check "minute-list-due"                "0,30 6 * * *"  2026-07-07T06:45:00Z 2026-07-06T06:30:00Z 6  due
+check "minute-list-after-first-slot"   "0,30 6 * * *"  2026-07-07T06:15:00Z 2026-07-07T06:05:00Z 6  skip
+
+# --- weekly (DOW) ---
+check "weekly-friday-due"              "5 10 * * 5"    2026-07-10T11:00:00Z 2026-07-03T10:05:00Z 6  due
+check "weekly-not-friday"              "5 10 * * 5"    2026-07-09T11:00:00Z 2026-07-03T10:05:00Z 6  skip
+
+# --- non-time schedules are never due ---
+check "workflow_dispatch-never"        "workflow_dispatch" 2026-07-07T08:00:00Z never             6  skip
+check "reactive-never"                 "reactive"          2026-07-07T08:00:00Z never             6  skip
+
+echo "---"
+echo "PASS: $pass   FAIL: $fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## Problem

GitHub delivers the `*/5` scheduler tick only **~10% of the time** — measured on a live instance: **16–40 of 288 ticks/day**, one tick every ~35–50 min instead of every 5. Two independent bugs turned that into **silently dropped skills**:

1. **Missed-slot drop.** The matcher fired a skill only on the first tick where `current_minute ≥ scheduled_minute`, then leaned on a fixed **2-hour** hour-window catch-up. When the gap between *delivered* ticks exceeded ~2h (routine at 10% delivery), a due slot **aged out of the window before any tick saw it** and never ran — with no record it was owed. Higher-minute skills in a contended hour were most exposed.

2. **Silent failed dispatch.** The dispatch loop never checked `gh workflow run`'s exit code, yet stamped `last_dispatch="dispatched"` regardless; the 150-min dedup then blocked retry. A dispatch GitHub rate-limited during a burst became a **hard drop**, and the 30-min auto-retry never triggered (it keys on `last_status="failed"`, never set).

## Fix

- **`scripts/cron-due.sh`** (new) — one exact rule: a skill is **DUE iff its most recent scheduled slot at-or-before now (within `CATCHUP_HOURS`) is newer than its last dispatch.** A debt ledger, not a wall-clock window:
  - Missed slots stay owed until some (late) tick pays them → **no more aged-out drops.**
  - Anchored on the exact slot → **can't double-fire, no dedup window needed.**
  - Bounded by `CATCHUP_HOURS` (default **12**) = the **max-lateness cap**; older slots are skipped, not fired stale.
  - Day-of-month/week evaluated against each candidate slot's **own date** → fixes alternating-day/weekly catch-up **across midnight**.
  - Correct **POSIX/Vixie-cron day semantics**: when both DOM and DOW are restricted, a day matches if **either** matches (the old scheduler ANDed them).
- **Both the per-skill and per-chain loops** now use it — the chain path's separate 1h-window+90m-dedup heuristic is gone, and so is the now-dead inline `cron_match` + `MINUTE/HOUR/DOM/MONTH/DOW/PREV_HOUR` in the workflow. Cron logic lives in one place.
- **Dispatch loop** — only stamps state for a dispatch GitHub actually accepted; a rejected one is left owed so the next tick retries (with a `::warning::`).

Net: replaces ~90 lines of coupled heuristic across two code paths with one shared, tested decision + a single tunable knob.

## Constraints honored
**Fully internal, zero new dependencies** — dependency-free bash. No external pinger, no library. (`AEON_DATE` overrides the `date` binary purely for local BSD/macOS testing; the runner uses GNU `date`.)

## Testing
`scripts/tests/test_cron_due.sh` — **38 cases, all green**, wired into `ci-tests`: drop-recovery, not-yet-due, already-ran (no double-fire), lateness cap, twice-daily `6,18`, cross-midnight alternating-day, `*/30` fire-once-catch-up, minute lists, weekly DOW, **DOM∧DOW→OR** (both-restricted), DOM-only/DOM-31, hour ranges & step-ranges, `*/7` odd minute step, every-minute, and the catch-up cap boundary. YAML parses; `shellcheck` clean.

## Tuning
`CATCHUP_HOURS=12` in `messages.yml` — how far back to catch up = max lateness. 12h covers a bad half-day tick outage while staying same-day (daily slots are 24h apart, so it can never double-fire). Lower for stricter freshness; raise toward 24 for "never drop a daily skill even after a full-day outage."

## Still a follow-up (deliberately not in this PR)
- **`STATE_BACKEND=issues`** (append-only, race-free cron state) — this is a **live-infra config flip**, not code, and its append path needs end-to-end verification against the *scheduler* (not just the executor's materialize step) before flipping on a production repo, or it could corrupt/drop state. Worth doing as its own change with that verification.

Will hammer more edge cases against the branch before merge.
