### PR TITLE
feat(attestation): sign a run manifest alongside the output

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -711,14 +711,50 @@ jobs:
           echo "attest=$ATTEST" >> "$GITHUB_OUTPUT"
           echo "::notice::attestation gate for ${SKILL_NAME}: attest=$ATTEST"
 
+      - name: Build run manifest
+        id: manifest
+        if: steps.attest-gate.outputs.attest == 'true'
+        env:
+          SKILL_NAME: ${{ steps.skill.outputs.name }}
+          SKILL_MODEL: ${{ steps.run.outputs.SKILL_MODEL }}
+        run: |
+          set -euo pipefail
+          # Bind Aeon-specific run facts (model, capability mode, trigger, commit)
+          # into a manifest that also hashes the output. Attested alongside the
+          # output itself (multi-subject), so `gh attestation verify <output>`
+          # still works AND the manifest carries the richer provenance.
+          SKILL="${SKILL_NAME}"
+          OUT="output/.chains/${SKILL}.md"
+          MODE="$(bash scripts/skill_mode.sh mode "$SKILL")"
+          DIGEST="$(sha256sum "$OUT" | cut -d' ' -f1)"
+          MANIFEST="output/.attest-${SKILL}.json"
+          jq -n \
+            --arg skill   "$SKILL" \
+            --arg model   "$SKILL_MODEL" \
+            --arg mode    "$MODE" \
+            --arg trigger "${GITHUB_EVENT_NAME:-}" \
+            --arg commit  "${GITHUB_SHA:-}" \
+            --arg run_id  "${GITHUB_RUN_ID:-}" \
+            --arg path    "$OUT" \
+            --arg sha     "$DIGEST" \
+            '{skill:$skill, model:$model, mode:$mode, trigger:$trigger,
+              commit:$commit, run_id:$run_id,
+              output:{path:$path, sha256:$sha}}' > "$MANIFEST"
+          echo "path=$MANIFEST" >> "$GITHUB_OUTPUT"
+          echo "::notice::run manifest for ${SKILL}: model=${SKILL_MODEL} mode=${MODE} output_sha256=${DIGEST}"
+
       - name: Attest skill execution
         if: steps.attest-gate.outputs.attest == 'true'
         # Pinned to the current major per this repo's supply-chain convention
         # (checkout@v7, setup-node@v6). Latest major confirmed at:
         # https://github.com/actions/attest-build-provenance/releases
+        # Multi-subject: one attestation covering both the output bytes and the
+        # run manifest (subject-path accepts a newline-separated list).
         uses: actions/attest-build-provenance@v4
         with:
-          subject-path: output/.chains/${{ steps.skill.outputs.name }}.md
+          subject-path: |
+            output/.chains/${{ steps.skill.outputs.name }}.md
+            output/.attest-${{ steps.skill.outputs.name }}.json
 
       - name: Analyze skill output
         id: analyze

--- a/docs/attestation.md
+++ b/docs/attestation.md
@@ -61,7 +61,9 @@ right after it — see [`docs/CORE.md`](CORE.md) for the full run loop:
         │
   Resolve attestation gate  → attest=true|false ← is THIS run attested?
         │
-  Attest skill execution    → Sigstore + Rekor  ← only if the gate opens
+  Build run manifest        → output/.attest-X.json ← model/mode/trigger + output digest
+        │
+  Attest skill execution    → Sigstore + Rekor  ← signs output + manifest (multi-subject)
         │
   Analyze / notify-jsonrender / commit …        ← unchanged
 ```
@@ -187,6 +189,29 @@ Browse all attestations under **Actions → Attestations**, list them with
 `gh attestation list --repo <owner>/<repo>`, or find the entry in the public
 Rekor log.
 
+### The run manifest
+
+Every attested run also produces a small JSON **run manifest**
+(`output/.attest-${SKILL}.json`) that binds the Aeon-specific facts the raw
+provenance doesn't carry — **model, capability mode, trigger** — plus a `sha256`
+of the output. It's signed in the *same* attestation as the output (a
+multi-subject attestation), so it costs no extra Rekor entry and doesn't change
+the command above: `gh attestation verify output/.chains/<skill>.md` still works.
+
+To read the richer metadata, verify the manifest instead and inspect its bytes
+(it's committed alongside the output):
+
+```bash
+gh attestation verify output/.attest-<skill>.json --repo <owner>/<repo>
+cat output/.attest-<skill>.json
+# { "skill": "...", "model": "claude-opus-4-8", "mode": "write",
+#   "trigger": "schedule", "commit": "<sha>", "run_id": "<id>",
+#   "output": { "path": "output/.chains/<skill>.md", "sha256": "<digest>" } }
+```
+
+Because both are subjects of the one attestation, the manifest's `output.sha256`
+also lets you cross-check the output bytes without a second verify.
+
 ### Worked example (validated)
 
 A real `github-trending` run on a public test instance, attested via the
@@ -208,30 +233,9 @@ The signer + commit are the guarantee: those exact bytes came from the unmodifie
 ## Optional enhancements
 
 None are required for correctness — add them if the extra rigor or presentation
-is worth it to you.
-
-### Attest the *run*, not just the file (run manifest)
-
-To bind model / mode / trigger / commit into the attested *subject* itself
-(rather than relying on the provenance predicate alone), build a small manifest
-from data Aeon already has and attest **that** instead of the raw output. Add a
-step before the attest step that writes a JSON manifest —
-
-```json
-{
-  "skill":   "crypto-scan",
-  "model":   "claude-opus-4-8",
-  "mode":    "write",
-  "trigger":  "schedule",
-  "commit":  "<GITHUB_SHA>",
-  "run_id":  "<GITHUB_RUN_ID>",
-  "output":  { "path": "output/.chains/crypto-scan.md", "sha256": "<digest>" }
-}
-```
-
-— and point `subject-path` at the manifest. To verify: verify the manifest, then
-re-hash the output and check it against the manifest's `output.sha256` — a
-two-link chain from workflow identity → manifest → output bytes.
+is worth it to you. (The **run manifest** — binding model/mode/trigger into the
+signed statement — is *not* on this list: it ships by default, see
+[The run manifest](#the-run-manifest) above.)
 
 ### Attest inbound & chained runs too
 


### PR DESCRIPTION
## What

Enhancement #1 from [docs/attestation.md](../blob/main/docs/attestation.md) — bind Aeon-specific run facts into the signed statement.

Adds a **Build run manifest** step (between the gate and attest steps) that writes `output/.attest-${SKILL}.json` with `skill / model / mode / trigger / commit / run_id` + a `sha256` of the output, and attests it **together with the output** in a single multi-subject attestation.

```yaml
subject-path: |
  output/.chains/${SKILL}.md      # unchanged — direct verify still works
  output/.attest-${SKILL}.json    # new — richer provenance
```

## Why multi-subject (not manifest-only)

`actions/attest`'s `subject-path` accepts a newline-separated list and produces **one attestation with multiple subjects** (confirmed in its docs). So:
- **No UX regression** — `gh attestation verify output/.chains/<skill>.md` still works exactly as before (what we demoed on `aeon-attest`).
- **No extra cost** — one attestation, one Rekor entry covers both.
- **Richer provenance** — the manifest binds model + capability mode + trigger, which the raw provenance predicate doesn't surface.

## Implementation notes

- All inputs already existed in `aeon.yml`: `steps.run.outputs.SKILL_MODEL`, `scripts/skill_mode.sh mode`, `GITHUB_SHA/RUN_ID/EVENT_NAME`.
- Manifest built with `jq -n --arg …` (safe JSON escaping, no fragile heredoc).
- Gated identically (`steps.attest-gate.outputs.attest == 'true'`), so it only runs when the gate opens.

## Verified locally

- YAML valid; `actionlint` clean on the new region.
- Manifest generation tested: valid JSON, 64-hex `sha256` binds the output, all fields present.
- `okf-validate` OK (95 concepts).

## Docs

`docs/attestation.md` updated: manifest added to the lifecycle diagram, a new **The run manifest** subsection under Verifying, and the run-manifest entry removed from *Optional enhancements* (it now ships by default). The two remaining optionals (messages/chain-runner coverage, feed badge) stay.
