### PR TITLE
feat(scheduler): wire the tick into the Issues-as-state backend (§3)

### DIFF
--- a/.github/workflows/messages.yml
+++ b/.github/workflows/messages.yml
@@ -23,7 +23,8 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  issues: read
+  issues: write   # write (was read) so the tick can append dispatch events to the
+                  # Issues-as-state ledger (§3); harmless when STATE_BACKEND is unset/file
   actions: write
 
 env:
@@ -55,6 +56,7 @@ jobs:
       - name: Determine and dispatch scheduled skills
         env:
           GH_TOKEN: ${{ secrets.GH_GLOBAL || secrets.GITHUB_TOKEN }}
+          STATE_BACKEND: ${{ vars.STATE_BACKEND }}
         run: |
           NOW_ISO=$(date -u +%FT%TZ)
           NOW_EPOCH=$(date -u +%s)
@@ -73,12 +75,47 @@ jobs:
           # called by both the per-skill and per-chain loops below.)
 
           # --- Load cron state ---
+          # Issues-as-state (hardening §3) tri-state, matching aeon.yml/chain-runner:
+          #   dual (DEFAULT) — committed file is authoritative; we ALSO mirror each
+          #                    dispatch to the pinned Issue below so the ledger is
+          #                    built up (the dual-write transition).
+          #   issues         — the Issue is source of truth: fold it into the file
+          #                    before reading, and skip the file commit at the end.
+          #   file           — legacy file-only; no Issue reads/writes.
           STATE_FILE="memory/cron-state.json"
+          BACKEND="${STATE_BACKEND:-dual}"
+          if [ "$BACKEND" = "issues" ]; then
+            if GH_REPO="$GITHUB_REPOSITORY" bash scripts/state_store.sh materialize "aeon:cron-state" "$STATE_FILE" >/dev/null 2>&1; then
+              echo "cron-state materialized from the Issues backend"
+            else
+              echo "::warning::could not materialize cron-state from the Issue; using committed file"
+            fi
+          fi
           if [ -f "$STATE_FILE" ] && jq empty "$STATE_FILE" 2>/dev/null; then
             STATE=$(cat "$STATE_FILE")
           else
             STATE='{}'
           fi
+
+          # Mirror a dispatch to the append-only Issue ledger (dual/issues): fold a
+          # "dispatched" event -> last_dispatch (scripts/state_reduce.py) so the
+          # watermark survives without a file commit. Memoizes the issue number and
+          # no-ops in file mode. Used for both skills ("$SKILL") and chains
+          # ("chain:$CH"). $NOW_ISO / $BACKEND are in scope from above.
+          STATE_ISSUE=""
+          STATE_ISSUE_TRIED=false
+          append_dispatch_event() {
+            local key="$1" ev
+            [ "$BACKEND" = "file" ] && return 0
+            if [ "$STATE_ISSUE_TRIED" = "false" ]; then
+              STATE_ISSUE_TRIED=true
+              STATE_ISSUE=$(GH_REPO="$GITHUB_REPOSITORY" bash scripts/state_store.sh ensure "aeon:cron-state" 2>/dev/null | tr -d '[:space:]' || true)
+            fi
+            [ -z "$STATE_ISSUE" ] && return 0
+            ev=$(jq -cn --arg s "$key" --arg ts "$NOW_ISO" '{skill:$s,status:"dispatched",ts:$ts}')
+            GH_REPO="$GITHUB_REPOSITORY" bash scripts/state_store.sh append "$STATE_ISSUE" "$ev" \
+              || echo "::warning::dispatch-event append failed for $key (backend=$BACKEND)"
+          }
 
           # --- Parse aeon.yml ---
           declare -A SKILL_ENABLED SKILL_SCHEDULE SKILL_VAR
@@ -243,9 +280,16 @@ jobs:
           # --- Dispatch chains ---
           for CH in "${MATCHED_CHAINS[@]}"; do
             echo "Dispatching chain: $CH"
-            gh workflow run chain-runner.yml -f chain="$CH"
-            STATE=$(echo "$STATE" | jq --arg s "chain:$CH" --arg ts "$NOW_ISO" \
-              '.[$s].last_dispatch = $ts | .[$s].last_status = "dispatched"')
+            # Same exit-code guard + Issue-ledger mirror as the per-skill dispatch:
+            # only record a dispatch GitHub accepted, so a rejected one retries next
+            # tick instead of being silently marked done.
+            if gh workflow run chain-runner.yml -f chain="$CH"; then
+              STATE=$(echo "$STATE" | jq --arg s "chain:$CH" --arg ts "$NOW_ISO" \
+                '.[$s].last_dispatch = $ts | .[$s].last_status = "dispatched"')
+              append_dispatch_event "chain:$CH"
+            else
+              echo "::warning::chain dispatch failed for $CH — leaving state untouched so the next tick retries"
+            fi
             sleep 2
           done
 
@@ -365,6 +409,7 @@ jobs:
               DISPATCHED+=("$SKILL")
               STATE=$(echo "$STATE" | jq --arg s "$SKILL" --arg ts "$NOW_ISO" \
                 '.[$s].last_dispatch = $ts | .[$s].last_status = "dispatched"')
+              append_dispatch_event "$SKILL"
             else
               echo "::warning::dispatch failed for $SKILL — leaving cron state untouched so the next tick retries"
             fi
@@ -372,8 +417,17 @@ jobs:
             sleep 2
           done
 
-          # --- Commit updated state ---
+          # --- Persist state ---
           mkdir -p memory
+          if [ "$BACKEND" = "issues" ]; then
+            # Issues mode: the pinned Issue is source of truth and the dispatches were
+            # appended above. The file is a dropped projection — discard any working-
+            # tree change so the churn-free end state isn't committed.
+            git checkout -- "$STATE_FILE" 2>/dev/null || rm -f "$STATE_FILE"
+            echo "issues mode: dispatches appended to the Issue; not committing cron-state.json"
+            exit 0
+          fi
+
           echo "$STATE" | jq '.' > "$STATE_FILE"
 
           git add "$STATE_FILE"

--- a/scripts/state_reduce.py
+++ b/scripts/state_reduce.py
@@ -11,6 +11,9 @@ the events. This module is that fold, kept pure so it's unit-testable.
 Event (one JSON object per line on stdin):
   {"skill":"x","status":"success|failed","ts":"2026-06-17T12:00:00Z",
    "quality_score":4,"error":"sig"}   # quality_score/error optional
+A "dispatched" event (posted by the scheduler when it kicks off a run) carries
+only {"skill","status":"dispatched","ts"} and advances the dispatch watermark
+(last_dispatch) without counting as a run outcome.
 
 Output: the same aggregate shape aeon.yml's apply_state_update produces, so heartbeat
 / skill-health read it unchanged.
@@ -21,7 +24,8 @@ import sys
 
 def _blank():
     return {
-        "last_status": None, "last_success": None, "last_failed": None,
+        "last_status": None, "last_dispatch": None,
+        "last_success": None, "last_failed": None,
         "total_runs": 0, "total_successes": 0, "total_failures": 0,
         "consecutive_failures": 0, "success_rate": 0.0,
         "last_quality_score": None, "last_error": None,
@@ -36,7 +40,17 @@ def reduce_events(events):
         if not skill:
             continue
         s = state.setdefault(skill, _blank())
-        status = "success" if e.get("status") == "success" else "failed"
+        raw = e.get("status")
+        # A "dispatched" event is the scheduler recording that it kicked off a run.
+        # It advances the dispatch watermark + last_status only — it is NOT a run
+        # outcome, so it must not touch run counters or consecutive_failures (else
+        # every dispatch would fold as a failure and spike reactive triggers).
+        if raw == "dispatched":
+            s["last_status"] = "dispatched"
+            if e.get("ts"):
+                s["last_dispatch"] = e["ts"]
+            continue
+        status = "success" if raw == "success" else "failed"
         s["total_runs"] += 1
         if status == "success":
             s["total_successes"] += 1

--- a/scripts/tests/test_state_reduce.py
+++ b/scripts/tests/test_state_reduce.py
@@ -73,7 +73,7 @@ class TestReduce(unittest.TestCase):
         # the materialized file silently loses a field. This is the contract that
         # makes the reader cutover safe — guard it explicitly.
         EXPECTED = {
-            "last_status", "last_success", "last_failed",
+            "last_status", "last_dispatch", "last_success", "last_failed",
             "total_runs", "total_successes", "total_failures",
             "consecutive_failures", "success_rate",
             "last_quality_score", "last_error",
@@ -82,6 +82,41 @@ class TestReduce(unittest.TestCase):
         self.assertEqual(set(x.keys()), EXPECTED)
         # _blank() (the zero-event shape) must carry the same keys too.
         self.assertEqual(set(sr._blank().keys()), EXPECTED)
+
+
+class TestDispatch(unittest.TestCase):
+    def test_dispatch_sets_watermark_not_counters(self):
+        x = sr.reduce_events([
+            {"skill": "x", "status": "dispatched", "ts": "2026-06-17T06:25:00Z"},
+        ])["x"]
+        self.assertEqual(x["last_dispatch"], "2026-06-17T06:25:00Z")
+        self.assertEqual(x["last_status"], "dispatched")
+        # A dispatch is not a run outcome — counters stay clean.
+        self.assertEqual(x["total_runs"], 0)
+        self.assertEqual(x["consecutive_failures"], 0)
+        self.assertEqual(x["last_failed"], None)
+
+    def test_dispatch_then_success(self):
+        x = sr.reduce_events([
+            {"skill": "x", "status": "dispatched", "ts": "2026-06-17T06:25:00Z"},
+            {"skill": "x", "status": "success", "ts": "2026-06-17T06:40:00Z", "quality_score": 4},
+        ])["x"]
+        self.assertEqual(x["last_dispatch"], "2026-06-17T06:25:00Z")
+        self.assertEqual(x["last_status"], "success")   # later run outcome wins
+        self.assertEqual(x["last_success"], "2026-06-17T06:40:00Z")
+        self.assertEqual(x["total_runs"], 1)
+
+    def test_dispatch_does_not_reset_or_spike_failures(self):
+        # A dispatch between failures must not clear consecutive_failures (that
+        # would defeat reactive triggers) nor count as a failure itself.
+        x = sr.reduce_events([
+            {"skill": "x", "status": "failed", "ts": "2026-06-17T05:00:00Z", "error": "e1"},
+            {"skill": "x", "status": "dispatched", "ts": "2026-06-17T06:00:00Z"},
+            {"skill": "x", "status": "failed", "ts": "2026-06-17T07:00:00Z", "error": "e2"},
+        ])["x"]
+        self.assertEqual(x["consecutive_failures"], 2)
+        self.assertEqual(x["total_runs"], 2)
+        self.assertEqual(x["last_dispatch"], "2026-06-17T06:00:00Z")
 
 
 class TestParse(unittest.TestCase):


### PR DESCRIPTION
Reopens #643 against main (it auto-closed when #642 merged and its base branch was deleted). Now that #642 is in main, this is a clean single-commit diff.

Makes STATE_BACKEND=issues safe for the scheduler. Full rationale + design in #643:
- state_reduce.py learns a "dispatched" event (advances last_dispatch only; no run counters / consecutive_failures) — otherwise a dispatch folds as a failure and last_dispatch never exists, mass-refiring every tick.
- messages.yml tick: tri-state (dual mirrors dispatches to the Issue; issues materializes+appends+skips commit; file legacy). Shared append_dispatch_event() covers skills AND chains; chains also get the exit-code guard.
- issues: read -> write.

Tests: reducer 12/12 (3 new dispatch cases), all run: scripts pass bash -n, cron-due 38/38 unchanged. CI green on the branch under #643.