### PR TITLE
feat(secrets): shrink static env → activate per-skill key injection

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -343,12 +343,13 @@ jobs:
           NOTIFY_EMAIL_TO: ${{ secrets.NOTIFY_EMAIL_TO }}
           NOTIFY_EMAIL_FROM: ${{ vars.NOTIFY_EMAIL_FROM || 'aeon@notifications.aeon.bot' }}
           NOTIFY_EMAIL_SUBJECT_PREFIX: ${{ vars.NOTIFY_EMAIL_SUBJECT_PREFIX || '[Aeon]' }}
-          XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
           GROK_CREDENTIALS: ${{ secrets.GROK_CREDENTIALS }}
-          COINGECKO_API_KEY: ${{ secrets.COINGECKO_API_KEY }}
-          ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
-          BANKR_API_KEY: ${{ secrets.BANKR_API_KEY }}
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          # Per-skill least privilege: skill-facing API keys are NO LONGER injected
+          # statically for every skill. Each skill now receives ONLY the keys it
+          # declares in its `requires:` frontmatter — resolved from ALL_SECRETS in the
+          # Run step below (see the "Injected declared secrets" loop). Removed from the
+          # shared env: XAI_API_KEY, COINGECKO_API_KEY, ALCHEMY_API_KEY, BANKR_API_KEY,
+          # VERCEL_TOKEN. Model-gateway / GITHUB_TOKEN / GROK / LANGFUSE stay (infra).
           BEAMR_GATEWAY_URL: ${{ secrets.BEAMR_GATEWAY_URL }}
           BEAMR_PAYER_KEY: ${{ secrets.BEAMR_PAYER_KEY }}
           BEAMR_NETWORK: ${{ vars.BEAMR_NETWORK }}


### PR DESCRIPTION
Follow-up to #682. Removes the 5 skill-facing keys (`XAI_API_KEY`, `COINGECKO_API_KEY`, `ALCHEMY_API_KEY`, `BANKR_API_KEY`, `VERCEL_TOKEN`) from the Run step's shared `env:`. Each is declared in its skills' `requires:`, so it now flows through the per-skill injection loop — a skill sees **only** the keys it declares. Infra (model routing, GITHUB_TOKEN, GROK, LANGFUSE) stays; the keys remain in the prefetch/analyze/postprocess steps that need them. Gap audit (#682) already confirmed zero skills reference an undeclared key.