### PR TITLE
fix(ci): P0 — unbreak aeon.yml + chain-runner.yml (empty ${{ }} in run: comment)

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -490,7 +490,8 @@ jobs:
           VAR="$SKILL_VAR"
 
           # Build prompt — inject chain context if running as part of a chain.
-          # env-bound (not ${{ }}-interpolated) + path-contained: the context file
+          # env-bound (passed via env:, not expanded into this run: block) +
+          # path-contained: the context file
           # must be a chain-runner artifact under output/.chains/, never an
           # arbitrary path — otherwise cat would read any file on the runner (e.g.
           # /proc/self/environ, secrets) into the prompt/logs. (GHSA-cqvj-gr78-24mc)

--- a/.github/workflows/chain-runner.yml
+++ b/.github/workflows/chain-runner.yml
@@ -42,7 +42,8 @@ jobs:
           _INPUT_CHAIN: ${{ inputs.chain }}
         run: |
           set -euo pipefail
-          # env-bound (not ${{ }}-interpolated) + allowlisted: a chain name is an
+          # env-bound (passed via env:, not expanded into this run: block) +
+          # allowlisted: a chain name is an
           # aeon.yml chains: key, so it must match ^[a-zA-Z0-9_-]+$. Interpolating
           # it into the shell source let a crafted value break out and run
           # arbitrary commands on the runner. (GHSA-h9v2-7m42-33m3)


### PR DESCRIPTION
## P0 — the runner is down

`#658` (the fix for GHSA-h9v2 + GHSA-cqvj) wrote a literal `${{ }}` inside a `#` comment in a `run:` block, in **both** `aeon.yml:493` and `chain-runner.yml:45`:

```yaml
# env-bound (not ${{ }}-interpolated) + ...
```

GitHub substitutes `${{ }}` expressions across the **entire** `run:` block — including shell comments (the block is a plain string at compile time; `#` only means 'comment' at shell-exec time, which never runs because compile fails first). Empty `${{ }}` = empty expression = **`startup_failure` on every dispatch**. The main skill runner *and* chains have been failing to compile since `ce64047` merged.

## Fix

Reword both comments to drop the literal token. **No logic change** — the security fixes (env-bind + allowlist / path-containment) are untouched.

## Verified

- `actionlint -shellcheck= -pyflakes= aeon.yml chain-runner.yml` → clean (was flagging `unexpected end of input ... [expression]`)
- No `${{ }}` remains in any run-block comment across all workflows

Merge ASAP — this restores the agent.