### PR TITLE
fix(vuln-scanner): make the scan arm functional (allowlist grant + tool-staging step)

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -272,6 +272,17 @@ jobs:
             echo "::warning::could not materialize cron-state from the Issue; readers use the committed file"
           fi
 
+      - name: Stage vuln-scanner tools
+        # Purpose-built binary staging for vuln-scanner's scan arm — NOT a network
+        # workaround (there is no network sandbox). Installs semgrep/trufflehog/
+        # osv-scanner/slither and appends /tmp/bin to the PATH file so the scanner
+        # bare-names resolve in the later claude -p step and its per-call fresh shells
+        # (an in-run `export PATH` doesn't survive between Claude's Bash calls).
+        # Execution is separately gated by the write-tier grant in scripts/skill_mode.sh.
+        # Best-effort: the script self-guards to vuln-scanner and never fails the run.
+        if: steps.work.outputs.mode != '' && steps.skill.outputs.name == 'vuln-scanner'
+        run: bash scripts/stage-vuln-scanner.sh "${{ steps.skill.outputs.name }}"
+
       - name: Run
         id: run
         if: steps.work.outputs.mode != ''

--- a/scripts/skill_mode.sh
+++ b/scripts/skill_mode.sh
@@ -40,6 +40,13 @@ BASE_TOOLS="$BASE_TOOLS,Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(sort:*),Bash(g
 # Write tier additionally gets repo-mutation tools + python (an interpreter is itself
 # a write vector, so it stays out of the read-only base; skills' python helpers run here).
 WRITE_TOOLS="Write,Edit,Bash(gh:*),Bash(git:*),Bash(python3:*),Bash(python:*)"
+# Security-scanner bare-names for vuln-scanner (Arm A). The skill stages these in-run
+# (`python3 -m pip install` for semgrep/slither, `curl -o … && chmod +x` for the Go
+# binaries) and invokes them by bare name. Without this grant `claude -p` denies the
+# invocation ("requires approval") and the scan arm silently degrades to manual review —
+# a live-test showed the run logging that denial as "Blocked by sandbox". These are
+# read-only static-analysis tools (no repo/network mutation of their own).
+WRITE_TOOLS="$WRITE_TOOLS,Bash(semgrep:*),Bash(osv-scanner:*),Bash(trufflehog:*),Bash(slither:*)"
 
 resolve_mode() {
   local skill="$1" f="skills/$1/SKILL.md" m=""
@@ -97,7 +104,7 @@ write_tools() { echo "$BASE_TOOLS,$WRITE_TOOLS"; }
 # Bash command globs allowed on every tier (mirror BASE_TOOLS' Bash(...:*) set).
 GROK_BASE_BASH="curl jq ./notify ./notify-jsonrender mkdir ls cat chmod date echo node npm npx head tail wc sort grep"
 # Additional Bash command globs for the write tier (mirror WRITE_TOOLS).
-GROK_WRITE_BASH="gh git python3 python"
+GROK_WRITE_BASH="gh git python3 python semgrep osv-scanner trufflehog slither"
 
 grok_args() {
   local mode="$1"

--- a/scripts/stage-vuln-scanner.sh
+++ b/scripts/stage-vuln-scanner.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Stage the vuln-scanner skill's scanner binaries in the WORKFLOW step, before
+# `claude -p` starts. This is purpose-built binary staging — NOT a network
+# workaround (there is no network sandbox; `curl` reaches the network fine).
+#
+# Two real reasons this belongs in a workflow step rather than in-run:
+#
+#   1. PATH persistence. Claude runs each Bash tool call in a FRESH shell, so an
+#      in-run `export PATH=/tmp/bin:$PATH` is gone by the next call — leaving
+#      /tmp/bin-only binaries (trufflehog, osv-scanner) unresolvable by bare
+#      name. Only a workflow step can append to $GITHUB_PATH, which makes
+#      /tmp/bin part of PATH for every SUBSEQUENT step — including `claude -p`
+#      and all the Bash subprocesses it spawns — so bare names resolve.
+#      (semgrep/slither dodge this only because pip puts them on the global PATH.)
+#   2. Install vectors. `pip` (bare) and `curl | sh` aren't on the `claude -p`
+#      --allowedTools allowlist, so installing here (full capability, no
+#      allowlist) is simplest. `python3 -m pip` / `curl -o` ARE allowlisted, so
+#      the skill keeps an in-run install as a fallback when this step is absent.
+#
+# EXECUTION of the staged tools is a separate concern, gated by the write-tier
+# grant in scripts/skill_mode.sh (Bash(semgrep:*) etc.). Both halves are needed:
+# staged + on PATH here, allowlisted there.
+#
+# No-ops for every skill except vuln-scanner. Best-effort: a tool that fails to
+# install is recorded `fail` and left for the skill to skip via its `command -v`
+# guard; a non-zero exit is non-fatal (the workflow step does not gate the run).
+set -uo pipefail
+
+SKILL="${1:-}"
+[ "$SKILL" = "vuln-scanner" ] || exit 0
+
+BIN=/tmp/bin
+mkdir -p "$BIN" /tmp/vuln-scan
+MANIFEST=/tmp/vuln-scan/prefetch.txt
+: > "$MANIFEST"
+
+# Make /tmp/bin resolvable by bare name in every later step (see reason #1 above).
+# Guarded so it no-ops outside GitHub Actions.
+[ -n "${GITHUB_PATH:-}" ] && echo "$BIN" >> "$GITHUB_PATH"
+
+log()    { echo "stage-vuln-scanner: $*"; }
+record() { echo "$1=$2" >> "$MANIFEST"; }   # tool=installed|fail|skipped
+
+pip_install() { # package
+  pip install --quiet "$1" 2>/dev/null \
+    || pip3 install --quiet "$1" 2>/dev/null \
+    || pip install --quiet --user "$1" 2>/dev/null \
+    || pip3 install --quiet --user "$1" 2>/dev/null
+}
+
+# --- Semgrep (SAST). Skill calls it bare, so it must be on PATH; symlink into
+#     /tmp/bin as belt-and-suspenders in case pip's bin dir isn't on PATH. ---
+if command -v semgrep >/dev/null 2>&1; then
+  log "semgrep already present ($(command -v semgrep))"
+  record semgrep installed
+elif pip_install semgrep && command -v semgrep >/dev/null 2>&1; then
+  ln -sf "$(command -v semgrep)" "$BIN/semgrep" 2>/dev/null || true
+  log "semgrep installed ($(semgrep --version 2>/dev/null | head -1))"
+  record semgrep installed
+else
+  log "WARN semgrep install failed"
+  record semgrep fail
+fi
+
+# --- TruffleHog (verified-secret scan) -> /tmp/bin ---
+if curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh \
+     | sh -s -- -b "$BIN" >/dev/null 2>&1 && [ -x "$BIN/trufflehog" ]; then
+  log "trufflehog installed -> $BIN/trufflehog ($("$BIN/trufflehog" --version 2>&1 | head -1))"
+  record trufflehog installed
+else
+  log "WARN trufflehog install failed"
+  record trufflehog fail
+fi
+
+# --- osv-scanner (dependency CVEs). GHA hosted runners are linux/amd64. ---
+OSV_URL="https://github.com/google/osv-scanner/releases/latest/download/osv-scanner_linux_amd64"
+if curl -sSfL -o "$BIN/osv-scanner" "$OSV_URL" 2>/dev/null \
+     && chmod +x "$BIN/osv-scanner" \
+     && "$BIN/osv-scanner" --version >/dev/null 2>&1; then
+  log "osv-scanner installed -> $BIN/osv-scanner"
+  record osv-scanner installed
+else
+  log "WARN osv-scanner install failed"
+  record osv-scanner fail
+fi
+
+# --- Slither (Solidity SAST) — optional; only needed when the target has *.sol.
+#     Don't fail the staging if it can't install. ---
+if command -v slither >/dev/null 2>&1; then
+  ln -sf "$(command -v slither)" "$BIN/slither" 2>/dev/null || true
+  record slither installed
+elif pip_install slither-analyzer && command -v slither >/dev/null 2>&1; then
+  ln -sf "$(command -v slither)" "$BIN/slither" 2>/dev/null || true
+  log "slither installed ($(slither --version 2>/dev/null | head -1))"
+  record slither installed
+else
+  log "slither not installed (optional — only used for Solidity repos)"
+  record slither skipped
+fi
+
+log "manifest (/tmp/vuln-scan/prefetch.txt):"
+cat "$MANIFEST"


### PR DESCRIPTION
## Makes vuln-scanner's scan arm actually functional

A live-test (on the `aeon-sb` fork) surfaced that vuln-scanner's scan arm has been **silently non-functional** — every run fell back to manual code review. Two root causes, both fixed here, both cross-confirmed against the operator's working **`aeon-vuln`** instance (which arrived at the identical solution).

### 1. Allowlist grant — `scripts/skill_mode.sh`
The scanner bare-names (`semgrep` / `osv-scanner` / `trufflehog` / `slither`) were never in the write-tier allowlist, so `claude -p` **denied** them (`"requires approval"`) — and the model logged that denial as *"Blocked by sandbox"* (the myth, resurfacing at runtime). Adds them to `WRITE_TOOLS` + the `GROK_WRITE_BASH` mirror. Read-only tier untouched.

✅ **Validated on aeon-sb** (scanning `aaronjmars/minitor`): semgrep flipped from `fail — "Blocked by sandbox"` → **`semgrep=ok`**.

### 2. Tool staging — `scripts/stage-vuln-scanner.sh` + workflow step
The grant alone gets **semgrep** working (pip installs it onto the global PATH) but not `osv-scanner` / `trufflehog` — Go binaries staged into `/tmp/bin`, which don't resolve by bare name because Claude runs each Bash tool call in a **fresh shell** (the skill's `export PATH=/tmp/bin:$PATH` doesn't survive to the scan call). Only a workflow step can append `/tmp/bin` to `$GITHUB_PATH` and make it persist.

Adds a **purpose-built, vuln-scanner-only** step (`if: skill == 'vuln-scanner'`) that installs the four scanners and writes `$GITHUB_PATH`. This is binary **staging**, **not** a network workaround (there is no network sandbox) — so the generic `prefetch-*.sh` convention stays removed: it's one conditional step + one self-guarded script. Same mechanism proven in `aeon-vuln`.

⏳ **Validating on aeon-sb** with the full fix (allowlist + staging) → expecting `trufflehog=ok` + `osv=ok`; result will be posted as a comment.

## Files
- `scripts/skill_mode.sh` — write-tier grant (+ grok mirror)
- `scripts/stage-vuln-scanner.sh` — **new**; installs the 4 scanners + writes `$GITHUB_PATH`; self-guards to vuln-scanner; best-effort (never fails the run)
- `.github/workflows/aeon.yml` — conditional "Stage vuln-scanner tools" step before Run

No change to `skills/vuln-scanner/SKILL.md` — its in-run install stays as a fallback for runs without the step, and its prose is cleaned separately in #692. `test_skill_mode.sh` passes 22/22; `actionlint` clean.

**Capability note:** this widens the write-tier allowlist to four read-only static-analysis tools. Flagged for conscious review.
