### PR TITLE
docs: fix scheduler model, skill count, and stale MCP examples

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -175,7 +175,7 @@ skills:
     var: "solana"               # topic for this skill
 ```
 
-Standard cron format, all times UTC. Supports `*`, `*/N`, exact values, comma lists. **Order matters** - the scheduler picks the first matching skill, so put day-specific skills before daily ones and `heartbeat` last.
+Standard cron format, all times UTC. Supports `*`, `*/N`, exact values, comma lists. On each tick the scheduler dispatches **every** enabled skill whose cron is due, and multiple due skills run in parallel. The only thing that orders dispatch is `depends_on:` (a skill's dependencies fire first); `heartbeat` is listed last purely by convention.
 
 ### The `var` field
 
@@ -301,9 +301,8 @@ chains:
     schedule: "0 7 * * *"
     on_error: fail-fast       # or: continue
     steps:
-      - parallel: [token-movers, hn-digest]  # run concurrently
-      - skill: digest                          # runs after parallel group
-        consume: [token-movers, hn-digest]   # gets their outputs injected
+      - parallel: [token-movers, github-trending]   # run concurrently
+      - skill: digest, consume: [token-movers, github-trending]   # runs after; outputs injected
 ```
 
 Each step runs as a separate workflow dispatch; outputs are saved to `output/.chains/{skill}.md` and injected into downstream steps that `consume:` them. `fail-fast` aborts on any failure, `continue` keeps going.
@@ -321,7 +320,7 @@ reactive:
 
 ### Scheduler frequency
 
-Edit `.github/workflows/messages.yml`:
+Edit `.github/workflows/scheduler.yml`:
 
 ```yaml
 schedule:
@@ -670,7 +669,7 @@ docs/                    ← reference docs, community registries, adopter examp
     skill-templates/     ← templates for building your own skills
     mcp/                 ← MCP quickstart config + .mcp.json.example
 soul/                    ← optional identity files (SOUL.md, STYLE.md, examples/, data/)
-skills/                  ← each skill is a SKILL.md prompt file (68 total; `category:` = its pack)
+skills/                  ← each skill is a SKILL.md prompt file (59 total; `category:` = its pack)
 apps/                    ← standalone sub-projects, each with its own package.json
   dashboard/             ← local web UI (Next.js + json-render feed)
   cli/                   ← headless CLI (`./aeon <command>`) — the dashboard's features as commands

--- a/apps/dashboard/lib/constants.ts
+++ b/apps/dashboard/lib/constants.ts
@@ -109,7 +109,7 @@ export const CATEGORY_BY_KEY: Record<string, { label: string; color: string }> =
 // CATEGORIES list above, kept as one source of truth so the two can't drift.
 // A skill's pack comes from its `pack` field (joined from packs.json in
 // /api/skills); `lab` is the catch-all for uncategorized skills. Order drives the
-// dashboard's non-default pack order (Core + Basics render first via DEFAULT_VISIBLE_PACKS).
+// dashboard's non-default pack order (Core, Evolution + Basics render first via DEFAULT_VISIBLE_PACKS).
 const PACKS = CATEGORIES
 
 export const PACK_BY_KEY: Record<string, { label: string; color: string }> =
@@ -123,10 +123,10 @@ export const PACK_BY_KEY: Record<string, { label: string; color: string }> =
 export const FIRST_PARTY_KEYS = new Set(PACKS.map(p => p.key))
 
 // Packs shown by default on the dashboard and locked always-on (not hideable):
-// `core` (Aeon's differentiators — self-evolution, fleet, autonomous action) and
-// `basics` (simple, immediately-runnable skills). Every other first-party pack is
-// hidden until the operator reveals it. Purely a view preference — no effect on
-// what runs.
+// `core` (Aeon's differentiators — fleet, autonomous action), `evolution` (the
+// self-improvement loop), and `basics` (simple, immediately-runnable skills).
+// Every other first-party pack is hidden until the operator reveals it. Purely a
+// view preference — no effect on what runs.
 export const DEFAULT_VISIBLE_PACKS = new Set(['core', 'evolution', 'basics'])
 
 const COMMUNITY_COLOR = '#A1A1AA'

--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -19,7 +19,7 @@ bin/add-mcp --build-only       # compile without registering (useful for CI / Cl
 bin/add-mcp --uninstall        # remove the 'aeon' server from Claude Code
 ```
 
-`bin/add-mcp` checks Node, builds the TypeScript, and runs `claude mcp add aeon node <path>` so every skill is immediately available as an `aeon-*` tool in Claude Code. Restart your Claude session and ask: *"Use the aeon-hn-digest tool"* or *"Run aeon-token-movers with var=AEON"*.
+`bin/add-mcp` checks Node, builds the TypeScript, and runs `claude mcp add aeon node <path>` so every skill is immediately available as an `aeon-*` tool in Claude Code. Restart your Claude session and ask: *"Use the aeon-digest tool"* or *"Run aeon-token-movers with var=AEON"*.
 
 Or build this app directly:
 
@@ -42,7 +42,7 @@ Every entry in `skills.json` becomes one tool:
 
 | | |
 |---|---|
-| **Name** | `aeon-<slug>` — e.g. `aeon-deep-research`, `aeon-hn-digest`, `aeon-token-movers`. |
+| **Name** | `aeon-<slug>` — e.g. `aeon-digest`, `aeon-pr-review`, `aeon-token-movers`. |
 | **Description** | `[Aeon · <Category>] <skill description> (cron: <schedule>)` or `(on-demand)`, generated from the manifest so Claude can pick the right tool. |
 | **Input** | A single optional `var` (string) — the skill's `${var}` input. Its description is the skill's own `var` contract, or a sensible category default. Leave it empty to use the skill's default behaviour. |
 
@@ -79,11 +79,11 @@ Before wiring it into a client, confirm the server lists and runs tools with the
 ```bash
 bin/add-mcp --build-only                          # produce dist/index.js
 pip install mcp                                 # official Anthropic MCP client
-python docs/examples/mcp/test_connection.py          # lists every aeon-* tool, then calls aeon-cost-report
+python docs/examples/mcp/test_connection.py          # lists every aeon-* tool, then calls aeon-heartbeat
 python docs/examples/mcp/test_connection.py aeon-token-movers AEON   # call a specific tool with a var
 ```
 
-You should see the full `aeon-*` tool list followed by a real skill output. If that works, your Claude Desktop / Claude Code wiring will too. `aeon-cost-report` is the default because it's fast and needs no external API.
+You should see the full `aeon-*` tool list followed by a real skill output. If that works, your Claude Desktop / Claude Code wiring will too. `aeon-heartbeat` is the default because it's fast and needs no secrets.
 
 ## How it works
 

--- a/docs/CORE.md
+++ b/docs/CORE.md
@@ -37,7 +37,7 @@ That comment is why you can see it already ran across the library: `skill-repair
 
 ### [`skill-health`](../skills/skill-health/SKILL.md) — the detector · daily 18:00
 
-Audits every enabled skill from `cron-state.json` + per-run Haiku quality scores (`memory/skill-health/*.json`) + a `skill-runs` fallback for sandbox-blocked runs. Classifies each as CRITICAL / DEGRADED / FLAPPING / WARNING / HEALTHY / NO-DATA via first-matching-rule, computes a severity score, and detects **systemic patterns** (≥2 skills sharing an API host or error signature).
+Audits every enabled skill from `cron-state.json` + per-run Haiku quality scores (`memory/skill-health/*.json`) + a `skill-runs` fallback for runs that crashed before writing state. Classifies each as CRITICAL / DEGRADED / FLAPPING / WARNING / HEALTHY / NO-DATA via first-matching-rule, computes a severity score, and detects **systemic patterns** (≥2 skills sharing an API host or error signature).
 
 It files issues into `memory/issues/ISS-NNN.md`, resolves them when a skill recovers (drops it from `affected_skills`, flips status to resolved), and notifies only on state change. It won't touch the issue tracker unless the operator has opted in by creating `INDEX.md`.
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,10 +1,10 @@
 # Aeon integration examples
 
-Aeon ships an [MCP server](../apps/mcp-server/) so any Claude client can call its 90+ skills. The scripts here are the shortest possible "first call works" demos — build the server, run `python <file>`, get a real Aeon output back.
+Aeon ships an [MCP server](../apps/mcp-server/) so any Claude client can call its 59 skills. The scripts here are the shortest possible "first call works" demos — build the server, run `python <file>`, get a real Aeon output back.
 
 | File | Stack | Skill called | What it shows |
 |------|-------|--------------|---------------|
-| [`mcp/test_connection.py`](mcp/test_connection.py) | MCP (stdio) | `aeon-cost-report` (default) | List + invoke any `aeon-*` tool |
+| [`mcp/test_connection.py`](mcp/test_connection.py) | MCP (stdio) | `aeon-heartbeat` (default) | List + invoke any `aeon-*` tool |
 | [`mcp/claude_desktop_config.json`](mcp/claude_desktop_config.json) | Claude Desktop | — | Drop-in config snippet |
 
 ## MCP — verify the round-trip
@@ -15,15 +15,15 @@ pip install mcp                 # official Anthropic MCP client
 python docs/examples/mcp/test_connection.py
 ```
 
-You should see the full list of `aeon-*` tools followed by a real `aeon-cost-report` output. Once that works, hand `apps/mcp-server/dist/index.js` to Claude Code with `bin/add-mcp` (already done if you ran `bin/add-mcp` without `--build-only`) or to Claude Desktop using [`mcp/claude_desktop_config.json`](mcp/claude_desktop_config.json) — replace `/ABSOLUTE/PATH/TO/aeon` with your actual repo path.
+You should see the full list of `aeon-*` tools followed by a real `aeon-heartbeat` output. Once that works, hand `apps/mcp-server/dist/index.js` to Claude Code with `bin/add-mcp` (already done if you ran `bin/add-mcp` without `--build-only`) or to Claude Desktop using [`mcp/claude_desktop_config.json`](mcp/claude_desktop_config.json) — replace `/ABSOLUTE/PATH/TO/aeon` with your actual repo path.
 
 ## Picking a different skill
 
-`skills.json` at the repo root is the source of truth — every entry is callable as `aeon-<slug>` from MCP. Some good first calls:
+`catalog/skills.json` is the source of truth — every entry is callable as `aeon-<slug>` from MCP. Some good first calls:
 
-- `aeon-cost-report` — fast, no external API needed, safe to run anywhere
+- `aeon-heartbeat` — reads local fleet health, no secrets required, safe to run anywhere
 - `aeon-token-movers` (`var=AEON`) — public CoinGecko data, no secrets required
-- `aeon-deep-research` (`var="your topic"`) — long-running; expect 5–10 min
+- `aeon-article` (`var="your topic"`) — long-running; expect several minutes
 - `aeon-fetch-tweets` (`var="your topic"`) — needs `XAI_API_KEY` in the Aeon repo's environment
 
 Skills that hit external APIs need the same secrets the Aeon GitHub Actions runner uses. Drop them into a `.env` file at the Aeon repo root before you start the MCP server.

--- a/docs/examples/mcp/test_connection.py
+++ b/docs/examples/mcp/test_connection.py
@@ -5,7 +5,7 @@ Sanity-check the Aeon MCP server end-to-end.
 What it does:
   1. Spawns `node apps/mcp-server/dist/index.js` as a stdio MCP server.
   2. Sends `tools/list` and prints every aeon-* tool that is registered.
-  3. Calls one tool (default: `aeon-cost-report`, fast and offline-safe)
+  3. Calls one tool (default: `aeon-heartbeat`, fast and needs no secrets)
      so you can confirm the full request/response cycle works.
 
 Why a separate Python script: the MCP SDK ships the JSON-RPC framing,
@@ -82,6 +82,6 @@ async def main(tool_name: str, var_value: str) -> int:
 
 
 if __name__ == "__main__":
-    tool = sys.argv[1] if len(sys.argv) > 1 else "aeon-cost-report"
+    tool = sys.argv[1] if len(sys.argv) > 1 else "aeon-heartbeat"
     var = sys.argv[2] if len(sys.argv) > 2 else ""
     sys.exit(asyncio.run(main(tool, var)))

--- a/docs/telegram-commands.md
+++ b/docs/telegram-commands.md
@@ -37,8 +37,8 @@ populates and the message-field menu button points at it. Registration is automa
 Every path reads `TELEGRAM_BOT_TOKEN` server-side (where secrets are readable) and calls
 `setMyCommands` + `setChatMenuButton` — identical result, no browser token handling.
 
-Command names can only use `a-z`, `0-9`, `_` — so a skill dir `deep-research`
-becomes `/deep_research`. The router inverts `_`→`-` when it dispatches.
+Command names can only use `a-z`, `0-9`, `_` — so a skill dir `token-movers`
+becomes `/token_movers`. The router inverts `_`→`-` when it dispatches.
 
 - `/skillname [args]` dispatches the skill instantly (no Claude call). `args` become
   the skill's `var`, e.g. `/article quantum computing`.


### PR DESCRIPTION
Residual doc drift from recent refactors that didn't fully propagate (the code itself was already current — README already said 59 skills / 6 packs / Resend / no a2a-server).

## Fixes
- **Scheduler model** — README said it "picks the **first matching skill**" → it dispatches **every** enabled skill whose cron is due, in parallel (`scheduler.yml:161-179`, `aeon.yml:3`). Also "Scheduler frequency" edited `messages.yml` → `scheduler.yml`.
- **Skill count** — repo-layout tree said `68 total` → **59** (matches the rest of the README + `catalog/skills.json`).
- **Chains example** — used the two-line `skill:`/`consume:` form that `CLAUDE.md` warns silently drops `consume:` → one-line form; `hn-digest` (removed) → `github-trending`.
- **MCP examples** — referenced removed skills (`aeon-cost-report`, `aeon-deep-research`, `aeon-hn-digest`) and "skills.json at the repo root" → real skills + `catalog/skills.json`. `test_connection.py` default → `aeon-heartbeat` so the demo runs out of the box.
- **CORE.md** — "`skill-runs` fallback for **sandbox-blocked runs**" → "for runs that crashed before writing state" (no network sandbox; #692).
- **dashboard/lib/constants.ts** — comments said default-visible packs are "Core + Basics" → "Core, Evolution + Basics" (matches `DEFAULT_VISIBLE_PACKS`).

## Verification
`ci-okf` gate passes locally (`okf-validate: OK — 95 concepts`). Docs-only + one dashboard comment; no runtime changes.