### PR TITLE
optimize: Omit<PackSkill> + shared capabilities parser (/optimize follow-up)

### DIFF
--- a/apps/dashboard/app/api/packs/route.ts
+++ b/apps/dashboard/app/api/packs/route.ts
@@ -14,7 +14,7 @@ interface PacksManifest {
     color: string
     category: string | null
     default_enabled?: string[]
-    skills?: Array<{ slug: string; name: string; description: string; category: string }>
+    skills?: Array<Omit<PackSkill, 'enabled'>>
   }>
 }
 

--- a/scripts/check-capabilities-parity.sh
+++ b/scripts/check-capabilities-parity.sh
@@ -24,6 +24,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 INSTALL_SCRIPT="$ROOT_DIR/bin/install-skill-pack"
 DOCS="$ROOT_DIR/docs/CAPABILITIES.md"
+source "$ROOT_DIR/scripts/lib/capabilities.sh"
 
 if [ ! -f "$INSTALL_SCRIPT" ]; then
   echo "::error::install-skill-pack not found at $INSTALL_SCRIPT" >&2
@@ -34,21 +35,8 @@ if [ ! -f "$DOCS" ]; then
   exit 2
 fi
 
-# (1) ALLOWED_CAPABILITIES=(... ) block from install-skill-pack.
-# Reads every non-empty, non-comment line between the opening "ALLOWED_CAPABILITIES=("
-# and the closing ")". Trims leading/trailing whitespace and strips trailing comments.
-extract_script_caps() {
-  awk '
-    /^ALLOWED_CAPABILITIES=\(/ { in_array=1; next }
-    in_array && /^\)/          { in_array=0; next }
-    in_array {
-      sub(/^[[:space:]]+/, "")
-      sub(/[[:space:]]+$/, "")
-      sub(/[[:space:]]*#.*$/, "")
-      if (length($0)) print
-    }
-  ' "$INSTALL_SCRIPT"
-}
+# (1) ALLOWED_CAPABILITIES=(... ) block from install-skill-pack (shared parser).
+extract_script_caps() { extract_allowed_capabilities "$INSTALL_SCRIPT"; }
 
 # (2) "## The taxonomy" table rows from docs/CAPABILITIES.md.
 # Each row is `| \`value\` | meaning |`; we extract the backtick-quoted value only.

--- a/scripts/lib/capabilities.sh
+++ b/scripts/lib/capabilities.sh
@@ -1,0 +1,20 @@
+# capabilities.sh — shared parser for install-skill-pack's capability allow-list.
+# Sourced by check-capabilities-parity.sh and validate-pack.sh so the
+# ALLOWED_CAPABILITIES=(...) array in bin/install-skill-pack stays the single
+# source of truth — the awk that reads it lives here once, not copied per script.
+
+# Print each capability in the given script's ALLOWED_CAPABILITIES=(...) block, one
+# per line: non-empty, non-comment lines between the opening and closing paren,
+# trimmed of surrounding whitespace and any trailing comment.
+extract_allowed_capabilities() {
+  awk '
+    /^ALLOWED_CAPABILITIES=\(/ { in_array=1; next }
+    in_array && /^\)/          { in_array=0; next }
+    in_array {
+      sub(/^[[:space:]]+/, "")
+      sub(/[[:space:]]+$/, "")
+      sub(/[[:space:]]*#.*$/, "")
+      if (length($0)) print
+    }
+  ' "$1"
+}

--- a/scripts/validate-pack.sh
+++ b/scripts/validate-pack.sh
@@ -41,6 +41,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 INSTALL_SCRIPT="$ROOT_DIR/bin/install-skill-pack"
+source "$ROOT_DIR/scripts/lib/capabilities.sh"
 
 PACK_DIR="."
 SUBPATH=""
@@ -99,16 +100,7 @@ ok()   { echo "  ✅ $1"; }
 # the validator correct automatically when the taxonomy changes.
 ALLOWED_CAPS=""
 if [[ -f "$INSTALL_SCRIPT" ]]; then
-  ALLOWED_CAPS=$(awk '
-    /^ALLOWED_CAPABILITIES=\(/ { in_array=1; next }
-    in_array && /^\)/          { in_array=0; next }
-    in_array {
-      sub(/^[[:space:]]+/, "")
-      sub(/[[:space:]]+$/, "")
-      sub(/[[:space:]]*#.*$/, "")
-      if (length($0)) print
-    }
-  ' "$INSTALL_SCRIPT" | tr '\n' ' ')
+  ALLOWED_CAPS=$(extract_allowed_capabilities "$INSTALL_SCRIPT" | tr '\n' ' ')
 fi
 
 is_allowed_cap() {


### PR DESCRIPTION
Follow-up to #655 — two clean, verified `/optimize` items.

| Item | Change | Verification |
|---|---|---|
| **types F5** | `packs/route.ts`: inline `{slug,name,description,category}` → `Omit<PackSkill,'enabled'>`, matching the sibling `Omit<CommunityPack,'installedCount'>` | `tsc` + 149 tests |
| **dedup F7** | Hoist the duplicated `ALLOWED_CAPABILITIES=()` awk parser (in `check-capabilities-parity.sh` + `validate-pack.sh`) into `scripts/lib/capabilities.sh` — `install-skill-pack` stays the single source of truth | `capabilities-parity: OK (6 values)`; `validate-pack` runs |

## Dropped from the original batch (surfaced during implementation)
The planned "`aeon.yml:1070` stale verdikta comment" fix turned out **not** to be a trivial one-liner: `scripts/postprocess-verdikta.sh` and the `verdikta-hunter` skill are both gone, but the workflow still wires `VERDIKTA_*` env/secrets (`.github/workflows/aeon.yml:199,1075-1080`), the dashboard still defines those secrets (`secrets/route.ts:44-45`), and `.gitignore` still lists verdikta caches. That's **orphaned scaffolding for a removed skill** across several files — a judgment call (are the secrets deliberately kept for forks?), not a zero-behavior comment fix. Left for a separate, deliberate review.
