### PR TITLE
ci: cache Claude Code global install across skill + message runs

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -146,12 +146,28 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Cache Claude Code (npm)
+        if: steps.work.outputs.mode != ''
+        # ~/.npm is npm's content-addressable download cache — reusing it lets the
+        # pinned install run fully offline. Version is baked into the key (immutable,
+        # ~100% hit after the first run of a version, shared with messages.yml). The
+        # restore-keys prefix degrades gracefully on a version bump. Keep the version
+        # in the key in sync with the pin below.
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: claude-code-${{ runner.os }}-2.1.168
+          restore-keys: |
+            claude-code-${{ runner.os }}-
+
       - name: Install Claude Code
         if: steps.work.outputs.mode != ''
         # Pinned for supply-chain safety — a freshly-published (or compromised)
         # version is never pulled automatically. Bump deliberately after reviewing
         # the release notes: https://github.com/anthropics/claude-code/releases
-        run: npm install -g @anthropic-ai/claude-code@2.1.168
+        # (--prefer-offline uses the cached tarball above; keep the pin and the
+        # cache key version in sync.)
+        run: npm install -g @anthropic-ai/claude-code@2.1.168 --prefer-offline
 
       - name: Validate skill secrets
         if: steps.work.outputs.mode != ''

--- a/.github/workflows/messages.yml
+++ b/.github/workflows/messages.yml
@@ -358,10 +358,22 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Cache Claude Code (npm)
+        if: steps.msg.outputs.source != ''
+        # Shares the pinned-version cache with aeon.yml so the global install runs
+        # offline. Keep the version in the key in sync with the pin below.
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: claude-code-${{ runner.os }}-2.1.168
+          restore-keys: |
+            claude-code-${{ runner.os }}-
+
       - name: Install Claude Code
         if: steps.msg.outputs.source != ''
-        # Pinned for supply-chain safety — keep in sync with aeon.yml's pin.
-        run: npm install -g @anthropic-ai/claude-code@2.1.168
+        # Pinned for supply-chain safety — keep in sync with aeon.yml's pin
+        # (and the cache key version above).
+        run: npm install -g @anthropic-ai/claude-code@2.1.168 --prefer-offline
 
       - name: Run
         id: run


### PR DESCRIPTION
## What

Cache the global Claude Code CLI install so skill and message runs stop re-downloading it every time.

Today **no workflow uses `actions/cache`**, and both runners install from scratch on every dispatch:
- `aeon.yml` — every skill run
- `messages.yml` — every inbound Telegram/Discord/Slack message

Since `@anthropic-ai/claude-code` is **pinned** (`2.1.168`), it's an ideal cache target: one immutable key, shared across both workflows.

## How

Before each `Install Claude Code` step, add:

```yaml
- name: Cache Claude Code (npm)
  uses: actions/cache@v4
  with:
    path: ~/.npm
    key: claude-code-${{ runner.os }}-2.1.168
    restore-keys: |
      claude-code-${{ runner.os }}-
```

and pass `--prefer-offline` to the install so it reuses the cached tarball.

## Why it's safe

- **`~/.npm`** is npm's content-addressable download cache — node-patch-version-independent, so it survives `setup-node@v6` resolving `22` to a newer patch.
- Caching only changes *how* the pinned version is fetched, never *what* is installed. A missing/broken cache silently falls back to a normal download — nothing breaks.
- `restore-keys` prefix degrades gracefully on a version bump (restores the old cache; the install just adds the new tarball → next run re-warms).
- Low-trust `issues: [labeled]` (`ai-build`) runs get **read-only** cache access per GitHub defaults — they restore but don't write, which is exactly what we want.

## Upside

- ~15–40s saved per run (mostly the network fetch), on *every* skill + message run — compounds across the fleet, and Actions bills by the minute.
- Fewer failures from live npm-registry hiccups.

## Maintenance note

The pinned version now lives in **three** spots per file (setup comment, install line, cache key). On a version bump, update all three. Forgetting the key just yields a slightly slower run via the `restore-keys` fallback — not a break.

Cache footprint: ~40–100MB against the 10GB repo limit; GitHub evicts after 7 days idle (Aeon runs far more often).
