### PR TITLE
fix(coingecko): use demo API-key header (free keys were 400'ing)

### DIFF
--- a/skills/defi-overview/SKILL.md
+++ b/skills/defi-overview/SKILL.md
@@ -145,16 +145,16 @@ curl -fsS "https://yields.llama.fi/pools"                         > .tmp/pools.j
 # --- CoinGecko (macro majors, breadth, global, trending) ---
 # Simple price for BTC, ETH, SOL + 24h change + mcap
 curl -s "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin,ethereum,solana&vs_currencies=usd&include_24hr_change=true&include_market_cap=true" \
-  ${COINGECKO_API_KEY:+-H "x-cg-pro-api-key: $COINGECKO_API_KEY"}  > .tmp/cg_price.json
+  ${COINGECKO_API_KEY:+-H "x-cg-demo-api-key: $COINGECKO_API_KEY"}  > .tmp/cg_price.json
 # Top 20 by mcap (movers + trend, 24h & 7d)
 curl -s "https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&order=market_cap_desc&per_page=20&page=1&sparkline=false&price_change_percentage=24h,7d" \
-  ${COINGECKO_API_KEY:+-H "x-cg-pro-api-key: $COINGECKO_API_KEY"}  > .tmp/cg_markets.json
+  ${COINGECKO_API_KEY:+-H "x-cg-demo-api-key: $COINGECKO_API_KEY"}  > .tmp/cg_markets.json
 # Global stats (total mcap, volume, dominance)
 curl -s "https://api.coingecko.com/api/v3/global" \
-  ${COINGECKO_API_KEY:+-H "x-cg-pro-api-key: $COINGECKO_API_KEY"}  > .tmp/cg_global.json
+  ${COINGECKO_API_KEY:+-H "x-cg-demo-api-key: $COINGECKO_API_KEY"}  > .tmp/cg_global.json
 # Trending coins
 curl -s "https://api.coingecko.com/api/v3/search/trending" \
-  ${COINGECKO_API_KEY:+-H "x-cg-pro-api-key: $COINGECKO_API_KEY"}  > .tmp/cg_trending.json
+  ${COINGECKO_API_KEY:+-H "x-cg-demo-api-key: $COINGECKO_API_KEY"}  > .tmp/cg_trending.json
 
 # --- Fear & Greed ---
 curl -s "https://api.alternative.me/fng/?limit=2"                > .tmp/fng.json

--- a/skills/picks-tracker/SKILL.md
+++ b/skills/picks-tracker/SKILL.md
@@ -47,13 +47,13 @@ For each unique token symbol, fetch the current price from CoinGecko.
 First, try the search endpoint to get the coin ID:
 ```bash
 curl -s "https://api.coingecko.com/api/v3/search?query=SYMBOL" \
-  ${COINGECKO_API_KEY:+-H "x-cg-pro-api-key: $COINGECKO_API_KEY"}
+  ${COINGECKO_API_KEY:+-H "x-cg-demo-api-key: $COINGECKO_API_KEY"}
 ```
 
 Then fetch the price:
 ```bash
 curl -s "https://api.coingecko.com/api/v3/simple/price?ids=COIN_ID&vs_currencies=usd&include_24hr_change=true" \
-  ${COINGECKO_API_KEY:+-H "x-cg-pro-api-key: $COINGECKO_API_KEY"}
+  ${COINGECKO_API_KEY:+-H "x-cg-demo-api-key: $COINGECKO_API_KEY"}
 ```
 
 **Fallback:** If curl fails, use WebFetch for the same URL (drop the API key header).

--- a/skills/token-movers/SKILL.md
+++ b/skills/token-movers/SKILL.md
@@ -56,13 +56,18 @@ Produce an **actionable** movers report. Plain % change lists are noise — the 
 Fetch market data and trending coins in parallel. Request multi-timeframe changes for context:
 
 ```bash
+# CoinGecko auth: a free/Demo key (the common case) authenticates on
+# api.coingecko.com with the `x-cg-demo-api-key` header — send it only when a key
+# is set; without one the same public endpoint still works at a lower rate limit.
+# (A paid Pro key instead uses pro-api.coingecko.com with `x-cg-pro-api-key`.)
+
 # Top 250 coins by market cap with 1h, 24h, and 7d % change
 curl -s "https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&order=market_cap_desc&per_page=250&page=1&sparkline=false&price_change_percentage=1h,24h,7d" \
-  ${COINGECKO_API_KEY:+-H "x-cg-pro-api-key: $COINGECKO_API_KEY"}
+  ${COINGECKO_API_KEY:+-H "x-cg-demo-api-key: $COINGECKO_API_KEY"}
 
 # Trending searches (top coins people are searching for)
 curl -s "https://api.coingecko.com/api/v3/search/trending" \
-  ${COINGECKO_API_KEY:+-H "x-cg-pro-api-key: $COINGECKO_API_KEY"}
+  ${COINGECKO_API_KEY:+-H "x-cg-demo-api-key: $COINGECKO_API_KEY"}
 ```
 
 If curl fails or returns empty JSON, retry once with **WebFetch** against the same URL.

--- a/skills/token-pick/SKILL.md
+++ b/skills/token-pick/SKILL.md
@@ -27,11 +27,11 @@ Produce ONE token call and ONE prediction-market call per day, each with a numer
 ```bash
 # Trending coins
 curl -s "https://api.coingecko.com/api/v3/search/trending" \
-  ${COINGECKO_API_KEY:+-H "x-cg-pro-api-key: $COINGECKO_API_KEY"}
+  ${COINGECKO_API_KEY:+-H "x-cg-demo-api-key: $COINGECKO_API_KEY"}
 
 # Top 250 by market cap with 24h and 7d changes
 curl -s "https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&order=market_cap_desc&per_page=250&page=1&sparkline=false&price_change_percentage=24h,7d" \
-  ${COINGECKO_API_KEY:+-H "x-cg-pro-api-key: $COINGECKO_API_KEY"}
+  ${COINGECKO_API_KEY:+-H "x-cg-demo-api-key: $COINGECKO_API_KEY"}
 
 # BTC + ETH 24h/7d for relative-strength benchmark (extract from the markets call above; no extra request needed)
 


### PR DESCRIPTION
The 4 CoinGecko skills sent `COINGECKO_API_KEY` as `x-cg-pro-api-key` against the demo host `api.coingecko.com` — a free/Demo key **400s** there, silently forcing the keyless WebFetch fallback. Verified against a real demo key: `x-cg-demo-api-key` → **200 + live data**, `x-cg-pro-api-key` → **400**. Switches `token-movers`, `defi-overview`, `picks-tracker`, `token-pick` to the correct header.