### PR TITLE
feat(notify): migrate email channel from SendGrid to Resend

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -229,12 +229,12 @@ Set the secret → channel activates. No code changes needed.
 | Telegram | `TELEGRAM_BOT_TOKEN` + `TELEGRAM_CHAT_ID` | Same |
 | Discord | `DISCORD_WEBHOOK_URL` | `DISCORD_BOT_TOKEN` + `DISCORD_CHANNEL_ID` |
 | Slack | `SLACK_WEBHOOK_URL` | `SLACK_BOT_TOKEN` + `SLACK_CHANNEL_ID` |
-| Email | `SENDGRID_API_KEY` + `NOTIFY_EMAIL_TO` | - |
+| Email | `RESEND_API_KEY` + `NOTIFY_EMAIL_TO` | - |
 
 **Telegram:** Create a bot with @BotFather → get token + chat ID. Saving the bot token in the dashboard **auto-registers** the slash-command menu (`/skillname` dispatches instantly, no LLM) — no manual step; a **Re-register commands** button re-syncs it after you toggle skills, and every notification carries **Run again / Schedule weekly** quick-action buttons, deep links, and stateless follow-up questions. Full guide: [docs/telegram-commands.md](../docs/telegram-commands.md).
 **Discord:** Outbound: Channel → Integrations → Webhooks → Create. Inbound: discord.com/developers → bot → add `channels:history` scope → copy token + channel ID.
 **Slack:** api.slack.com → Create App → Incoming Webhooks → install → copy URL. Inbound: add `channels:history`, `reactions:write` scopes → copy bot token + channel ID.
-**Email:** sendgrid.com/settings/api_keys → Create API Key (Mail Send permission) → add as `SENDGRID_API_KEY`, set `NOTIFY_EMAIL_TO`. Optional repo variables: `NOTIFY_EMAIL_FROM` (default `aeon@notifications.aeon.bot`), `NOTIFY_EMAIL_SUBJECT_PREFIX` (default `[Aeon]`).
+**Email:** resend.com/api-keys → Create API Key → add as `RESEND_API_KEY`, set `NOTIFY_EMAIL_TO` to your inbox. Optional repo variables: `NOTIFY_EMAIL_FROM` (default `aeon@notifications.aeon.bot` — **must be a domain/sender verified in Resend**), `NOTIFY_EMAIL_SUBJECT_PREFIX` (default `[Aeon]`). This is the same `RESEND_API_KEY` used for security disclosures, so one Resend key powers all of Aeon's outbound email.
 
 **Restrict who can command the agent (inbound):** Telegram is already scoped to a single `TELEGRAM_CHAT_ID`. For Discord and Slack, set the optional repo variables `DISCORD_ALLOWED_AUTHOR_ID` / `SLACK_ALLOWED_USER_ID` (or same-named secrets) to the authorized sender's user ID — inbound messages from anyone else in the channel are then ignored. **Leaving them unset processes commands from any non-bot member of the channel**, so set them whenever the channel isn't private to you.
 

--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -340,7 +340,6 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
           NOTIFY_EMAIL_TO: ${{ secrets.NOTIFY_EMAIL_TO }}
           NOTIFY_EMAIL_FROM: ${{ vars.NOTIFY_EMAIL_FROM || 'aeon@notifications.aeon.bot' }}
           NOTIFY_EMAIL_SUBJECT_PREFIX: ${{ vars.NOTIFY_EMAIL_SUBJECT_PREFIX || '[Aeon]' }}
@@ -1014,7 +1013,7 @@ jobs:
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           NOTIFY_EMAIL_TO: ${{ secrets.NOTIFY_EMAIL_TO }}
           NOTIFY_EMAIL_FROM: ${{ vars.NOTIFY_EMAIL_FROM || 'aeon@notifications.aeon.bot' }}
           NOTIFY_EMAIL_SUBJECT_PREFIX: ${{ vars.NOTIFY_EMAIL_SUBJECT_PREFIX || '[Aeon]' }}
@@ -1073,6 +1072,19 @@ jobs:
               curl -sf -X POST "$SLACK_WEBHOOK_URL" \
                 -H "Content-Type: application/json" \
                 -d "$(jq -n --arg text "$MSG" '{text: $text}')" > /dev/null 2>&1 || true
+            fi
+            # Email (Resend) — same key as the vuln-disclosure sender
+            if [ -n "${RESEND_API_KEY:-}" ] && [ -n "${NOTIFY_EMAIL_TO:-}" ]; then
+              EMAIL_FROM="${NOTIFY_EMAIL_FROM:-aeon@notifications.aeon.bot}"
+              EMAIL_SUBJECT="${NOTIFY_EMAIL_SUBJECT_PREFIX:-[Aeon]} ${SKILL_NAME:-notification}"
+              EMAIL_HTML=$(printf '%s' "$MSG" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g')
+              EMAIL_HTML="<html><body><pre style=\"font-family:monospace;white-space:pre-wrap;\">${EMAIL_HTML}</pre></body></html>"
+              curl -sf -X POST "https://api.resend.com/emails" \
+                -H "Authorization: Bearer ${RESEND_API_KEY}" \
+                -H "Content-Type: application/json" \
+                -d "$(jq -n --arg from "$EMAIL_FROM" --arg to "$NOTIFY_EMAIL_TO" --arg subject "$EMAIL_SUBJECT" \
+                      --arg html "$EMAIL_HTML" --arg text "$MSG" \
+                      '{from:$from, to:[$to], subject:$subject, html:$html, text:$text}')" > /dev/null 2>&1 || true
             fi
           done
           rm -rf .pending-notify

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ Two exemptions: **reserved `index.md`/`log.md`** stay untyped (OKF §6/§7), and
 
 ## Tools
 
-- **`./notify "message"`** — Send to all configured channels (Telegram, Discord, Slack, SendGrid email, json-render). Unconfigured channels are skipped silently.
+- **`./notify "message"`** — Send to all configured channels (Telegram, Discord, Slack, Resend email, json-render). Unconfigured channels are skipped silently.
   - **Multi-line content: `./notify -f path/to/file.md`** (`--file`/`--body` also accepted). Do NOT use `./notify "$(cat file.md)"` — long multi-line argv trips the sandbox; the `-f` flag reads the file inside the script so argv stays short.
   - Optional flags: `--title`, `--severity {info|success|warn|critical}`, `--link`. Note: short messages containing `test`/`ping`/`debug`/`trace` are suppressed as diagnostic probes, and `NOTIFY_MIN_SEVERITY` gates low-severity sends — so don't rely on a "test" ping to confirm delivery.
   - **Formatting is global — just write ordinary Markdown.** `notify` renders each channel for you: `##` headings, `**bold**`, `- bullets`, `| tables |`, `` `code` ``, ```` ``` ```` fences, and `[label](url)` links all render correctly on Telegram (normalized to HTML by `scripts/notify_format.py`), Discord, and Slack. Don't hand-format for Telegram, don't cap length for "Telegram limits" (it auto-chunks at ~3900 chars with `[i/N]`), and don't worry about stray `*`/`_`/`<` breaking the message. Keep messages tight for **signal**, not for the transport. (Editorial choices are still yours: use `x.com/handle` not `@handle` to avoid pinging users; `./notify` bodies are the only channel where email renders as plain text — see the send-email/vuln-scanner notes.)

--- a/apps/dashboard/components/ui/ServiceIcon.tsx
+++ b/apps/dashboard/components/ui/ServiceIcon.tsx
@@ -31,7 +31,6 @@ const DOMAINS: Record<string, string> = {
   SLACK_BOT_TOKEN: 'slack.com',
   SLACK_CHANNEL_ID: 'slack.com',
   SLACK_WEBHOOK_URL: 'slack.com',
-  SENDGRID_API_KEY: 'sendgrid.com',
   // Skill keys
   XAI_API_KEY: 'x.ai',
   COINGECKO_API_KEY: 'coingecko.com',

--- a/apps/dashboard/lib/secrets-catalog.ts
+++ b/apps/dashboard/lib/secrets-catalog.ts
@@ -27,8 +27,7 @@ export const BUILTIN_SECRETS: Omit<Secret, 'isSet'>[] = [
   { name: 'SLACK_BOT_TOKEN', group: 'Slack', description: 'Slack bot OAuth token' },
   { name: 'SLACK_CHANNEL_ID', group: 'Slack', description: 'Channel ID for messages' },
   { name: 'SLACK_WEBHOOK_URL', group: 'Slack', description: 'Webhook URL for notifications' },
-  { name: 'SENDGRID_API_KEY', group: 'Email', description: 'SendGrid API key (SendGrid is a Twilio product) - keys & API reference at www.twilio.com/docs/sendgrid/api-reference' },
-  { name: 'NOTIFY_EMAIL_TO', group: 'Email', description: 'Recipient email address for skill notifications' },
+  { name: 'NOTIFY_EMAIL_TO', group: 'Email', description: 'Recipient address for the email notification channel - pairs with RESEND_API_KEY to email you (the operator) every skill notification, alongside Telegram/Discord/Slack. Optional repo variables: NOTIFY_EMAIL_FROM (default aeon@notifications.aeon.bot, must be a Resend-verified sender), NOTIFY_EMAIL_SUBJECT_PREFIX (default [Aeon]).' },
   // Observability - optional. Set both keys to stream every Claude Code run to a
   // Langfuse project as a trace (LLM calls, tokens, cost, prompts/responses) via
   // OpenTelemetry. No-op when unset. Region/host + toggles are repo VARIABLES:
@@ -47,7 +46,7 @@ export const BUILTIN_SECRETS: Omit<Secret, 'isSet'>[] = [
   { name: 'BANKR_API_KEY', group: 'Skill Keys', description: 'Bankr Wallet API key (X-API-Key) - token distribution skills (distribute-tokens). Enable at bankr.bot/api-keys' },
   { name: 'VERCEL_TOKEN', group: 'Skill Keys', description: 'Vercel access token - deploy skills (deploy-prototype). Create at vercel.com/account/settings/tokens' },
   { name: 'REPLICATE_API_TOKEN', group: 'Skill Keys', description: 'Replicate API token - hero image generation (article). Get one at replicate.com/account/api-tokens' },
-  { name: 'RESEND_API_KEY', group: 'Skill Keys', description: 'Resend API key - emailed digests & security disclosures (send-email, heartbeat, vuln-scanner). Create at resend.com' },
+  { name: 'RESEND_API_KEY', group: 'Skill Keys', description: 'Resend API key - powers ALL outbound email: the operator email-notification channel (with NOTIFY_EMAIL_TO), emailed digests, and security disclosures (send-email, heartbeat, vuln-scanner). Create at resend.com' },
   { name: 'ADMANAGE_API_KEY', group: 'Skill Keys', description: 'AdManage API key - ad-campaign skill (schedule-ads). From admanage.ai/api-docs' },
   { name: 'GH_GLOBAL', group: 'Skill Keys', description: 'GitHub PAT with cross-repo WRITE access - cross-repo skills & deploys (changelog push-to, feature external, deploy-prototype, vuln-scanner). Auto-promoted to the run\'s GITHUB_TOKEN. Create one at github.com/settings/tokens' },
   { name: 'GH_READ_PAT', group: 'Skill Keys', description: 'GitHub read-only PAT - optional. Used only by prefetch steps to enrich cross-repo / private-repo reads (bd-radar); kept separate from the write-capable GH_GLOBAL for least privilege. Without it those skills fall back to public data. Create a read-only token at github.com/settings/tokens' },

--- a/bin/onboard
+++ b/bin/onboard
@@ -225,7 +225,7 @@ check_channel() {
 check_channel "Telegram" TELEGRAM_BOT_TOKEN TELEGRAM_CHAT_ID
 check_channel "Discord"  DISCORD_WEBHOOK_URL
 check_channel "Slack"    SLACK_WEBHOOK_URL
-check_channel "Email"    SENDGRID_API_KEY NOTIFY_EMAIL_TO
+check_channel "Email"    RESEND_API_KEY NOTIFY_EMAIL_TO
 
 if [[ ${#channels_found[@]} -ge 1 ]]; then
   joined=$(printf "%s, " "${channels_found[@]}")
@@ -233,7 +233,7 @@ if [[ ${#channels_found[@]} -ge 1 ]]; then
   emit pass "notification channel" "$joined configured" ""
 elif [[ "$channels_unverified" == "true" ]]; then
   emit warn "notification channel" "could not verify (gh not authenticated)" \
-    "Authenticate with 'gh auth login' or check Settings → Secrets for one of: TELEGRAM_BOT_TOKEN+TELEGRAM_CHAT_ID, DISCORD_WEBHOOK_URL, SLACK_WEBHOOK_URL, SENDGRID_API_KEY+NOTIFY_EMAIL_TO."
+    "Authenticate with 'gh auth login' or check Settings → Secrets for one of: TELEGRAM_BOT_TOKEN+TELEGRAM_CHAT_ID, DISCORD_WEBHOOK_URL, SLACK_WEBHOOK_URL, RESEND_API_KEY+NOTIFY_EMAIL_TO."
 else
   emit fail "notification channel" "no channel configured" \
     "Pick one — Telegram is fastest. See README → Notifications for the @BotFather + chat_id walk-through, then: gh secret set TELEGRAM_BOT_TOKEN -R $REPO_SLUG && gh secret set TELEGRAM_CHAT_ID -R $REPO_SLUG"

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -256,19 +256,22 @@ if [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
   fi
 fi
 
-# Email via SendGrid (unchanged)
-if [ -n "${SENDGRID_API_KEY:-}" ] && [ -n "${NOTIFY_EMAIL_TO:-}" ]; then
+# Email via Resend (operator-notify channel — same provider/key as the vuln
+# disclosure sender in scripts/postprocess-email.sh, one Resend account for all
+# outbound mail). Best-effort inline; the workflow's "Send pending notifications"
+# step re-delivers via Resend if this is blocked in the sandbox.
+if [ -n "${RESEND_API_KEY:-}" ] && [ -n "${NOTIFY_EMAIL_TO:-}" ]; then
   FROM="${NOTIFY_EMAIL_FROM:-aeon@notifications.aeon.bot}"
   PREFIX="${NOTIFY_EMAIL_SUBJECT_PREFIX:-[Aeon]}"
   SUBJECT="$PREFIX ${TITLE:-${SKILL_NAME:-notification}}"
   HTML_BODY=$(printf '%s' "$PLAIN" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g')
   HTML_BODY="<html><body><pre style=\"font-family:monospace;white-space:pre-wrap;\">${HTML_BODY}</pre></body></html>"
-  curl -sf -X POST "https://api.sendgrid.com/v3/mail/send" \
-    -H "Authorization: Bearer ${SENDGRID_API_KEY}" \
+  curl -sf -X POST "https://api.resend.com/emails" \
+    -H "Authorization: Bearer ${RESEND_API_KEY}" \
     -H "Content-Type: application/json" \
     -d "$(jq -n --arg from "$FROM" --arg to "$NOTIFY_EMAIL_TO" --arg subject "$SUBJECT" \
           --arg html "$HTML_BODY" --arg text "$PLAIN" \
-          '{personalizations:[{to:[{email:$to}]}],from:{email:$from},subject:$subject,content:[{type:"text/plain",value:$text},{type:"text/html",value:$html}]}')" > /dev/null 2>&1 || true
+          '{from:$from, to:[$to], subject:$subject, html:$html, text:$text}')" > /dev/null 2>&1 && DELIVERED=true || true
 fi
 
 # json-render channel — save raw message for post-run conversion

--- a/scripts/postprocess-email.sh
+++ b/scripts/postprocess-email.sh
@@ -12,10 +12,11 @@
 # workflow runs AFTER Claude finishes, with full env access — does the actual
 # send. Same split as scripts/postprocess-replicate.sh.
 #
-# This is OUTBOUND mail to third-party maintainers. It is deliberately separate
-# from the SendGrid operator-notify channel wired into the "Send pending
-# notifications" workflow step (that one tells the *operator* things; this one
-# tells *maintainers* about their bugs).
+# This is OUTBOUND mail to third-party maintainers. It shares the Resend account
+# with the operator-notify email channel wired into the "Send pending
+# notifications" workflow step, but stays a distinct purpose and from-address:
+# that one tells the *operator* things (RESEND_API_KEY + NOTIFY_EMAIL_TO/_FROM);
+# this one tells *maintainers* about their bugs (RESEND_FROM disclosure sender).
 #
 # CONTRACT with the skill (.pending-email/<slug>.json):
 #   { "draft_path": "memory/pending-disclosures/<file>.md",   # for status flip

--- a/scripts/tests/test_notify.sh
+++ b/scripts/tests/test_notify.sh
@@ -8,7 +8,7 @@ NOTIFY="scripts/notify.sh"
 
 # Channels unset → everything falls back to .pending-notify
 unset TELEGRAM_BOT_TOKEN TELEGRAM_CHAT_ID DISCORD_WEBHOOK_URL SLACK_WEBHOOK_URL \
-      SENDGRID_API_KEY NOTIFY_EMAIL_TO JSONRENDER_ENABLED NOTIFY_MIN_SEVERITY 2>/dev/null
+      RESEND_API_KEY NOTIFY_EMAIL_TO JSONRENDER_ENABLED NOTIFY_MIN_SEVERITY 2>/dev/null
 
 WORK=".pending-notify"
 fail=0

--- a/skills/vuln-scanner/SKILL.md
+++ b/skills/vuln-scanner/SKILL.md
@@ -490,7 +490,7 @@ When Arm A finds an exploitable **code** flaw (not a public dep CVE) in a repo t
 
 This is **fully autonomous** (operator chose this): an armed draft is sent without waiting for a human. That makes the **arming gate the only safeguard**, so this arm is conservative — it queues *only* drafts that pass every check below, and the post-send notification tells the operator exactly what went out.
 
-This is **outbound mail to third parties**. It is unrelated to the SendGrid operator-notify channel (which mails *the operator*). Do not conflate them.
+This is **outbound mail to third parties**. It shares the Resend account with the operator-notify email channel (which mails *the operator*) but is a distinct purpose and from-address. Do not conflate them.
 
 ### Eligibility — a draft is queued ONLY if ALL of these hold
 


### PR DESCRIPTION
## What & why

Aeon already runs **Resend** for outbound vuln disclosures (`postprocess-email.sh`). The operator email-notification channel behind `./notify` was the *only* thing still on **SendGrid** — a second email provider and secret doing the same job. This migrates that channel to Resend and removes SendGrid entirely, so **one Resend key powers all outbound email**.

## The wiring gap this also fixes

`./notify`'s email send was **inline-only**. In CI, the sandbox blocks secret-bearing outbound curls, and — unlike Telegram/Discord/Slack — the post-run **"Send pending notifications"** fallback step had **no email re-delivery**. So emailed notifications were effectively never delivered from CI. This PR adds email to that fallback loop, mirroring the other three channels, so the email channel is now genuinely wired.

## Changes

**Delivery**
- `scripts/notify.sh` — inline send → `api.resend.com/emails`; gated on `RESEND_API_KEY` + `NOTIFY_EMAIL_TO`; sets `DELIVERED` on success so it dedups against the fallback.
- `.github/workflows/aeon.yml`
  - **Fallback step**: added Resend email re-delivery (the fix above); swapped its email env `SENDGRID_API_KEY` → `RESEND_API_KEY`.
  - **Main sandboxed run step**: removed the email key outright. `RESEND_API_KEY` is deliberately kept **out of the in-sandbox run** (it's also the disclosure key — same isolation the disclosure flow already relies on); email is delivered from the post-run step.

**Catalog / docs / sweep**
- `secrets-catalog.ts` — removed `SENDGRID_API_KEY`; `NOTIFY_EMAIL_TO` + `RESEND_API_KEY` descriptions now describe the Resend-backed email channel.
- `ServiceIcon.tsx`, `bin/onboard`, `scripts/tests/test_notify.sh` — SendGrid → Resend.
- Docs: `.github/README.md` (channel table + setup: resend.com/api-keys, verified-sender note), `CLAUDE.md` (`./notify` channel list), `postprocess-email.sh` + `vuln-scanner` disclosure notes (SendGrid → shared-Resend framing).

## Operator action after merge

Set `RESEND_API_KEY` (already have it if disclosures are configured) + `NOTIFY_EMAIL_TO`, and ensure `NOTIFY_EMAIL_FROM` is a **Resend-verified sender**. `SENDGRID_API_KEY` can be deleted from repo secrets — nothing reads it anymore.

## Verification
- 15/15 `test_notify.sh` pass · `actionlint` clean · `bash -n` clean on all touched scripts
- Resend `POST /emails` payloads validated for both the inline and fallback paths (`from`/`to[]`/`subject`/`html`/`text`, HTML-escaped)
- `okf-validate` OK (95 concepts); no `skills.json` regen needed (prose-only SKILL.md change, `ci-skills-json` normalizes sha/timestamp)
