### PR TITLE
docs(attestation): document skill-execution provenance

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -489,6 +489,12 @@ Optional, opt-in tracing. Set the repo secrets `LANGFUSE_PUBLIC_KEY` + `LANGFUSE
 
 Under the hood `scripts/langfuse-otel.sh` exports Claude Code's OpenTelemetry env so its span tree ships to Langfuse's OTLP endpoint — out of band, so a Langfuse outage never affects a run. Region/toggles are repo **variables**: `LANGFUSE_HOST` (default EU cloud; US = `https://us.cloud.langfuse.com`), `LANGFUSE_TRACING=0` to disable, `LANGFUSE_LOG_CONTENT=0` for metadata-only (no prompt/response text). Covers the skill run, scorer, feed, and message poller; the grok harness is not traced. Full guide: [docs/langfuse.md](../docs/langfuse.md).
 
+### Provenance (attestation)
+
+Optional, off by default. Set the repo variable `ATTEST_ENABLED=true` and successful skill runs get a Sigstore-signed [GitHub Artifact Attestation](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds) binding the run's output bytes to the exact workflow identity that produced them — repo, commit SHA, `aeon.yml`, runner, trigger — logged to the public Rekor transparency log. Anyone can then confirm a piece of Aeon output really came from an unmodified skill at a known commit (`gh attestation verify <file> --repo <owner>/<repo>`), without trusting you. It proves *provenance of bytes*, not correctness of behaviour, and touches **zero skills** — it runs in the trusted workflow layer on output Aeon already captures.
+
+Opt in per skill with `attest: true` in `aeon.yml` (or `attest: false` to force-exclude), or in a `SKILL.md`'s frontmatter to make it travel with the skill; with neither, the default policy attests only runs that **published to the json-render feed** (the trust boundary that benefits), keeping the public Rekor log meaningful. **Public repos work on any plan; private repos need GitHub Team/Enterprise.** Full guide: [docs/attestation.md](../docs/attestation.md).
+
 ### Strategy
 
 `STRATEGY.md` is Aeon's north-star - your overarching goal, top priorities, audience, and hard constraints. It's imported into `CLAUDE.md`, so it rides along in the context of **every** skill run: when a choice isn't otherwise determined, the strategy breaks the tie ("showcase real output over new features", "depth over breadth"). Keep it tight (it costs tokens every run) and specific (a vague strategy can't break a tie).

--- a/docs/attestation.md
+++ b/docs/attestation.md
@@ -1,0 +1,280 @@
+---
+type: Reference
+---
+
+# Skill-execution attestation
+
+Aeon can produce **verifiable provenance for skill runs** using
+[GitHub Artifact Attestations](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds).
+
+When enabled, an attested run emits a Sigstore-signed, tamper-evident statement
+binding the run's **output bytes** to the exact workflow identity that produced
+them — repo, commit SHA, workflow file, runner, trigger event, time — signed
+through Sigstore and logged to the public
+[Rekor transparency log](https://docs.sigstore.dev/logging/overview/). Anyone can
+later confirm a piece of Aeon output was really produced by an unmodified skill
+at a known commit, **without trusting the repo or its operator**.
+
+It's off by default and lives entirely in the trusted workflow layer — it touches
+**zero skills** and adds no git churn to the attestation itself (attestations are
+stored in GitHub's store keyed by the output's digest, not committed).
+
+## What it proves — and what it doesn't
+
+- ✅ **Proves:** *these exact output bytes* came from *skill X*, in workflow
+  `aeon.yml`, at *commit C*, on a GitHub runner, at *time T*, triggered by
+  *event E* — non-repudiable, tamper-evident, third-party-verifiable.
+- ❌ **Does not prove:** that the output is *correct*, truthful, or that the model
+  reasoned faithfully. Attestation is provenance of *bytes*, not a guarantee of
+  *behavior*.
+
+It answers *"was this really produced by an unmodified skill at a known commit,
+or tampered with after the fact?"* — not *"is the output any good?"*
+
+## Prerequisites
+
+- **A GitHub-hosted runner** — Aeon already uses `ubuntu-latest`. ✔
+- **Attestation availability for your repo:**
+  - **Public repo** → works out of the box on every plan.
+  - **Private repo** → the attestation store requires a plan that includes
+    Artifact Attestations (**GitHub Team or Enterprise**). On a Free/Pro private
+    repo the *Attest skill execution* step will fail. **Check your plan, or make
+    the repo public, before enabling.**
+- **`gh` CLI ≥ 2.49** locally *only if you want to verify* attestations yourself
+  (`gh attestation verify`). Not needed to *produce* them.
+
+> `aeon.yml` runs on `push` / `schedule` / `workflow_dispatch` on your own repo,
+> so it always has a full workflow token — the fork-PR restrictions that limit
+> `id-token` on `pull_request` events from forks do **not** apply.
+
+## How it plugs into the run lifecycle
+
+Nothing about a skill run changes. Aeon already captures every successful run's
+output to `output/.chains/${SKILL}.md` (the **Capture skill output** step in
+[`.github/workflows/aeon.yml`](../.github/workflows/aeon.yml)). Two steps run
+right after it — see [`docs/CORE.md`](CORE.md) for the full run loop:
+
+```
+  Skill runs (claude -p)                     ← unchanged, in sandbox
+        │
+  Capture skill output  → output/.chains/X.md   ← already exists
+        │
+  Resolve attestation gate  → attest=true|false ← is THIS run attested?
+        │
+  Attest skill execution    → Sigstore + Rekor  ← only if the gate opens
+        │
+  Analyze / notify-jsonrender / commit …        ← unchanged
+```
+
+Two workflow permissions make this possible (already in `aeon.yml`):
+
+```yaml
+permissions:
+  id-token: write        # mint the OIDC token that signs the attestation
+  attestations: write    # write the attestation to the repo's attestation store
+```
+
+The attest step reuses the capture guard (`steps.run.outcome == 'success'`), so
+**failed runs are never attested** — there's no meaningful output to bind.
+
+## Turning it on
+
+Attestation is **off by default**. There are three switches, in precedence order,
+all gated behind one global kill switch.
+
+### 1. Global — enable the feature (required)
+
+Set the repo variable (dashboard → Variables, or CLI):
+
+```bash
+gh variable set ATTEST_ENABLED --body true --repo <owner>/<repo>
+```
+
+With this on and **no** per-skill config, the **default policy** applies: only
+runs that **published output to the json-render feed** get attested (see
+[What actually gets attested](#what-actually-gets-attested) below).
+
+### 2. Per-skill — operator opt-in (no skill file changes)
+
+Add `attest: true` to a skill's inline map in `aeon.yml`:
+
+```yaml
+  # before
+  crypto-scan: { enabled: true, schedule: "0 12 * * *" }
+  # after
+  crypto-scan: { enabled: true, schedule: "0 12 * * *", attest: true }
+```
+
+Use `attest: false` to **force-exclude** a skill even when everything else says
+yes (e.g. a noisy `price-alert` you never want in the public transparency log).
+
+### 3. Author-declared — portable intent (one frontmatter line)
+
+To make a skill *demand* provenance wherever it's installed, add to its
+`skills/<name>/SKILL.md` frontmatter (same shape as `mode:`):
+
+```yaml
+---
+name: disclosure-emailer
+category: security
+mode: write
+attest: true          # always attest this skill's output
+---
+```
+
+This travels with the skill through `bin/export-skill` and the catalog.
+
+### Precedence
+
+```
+aeon.yml attest:false (opt-out)  →  aeon.yml attest:true  →  SKILL.md attest:true  →  feed-published default
+```
+
+…all gated behind the global `ATTEST_ENABLED` switch. An explicit `attest: false`
+in `aeon.yml` always wins.
+
+## What actually gets attested
+
+With the global switch on but no per-skill override, the **default policy attests
+only runs whose output crossed the trust boundary** — i.e. runs that
+**published to the json-render feed**. Concretely, the gate checks for
+`apps/dashboard/outputs/.pending-${SKILL}.md`, which is written **only when a
+skill actually calls `./notify`** (with `JSONRENDER_ENABLED` on, its default).
+
+**This is deliberate.** Each attestation is a Sigstore signing plus a permanent,
+public Rekor entry — a real cost and a public record. Attesting *what you publish*
+rather than *every run of every skill* keeps the transparency log meaningful and
+cheap.
+
+Practical consequence worth remembering:
+
+- A skill that finds nothing and stays silent (`heartbeat` on a clean run) sends
+  no notification, writes no `.pending` file, and is **not** auto-attested. That's
+  correct — nothing crossed the boundary.
+- A skill that *describes* its notification instead of invoking `./notify` also
+  won't publish, so the default policy won't fire for it. If you want such a run
+  attested regardless, use the per-skill opt-in (switch 2) — that fires on the
+  captured `output/.chains/${SKILL}.md` bytes independent of the feed.
+
+## Verifying an attestation
+
+Given the output bytes (checked out of `output/.chains/`, or downloaded from the
+feed), verify against the repo:
+
+```bash
+gh attestation verify output/.chains/<skill>.md --repo <owner>/<repo>
+```
+
+`gh attestation verify` exits `0` on success. Inspect the bound provenance with
+`--format json`; the fields that matter:
+
+| Field | Meaning |
+|---|---|
+| `buildSignerURI` | the signing workflow, e.g. `https://github.com/<owner>/<repo>/.github/workflows/aeon.yml@refs/heads/main` |
+| `sourceRepositoryURI` | the repo that produced it |
+| `sourceRepositoryDigest` | the exact commit SHA the run executed at |
+| `runInvocationURI` | the specific Actions run |
+
+You can also scope verification to an owner or require a specific workflow:
+
+```bash
+gh attestation verify <file> \
+  --owner <owner> \
+  --signer-workflow <owner>/<repo>/.github/workflows/aeon.yml
+```
+
+Browse all attestations under **Actions → Attestations**, list them with
+`gh attestation list --repo <owner>/<repo>`, or find the entry in the public
+Rekor log.
+
+### Worked example (validated)
+
+A real `github-trending` run on a public test instance, attested via the
+per-skill opt-in:
+
+```
+Attest step signed:   github-trending.md@sha256:11137951…f2a24f
+Bytes pulled from repo:                  sha256:11137951…f2a24f   ← exact match
+gh attestation verify … → exit 0
+
+buildSignerURI:         .../aeon-attest/.github/workflows/aeon.yml@refs/heads/main
+sourceRepositoryDigest: 26b6715034d4dafd723d3a724c6d7980bd198abd
+runInvocationURI:       .../actions/runs/28832559487
+```
+
+The signer + commit are the guarantee: those exact bytes came from the unmodified
+`aeon.yml` at that commit, on a GitHub runner.
+
+## Optional enhancements
+
+None are required for correctness — add them if the extra rigor or presentation
+is worth it to you.
+
+### Attest the *run*, not just the file (run manifest)
+
+To bind model / mode / trigger / commit into the attested *subject* itself
+(rather than relying on the provenance predicate alone), build a small manifest
+from data Aeon already has and attest **that** instead of the raw output. Add a
+step before the attest step that writes a JSON manifest —
+
+```json
+{
+  "skill":   "crypto-scan",
+  "model":   "claude-opus-4-8",
+  "mode":    "write",
+  "trigger":  "schedule",
+  "commit":  "<GITHUB_SHA>",
+  "run_id":  "<GITHUB_RUN_ID>",
+  "output":  { "path": "output/.chains/crypto-scan.md", "sha256": "<digest>" }
+}
+```
+
+— and point `subject-path` at the manifest. To verify: verify the manifest, then
+re-hash the output and check it against the manifest's `output.sha256` — a
+two-link chain from workflow identity → manifest → output bytes.
+
+### Attest inbound & chained runs too
+
+[`messages.yml`](../.github/workflows/messages.yml) (inbound Telegram/Discord/
+Slack) and [`chain-runner.yml`](../.github/workflows/chain-runner.yml) run the
+same skill prompt and capture output the same way. To attest those, apply the
+same two permission lines and the same two steps to each. (`scheduler.yml` is a
+pure dispatcher — it captures no skill output, so there's nothing to attest
+there.)
+
+### Provenance badge in the feed
+
+Since attested feed items now have verifiable provenance, `apps/dashboard` could
+surface a "✓ verified" badge that runs `gh attestation verify` (or the Sigstore
+JS verifier) against the item's bytes and links to the Rekor entry. Purely
+presentational; no workflow change.
+
+## Rollback
+
+Fully reversible, zero skill impact:
+
+- **Pause instantly:** `gh variable set ATTEST_ENABLED --body false` (or delete
+  the variable). The gate closes; runs proceed exactly as before.
+- **Remove entirely:** delete the *Resolve attestation gate* + *Attest skill
+  execution* steps and the `id-token` / `attestations` permission lines from
+  `aeon.yml`. No skill, memory, or catalog change is involved.
+
+## Gotchas
+
+- **Off by default.** Nothing attests until `ATTEST_ENABLED=true`.
+- **Success only.** Failed runs are never attested (no meaningful output to bind).
+- **Private repos need a plan.** See [Prerequisites](#prerequisites) — Free/Pro
+  private repos can't write to the attestation store; make the repo public or use
+  Team/Enterprise.
+- **Read-only skills are fine.** `output/.chains/${SKILL}.md` is written by the
+  *workflow*, not the skill, so it survives the read-only post-run revert.
+- **The store outlives the file.** Attestations are keyed by digest in GitHub's
+  store + Rekor and persist even if `output/` is later overwritten — but to
+  *verify* you need the original bytes.
+- **Cost is a public record.** Each attestation is a Sigstore signing + a
+  permanent public Rekor entry. That's the argument for the selective default:
+  attest what crosses a trust boundary, not every run of every skill.
+- **Pin the action.** The attest step pins `actions/attest-build-provenance@v4`
+  per Aeon's supply-chain convention (`checkout@v7`, `setup-node@v6`). Confirm the
+  [current major](https://github.com/actions/attest-build-provenance/releases)
+  before bumping.


### PR DESCRIPTION
## What

Documents the skill-execution attestation feature shipped in #650. Docs-only — no workflow or skill change.

- **`docs/attestation.md`** (new, `type: Reference`) — the full guide.
- **`.github/README.md`** — a `### Provenance (attestation)` subsection under *Advanced*, matching the existing "Full guide: [docs/X.md]" pattern.

## Covers

- **What it proves / doesn't** — provenance of *bytes* (repo, commit, workflow, runner, trigger, time), not correctness of behaviour.
- ⚠️ **Private-repo caveat** — public repos work on any plan; **private repos need GitHub Team/Enterprise** (Free/Pro private → the attest step fails). Called out in Prerequisites and Gotchas.
- **Turning it on** — the three switches (global `ATTEST_ENABLED` → per-skill `aeon.yml attest:` → `SKILL.md` frontmatter) and their precedence.
- **What actually gets attested** — the default policy fires **only for runs that publish to the feed**, i.e. that genuinely call `./notify` (write `.pending-${SKILL}.md`). A silent `heartbeat`, or a skill that *prints* its notification instead of invoking `./notify`, won't auto-attest — use the per-skill opt-in for those. This is the intended selective "attest what crosses the trust boundary" behaviour that keeps the public Rekor log cheap and meaningful.
- **Verifying** — `gh attestation verify`, the provenance fields, and a **validated worked example** (real digest match + signer identity from a live `github-trending` run).
- **Optional enhancements** — run-manifest subject, attesting `messages.yml` / `chain-runner.yml` (note: `scheduler.yml` is dispatch-only, nothing to attest), the "✓ verified" feed badge.
- **Rollback** and **gotchas** (off-by-default, success-only, read-only-safe, store-outlives-file, `@v4` pin).

## Checks

- `node scripts/okf-validate.mjs` → OK (95 concepts; new doc carries `type: Reference`).
- All internal links resolve.
