### PR TITLE
Per-skill least-privilege secrets + "under the hood" run summary

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -480,6 +480,23 @@ jobs:
               echo "MCP enabled: $(jq -r '.mcpServers | keys | join(", ")' .mcp.json)"
             fi
           fi
+
+          # Per-skill least-privilege secrets: inject ONLY the keys this skill
+          # declares in its `requires:` frontmatter (both required and `?` works-better
+          # tiers). Same resolve-from-ALL_SECRETS shape as the MCP loop above. A skill
+          # sees nothing else from the secret store — so an injected read skill has
+          # only its own (capped) keys to leak. Optional key with no secret set → not
+          # exported, skill degrades to its public path (unchanged behaviour).
+          SECRETS_JSON="${ALL_SECRETS:-}"; [ -z "$SECRETS_JSON" ] && SECRETS_JSON='{}'
+          INJECTED=""
+          while IFS= read -r key; do
+            [ -z "$key" ] && continue
+            [ -n "${!key:-}" ] && continue                     # already in env (infra) — leave it
+            val="$(jq -r --arg k "$key" '.[$k] // empty' <<<"$SECRETS_JSON")"
+            [ -n "$val" ] && { export "$key=$val"; INJECTED="$INJECTED $key"; }
+          done < <(bash scripts/skill_requires.sh "$SKILL_NAME" 2>/dev/null)
+          [ -n "$INJECTED" ] && echo "::notice::Injected declared secrets for ${SKILL_NAME}:${INJECTED}"
+
           unset ALL_SECRETS   # drop the secrets blob before any skill/Claude code runs
 
           SKILL_NAME="${{ steps.skill.outputs.name }}"
@@ -597,6 +614,10 @@ jobs:
           echo "SKILL_CACHE_READ_TOKENS=$CACHE_READ" >> "$GITHUB_OUTPUT"
           echo "SKILL_CACHE_CREATION_TOKENS=$CACHE_CREATION" >> "$GITHUB_OUTPUT"
           echo "SKILL_TOTAL_TOKENS=$TOTAL_TOKENS" >> "$GITHUB_OUTPUT"
+          # Session id → lets the post-run "Under the hood" step locate this run's
+          # transcript (~/.claude/projects/*/<id>.jsonl) and tally tool actions.
+          # Empty on the grok harness (no Claude transcript) — the step then no-ops.
+          echo "SESSION_ID=$(echo "$CLAUDE_OUTPUT" | jq -r '.session_id // empty')" >> "$GITHUB_OUTPUT"
 
           echo "::notice::Token usage — input: $INPUT_TOKENS, output: $OUTPUT_TOKENS, cache_read: $CACHE_READ, cache_creation: $CACHE_CREATION, total: $TOTAL_TOKENS"
 
@@ -663,6 +684,24 @@ jobs:
           echo "| Cache read | $CACHE_READ |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Cache creation | $CACHE_CREATION |" >> "$GITHUB_STEP_SUMMARY"
           echo "| **Total** | **$TOTAL** |" >> "$GITHUB_STEP_SUMMARY"
+
+      # "Under the hood" — tally the tool actions Claude actually took this run
+      # (Read/Edit/Grep/Bash + network/exec breakdown), from its session transcript.
+      # Renders a table into the Actions run summary and appends a one-line footer to
+      # today's memory log so the record lives in git. Never fails the run.
+      - name: Under the hood (tool actions)
+        if: steps.work.outputs.mode != '' && steps.run.outcome == 'success' && steps.run.outputs.SESSION_ID != ''
+        env:
+          SESSION_ID: ${{ steps.run.outputs.SESSION_ID }}
+          SKILL_NAME: ${{ steps.skill.outputs.name }}
+        run: |
+          bash scripts/run-actions-summary.sh --md "" "$SESSION_ID" >> "$GITHUB_STEP_SUMMARY" || true
+          LINE=$(bash scripts/run-actions-summary.sh --line "" "$SESSION_ID" || true)
+          if [ -n "$LINE" ]; then
+            echo "::notice::$LINE"
+            TODAY=$(date -u +%Y-%m-%d); mkdir -p memory/logs
+            printf '\n### %s — under the hood\n- %s\n' "$SKILL_NAME" "$LINE" >> "memory/logs/${TODAY}.md"
+          fi
 
       - name: Track token costs
         if: steps.work.outputs.mode != '' && steps.run.outcome == 'success'

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -40,6 +40,10 @@ jobs:
         run: python3 scripts/tests/test_prune_skills.py
       - name: capability mode tests
         run: bash scripts/tests/test_skill_mode.sh
+      - name: per-skill requires parse tests
+        run: bash scripts/tests/test_skill_requires.sh
+      - name: run actions summary tests
+        run: bash scripts/tests/test_run_actions_summary.sh
       - name: skill-pack manifest validation tests
         run: bash scripts/tests/test_validate_pack.sh
       - name: grok harness runner tests

--- a/scripts/run-actions-summary.sh
+++ b/scripts/run-actions-summary.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# run-actions-summary — "what happened under the hood" for one skill run.
+#
+# Reads Claude Code's session transcript (JSONL) and tallies the tool calls the
+# agent actually made — Read/Edit/Write/Grep/WebFetch/Bash/… — plus a second-level
+# breakdown of Bash by the real command (curl, git, gh, jq, python…). Non-invasive:
+# it parses the transcript AFTER the run; it never touches the run itself.
+#
+# Usage:
+#   run-actions-summary.sh [--md|--line] [transcript.jsonl] [session_id]
+#     --line  one compact line (default; good for a notify footer / log)
+#     --md    a Markdown block (good for $GITHUB_STEP_SUMMARY)
+#   With no path, locates the transcript by SESSION_ID (arg or env), else the newest.
+#
+# Emits nothing (exit 0) when no transcript is found — a missing summary must never
+# fail a run.
+set -euo pipefail
+
+FMT=line
+case "${1:-}" in --md) FMT=md; shift;; --line) FMT=line; shift;; esac
+TX="${1:-}"
+SID="${2:-${SESSION_ID:-}}"
+
+# Resolve the transcript: explicit path → by session id → newest under ~/.claude.
+if [ -z "$TX" ]; then
+  if [ -n "$SID" ]; then
+    TX=$(ls -t "$HOME"/.claude/projects/*/"$SID".jsonl 2>/dev/null | head -1 || true)
+  fi
+  [ -z "$TX" ] && TX=$(ls -t "$HOME"/.claude/projects/*/*.jsonl 2>/dev/null | head -1 || true)
+fi
+[ -n "$TX" ] && [ -f "$TX" ] || { echo "run-actions-summary: no transcript found" >&2; exit 0; }
+
+# Every tool_use, one per line, as "<name>\t<command-or-empty>".
+# Tolerate both .message.content (current) and a bare .content wrapper.
+records() {
+  jq -rc '
+    (.message.content? // .content? // empty) as $c
+    | select((.type=="assistant") or (.message.role?=="assistant"))
+    | ($c[]? | select(.type=="tool_use"))
+    | [ .name, (.input.command // "") ] | @tsv
+  ' "$TX" 2>/dev/null || true
+}
+
+TOTAL=$(records | wc -l | tr -d ' ')
+[ "$TOTAL" -eq 0 ] && { echo "run-actions-summary: 0 tool calls" >&2; exit 0; }
+
+# Level 1 — by tool name.
+TOOLS=$(records | cut -f1 | sort | uniq -c | sort -rn)
+
+# Level 2 — "actions of note": scan every Bash command's text for a curated set of
+# side-effecting / exec commands and count how many commands invoke each. Occurrence-
+# based (not first-token) so it's robust to `cd … &&`, env prefixes, pipes and
+# multi-line commands — and it surfaces exactly the network/exec/write actions the
+# run's blast radius is about (what did it curl, push, install, delete). Plumbing
+# (echo/cat/jq/grep/…) is deliberately ignored.
+BASHTXT=$(records | awk -F'\t' '$1=="Bash"{print $2}')
+bash_hits() {  # <regex> — count Bash commands whose text matches
+  printf '%s\n' "$BASHTXT" | grep -cE "$1" || true
+}
+NOTE=""
+add_note() { [ "$2" -gt 0 ] && NOTE="${NOTE}${2}× ${1}, "; return 0; }  # return 0: never trip set -e
+add_note "curl/wget"   "$(bash_hits '(^|[^[:alnum:]_])(curl|wget)([^[:alnum:]_]|$)')"
+add_note "gh"          "$(bash_hits '(^|[^[:alnum:]_])gh[[:space:]]')"
+add_note "git"         "$(bash_hits '(^|[^[:alnum:]_])git[[:space:]]')"
+add_note "python"      "$(bash_hits '(^|[^[:alnum:]_])python3?([^[:alnum:]_]|$)')"
+add_note "node/npm"    "$(bash_hits '(^|[^[:alnum:]_])(node|npm|npx)([^[:alnum:]_]|$)')"
+add_note "pip/install" "$(bash_hits '(pip[0-9]?[[:space:]]+install|[[:space:]]install[[:space:]]|curl[^|]*\|[[:space:]]*sh)')"
+add_note "rm"          "$(bash_hits '(^|[^[:alnum:]_])rm[[:space:]]')"
+NOTE="${NOTE%, }"
+
+fmt_inline() { awk '{printf "%d× %s, ", $1, $2}' | sed 's/, $//'; }
+
+if [ "$FMT" = md ]; then
+  echo "## 🔧 Under the hood — ${TOTAL} tool calls"
+  echo ""
+  echo "| Tool | Calls |"
+  echo "|------|------:|"
+  echo "$TOOLS" | awk '{printf "| %s | %d |\n", $2, $1}'
+  if [ -n "$NOTE" ]; then
+    echo ""
+    echo "**Network/exec actions:** $NOTE"
+  fi
+else
+  LINE=$(echo "$TOOLS" | fmt_inline)
+  printf '🔧 %d tool calls — %s' "$TOTAL" "$LINE"
+  [ -n "$NOTE" ] && printf '  ·  actions: %s' "$NOTE"
+  printf '\n'
+fi

--- a/scripts/skill_requires.sh
+++ b/scripts/skill_requires.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# skill_requires — the API-key names a skill declares in its `requires:` frontmatter,
+# one per line, with the `?` "works-better" marker stripped. Both tiers are returned
+# (bare = required, `?` = optional/works-better); the caller injects whichever secret
+# actually exists. This is the allowlist for per-skill, least-privilege secret env:
+# a skill sees ONLY the keys it declares here — nothing else from the secret store.
+#
+# Format parsed (matches bin/generate-skills-json):
+#   requires: [COINGECKO_API_KEY?, ALCHEMY_API_KEY?, BASE_RPC_URL?]
+#
+# Usage: skill_requires.sh <skill-name>
+set -euo pipefail
+f="skills/${1:?skill name required}/SKILL.md"
+[ -f "$f" ] || exit 0
+awk '/^---$/{n++; next} n==1 && /^requires:[[:space:]]*\[/{
+       sub(/^requires:[[:space:]]*\[/,""); sub(/\].*/,"");
+       gsub(/[[:space:]]/,""); print; exit
+     }' "$f" \
+  | tr ',' '\n' | sed 's/?[[:space:]]*$//' \
+  | grep -E '^[A-Z][A-Z0-9_]{2,}$' || true

--- a/scripts/tests/test_run_actions_summary.sh
+++ b/scripts/tests/test_run_actions_summary.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Tests for scripts/run-actions-summary.sh. Run: bash scripts/tests/test_run_actions_summary.sh
+# Verifies tool tallying + network/exec breakdown against a synthetic transcript,
+# and that a missing/empty transcript no-ops (exit 0) rather than failing a run.
+set -uo pipefail
+cd "$(dirname "$0")/../.." || exit 1
+S="scripts/run-actions-summary.sh"
+fail=0
+pass() { echo "ok   - $1"; }
+bad()  { echo "FAIL - $1"; fail=1; }
+
+TX="$(mktemp)"; trap 'rm -f "$TX"' EXIT
+# Synthetic Claude Code transcript: assistant messages carrying tool_use blocks.
+au() { printf '{"type":"assistant","message":{"role":"assistant","content":[%s]}}\n' "$1" >> "$TX"; }
+au '{"type":"tool_use","name":"Read","input":{"file_path":"a"}}'
+au '{"type":"tool_use","name":"Read","input":{"file_path":"b"}},{"type":"tool_use","name":"Grep","input":{"pattern":"x"}}'
+au '{"type":"tool_use","name":"Bash","input":{"command":"cd /r && curl -s https://api.example.com"}}'
+au '{"type":"tool_use","name":"Bash","input":{"command":"gh pr create --title t"}}'
+au '{"type":"tool_use","name":"Bash","input":{"command":"echo hello"}}'
+printf '{"type":"user","message":{"role":"user","content":[{"type":"tool_result"}]}}\n' >> "$TX"
+
+LINE=$(bash "$S" --line "$TX")
+echo "$LINE" | grep -q "6 tool calls" && pass "counts total tool calls (6)" || bad "counts total tool calls (got: $LINE)"
+echo "$LINE" | grep -q "2× Read"      && pass "tallies Read×2"                || bad "tallies Read×2 (got: $LINE)"
+echo "$LINE" | grep -q "3× Bash"      && pass "tallies Bash×3"                || bad "tallies Bash×3 (got: $LINE)"
+echo "$LINE" | grep -q "curl"         && pass "flags curl network action"    || bad "flags curl network action (got: $LINE)"
+echo "$LINE" | grep -q "gh"           && pass "flags gh action"              || bad "flags gh action (got: $LINE)"
+
+MD=$(bash "$S" --md "$TX")
+echo "$MD" | grep -q "Under the hood" && pass "md form has header" || bad "md form has header"
+echo "$MD" | grep -qi "Network/exec"  && pass "md form has actions line" || bad "md form has actions line"
+
+# safety: missing transcript no-ops, exit 0
+bash "$S" --line "/no/such/file.jsonl-$$" >/dev/null 2>&1; rc=$?
+[ "$rc" -eq 0 ] && pass "missing transcript → exit 0 (never fails a run)" || bad "missing transcript → exit 0 (got rc=$rc)"
+
+[ "$fail" -eq 0 ] && echo "PASS test_run_actions_summary" || { echo "FAILURES in test_run_actions_summary"; exit 1; }

--- a/scripts/tests/test_skill_requires.sh
+++ b/scripts/tests/test_skill_requires.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Tests for scripts/skill_requires.sh. Run: bash scripts/tests/test_skill_requires.sh
+# Verifies the per-skill secret allowlist parse: both required and `?` works-better
+# keys are returned, `?` stripped, junk/non-secret refs excluded, missing → empty.
+set -uo pipefail
+cd "$(dirname "$0")/../.." || exit 1
+S="scripts/skill_requires.sh"
+fail=0
+pass() { echo "ok   - $1"; }
+bad()  { echo "FAIL - $1"; fail=1; }
+
+mk() { mkdir -p "skills/$1"; printf '%s\n' "---" "name: $1" "${2:-}" "---" "body" > "skills/$1/SKILL.md"; }
+BOTH="zzz-test-req-both-$$"; NONE="zzz-test-req-none-$$"; EMPTY="zzz-test-req-empty-$$"
+cleanup() { rm -rf "skills/$BOTH" "skills/$NONE" "skills/$EMPTY"; }
+trap cleanup EXIT
+
+mk "$BOTH"  "requires: [COINGECKO_API_KEY?, ALCHEMY_API_KEY?, GH_GLOBAL]"   # mix of ? and bare
+mk "$NONE"  ""                                                              # no requires: line
+mk "$EMPTY" "requires: []"                                                  # empty list
+
+# both tiers returned, `?` stripped, order preserved
+OUT=$(bash "$S" "$BOTH" | tr '\n' ' ')
+[ "$OUT" = "COINGECKO_API_KEY ALCHEMY_API_KEY GH_GLOBAL " ] \
+  && pass "returns required + works-better keys, ? stripped" \
+  || bad "returns required + works-better keys (got: '$OUT')"
+
+# no requires: → no output
+[ -z "$(bash "$S" "$NONE")" ] && pass "no requires: yields nothing" || bad "no requires: yields nothing"
+# empty list → no output
+[ -z "$(bash "$S" "$EMPTY")" ] && pass "empty requires: yields nothing" || bad "empty requires: yields nothing"
+# missing skill → no output, exit 0
+OUT=$(bash "$S" "nonexistent-skill-xyz-$$"); rc=$?
+[ -z "$OUT" ] && [ "$rc" -eq 0 ] && pass "missing skill → empty, exit 0" || bad "missing skill → empty, exit 0"
+
+# every emitted token is a valid SHELL-SAFE secret name (no lowercase, spaces, brackets)
+if bash "$S" "$BOTH" | grep -qvE '^[A-Z][A-Z0-9_]+$'; then bad "all tokens are valid secret names"; else pass "all tokens are valid secret names"; fi
+
+[ "$fail" -eq 0 ] && echo "PASS test_skill_requires" || { echo "FAILURES in test_skill_requires"; exit 1; }


### PR DESCRIPTION
## What

Two additive changes, both **inert until a follow-up shrinks the static `env:` block** — safe to land and observe on real runs first.

### 1. Per-skill least-privilege secrets
- `scripts/skill_requires.sh` — parses a skill's `requires:` frontmatter (both required and `?` works-better tiers, `?` stripped) into the exact key allowlist for that skill.
- The `Run` step now resolves **only those keys** from `ALL_SECRETS` into the agent env (same shape as the existing MCP-secret loop), then unsets the blob. A skill sees nothing else from the secret store.
- **Gap audit across all 59 skills: zero real gaps** — every API secret a skill actually uses is already declared in its `requires:`. So shrinking the broad env next won't break any skill.

Proven locally (simulated secret store): `token-movers` receives only `COINGECKO_API_KEY`/`ALCHEMY_API_KEY` and does **not** see an undeclared `BANKR_API_KEY` in the store.

### 2. "Under the hood" run summary
- `scripts/run-actions-summary.sh` — reads the run's session transcript and tallies tool calls (Read/Edit/Grep/Bash…) plus a curated **network/exec breakdown** (curl/gh/git/python/installs/rm).
- New workflow step renders it into the Actions run summary and appends a one-line footer to `memory/logs/`. `SESSION_ID` is exported from the run envelope to locate the transcript. No-ops on the grok harness or a missing transcript; **never fails a run**.

## Tests
`scripts/tests/test_skill_requires.sh` + `scripts/tests/test_run_actions_summary.sh`, wired into `ci-tests.yml`. Both green locally.

## Follow-up (separate PR, deliberately not here)
Shrink the static `env:` block to infra-only + delete the prefetch/postprocess airlock (keep the email/money postprocess as the on-success gate). That flip is what *activates* the isolation; keeping it separate makes each step diagnosable.