### PR TITLE
chore(scheduler): default STATE_BACKEND to file (best for fork-and-forget)

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -1114,17 +1114,19 @@ jobs:
           fi
 
           # Issues-as-state (hardening §3). STATE_BACKEND tri-state:
-          #   dual   (DEFAULT) — append the run event to the pinned state Issue AND keep
-          #                      committing cron-state.json. Readers are unchanged and
-          #                      there is zero staleness risk; the Issue is built up and
-          #                      proven live. This is the dual-write transition.
-          #   issues          — append + SKIP the file-commit/rebase loop (churn-free end
-          #                      state). Requires the pre-run materialize step's reader
-          #                      cutover; flip to this once dual-write is proven.
-          #   file            — legacy file-only escape hatch (no Issue writes).
+          #   file   (DEFAULT) — self-contained: commit cron-state.json only, no Issue
+          #                      writes. Best for fork-and-forget; the debt-model scheduler
+          #                      self-heals the occasional commit race (a lost write just
+          #                      re-fires next tick), so there is no silent-drop risk.
+          #   dual             — opt-in dual-write transition: append the run event to the
+          #                      pinned state Issue AND keep committing the file, building
+          #                      the Issue ledger up so a later `issues` flip is seamless.
+          #   issues           — append + SKIP the file-commit/rebase loop (churn-free).
+          #                      Needs the pre-run materialize; for high-volume operators
+          #                      who also run a ledger-compaction pass.
           # Append failures never lose data: in dual/issues the file path still records
           # the run (issues mode only exits early on a SUCCESSFUL append).
-          BACKEND="${STATE_BACKEND:-dual}"
+          BACKEND="${STATE_BACKEND:-file}"
           if [ "$BACKEND" != "file" ]; then
             EVENT=$(jq -cn --arg s "$SKILL" --arg st "$CRON_STATUS" --arg ts "$NOW_ISO" \
               --argjson q "${QUALITY_SCORE:-0}" --arg err "$ERROR_SIG" \

--- a/.github/workflows/chain-runner.yml
+++ b/.github/workflows/chain-runner.yml
@@ -294,10 +294,11 @@ jobs:
           STATE_FILE="memory/cron-state.json"
 
           # Issues backend (hardening §3) — STATE_BACKEND tri-state, matching aeon.yml:
-          # dual (DEFAULT) appends the chain event to the shared state Issue AND keeps
-          # committing the file; issues appends + skips the file/rebase path; file is the
-          # legacy escape hatch. Append failure falls through to the file either way.
-          BACKEND="${STATE_BACKEND:-dual}"
+          # file (DEFAULT) commits the file only, no Issue writes (best for
+          # fork-and-forget); dual also appends the chain event to the shared state
+          # Issue (opt-in transition); issues appends + skips the file/rebase path.
+          # Append failure falls through to the file either way.
+          BACKEND="${STATE_BACKEND:-file}"
           if [ "$BACKEND" != "file" ]; then
             EVENT=$(jq -cn --arg s "chain:$CHAIN" --arg st "$STATUS" --arg ts "$NOW_ISO" \
               '{skill:$s,status:$st,ts:$ts}')

--- a/.github/workflows/messages.yml
+++ b/.github/workflows/messages.yml
@@ -76,14 +76,15 @@ jobs:
 
           # --- Load cron state ---
           # Issues-as-state (hardening §3) tri-state, matching aeon.yml/chain-runner:
-          #   dual (DEFAULT) — committed file is authoritative; we ALSO mirror each
-          #                    dispatch to the pinned Issue below so the ledger is
-          #                    built up (the dual-write transition).
-          #   issues         — the Issue is source of truth: fold it into the file
-          #                    before reading, and skip the file commit at the end.
-          #   file           — legacy file-only; no Issue reads/writes.
+          #   file (DEFAULT) — self-contained: commit cron-state.json only, no Issue
+          #                    reads/writes. Best for fork-and-forget; the debt model
+          #                    self-heals the rare commit race (a lost write re-fires).
+          #   dual           — opt-in: file authoritative, but ALSO mirror each dispatch
+          #                    to the pinned Issue so the ledger builds up for a later flip.
+          #   issues         — the Issue is source of truth: fold it into the file before
+          #                    reading, append dispatches, and skip the file commit.
           STATE_FILE="memory/cron-state.json"
-          BACKEND="${STATE_BACKEND:-dual}"
+          BACKEND="${STATE_BACKEND:-file}"
           if [ "$BACKEND" = "issues" ]; then
             if GH_REPO="$GITHUB_REPOSITORY" bash scripts/state_store.sh materialize "aeon:cron-state" "$STATE_FILE" >/dev/null 2>&1; then
               echo "cron-state materialized from the Issues backend"

--- a/docs/CORE.md
+++ b/docs/CORE.md
@@ -59,7 +59,7 @@ Backpressure: if 3+ improvement PRs are already open, it exits without creating 
 
 `skill-health` **detects** → file issue → `skill-repair` **fixes** → PR → merge → cron-state recovers → `skill-health` **resolves** the issue. `CLAUDE.md` codifies the contract: **the health skill files issues, repair skills close them.**
 
-**Votable health** runs alongside this loop. Whenever a skill regresses (Haiku score 1–2 or a failure flag), the run appends a `⚠️ Regression …` comment to a per-skill GitHub Issue titled `health: <skill>` — silent on clean runs, so no spam. A human 👍/👎 on that issue sets repair priority (`health_triage.prioritize` ranks open items by votes, then severity), so `self-improve` / `skill-repair` fix what people care about and what's worst, first. On by default; disable with the repo variable `HEALTH_ISSUES=0`. State itself rides an append-only Issue too — see [Durable state](https://github.com/aaronjmars/aeon#durable-state-without-the-churn) (`STATE_BACKEND`).
+**Votable health** runs alongside this loop. Whenever a skill regresses (Haiku score 1–2 or a failure flag), the run appends a `⚠️ Regression …` comment to a per-skill GitHub Issue titled `health: <skill>` — silent on clean runs, so no spam. A human 👍/👎 on that issue sets repair priority (`health_triage.prioritize` ranks open items by votes, then severity), so `self-improve` / `skill-repair` fix what people care about and what's worst, first. On by default; disable with the repo variable `HEALTH_ISSUES=0`. State can optionally ride an append-only Issue too (opt-in via `STATE_BACKEND`; the default is a self-contained committed file) — see [Durable state](https://github.com/aaronjmars/aeon#durable-state-without-the-churn).
 
 ---
 


### PR DESCRIPTION
Makes the zero-config fork experience clean and self-contained.

## Why
`dual` (the old default) is a migration *transition*, not a resting state. A fork that never flips got stuck paying file-commit churn AND silently auto-creating a GitHub Issue that grows forever, never read. Worst case for a template: every fork sprouts a mystery growing Issue.

## Change
Default -> `file` in all three readers (aeon.yml, chain-runner.yml, messages.yml):
- **Self-contained** — state lives only in `memory/cron-state.json`; no Issue created in the fork.
- **Self-healing** — post the debt-model scheduler (#642), a dispatch write lost to a rebase conflict just re-fires next tick (bounded by `CATCHUP_HOURS`), so the race that motivated the Issues backend no longer risks a silent drop. Shipped config enables only heartbeat (~1 run/day) => ~zero contention anyway.
- **No growth trap** — `issues` mode reads every Issue comment per tick/run; `file` has no such failure mode for an unmaintained fork.

`dual`/`issues` remain explicit opt-ins for high-volume operators (and `issues` still wants a compaction pass). Tri-state docs + the CORE.md durable-state note updated to match. Makes #642/#644 machinery dormant-by-default — correct, it should only wake on opt-in.