### PR TITLE
dashboard: more-visible Templates buttons + rename skill Remove→Delete

### DIFF
--- a/apps/dashboard/components/SkillDetail.tsx
+++ b/apps/dashboard/components/SkillDetail.tsx
@@ -195,10 +195,10 @@ export function SkillDetail({ skill, runs, model, harness, secrets, mcpServers, 
               {busy[`r-${skill.name}`] ? '…' : 'Run now'}
             </button>
             <button
-              onClick={() => { if (confirm(`Remove ${displayName(skill.name)}?`)) onDelete(skill.name) }}
+              onClick={() => { if (confirm(`Delete ${displayName(skill.name)}?`)) onDelete(skill.name) }}
               className="btn-mini-danger ml-auto uppercase tracking-[0.18em]"
             >
-              Remove
+              Delete
             </button>
           </div>
         </div>

--- a/apps/dashboard/components/SoulPanel.tsx
+++ b/apps/dashboard/components/SoulPanel.tsx
@@ -180,7 +180,7 @@ export function SoulPanel({ soul, style, loading, saving, building, installing, 
             : <span className="text-[10px] font-mono uppercase tracking-[0.18em] text-eva-green">configured</span>}
           <button
             onClick={() => setShowTemplates(v => !v)}
-            className="text-[10px] font-mono uppercase tracking-[0.14em] px-2 py-1 border border-[rgba(250,250,250,0.12)] text-primary-50 hover:text-primary-100 hover:border-[rgba(250,250,250,0.22)] transition-colors cursor-target"
+            className="btn-mini cursor-target"
           >
             {showTemplates ? 'Close' : 'Templates'}
           </button>

--- a/apps/dashboard/components/StrategyPanel.tsx
+++ b/apps/dashboard/components/StrategyPanel.tsx
@@ -123,7 +123,7 @@ export function StrategyPanel({ content, loading, saving, building, onSave, onBu
             : <span className="text-[10px] font-mono uppercase tracking-[0.18em] text-eva-green">customized</span>}
           <button
             onClick={() => setShowTemplates(v => !v)}
-            className="text-[10px] font-mono uppercase tracking-[0.14em] px-2 py-1 border border-[rgba(250,250,250,0.12)] text-primary-50 hover:text-primary-100 hover:border-[rgba(250,250,250,0.22)] transition-colors cursor-target"
+            className="btn-mini cursor-target"
           >
             {showTemplates ? 'Close' : 'Templates'}
           </button>


### PR DESCRIPTION
- **Templates** button on Strategy & Soul panels was near-invisible faint text; now uses the `btn-mini` ghost style (display font, stronger border) so it reads as a button.
- Skill page: rename **Remove** button (and its confirm text) to **Delete**.

`tsc` clean.