### PR TITLE
fix(attestation): attest an immutable run-scoped snapshot

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -719,15 +719,20 @@ jobs:
           SKILL_MODEL: ${{ steps.run.outputs.SKILL_MODEL }}
         run: |
           set -euo pipefail
-          # Bind Aeon-specific run facts (model, capability mode, trigger, commit)
-          # into a manifest that also hashes the output. Attested alongside the
-          # output itself (multi-subject), so `gh attestation verify <output>`
-          # still works AND the manifest carries the richer provenance.
+          # Attest an IMMUTABLE, run-scoped snapshot — never the shared
+          # output/.chains/${SKILL}.md. That shared path is rewritten by concurrent
+          # runs and the commit step's conflict resolver marker-strips output/* on a
+          # rebase conflict, so its committed bytes can differ from what we attest
+          # (breaking `gh attestation verify`). A ${GITHUB_RUN_ID}-scoped path is
+          # unique to this run: no other run touches it, so committed == attested.
           SKILL="${SKILL_NAME}"
-          OUT="output/.chains/${SKILL}.md"
+          SRC="output/.chains/${SKILL}.md"
           MODE="$(bash scripts/skill_mode.sh mode "$SKILL")"
-          DIGEST="$(sha256sum "$OUT" | cut -d' ' -f1)"
-          MANIFEST="output/.attest-${SKILL}.json"
+          DIGEST="$(sha256sum "$SRC" | cut -d' ' -f1)"
+          mkdir -p output/.attest
+          SNAPSHOT="output/.attest/${SKILL}-${GITHUB_RUN_ID}.md"
+          MANIFEST="output/.attest/${SKILL}-${GITHUB_RUN_ID}.json"
+          cp "$SRC" "$SNAPSHOT"
           jq -n \
             --arg skill   "$SKILL" \
             --arg model   "$SKILL_MODEL" \
@@ -735,26 +740,28 @@ jobs:
             --arg trigger "${GITHUB_EVENT_NAME:-}" \
             --arg commit  "${GITHUB_SHA:-}" \
             --arg run_id  "${GITHUB_RUN_ID:-}" \
-            --arg path    "$OUT" \
+            --arg path    "$SNAPSHOT" \
             --arg sha     "$DIGEST" \
             '{skill:$skill, model:$model, mode:$mode, trigger:$trigger,
               commit:$commit, run_id:$run_id,
               output:{path:$path, sha256:$sha}}' > "$MANIFEST"
-          echo "path=$MANIFEST" >> "$GITHUB_OUTPUT"
-          echo "::notice::run manifest for ${SKILL}: model=${SKILL_MODEL} mode=${MODE} output_sha256=${DIGEST}"
+          echo "snapshot=$SNAPSHOT" >> "$GITHUB_OUTPUT"
+          echo "manifest=$MANIFEST" >> "$GITHUB_OUTPUT"
+          echo "::notice::run manifest for ${SKILL}: model=${SKILL_MODEL} mode=${MODE} snapshot=${SNAPSHOT} sha256=${DIGEST}"
 
       - name: Attest skill execution
         if: steps.attest-gate.outputs.attest == 'true'
         # Pinned to the current major per this repo's supply-chain convention
         # (checkout@v7, setup-node@v6). Latest major confirmed at:
         # https://github.com/actions/attest-build-provenance/releases
-        # Multi-subject: one attestation covering both the output bytes and the
-        # run manifest (subject-path accepts a newline-separated list).
+        # Multi-subject: one attestation over both run-scoped artifacts (the output
+        # snapshot and its manifest). Both paths are ${GITHUB_RUN_ID}-unique, so the
+        # committed bytes always match what was attested.
         uses: actions/attest-build-provenance@v4
         with:
           subject-path: |
-            output/.chains/${{ steps.skill.outputs.name }}.md
-            output/.attest-${{ steps.skill.outputs.name }}.json
+            ${{ steps.manifest.outputs.snapshot }}
+            ${{ steps.manifest.outputs.manifest }}
 
       - name: Analyze skill output
         id: analyze

--- a/docs/attestation.md
+++ b/docs/attestation.md
@@ -61,9 +61,9 @@ right after it — see [`docs/CORE.md`](CORE.md) for the full run loop:
         │
   Resolve attestation gate  → attest=true|false ← is THIS run attested?
         │
-  Build run manifest        → output/.attest-X.json ← model/mode/trigger + output digest
+  Build run manifest        → output/.attest/X-<run_id>.{md,json} ← immutable snapshot + metadata
         │
-  Attest skill execution    → Sigstore + Rekor  ← signs output + manifest (multi-subject)
+  Attest skill execution    → Sigstore + Rekor  ← signs the run-scoped snapshot + manifest
         │
   Analyze / notify-jsonrender / commit …        ← unchanged
 ```
@@ -160,11 +160,14 @@ Practical consequence worth remembering:
 
 ## Verifying an attestation
 
-Given the output bytes (checked out of `output/.chains/`, or downloaded from the
-feed), verify against the repo:
+Attestation targets an **immutable, run-scoped snapshot** of the output at
+`output/.attest/<skill>-<run_id>.{md,json}` — *not* the shared
+`output/.chains/<skill>.md` (see [Why a run-scoped snapshot](#why-a-run-scoped-snapshot)).
+Verify that snapshot (or its manifest) against the repo:
 
 ```bash
-gh attestation verify output/.chains/<skill>.md --repo <owner>/<repo>
+gh attestation verify output/.attest/<skill>-<run_id>.md --repo <owner>/<repo>
+# don't know the run_id? list them:  ls output/.attest/<skill>-*.md
 ```
 
 `gh attestation verify` exits `0` on success. Inspect the bound provenance with
@@ -191,23 +194,32 @@ Rekor log.
 
 ### The run manifest
 
-Every attested run also produces a small JSON **run manifest**
-(`output/.attest-${SKILL}.json`) that binds the Aeon-specific facts the raw
-provenance doesn't carry — **model, capability mode, trigger** — plus a `sha256`
-of the output. It's signed in the *same* attestation as the output (a
-multi-subject attestation), so it costs no extra Rekor entry and doesn't change
-the command above: `gh attestation verify output/.chains/<skill>.md` still works.
+Alongside the output snapshot, each attested run writes a small JSON **run
+manifest** (`output/.attest/<skill>-<run_id>.json`) that binds the Aeon-specific
+facts the raw provenance doesn't carry — **model, capability mode, trigger** —
+plus a `sha256` of the snapshot. It's signed in the *same* attestation as the
+snapshot (a multi-subject attestation), so it costs no extra Rekor entry.
 
-To read the richer metadata, verify the manifest instead and inspect its bytes
-(it's committed alongside the output):
+To read the richer metadata, verify the manifest and inspect its bytes:
 
 ```bash
-gh attestation verify output/.attest-<skill>.json --repo <owner>/<repo>
-cat output/.attest-<skill>.json
-# { "skill": "...", "model": "claude-opus-4-8", "mode": "write",
+gh attestation verify output/.attest/<skill>-<run_id>.json --repo <owner>/<repo>
+cat output/.attest/<skill>-<run_id>.json
+# { "skill": "...", "model": "claude-opus-4-8", "mode": "read-only",
 #   "trigger": "schedule", "commit": "<sha>", "run_id": "<id>",
-#   "output": { "path": "output/.chains/<skill>.md", "sha256": "<digest>" } }
+#   "output": { "path": "output/.attest/<skill>-<run_id>.md", "sha256": "<digest>" } }
 ```
+
+### Why a run-scoped snapshot
+
+The attested subject is a snapshot keyed by `${GITHUB_RUN_ID}`, not the shared
+`output/.chains/<skill>.md`. That shared path is rewritten every run and, when
+two runs push to `main` concurrently, the commit step's rebase-conflict resolver
+**marker-strips** `output/*` files — concatenating both sides into bytes that
+match *neither* run's attestation. Attesting a run-unique path sidesteps that
+entirely: no other run writes it, so the committed bytes are always exactly what
+was signed. (The shared `output/.chains/<skill>.md` is still produced as before
+for chain consumption — it's just not the attestation subject.)
 
 Because both are subjects of the one attestation, the manifest's `output.sha256`
 also lets you cross-check the output bytes without a second verify.
@@ -270,8 +282,9 @@ Fully reversible, zero skill impact:
 - **Private repos need a plan.** See [Prerequisites](#prerequisites) — Free/Pro
   private repos can't write to the attestation store; make the repo public or use
   Team/Enterprise.
-- **Read-only skills are fine.** `output/.chains/${SKILL}.md` is written by the
-  *workflow*, not the skill, so it survives the read-only post-run revert.
+- **Read-only skills are fine.** The attested snapshot in `output/.attest/` is
+  written by the *workflow*, not the skill, so it survives the read-only post-run
+  revert (which only reverts code/config the skill touched, not `output/`).
 - **The store outlives the file.** Attestations are keyed by digest in GitHub's
   store + Rekor and persist even if `output/` is later overwritten — but to
   *verify* you need the original bytes.


### PR DESCRIPTION
## The bug

A live test surfaced that the committed output could differ from the *attested* bytes: `gh attestation verify output/.chains/<skill>.md` returned **404** because the committed file was never the thing that got signed.

**Root cause** (`.github/workflows/aeon.yml`, commit step ~L1160): the rebase-conflict auto-resolver handles `output/*` conflicts by **stripping conflict markers** —

```bash
if [[ "$f" == output/* ]] ...; then
  sed -i '/^<<<<<<< /d; /^=======/d; /^>>>>>>> /d' "$f"   # keeps BOTH sides concatenated
```

So when two runs push to `main` concurrently and collide on the shared `output/.chains/<skill>.md`, the committed file becomes a marker-stripped concatenation matching **neither** run's attestation. Attestation's byte-exactness exposes this pre-existing behavior. (An isolated run — like the #650 demo — verifies fine, which is why it went unnoticed.)

## The fix

Attest an **immutable, run-scoped snapshot** instead of the shared path:

```
output/.attest/<skill>-<GITHUB_RUN_ID>.md     # snapshot of the captured output
output/.attest/<skill>-<GITHUB_RUN_ID>.json   # manifest (model/mode/trigger + digest)
```

`GITHUB_RUN_ID` is unique per run, so **no other run ever writes these paths** → no conflict → the resolver never touches them → **committed bytes == attested bytes, always**. The shared `output/.chains/<skill>.md` is still produced as before (chains consume it); it's just no longer the attestation subject.

## Verify (updated)

```bash
gh attestation verify output/.attest/<skill>-<run_id>.md --repo <owner>/<repo>   # exit 0
```

## Tested

- YAML valid; `actionlint` clean; `okf-validate` OK (95 concepts).
- Snapshot logic unit-tested locally: `snapshot digest == manifest.output.sha256 == source digest`, manifest `output.path` points at the attested snapshot.
- End-to-end re-test on the public `aeon-attest` instance in progress (see follow-up).

## Tradeoff

Each attested run leaves two small files in `output/.attest/`. Attestation is selective (feed-published / opt-in), so growth is slow; a bounded prune (keep newest N per skill) is an easy follow-up if desired.

## Docs

`docs/attestation.md` updated: run-scoped paths in the lifecycle diagram + verify commands, a new **Why a run-scoped snapshot** section explaining the concurrency hazard, and the read-only gotcha corrected.
