### PR TITLE
Community skill pack listing: AgentLink (techdigger/aeon-skill-pack-agentlink)

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -603,6 +603,7 @@ Either way the installer reads the pack's `skills-pack.json` manifest, runs the 
 | [clawhunter-skills](https://github.com/clawhunter/clawhunter-skills) | 2 | Aggregates and AI-triages crypto bounties across venues (Pump Fun GO, Atelier, EarnFi, tiny.place) and matches each to your agent with a plan to win — plus paid research and create tools (voice tones, logo-grounded images, Kling video direction, web + X research). Paid tools settle via x402 (USDC on Solana or Base). |
 | [Polymarket Trader by Simmer](https://github.com/SpartanLabsXyz/aeon-skill-pack-polymarket/tree/main/aeon-skill-pack) (`--path aeon-skill-pack`) | 3 | Signal, discovery, and real position-taking on **Polymarket** - the deepest prediction-market venue - powered by Simmer. Unlike monitor-only packs, polymarket-trade places actual orders (simulate-by-default, live opt-in, bounded) |
 | [Charon for AEON](https://github.com/CharonAI-code/charon/tree/main/skills/aeon) (`--path skills/aeon`) | 2 | Repo-local policy enforcement for AEON runs, with guided setup and natural-language policy management |
+| [aeon-skill-pack-agentlink](https://github.com/techdigger/aeon-skill-pack-agentlink) | 1 | Give an agent a verified, human-backed on-chain identity on Base via AgentLink - checks link status, hands the human owner a linker URL to biomap + sign, then signs requests to free partner endpoints (XONA, WURK). Read-only, on-demand. |
 
 **To list a pack here**, open a PR adding a row. Guidelines:
 

--- a/catalog/skill-packs.json
+++ b/catalog/skill-packs.json
@@ -176,6 +176,27 @@
         "external_api",
         "writes_external_host"
       ]
+    },
+    {
+      "repo": "techdigger/aeon-skill-pack-agentlink",
+      "name": "AgentLink",
+      "description": "Give an aeon agent a verified, human-backed on-chain identity on Base via AgentLink — check link status, hand the owner a linker URL, then sign requests to free partner endpoints (XONA, WURK).",
+      "author": "techdigger",
+      "license": "MIT",
+      "homepage": "https://agentlink.id",
+      "category": "crypto",
+      "trust_level": "community",
+      "skills": [
+        "agentlink"
+      ],
+      "secrets_required": [
+        "AGENT_PRIVATE_KEY"
+      ],
+      "capabilities": [
+        "read_only",
+        "external_api",
+        "sends_notifications"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## What

List the **AgentLink** community skill pack in the registry — one row in the Community Skill Packs table (`.github/README.md`) and a matching entry in `catalog/skill-packs.json`.

## Why

[AgentLink](https://agentlink.id) gives an aeon agent a verified, human-backed on-chain identity on Base: the agent is linked to a biomapped human owner (proving a real, unique human without revealing who), appears in the on-chain `BiomapperAgentRegistry`, and can sign requests to free partner endpoints. The pack packages the official AgentLink agent skill so any operator can install it with `bin/install-skill-pack techdigger/aeon-skill-pack-agentlink`.

## Type of change

- [x] Community skill pack listing

---

### Community skill pack listing

- [x] Pack repo is public with a clear license (MIT) — https://github.com/techdigger/aeon-skill-pack-agentlink
- [x] Pack has a `skills-pack.json` manifest at its root and a `SKILL.md` per skill
- [x] Write / onchain / bet skills are `default_enabled: false` (this skill is read-only and on-demand, and never submits an on-chain tx — the human owner signs the link)
- [x] This PR adds **both** a README table row and a matching `skill-packs.json` entry
- [x] No monkey-patching of Aeon internals; no private or auth-walled endpoints required to run

---

**Pack:** [`techdigger/aeon-skill-pack-agentlink`](https://github.com/techdigger/aeon-skill-pack-agentlink) — 1 skill (`agentlink`, category `crypto`, `mode: read-only`, `workflow_dispatch`).
**Capabilities:** `read_only`, `external_api`, `sends_notifications`.
**Secrets:** `AGENT_PRIVATE_KEY` (required), `AGENTLINK_OWNER_ADDRESS` (only to link).
**Validated locally:** `bash scripts/validate-pack.sh <pack>` → valid, 0 warnings; `bin/install-skill-pack --list` renders the new entry with the right caps/secret badges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
