### PR TITLE
Grok harness: cover XAI_API_KEY via built-in web search (no key needed)

### DIFF
--- a/apps/dashboard/app/page.tsx
+++ b/apps/dashboard/app/page.tsx
@@ -214,7 +214,7 @@ export default function Dashboard() {
       <LeftSidebar
         view={view} setView={(v) => { setView(v); setSelectedSkill(null) }}
         selectedSkill={selectedSkill} setSelectedSkill={setSelectedSkill}
-        skills={visibleSkills} runs={runs} secrets={secrets} repo={repo}
+        skills={visibleSkills} runs={runs} secrets={secrets} repo={repo} harness={harness}
         enabledCount={enabledCount} workingCount={workingCount}
         categoryFilter={categoryFilter} setCategoryFilter={setCategoryFilter}
         onSkillSelect={(name) => { setSelectedSkill(name); setView('hq') }}
@@ -232,7 +232,7 @@ export default function Dashboard() {
 
         <div ref={mainScrollRef} className="flex-1 overflow-y-auto p-[var(--space-lg)]">
           {view === 'secrets' && !selectedSkill && (
-            <SecretsPanel secrets={secrets} skills={skills} busy={busy} repo={repo} focusKey={secretFocus} onFocusHandled={() => setSecretFocus(null)} onSave={saveSecret} onDelete={deleteSecret} onSelectSkill={(name) => { setSelectedSkill(name); setView('hq') }} onConnectClaude={() => setupAuth()} connecting={authLoading} onConnectGrok={() => setupGrokAuth()} grokConnecting={grokLoading} />
+            <SecretsPanel secrets={secrets} skills={skills} busy={busy} repo={repo} harness={harness} focusKey={secretFocus} onFocusHandled={() => setSecretFocus(null)} onSave={saveSecret} onDelete={deleteSecret} onSelectSkill={(name) => { setSelectedSkill(name); setView('hq') }} onConnectClaude={() => setupAuth()} connecting={authLoading} onConnectGrok={() => setupGrokAuth()} grokConnecting={grokLoading} />
           )}
           {view === 'strategy' && !selectedSkill && (
             strategyError
@@ -259,7 +259,7 @@ export default function Dashboard() {
           )}
           {skill && (
             <SkillDetail
-              skill={skill} runs={runs} model={model} secrets={secrets} mcpServers={mcpServers} busy={busy}
+              skill={skill} runs={runs} model={model} harness={harness} secrets={secrets} mcpServers={mcpServers} busy={busy}
               onToggle={toggleSkill} onRun={runSkill} onDelete={deleteSkill}
               onUpdateSchedule={updateSchedule} onUpdateVar={updateVar} onUpdateModel={updateSkillModel}
               onGoToSecret={goToSecret} onGoToMcp={goToMcp}

--- a/apps/dashboard/components/LeftSidebar.tsx
+++ b/apps/dashboard/components/LeftSidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import type { Skill, Run, Secret } from '../lib/types'
-import { packGroups } from '../lib/constants'
+import { packGroups, keyProvidedByHarness } from '../lib/constants'
 import { displayName, initials, getSkillStatus, statusDot } from '../lib/utils'
 
 interface LeftSidebarProps {
@@ -14,6 +14,7 @@ interface LeftSidebarProps {
   runs: Run[]
   secrets: Secret[]
   repo: string
+  harness: string
   enabledCount: number
   workingCount: number
   categoryFilter: string | null
@@ -22,7 +23,7 @@ interface LeftSidebarProps {
   onShowImport: () => void
 }
 
-export function LeftSidebar({ view, setView, selectedSkill, skills, runs, secrets, repo, enabledCount, workingCount, categoryFilter, setCategoryFilter, onSkillSelect, onShowImport }: LeftSidebarProps) {
+export function LeftSidebar({ view, setView, selectedSkill, skills, runs, secrets, repo, harness, enabledCount, workingCount, categoryFilter, setCategoryFilter, onSkillSelect, onShowImport }: LeftSidebarProps) {
   const [skillSearch, setSkillSearch] = useState('')
   // The roster only ever holds skills from *enabled packs* (Core by default —
   // the parent filters before passing `skills`), so it's already focused. We
@@ -32,14 +33,16 @@ export function LeftSidebar({ view, setView, selectedSkill, skills, runs, secret
   const [availableOnly, setAvailableOnly] = useState(false)
 
   // A skill is "key-blocked" when it's enabled but a required (non-optional)
-  // credential it declares isn't set - flagged inline so the operator sees it
-  // without opening each skill.
+  // credential it declares isn't set AND isn't provided natively by the active
+  // harness (Grok Build covers XAI_API_KEY) - flagged inline so the operator sees
+  // it without opening each skill.
   const setSecretNames = new Set(secrets.filter(s => s.isSet).map(s => s.name))
   const missingRequiredKeys = (s: Skill) =>
-    (s.requires ?? []).filter(r => !r.optional && !setSecretNames.has(r.key))
+    (s.requires ?? []).filter(r => !r.optional && !setSecretNames.has(r.key) && !keyProvidedByHarness(r.key, harness))
 
-  // "Available" = runnable out of the box: every declared key is optional.
-  const needsNoKey = (s: Skill) => (s.requires ?? []).every(r => r.optional)
+  // "Available" = runnable out of the box: every declared key is either optional
+  // or provided natively by the current harness.
+  const needsNoKey = (s: Skill) => (s.requires ?? []).every(r => r.optional || keyProvidedByHarness(r.key, harness))
 
   // `categoryFilter` holds a PACK key - the sidebar groups by pack. Picking a
   // pack reveals ALL its skills (enabled + disabled) so you can switch them on in

--- a/apps/dashboard/components/SecretsPanel.tsx
+++ b/apps/dashboard/components/SecretsPanel.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react'
 import type { Secret, Skill } from '../lib/types'
 import { inputCls, displayName } from '../lib/utils'
+import { keyProvidedByHarness } from '../lib/constants'
 import { Scramble } from './ui/Animated'
 import { ServiceIcon } from './ui/ServiceIcon'
 import { linkify } from './ui/Linkify'
@@ -28,6 +29,7 @@ interface SecretsPanelProps {
   skills: Skill[]
   busy: Record<string, boolean>
   repo: string
+  harness: string
   focusKey?: string | null
   onFocusHandled?: () => void
   onSave: (name: string, value: string) => void
@@ -39,7 +41,7 @@ interface SecretsPanelProps {
   grokConnecting?: boolean
 }
 
-export function SecretsPanel({ secrets, skills, busy, repo, focusKey, onFocusHandled, onSave, onDelete, onSelectSkill, onConnectClaude, connecting, onConnectGrok, grokConnecting }: SecretsPanelProps) {
+export function SecretsPanel({ secrets, skills, busy, repo, harness, focusKey, onFocusHandled, onSave, onDelete, onSelectSkill, onConnectClaude, connecting, onConnectGrok, grokConnecting }: SecretsPanelProps) {
   const [editingSecret, setEditingSecret] = useState<string | null>(null)
   const [secretValue, setSecretValue] = useState('')
   const [addingSecret, setAddingSecret] = useState(false)
@@ -130,6 +132,12 @@ export function SecretsPanel({ secrets, skills, busy, repo, focusKey, onFocusHan
                       <div className="min-w-0">
                       <div className="flex items-center gap-2"><span className="font-mono text-xs">{secret.name}</span><span className={`w-2 h-2 rounded-full ${secret.isSet ? 'bg-eva-green' : 'bg-[rgba(250,250,250,0.15)]'}`} /></div>
                       <div className="text-[11px] text-primary-40 font-mono">{linkify(secret.description)}</div>
+                      {keyProvidedByHarness(secret.name, harness) && !secret.isSet && (
+                        <div className="text-[10px] text-eva-green/80 font-mono mt-1 flex items-center gap-1.5">
+                          <span className="w-1.5 h-1.5 rounded-full bg-eva-green shrink-0" />
+                          Provided natively by the Grok Build harness — optional here, set it to also run these skills on the Claude harness.
+                        </div>
+                      )}
                       {secret.name === 'TELEGRAM_BOT_TOKEN' && (
                         <a
                           href="https://t.me/BotFather"

--- a/apps/dashboard/components/SecretsPanel.tsx
+++ b/apps/dashboard/components/SecretsPanel.tsx
@@ -135,7 +135,7 @@ export function SecretsPanel({ secrets, skills, busy, repo, harness, focusKey, o
                       {keyProvidedByHarness(secret.name, harness) && !secret.isSet && (
                         <div className="text-[10px] text-eva-green/80 font-mono mt-1 flex items-center gap-1.5">
                           <span className="w-1.5 h-1.5 rounded-full bg-eva-green shrink-0" />
-                          Provided natively by the Grok Build harness — optional here, set it to also run these skills on the Claude harness.
+                          Covered by the Grok Build harness (built-in web search) — optional here; set it for the premium xAI x_search feed, used by both harnesses.
                         </div>
                       )}
                       {secret.name === 'TELEGRAM_BOT_TOKEN' && (

--- a/apps/dashboard/components/SkillDetail.tsx
+++ b/apps/dashboard/components/SkillDetail.tsx
@@ -57,7 +57,7 @@ function KeyRow({ kref, secret, harness, onGoTo }: { kref: { key: string; option
   const dot = satisfied ? 'bg-eva-green' : kref.optional ? 'bg-eva-orange/60' : 'bg-eva-red'
   const tierLabel = kref.optional ? 'Works better' : 'Required'
   const tierColor = kref.optional ? 'text-eva-orange/80' : 'text-aeon-red'
-  const statusText = isSet ? '· set' : providedByHarness ? '· native to Grok Build' : '· not set'
+  const statusText = isSet ? '· set' : providedByHarness ? '· covered by Grok Build' : '· not set'
 
   return (
     <div className="px-[var(--space-md)] py-[var(--space-sm)]">
@@ -70,7 +70,7 @@ function KeyRow({ kref, secret, harness, onGoTo }: { kref: { key: string; option
             <span className="text-[9px] font-mono uppercase tracking-[0.18em] text-primary-35">{statusText}</span>
           </div>
           <div className="text-[11px] text-primary-40 font-mono mt-0.5 leading-relaxed">
-            {providedByHarness ? 'Provided natively by the Grok Build harness (built-in X search) — set a key only to also use it on the Claude harness.' : desc}
+            {providedByHarness ? 'Covered by the Grok Build harness via its built-in web search — set a key for the premium xAI x_search feed (used by both harnesses).' : desc}
           </div>
         </div>
         <button

--- a/apps/dashboard/components/SkillDetail.tsx
+++ b/apps/dashboard/components/SkillDetail.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import type { Skill, Run, Secret, SkillMcpRef, McpServers } from '../lib/types'
-import { MODELS, CATEGORY_BY_KEY } from '../lib/constants'
+import { MODELS, CATEGORY_BY_KEY, keyProvidedByHarness } from '../lib/constants'
 import { MCP_BY_SLUG } from '../lib/mcp-catalog'
 import { displayName, getSkillStatus, cronLabel, statusDot, inputCls } from '../lib/utils'
 import { ScheduleEditor } from './ScheduleEditor'
@@ -13,6 +13,7 @@ interface SkillDetailProps {
   skill: Skill
   runs: Run[]
   model: string
+  harness: string
   secrets: Secret[]
   mcpServers: McpServers
   busy: Record<string, boolean>
@@ -43,14 +44,20 @@ function Section({ index, label, action, children }: { index: string; label: str
 // A single declared credential. The key name and the right-hand action both
 // jump to Settings → Access Keys, scrolled to this key with its input open —
 // so the operator can paste the value in one click.
-function KeyRow({ kref, secret, onGoTo }: { kref: { key: string; optional: boolean }; secret?: Secret; onGoTo: (name: string) => void }) {
+function KeyRow({ kref, secret, harness, onGoTo }: { kref: { key: string; optional: boolean }; secret?: Secret; harness: string; onGoTo: (name: string) => void }) {
   const isSet = !!secret?.isSet
+  // The harness may cover this key natively (Grok Build → XAI_API_KEY). Then the
+  // row reads as satisfied even unset, but the key stays settable as an override
+  // (it's what the Claude harness uses, and it also powers the grok gateway).
+  const providedByHarness = !isSet && keyProvidedByHarness(kref.key, harness)
+  const satisfied = isSet || providedByHarness
   const desc = secret?.description || 'Third-party credential referenced by this skill.'
 
-  // Status color: set → green. Missing required → red. Missing "works better" → muted amber.
-  const dot = isSet ? 'bg-eva-green' : kref.optional ? 'bg-eva-orange/60' : 'bg-eva-red'
+  // Status color: satisfied → green. Missing required → red. Missing "works better" → muted amber.
+  const dot = satisfied ? 'bg-eva-green' : kref.optional ? 'bg-eva-orange/60' : 'bg-eva-red'
   const tierLabel = kref.optional ? 'Works better' : 'Required'
   const tierColor = kref.optional ? 'text-eva-orange/80' : 'text-aeon-red'
+  const statusText = isSet ? '· set' : providedByHarness ? '· native to Grok Build' : '· not set'
 
   return (
     <div className="px-[var(--space-md)] py-[var(--space-sm)]">
@@ -60,15 +67,17 @@ function KeyRow({ kref, secret, onGoTo }: { kref: { key: string; optional: boole
             <span className={`w-2 h-2 rounded-full shrink-0 ${dot}`} />
             <button onClick={() => onGoTo(kref.key)} title="Open in Settings to set this key" className="font-mono text-xs text-aeon-fg hover:text-eva-orange underline decoration-dotted underline-offset-2 transition-colors">{kref.key}</button>
             <span className={`text-[9px] font-mono uppercase tracking-[0.18em] ${tierColor}`}>{tierLabel}</span>
-            <span className="text-[9px] font-mono uppercase tracking-[0.18em] text-primary-35">{isSet ? '· set' : '· not set'}</span>
+            <span className="text-[9px] font-mono uppercase tracking-[0.18em] text-primary-35">{statusText}</span>
           </div>
-          <div className="text-[11px] text-primary-40 font-mono mt-0.5 leading-relaxed">{desc}</div>
+          <div className="text-[11px] text-primary-40 font-mono mt-0.5 leading-relaxed">
+            {providedByHarness ? 'Provided natively by the Grok Build harness (built-in X search) — set a key only to also use it on the Claude harness.' : desc}
+          </div>
         </div>
         <button
           onClick={() => onGoTo(kref.key)}
           className={`text-[11px] font-mono px-2 py-1 shrink-0 uppercase tracking-[0.14em] transition-colors ${isSet ? 'text-eva-green hover:text-aeon-fg' : 'text-primary-40 hover:text-eva-orange'}`}
         >
-          {isSet ? '✓ in vault' : 'Set →'}
+          {isSet ? '✓ in vault' : providedByHarness ? 'Override →' : 'Set →'}
         </button>
       </div>
     </div>
@@ -115,7 +124,7 @@ function McpRow({ mref, installed, onGoTo }: { mref: SkillMcpRef; installed: boo
   )
 }
 
-export function SkillDetail({ skill, runs, model, secrets, mcpServers, busy, onToggle, onRun, onDelete, onUpdateSchedule, onUpdateVar, onUpdateModel, onGoToSecret, onGoToMcp, onViewRun }: SkillDetailProps) {
+export function SkillDetail({ skill, runs, model, harness, secrets, mcpServers, busy, onToggle, onRun, onDelete, onUpdateSchedule, onUpdateVar, onUpdateModel, onGoToSecret, onGoToMcp, onViewRun }: SkillDetailProps) {
   const modelOptions = MODELS
   const [editingSchedule, setEditingSchedule] = useState(false)
   const [editingVar, setEditingVar] = useState(false)
@@ -131,7 +140,9 @@ export function SkillDetail({ skill, runs, model, secrets, mcpServers, busy, onT
   const requires = skill.requires ?? []
   const requiredKeys = requires.filter(r => !r.optional)
   const worksBetterKeys = requires.filter(r => r.optional)
-  const missingRequired = requiredKeys.filter(r => !secretByName.get(r.key)?.isSet)
+  // A required key is only "missing" if it's neither set nor provided natively by
+  // the active harness (Grok Build covers XAI_API_KEY via its built-in search_x).
+  const missingRequired = requiredKeys.filter(r => !secretByName.get(r.key)?.isSet && !keyProvidedByHarness(r.key, harness))
 
   // Join the skill's declared `mcp:` servers against the live .mcp.json config
   // (installed = its URL is present) and the MCP catalog for name/logo/url.
@@ -231,7 +242,7 @@ export function SkillDetail({ skill, runs, model, secrets, mcpServers, busy, onT
               <div className="text-[10px] font-mono uppercase tracking-[0.18em] text-aeon-red mb-2">Required to run</div>
               <div className="border border-[rgba(250,250,250,0.10)] divide-y divide-[rgba(250,250,250,0.08)]">
                 {requiredKeys.map(r => (
-                  <KeyRow key={r.key} kref={r} secret={secretByName.get(r.key)} onGoTo={onGoToSecret} />
+                  <KeyRow key={r.key} kref={r} secret={secretByName.get(r.key)} harness={harness} onGoTo={onGoToSecret} />
                 ))}
               </div>
             </div>
@@ -241,7 +252,7 @@ export function SkillDetail({ skill, runs, model, secrets, mcpServers, busy, onT
               <div className="text-[10px] font-mono uppercase tracking-[0.18em] text-eva-orange/80 mb-2">Works better with</div>
               <div className="border border-[rgba(250,250,250,0.10)] divide-y divide-[rgba(250,250,250,0.08)]">
                 {worksBetterKeys.map(r => (
-                  <KeyRow key={r.key} kref={r} secret={secretByName.get(r.key)} onGoTo={onGoToSecret} />
+                  <KeyRow key={r.key} kref={r} secret={secretByName.get(r.key)} harness={harness} onGoTo={onGoToSecret} />
                 ))}
               </div>
             </div>

--- a/apps/dashboard/lib/constants.test.ts
+++ b/apps/dashboard/lib/constants.test.ts
@@ -9,7 +9,7 @@
 import { describe, it } from "node:test";
 import { strict as assert } from "node:assert";
 
-import { packGroups, FIRST_PARTY_KEYS } from "./constants";
+import { packGroups, FIRST_PARTY_KEYS, keyProvidedByHarness } from "./constants";
 
 const sk = (name: string, pack: string, packName = "") => ({ pack, packName });
 
@@ -50,5 +50,23 @@ describe("packGroups", () => {
   it("defaults a missing pack to the lab catch-all", () => {
     const groups = packGroups([{ pack: "", packName: "" }]);
     assert.deepEqual(groups.map(g => g.key), ["lab"]);
+  });
+});
+
+describe("keyProvidedByHarness", () => {
+  it("the grok harness natively provides XAI_API_KEY (built-in search_x)", () => {
+    assert.equal(keyProvidedByHarness("XAI_API_KEY", "grok"), true);
+  });
+
+  it("the claude harness provides no keys natively — XAI_API_KEY still required", () => {
+    assert.equal(keyProvidedByHarness("XAI_API_KEY", "claude"), false);
+  });
+
+  it("does not cover unrelated keys even on the grok harness", () => {
+    assert.equal(keyProvidedByHarness("COINGECKO_API_KEY", "grok"), false);
+  });
+
+  it("is safe for an unknown harness", () => {
+    assert.equal(keyProvidedByHarness("XAI_API_KEY", "whatever"), false);
   });
 });

--- a/apps/dashboard/lib/constants.ts
+++ b/apps/dashboard/lib/constants.ts
@@ -64,6 +64,27 @@ export function authSecretsForHarness(harness: string): string[] {
   return harness === 'grok' ? GROK_AUTH_SECRETS : CLAUDE_AUTH_SECRETS
 }
 
+// Credentials whose CAPABILITY a harness provides natively — so a skill that
+// `requires:` that key is runnable on that harness with the secret unset. Grok
+// Build ships a built-in real-time X/Twitter search (`search_x`) + web search,
+// which is exactly what skills use XAI_API_KEY for (the `x_search` prefetch into
+// .xai-cache/). So on the grok harness XAI_API_KEY is covered by the harness
+// itself; the claude harness has no such native provider, so it still needs the
+// key. This only drops the dashboard's "needs key" gate — the runtime half lives
+// in scripts/run-grok.sh, whose compat `--rules` tell the model to call its
+// native search_x in place of the (absent) prefetch cache. The key stays fully
+// settable either way (it powers the Claude-harness prefetch + the grok gateway).
+export const HARNESS_NATIVE_KEYS: Record<string, string[]> = {
+  grok: ['XAI_API_KEY'],
+}
+
+// Does `harness` natively provide `key`'s capability (so a skill requiring it
+// runs on that harness with no secret set)? Drives the "provided by <harness>"
+// state in the dashboard's requirement checks.
+export function keyProvidedByHarness(key: string, harness: string): boolean {
+  return (HARNESS_NATIVE_KEYS[harness] ?? []).includes(key)
+}
+
 export const DAYS = [
   { label: 'All', value: -1 }, { label: 'Mon', value: 1 }, { label: 'Tue', value: 2 },
   { label: 'Wed', value: 3 }, { label: 'Thu', value: 4 }, { label: 'Fri', value: 5 },

--- a/apps/dashboard/lib/constants.ts
+++ b/apps/dashboard/lib/constants.ts
@@ -64,23 +64,24 @@ export function authSecretsForHarness(harness: string): string[] {
   return harness === 'grok' ? GROK_AUTH_SECRETS : CLAUDE_AUTH_SECRETS
 }
 
-// Credentials whose CAPABILITY a harness provides natively — so a skill that
-// `requires:` that key is runnable on that harness with the secret unset. Grok
-// Build ships a built-in real-time X/Twitter search (`search_x`) + web search,
-// which is exactly what skills use XAI_API_KEY for (the `x_search` prefetch into
-// .xai-cache/). So on the grok harness XAI_API_KEY is covered by the harness
-// itself; the claude harness has no such native provider, so it still needs the
-// key. This only drops the dashboard's "needs key" gate — the runtime half lives
-// in scripts/run-grok.sh, whose compat `--rules` tell the model to call its
-// native search_x in place of the (absent) prefetch cache. The key stays fully
-// settable either way (it powers the Claude-harness prefetch + the grok gateway).
+// Credentials whose CAPABILITY a harness covers with its own built-in tools — so a
+// skill that `requires:` that key is runnable on that harness with the secret unset.
+// Grok Build fetches X/Twitter posts with its built-in WebSearch/WebFetch, which is
+// enough to run the skills that use XAI_API_KEY for the `x_search` prefetch (into
+// .xai-cache/) without the key — at web-search quality, NOT the premium xAI x_search
+// feed. So on the grok harness XAI_API_KEY is not required to get output; we drop the
+// dashboard's "needs key" gate there (only there — claude skills still declare it).
+// The runtime half lives in scripts/run-grok.sh, whose compat `--rules` tell the model
+// to fetch X via WebSearch when the cache + key are absent instead of hard-exiting.
+// The key stays fully settable either way — it powers the prefetch on BOTH harnesses
+// (premium data) and the grok gateway.
 export const HARNESS_NATIVE_KEYS: Record<string, string[]> = {
   grok: ['XAI_API_KEY'],
 }
 
-// Does `harness` natively provide `key`'s capability (so a skill requiring it
-// runs on that harness with no secret set)? Drives the "provided by <harness>"
-// state in the dashboard's requirement checks.
+// Does `harness` cover `key`'s capability with its own built-in tools (so a skill
+// requiring it runs on that harness with no secret set)? Drives the "covered by
+// <harness>" state in the dashboard's requirement checks.
 export function keyProvidedByHarness(key: string, harness: string): boolean {
   return (HARNESS_NATIVE_KEYS[harness] ?? []).includes(key)
 }

--- a/scripts/run-grok.sh
+++ b/scripts/run-grok.sh
@@ -227,6 +227,10 @@ if [ -n "${GROK_JSON_SCHEMA:-}" ]; then RUN_FLAGS+=(--json-schema "$GROK_JSON_SC
 # tokens/run). It pairs with --permission-mode bypassPermissions from skill_mode.sh:
 # bypass stops the hard turn-abort, these rules stop the soft "I'll try other ways" give-up.
 # Override/extend via GROK_COMPAT_RULES in the environment.
+# EDITING NOTE: this heredoc sits inside "$(cat <<'RULES' … )" — bash's scanner for
+# that construct still counts apostrophes/backticks in the body, so keep them
+# BALANCED (even count) or the whole assignment breaks at EOF. Prefer "do not" over
+# "don't" and pair every backtick. (bash -n scripts/run-grok.sh catches a slip.)
 GROK_COMPAT_RULES="${GROK_COMPAT_RULES:-$(cat <<'RULES'
 This skill was authored for the Claude Code harness. Adapt its instructions to your
 own tools; do not abort when something does not match one-to-one:
@@ -235,6 +239,14 @@ own tools; do not abort when something does not match one-to-one:
   URL with your web tools instead.
 - When a skill relies on the gh CLI (e.g. `gh api`) and gh is unavailable, call the
   GitHub REST API directly over the web (https://api.github.com/...) — public for reads.
+- X/Twitter data: you have a NATIVE real-time X search (search_x) plus web search. A
+  skill step that reads a `.xai-cache/*.json` file, curls the xAI `x_search` API, or
+  says it needs XAI_API_KEY to pull posts is describing a capability you already have
+  built in — just run the search yourself with search_x (and search_web for the wider
+  web) and use those results in place of the cache. Never skip a section, fall back to
+  a lower-quality path, or emit a NO_KEY / NO_API_KEY / missing-cache status merely
+  because XAI_API_KEY or the prefetch cache is absent: that cache is only a
+  Claude-harness optimization you do not need.
 - If any tool is missing, denied, or returns unusable content, do NOT stop or end the
   turn. Try another route and finish the task; only surface a failure after you have
   exhausted the alternatives the skill names.

--- a/scripts/run-grok.sh
+++ b/scripts/run-grok.sh
@@ -239,14 +239,12 @@ own tools; do not abort when something does not match one-to-one:
   URL with your web tools instead.
 - When a skill relies on the gh CLI (e.g. `gh api`) and gh is unavailable, call the
   GitHub REST API directly over the web (https://api.github.com/...) — public for reads.
-- X/Twitter data: you have a NATIVE real-time X search (search_x) plus web search. A
-  skill step that reads a `.xai-cache/*.json` file, curls the xAI `x_search` API, or
-  says it needs XAI_API_KEY to pull posts is describing a capability you already have
-  built in — just run the search yourself with search_x (and search_web for the wider
-  web) and use those results in place of the cache. Never skip a section, fall back to
-  a lower-quality path, or emit a NO_KEY / NO_API_KEY / missing-cache status merely
-  because XAI_API_KEY or the prefetch cache is absent: that cache is only a
-  Claude-harness optimization you do not need.
+- X/Twitter data: fetch it with your built-in WebSearch and WebFetch tools. A skill
+  step that reads a `.xai-cache/*.json` file, curls the xAI `x_search` API, or needs
+  XAI_API_KEY to pull posts is Claude-harness scaffolding — when that cache and key are
+  absent, get the same posts by searching the web for x.com results yourself and carry
+  on. Never skip a section, or emit a NO_KEY / NO_API_KEY / missing-cache status just
+  because XAI_API_KEY or the prefetch cache is absent; WebSearch covers it.
 - If any tool is missing, denied, or returns unusable content, do NOT stop or end the
   turn. Try another route and finish the task; only surface a failure after you have
   exhausted the alternatives the skill names.


### PR DESCRIPTION
## What

On the **Grok Build harness**, a skill that `requires: [XAI_API_KEY]` should run without setting the key — Grok Build fetches X/Twitter data with its built-in web search, so the tweet skills work with nothing set up. The key stays fully meaningful for the **Claude harness** (it powers the `x_search` prefetch) and can still be set to upgrade **both** harnesses.

Implemented as a **harness-capability layer**, not a blanket bypass.

## The two halves

**Runtime — `scripts/run-grok.sh`:** the compat `--rules` now tell the model to fetch X data with its built-in WebSearch/WebFetch when the `.xai-cache/` prefetch and `XAI_API_KEY` are absent, and to never emit a `NO_KEY` / `NO_API_KEY` / missing-cache status or hard-exit just because the key is unset. This is the functional core — it stops the `TWEET_DIGEST_NO_KEY`-style bailouts and keeps the run producing output.

**Dashboard — `lib/constants.ts` + `SkillDetail`/`LeftSidebar`/`SecretsPanel` (threaded via `page.tsx`):**
- New `HARNESS_NATIVE_KEYS` map + `keyProvidedByHarness(key, harness)` helper (`grok → XAI_API_KEY`).
- Under the Grok harness, `XAI_API_KEY`-requiring skills are no longer gated: no red "missing required key" banner, counted as **available**, shown as **"covered by Grok Build"** with the key still settable as an **Override**.
- Secrets vault shows a note explaining the key is optional on Grok and unlocks the premium xAI `x_search` feed on both harnesses.

`requires:` is UX-only (nothing in the workflow enforces it), so this is purely a gating/behavior change — no skill files touched.

## Live-tested (and it corrected a wrong assumption)

Ran `fetch-tweets` through the real `run-grok.sh` path with the X-account session, `XAI_API_KEY` unset, and no cache. It returned real same-day tweets with live links and **no hard-exit** — goal met. But it used **WebSearch**, and `grok --help` / `grok inspect` confirm **Grok Build CLI 0.2.82 has no dedicated `search_x` tool** — its built-in retrieval is WebSearch/WebFetch (Claude-Code-style tools). An earlier draft of the rule pointed at a phantom `search_x`; this is corrected to reflect reality.

**Net:** works without a key at web-search quality (= the skills' existing Path C), not a premium native X feed. Set `XAI_API_KEY` for the structured `x_search` prefetch, which runs on both harnesses.

## Validation

- `bash -n scripts/run-grok.sh` clean; **37/37** `scripts/tests/test_run_grok.sh` pass.
- Dashboard `tsc --noEmit` clean; **149/149** unit tests pass (added 4 for `keyProvidedByHarness`).

_Note: `run-grok.sh`'s compat rules live in a `"$(cat <<'RULES'…)"` heredoc whose scanner counts apostrophes/backticks — an inline caution + `bash -n` guard the footgun._
