### PR TITLE
feat(scheduler): wire the tick into the Issues-as-state backend (§3)

### DIFF
--- a/.github/workflows/messages.yml
+++ b/.github/workflows/messages.yml
@@ -23,7 +23,8 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  issues: read
+  issues: write   # write (was read) so the tick can append dispatch events to the
+                  # Issues-as-state ledger (§3); harmless when STATE_BACKEND is unset/file
   actions: write
 
 env:
@@ -55,6 +56,7 @@ jobs:
       - name: Determine and dispatch scheduled skills
         env:
           GH_TOKEN: ${{ secrets.GH_GLOBAL || secrets.GITHUB_TOKEN }}
+          STATE_BACKEND: ${{ vars.STATE_BACKEND }}
         run: |
           NOW_ISO=$(date -u +%FT%TZ)
           NOW_EPOCH=$(date -u +%s)
@@ -73,12 +75,47 @@ jobs:
           # called by both the per-skill and per-chain loops below.)
 
           # --- Load cron state ---
+          # Issues-as-state (hardening §3) tri-state, matching aeon.yml/chain-runner:
+          #   dual (DEFAULT) — committed file is authoritative; we ALSO mirror each
+          #                    dispatch to the pinned Issue below so the ledger is
+          #                    built up (the dual-write transition).
+          #   issues         — the Issue is source of truth: fold it into the file
+          #                    before reading, and skip the file commit at the end.
+          #   file           — legacy file-only; no Issue reads/writes.
           STATE_FILE="memory/cron-state.json"
+          BACKEND="${STATE_BACKEND:-dual}"
+          if [ "$BACKEND" = "issues" ]; then
+            if GH_REPO="$GITHUB_REPOSITORY" bash scripts/state_store.sh materialize "aeon:cron-state" "$STATE_FILE" >/dev/null 2>&1; then
+              echo "cron-state materialized from the Issues backend"
+            else
+              echo "::warning::could not materialize cron-state from the Issue; using committed file"
+            fi
+          fi
           if [ -f "$STATE_FILE" ] && jq empty "$STATE_FILE" 2>/dev/null; then
             STATE=$(cat "$STATE_FILE")
           else
             STATE='{}'
           fi
+
+          # Mirror a dispatch to the append-only Issue ledger (dual/issues): fold a
+          # "dispatched" event -> last_dispatch (scripts/state_reduce.py) so the
+          # watermark survives without a file commit. Memoizes the issue number and
+          # no-ops in file mode. Used for both skills ("$SKILL") and chains
+          # ("chain:$CH"). $NOW_ISO / $BACKEND are in scope from above.
+          STATE_ISSUE=""
+          STATE_ISSUE_TRIED=false
+          append_dispatch_event() {
+            local key="$1" ev
+            [ "$BACKEND" = "file" ] && return 0
+            if [ "$STATE_ISSUE_TRIED" = "false" ]; then
+              STATE_ISSUE_TRIED=true
+              STATE_ISSUE=$(GH_REPO="$GITHUB_REPOSITORY" bash scripts/state_store.sh ensure "aeon:cron-state" 2>/dev/null | tr -d '[:space:]' || true)
+            fi
+            [ -z "$STATE_ISSUE" ] && return 0
+            ev=$(jq -cn --arg s "$key" --arg ts "$NOW_ISO" '{skill:$s,status:"dispatched",ts:$ts}')
+            GH_REPO="$GITHUB_REPOSITORY" bash scripts/state_store.sh append "$STATE_ISSUE" "$ev" \
+              || echo "::warning::dispatch-event append failed for $key (backend=$BACKEND)"
+          }
 
           # --- Parse aeon.yml ---
           declare -A SKILL_ENABLED SKILL_SCHEDULE SKILL_VAR
@@ -243,9 +280,16 @@ jobs:
           # --- Dispatch chains ---
           for CH in "${MATCHED_CHAINS[@]}"; do
             echo "Dispatching chain: $CH"
-            gh workflow run chain-runner.yml -f chain="$CH"
-            STATE=$(echo "$STATE" | jq --arg s "chain:$CH" --arg ts "$NOW_ISO" \
-              '.[$s].last_dispatch = $ts | .[$s].last_status = "dispatched"')
+            # Same exit-code guard + Issue-ledger mirror as the per-skill dispatch:
+            # only record a dispatch GitHub accepted, so a rejected one retries next
+            # tick instead of being silently marked done.
+            if gh workflow run chain-runner.yml -f chain="$CH"; then
+              STATE=$(echo "$STATE" | jq --arg s "chain:$CH" --arg ts "$NOW_ISO" \
+                '.[$s].last_dispatch = $ts | .[$s].last_status = "dispatched"')
+              append_dispatch_event "chain:$CH"
+            else
+              echo "::warning::chain dispatch failed for $CH — leaving state untouched so the next tick retries"
+            fi
             sleep 2
           done
 
@@ -365,6 +409,7 @@ jobs:
               DISPATCHED+=("$SKILL")
               STATE=$(echo "$STATE" | jq --arg s "$SKILL" --arg ts "$NOW_ISO" \
                 '.[$s].last_dispatch = $ts | .[$s].last_status = "dispatched"')
+              append_dispatch_event "$SKILL"
             else
               echo "::warning::dispatch failed for $SKILL — leaving cron state untouched so the next tick retries"
             fi
@@ -372,8 +417,17 @@ jobs:
             sleep 2
           done
 
-          # --- Commit updated state ---
+          # --- Persist state ---
           mkdir -p memory
+          if [ "$BACKEND" = "issues" ]; then
+            # Issues mode: the pinned Issue is source of truth and the dispatches were
+            # appended above. The file is a dropped projection — discard any working-
+            # tree change so the churn-free end state isn't committed.
+            git checkout -- "$STATE_FILE" 2>/dev/null || rm -f "$STATE_FILE"
+            echo "issues mode: dispatches appended to the Issue; not committing cron-state.json"
+            exit 0
+          fi
+
           echo "$STATE" | jq '.' > "$STATE_FILE"
 
           git add "$STATE_FILE"

--- a/scripts/state_reduce.py
+++ b/scripts/state_reduce.py
@@ -11,6 +11,9 @@ the events. This module is that fold, kept pure so it's unit-testable.
 Event (one JSON object per line on stdin):
   {"skill":"x","status":"success|failed","ts":"2026-06-17T12:00:00Z",
    "quality_score":4,"error":"sig"}   # quality_score/error optional
+A "dispatched" event (posted by the scheduler when it kicks off a run) carries
+only {"skill","status":"dispatched","ts"} and advances the dispatch watermark
+(last_dispatch) without counting as a run outcome.
 
 Output: the same aggregate shape aeon.yml's apply_state_update produces, so heartbeat
 / skill-health read it unchanged.
@@ -21,7 +24,8 @@ import sys
 
 def _blank():
     return {
-        "last_status": None, "last_success": None, "last_failed": None,
+        "last_status": None, "last_dispatch": None,
+        "last_success": None, "last_failed": None,
         "total_runs": 0, "total_successes": 0, "total_failures": 0,
         "consecutive_failures": 0, "success_rate": 0.0,
         "last_quality_score": None, "last_error": None,
@@ -36,7 +40,17 @@ def reduce_events(events):
         if not skill:
             continue
         s = state.setdefault(skill, _blank())
-        status = "success" if e.get("status") == "success" else "failed"
+        raw = e.get("status")
+        # A "dispatched" event is the scheduler recording that it kicked off a run.
+        # It advances the dispatch watermark + last_status only — it is NOT a run
+        # outcome, so it must not touch run counters or consecutive_failures (else
+        # every dispatch would fold as a failure and spike reactive triggers).
+        if raw == "dispatched":
+            s["last_status"] = "dispatched"
+            if e.get("ts"):
+                s["last_dispatch"] = e["ts"]
+            continue
+        status = "success" if raw == "success" else "failed"
         s["total_runs"] += 1
         if status == "success":
             s["total_successes"] += 1

--- a/scripts/tests/test_state_reduce.py
+++ b/scripts/tests/test_state_reduce.py
@@ -73,7 +73,7 @@ class TestReduce(unittest.TestCase):
         # the materialized file silently loses a field. This is the contract that
         # makes the reader cutover safe — guard it explicitly.
         EXPECTED = {
-            "last_status", "last_success", "last_failed",
+            "last_status", "last_dispatch", "last_success", "last_failed",
             "total_runs", "total_successes", "total_failures",
             "consecutive_failures", "success_rate",
             "last_quality_score", "last_error",
@@ -82,6 +82,41 @@ class TestReduce(unittest.TestCase):
         self.assertEqual(set(x.keys()), EXPECTED)
         # _blank() (the zero-event shape) must carry the same keys too.
         self.assertEqual(set(sr._blank().keys()), EXPECTED)
+
+
+class TestDispatch(unittest.TestCase):
+    def test_dispatch_sets_watermark_not_counters(self):
+        x = sr.reduce_events([
+            {"skill": "x", "status": "dispatched", "ts": "2026-06-17T06:25:00Z"},
+        ])["x"]
+        self.assertEqual(x["last_dispatch"], "2026-06-17T06:25:00Z")
+        self.assertEqual(x["last_status"], "dispatched")
+        # A dispatch is not a run outcome — counters stay clean.
+        self.assertEqual(x["total_runs"], 0)
+        self.assertEqual(x["consecutive_failures"], 0)
+        self.assertEqual(x["last_failed"], None)
+
+    def test_dispatch_then_success(self):
+        x = sr.reduce_events([
+            {"skill": "x", "status": "dispatched", "ts": "2026-06-17T06:25:00Z"},
+            {"skill": "x", "status": "success", "ts": "2026-06-17T06:40:00Z", "quality_score": 4},
+        ])["x"]
+        self.assertEqual(x["last_dispatch"], "2026-06-17T06:25:00Z")
+        self.assertEqual(x["last_status"], "success")   # later run outcome wins
+        self.assertEqual(x["last_success"], "2026-06-17T06:40:00Z")
+        self.assertEqual(x["total_runs"], 1)
+
+    def test_dispatch_does_not_reset_or_spike_failures(self):
+        # A dispatch between failures must not clear consecutive_failures (that
+        # would defeat reactive triggers) nor count as a failure itself.
+        x = sr.reduce_events([
+            {"skill": "x", "status": "failed", "ts": "2026-06-17T05:00:00Z", "error": "e1"},
+            {"skill": "x", "status": "dispatched", "ts": "2026-06-17T06:00:00Z"},
+            {"skill": "x", "status": "failed", "ts": "2026-06-17T07:00:00Z", "error": "e2"},
+        ])["x"]
+        self.assertEqual(x["consecutive_failures"], 2)
+        self.assertEqual(x["total_runs"], 2)
+        self.assertEqual(x["last_dispatch"], "2026-06-17T06:00:00Z")
 
 
 class TestParse(unittest.TestCase):


### PR DESCRIPTION
Stacks on #642 (base = its branch). Makes `STATE_BACKEND=issues` actually safe for the scheduler — today it is **not**.

## Why flipping the var is unsafe today
The Issues-as-state ledger (hardening §3) is wired into the executor (`aeon.yml`) and chains, but **never the scheduler tick**, and the reducer has no concept of a dispatch. So `STATE_BACKEND=issues` today would break two ways:

1. **Reducer counts a dispatch as a failure.** `state_reduce.py` folds only `success`/`failed`. A `"dispatched"` event → `status != "success"` → **counted as a failure** (spikes `consecutive_failures`, fires reactive repair), and `last_dispatch` never exists → `cron-due.sh` sees epoch 0 → **every skill/chain always due → mass re-fire every tick.**
2. **The tick goes blind.** It reads/commits the file only; under `issues` the executor stops committing outcomes to the file, so the tick's failed-retry + reactive triggers never see `failed`/`consecutive_failures`.

## What this wires
- **`state_reduce.py`** — a `"dispatched"` event advances `last_dispatch` (+ `last_status`) **only**; no run counters, no `consecutive_failures` touch. New `last_dispatch` key added to the schema; the `test_schema_parity_with_file_writer` contract is updated to match.
- **`messages.yml` tick — tri-state** (matching `aeon.yml`/`chain-runner`):
  - **`dual` (DEFAULT)** — committed file stays authoritative **and** every dispatch is mirrored to the pinned Issue, so the ledger builds up (the dual-write transition) and a later flip is seamless.
  - **`issues`** — materialize the Issue → file before reading; append dispatches; **skip the file commit** (churn-free).
  - **`file`** — legacy file-only; no Issue reads/writes.
  - Shared `append_dispatch_event()` helper (memoized `ensure`) covers **both** the per-skill and per-chain dispatch paths.
- **Chains** get the same exit-code guard + ledger mirror as skills (chain dispatch previously stamped state even if `gh workflow run` was rejected — same silent-drop class #642 fixed for skills).
- **Permissions** — `issues: read → write` (append comments); harmless when the var is unset/`file`.

## Testing
- `state_reduce` dispatch cases added (watermark-not-counters, dispatch→success, dispatch doesn't reset/spike failures); schema-parity updated → **12 reducer tests green**.
- All **13** embedded `run:` scripts pass `bash -n`; YAML parses; **cron-due 38/38** unchanged.

## Default behavior
Substantively unchanged: `dual` already writes the Issue from the executor by default — the tick now co-populates it too. Set `STATE_BACKEND=issues` to cut over once dual-write has accrued dispatch history.

## Known characteristics (not addressed here)
- **`issues`-mode read cost / ledger growth** — every tick + run reads all Issue comments; the ledger grows unbounded. This is pre-existing for the executor's issues mode; compaction is a separate concern.
- Recommend flipping to `issues` **only after** a few days on `dual` so `last_dispatch` history exists (otherwise the first materialize has no dispatch watermarks and the first tick catches everything up once — bounded, but avoidable).
