### PR TITLE
feat(workflows): skill-execution attestation (Sigstore provenance)

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -71,6 +71,8 @@ on:
 
 permissions:
   contents: write
+  id-token: write        # mint the OIDC token that signs skill-run attestations
+  attestations: write    # write the attestation to the repo's attestation store
   pull-requests: write
   issues: write   # write (was read) for Issues-as-state append (§3) + votable health Issues (§7); harmless when STATE_BACKEND / HEALTH_ISSUES unset
   actions: read
@@ -661,6 +663,62 @@ jobs:
             echo "_No output captured._" > "output/.chains/${SKILL}.md"
           fi
           echo "::notice::Skill output captured to output/.chains/${SKILL}.md ($(wc -c < "output/.chains/${SKILL}.md") bytes)"
+
+      - name: Resolve attestation gate
+        id: attest-gate
+        if: steps.work.outputs.mode != '' && steps.run.outcome == 'success'
+        env:
+          ATTEST_ENABLED: ${{ vars.ATTEST_ENABLED || 'false' }}
+          JSONRENDER_ENABLED: ${{ vars.JSONRENDER_ENABLED || 'true' }}
+          SKILL_NAME: ${{ steps.skill.outputs.name }}
+        run: |
+          set -euo pipefail
+          ATTEST=false
+
+          # Tier 0 — global kill switch (repo var, default OFF so forks opt in).
+          if [ "${ATTEST_ENABLED}" = "true" ]; then
+            SKILL="${SKILL_NAME}"
+
+            # Tier 1 — per-skill override in aeon.yml (operator config, one line,
+            # no skill file touched). Same grep idiom as model:/harness:, but with
+            # ERE alternation (sed -nE) so (true|false) is portable across BSD/GNU sed.
+            SKILL_ATTEST=$(grep "^  ${SKILL}:" aeon.yml \
+              | sed -nE 's/.*attest:[[:space:]]*(true|false).*/\1/p' || true)
+
+            # Tier 2 — SKILL.md frontmatter (author intent, travels with the skill).
+            FM_ATTEST=$(awk '/^---$/{n++; next}
+              n==1 && /^attest:/{
+                v=$0; sub(/^attest:[ \t]*/,"",v); sub(/[ \t]*#.*$/,"",v);
+                gsub(/^[ \t"]+|[ \t"]+$/,"",v); print v; exit
+              }' "skills/${SKILL}/SKILL.md" 2>/dev/null || true)
+
+            # Tier 3 — default policy: attest runs whose output is PUBLISHED to the
+            # json-render feed (the trust boundary that actually benefits).
+            PUBLISHED=false
+            if [ "${JSONRENDER_ENABLED}" = "true" ] \
+               && [ -f "apps/dashboard/outputs/.pending-${SKILL}.md" ]; then
+              PUBLISHED=true
+            fi
+
+            if [ "$SKILL_ATTEST" = "false" ]; then
+              ATTEST=false                       # explicit operator opt-out wins
+            elif [ "$SKILL_ATTEST" = "true" ] || [ "$FM_ATTEST" = "true" ] \
+                 || [ "$PUBLISHED" = "true" ]; then
+              ATTEST=true
+            fi
+          fi
+
+          echo "attest=$ATTEST" >> "$GITHUB_OUTPUT"
+          echo "::notice::attestation gate for ${SKILL_NAME}: attest=$ATTEST"
+
+      - name: Attest skill execution
+        if: steps.attest-gate.outputs.attest == 'true'
+        # Pinned to the current major per this repo's supply-chain convention
+        # (checkout@v7, setup-node@v6). Latest major confirmed at:
+        # https://github.com/actions/attest-build-provenance/releases
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: output/.chains/${{ steps.skill.outputs.name }}.md
 
       - name: Analyze skill output
         id: analyze


### PR DESCRIPTION
## What

Adds **verifiable provenance for skill runs** via [GitHub Artifact Attestations](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds). Each attested run produces a Sigstore-signed, Rekor-logged statement binding the run's captured output bytes to the exact workflow identity (repo, commit, workflow file, runner, trigger, time) that produced them — third-party verifiable via `gh attestation verify`, no trust in the repo required.

Touches **zero skills** — attestation happens in the trusted workflow layer on output Aeon already captures (`output/.chains/${SKILL}.md`).

## Changes (`.github/workflows/aeon.yml`)

- **Permissions**: `+ id-token: write`, `+ attestations: write`.
- **Two steps** after *Capture skill output*:
  - **Resolve attestation gate** — tiered opt-in: global `ATTEST_ENABLED` kill switch → per-skill `attest:` in `aeon.yml` → `SKILL.md` frontmatter `attest:` → default policy (attest feed-published runs). Explicit `attest: false` wins.
  - **Attest skill execution** — runs only when the gate opens.

## Off by default

Nothing attests until `ATTEST_ENABLED=true`. With it on and no per-skill config, only **feed-published** runs get attested (the trust boundary that benefits). Success-only (reuses the capture guard); read-only skills are fine (the workflow writes the subject file, not the skill).

```bash
gh variable set ATTEST_ENABLED --body true --repo aaronjmars/aeon
```

## Two corrections vs. the source guide

- ⚠️ Pinned **`actions/attest-build-provenance@v4`** (current major; guide said `@v2`). Matches this repo's major-tag pinning (`checkout@v7`, `setup-node@v6`).
- 🐛 Made the Tier-1 gate `sed` **portable** (`sed -nE '…(true|false)…'`). The guide's `\(true\|false\)` is a GNU-sed-only extension — works on `ubuntu-latest` but silently returns empty on BSD sed, which broke local testing.

## Verification

- YAML valid; `actionlint` clean on the new steps.
- 9/9 gate cases pass (global-off, Tier-1 opt-in/opt-out, Tier-2 frontmatter, Tier-3 published + JSONRENDER gating, opt-out precedence, unknown-skill-no-crash under `set -euo pipefail`).
- Repo is **public** → attestation works out of the box (no Team/Enterprise plan needed).

## Rollback

Fully reversible: `gh variable set ATTEST_ENABLED --body false`, or delete the two steps + two permission lines. No skill/memory/catalog change.

## Not included (optional follow-ups)

Run-manifest subject (bind model/mode/trigger), attesting `messages.yml` / `chain-runner.yml`, dashboard "✓ verified" badge. (`scheduler.yml` from #649 is dispatch-only — no output to attest.)
