### PR TITLE
fix(dashboard): transparent bordered mini-buttons (match Off Duty pill)

### DIFF
--- a/apps/dashboard/app/globals.css
+++ b/apps/dashboard/app/globals.css
@@ -388,27 +388,28 @@ body::before {
 
 /* ──────────────────────────────────────────────────────────
    COMPACT INLINE ACTIONS - Set / Edit / Remove / Cancel / Save
-   These tertiary actions used to render as bare text and didn't
-   read as buttons. Each variant is a bordered, faintly-filled
-   chip with explicit hover / active / disabled states so it's
-   unmistakably clickable.
+   A compact take on .btn-ghost: transparent fill, a real border,
+   uppercase display type. Tertiary actions that used to be bare
+   text now read as buttons, with a subtle tinted hover per intent.
    ────────────────────────────────────────────────────────── */
 .btn-mini,
 .btn-mini-danger,
 .btn-mini-go {
-  font-family: var(--font-mono-space), ui-monospace, monospace;
-  font-size: 11px;
-  letter-spacing: 0.04em;
+  font-family: var(--font-display-dela), 'Arial Black', sans-serif;
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
   line-height: 1;
-  padding: 6px 12px;
+  padding: 8px 14px;
+  background: transparent;
   border: 1px solid;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  transition: background 0.18s ease, color 0.18s ease,
-              border-color 0.18s ease, transform 0.12s ease,
-              box-shadow 0.18s ease;
+  transition: color 0.2s ease, border-color 0.2s ease,
+              background 0.2s ease,
+              transform 0.2s cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 .btn-mini:disabled,
 .btn-mini-danger:disabled,
@@ -416,48 +417,40 @@ body::before {
   opacity: 0.4;
   cursor: not-allowed;
 }
-.btn-mini:active:not(:disabled),
-.btn-mini-danger:active:not(:disabled),
-.btn-mini-go:active:not(:disabled) {
-  transform: translateY(1px);
+.btn-mini:hover:not(:disabled),
+.btn-mini-danger:hover:not(:disabled),
+.btn-mini-go:hover:not(:disabled) {
+  transform: translateY(-1px);
 }
 
 /* Neutral - Cancel / Revert / Set / Edit / Clear */
 .btn-mini {
   color: var(--aeon-gray);
-  background: var(--aeon-rule-soft);
-  border-color: var(--aeon-rule);
+  border-color: var(--aeon-rule-strong);
 }
 .btn-mini:hover:not(:disabled) {
   color: var(--aeon-fg);
-  background: rgba(250, 250, 250, 0.11);
-  border-color: var(--aeon-rule-strong);
+  border-color: var(--aeon-fg);
 }
 
 /* Danger - Remove / Delete / Uninstall */
 .btn-mini-danger {
   color: var(--aeon-red-alert);
-  background: rgba(255, 82, 82, 0.08);
-  border-color: rgba(255, 82, 82, 0.34);
+  border-color: rgba(255, 82, 82, 0.4);
 }
 .btn-mini-danger:hover:not(:disabled) {
-  color: #ffffff;
-  background: var(--aeon-red-alert);
   border-color: var(--aeon-red-alert);
-  box-shadow: 0 4px 14px rgba(255, 82, 82, 0.28);
+  background: rgba(255, 82, 82, 0.08);
 }
 
 /* Confirm - Save / Set / Add (commits a value) */
 .btn-mini-go {
-  color: #04240f;
-  background: var(--aeon-green);
-  border-color: var(--aeon-green);
-  font-weight: 600;
+  color: var(--aeon-green);
+  border-color: rgba(67, 193, 101, 0.42);
 }
 .btn-mini-go:hover:not(:disabled) {
-  background: #4fd074;
-  border-color: #4fd074;
-  box-shadow: 0 4px 14px rgba(67, 193, 101, 0.3);
+  border-color: var(--aeon-green);
+  background: rgba(67, 193, 101, 0.1);
 }
 
 /* ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Replaces the filled green/red mini-button chips with a compact **btn-ghost** style: transparent fill, real border, uppercase display type, and a subtle tinted hover per intent (neutral / danger-red / go-green). Matches the Off/On Duty pill.

CSS-only change - components already reference `.btn-mini` / `.btn-mini-danger` / `.btn-mini-go`.

`npx tsc --noEmit` clean.