### PR TITLE
fix(dashboard): style remaining inline actions (Set/Edit/Install) + move Re-register button

### DIFF
--- a/apps/dashboard/components/McpPanel.tsx
+++ b/apps/dashboard/components/McpPanel.tsx
@@ -170,7 +170,7 @@ export function McpPanel({ servers, loading, saving, secrets, busy, onSave, onSe
                 {installed ? (
                   <span className="text-[10px] font-mono uppercase tracking-[0.14em] text-eva-green shrink-0">✓ installed</span>
                 ) : (
-                  <button onClick={() => installFeatured(f)} disabled={saving} className="bg-eva-green text-white text-[11px] px-3 py-1.5 font-mono hover:opacity-90 transition-opacity disabled:opacity-40 shrink-0">Install</button>
+                  <button onClick={() => installFeatured(f)} disabled={saving} className="btn-mini-go shrink-0">Install</button>
                 )}
               </div>
             )

--- a/apps/dashboard/components/SkillDetail.tsx
+++ b/apps/dashboard/components/SkillDetail.tsx
@@ -75,7 +75,7 @@ function KeyRow({ kref, secret, harness, onGoTo }: { kref: { key: string; option
         </div>
         <button
           onClick={() => onGoTo(kref.key)}
-          className={`text-[11px] font-mono px-2 py-1 shrink-0 uppercase tracking-[0.14em] transition-colors ${isSet ? 'text-eva-green hover:text-aeon-fg' : 'text-primary-40 hover:text-eva-orange'}`}
+          className={`${isSet ? 'btn-mini-go' : 'btn-mini'} shrink-0`}
         >
           {isSet ? '✓ in vault' : providedByHarness ? 'Override →' : 'Set →'}
         </button>
@@ -115,7 +115,7 @@ function McpRow({ mref, installed, onGoTo }: { mref: SkillMcpRef; installed: boo
         </div>
         <button
           onClick={onGoTo}
-          className={`text-[11px] font-mono px-2 py-1 shrink-0 uppercase tracking-[0.14em] transition-colors ${installed ? 'text-eva-green hover:text-aeon-fg' : 'text-primary-40 hover:text-eva-orange'}`}
+          className={`${installed ? 'btn-mini-go' : 'btn-mini'} shrink-0`}
         >
           {installed ? '✓ installed' : 'Install →'}
         </button>
@@ -285,7 +285,7 @@ export function SkillDetail({ skill, runs, model, harness, secrets, mcpServers, 
         action={
           <button
             onClick={() => setEditingSchedule(!editingSchedule)}
-            className="text-[11px] text-primary-40 font-mono uppercase tracking-[0.18em] hover:text-aeon-red transition-colors"
+            className="btn-mini uppercase tracking-[0.18em]"
           >
             {editingSchedule ? 'Cancel' : 'Edit'}
           </button>

--- a/apps/dashboard/components/TelegramCommandsCard.tsx
+++ b/apps/dashboard/components/TelegramCommandsCard.tsx
@@ -40,33 +40,37 @@ export function TelegramCommandsCard({ tokenSet }: TelegramCommandsCardProps) {
 
   return (
     <div className="px-[var(--space-md)] py-[var(--space-sm)]">
-      <div className="flex items-center gap-2">
-        <span className="font-mono text-xs">⌘ Slash commands</span>
-        <span className="text-[10px] font-mono uppercase tracking-[0.14em] text-primary-35">auto</span>
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="font-mono text-xs">⌘ Slash commands</span>
+            <span className="text-[10px] font-mono uppercase tracking-[0.14em] text-primary-35">auto</span>
+          </div>
+          <div className="text-[11px] text-primary-40 font-mono mt-1">
+            Enabled skills become Telegram <span className="text-primary-70">/</span> commands - then{' '}
+            <span className="text-primary-70">/skillname</span> runs instantly, no LLM call. They register
+            automatically when you save the bot token; use this to re-sync after toggling skills.
+          </div>
+          {!tokenSet && (
+            <p className="text-[11px] text-primary-35 mt-2">
+              Set the bot token above first - commands register automatically once it&apos;s saved.
+            </p>
+          )}
+          {status && (
+            <p className={`text-[11px] font-mono mt-2 ${status.ok ? 'text-eva-green' : 'text-eva-red/80'}`}>{status.msg}</p>
+          )}
+        </div>
+        <button
+          onClick={register}
+          disabled={!tokenSet || busy}
+          title={tokenSet
+            ? 'Runs the Setup Telegram Commands workflow - reuses the stored bot token server-side, no pasting.'
+            : 'Set TELEGRAM_BOT_TOKEN first; commands register automatically once it is saved.'}
+          className="text-[11px] text-aeon-bg bg-aeon-fg font-mono px-2.5 py-1 hover:opacity-90 transition-opacity disabled:opacity-50 shrink-0"
+        >
+          {busy ? 'Registering…' : 'Re-register commands'}
+        </button>
       </div>
-      <div className="text-[11px] text-primary-40 font-mono mb-2">
-        Enabled skills become Telegram <span className="text-primary-70">/</span> commands - then{' '}
-        <span className="text-primary-70">/skillname</span> runs instantly, no LLM call. They register
-        automatically when you save the bot token; use this to re-sync after toggling skills.
-      </div>
-      <button
-        onClick={register}
-        disabled={!tokenSet || busy}
-        title={tokenSet
-          ? 'Runs the Setup Telegram Commands workflow - reuses the stored bot token server-side, no pasting.'
-          : 'Set TELEGRAM_BOT_TOKEN first; commands register automatically once it is saved.'}
-        className="bg-eva-green text-white text-[11px] px-4 py-2 font-mono hover:opacity-90 transition-opacity disabled:opacity-50 shrink-0"
-      >
-        {busy ? 'Registering…' : 'Re-register commands'}
-      </button>
-      {!tokenSet && (
-        <p className="text-[11px] text-primary-35 mt-2">
-          Set the bot token above first - commands register automatically once it&apos;s saved.
-        </p>
-      )}
-      {status && (
-        <p className={`text-[11px] font-mono mt-2 ${status.ok ? 'text-eva-green' : 'text-eva-red/80'}`}>{status.msg}</p>
-      )}
     </div>
   )
 }


### PR DESCRIPTION
Follow-up to the button-state pass — catches the inline actions that were still bare text:

- **SkillDetail**: `Set →` / `Override →` / `✓ in vault` (key rows), `Install →` / `✓ installed` (MCP rows), and the schedule **Edit/Cancel** action now use the transparent `btn-mini` / `btn-mini-go` ghost style.
- **McpPanel**: featured **Install** uses `btn-mini-go`.
- **TelegramCommandsCard**: **Re-register commands** moved to the right of the row and restyled to match the **Connect** button (solid white pill).

`npx tsc --noEmit` clean · `npm test` 149/149.