### PR TITLE
fix(workflow): align model backstop with config default (opus-4-8 → sonnet-4-6)

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -370,7 +370,7 @@ jobs:
           elif [ -n "$SKILL_MODEL" ]; then
             MODEL="$SKILL_MODEL"
           else
-            MODEL="${CONFIG_MODEL:-claude-opus-4-8}"
+            MODEL="${CONFIG_MODEL:-claude-sonnet-4-6}"
           fi
 
           # --- Harness resolution (which agent CLI runs the skill) ---

--- a/.github/workflows/messages.yml
+++ b/.github/workflows/messages.yml
@@ -442,7 +442,7 @@ jobs:
         run: |
           TODAY=$(date -u +%Y-%m-%d)
           CONFIG_MODEL=$(grep -E '^model:' aeon.yml | sed 's/^model: *//' | tr -d ' ')
-          MODEL="${CONFIG_MODEL:-claude-opus-4-8}"
+          MODEL="${CONFIG_MODEL:-claude-sonnet-4-6}"
 
           # Harness resolution — inbound messaging isn't a per-skill run, so it
           # follows the repo's global `harness:` in aeon.yml (same default/guard as


### PR DESCRIPTION
The two execution-model fallbacks in the workflows returned an Opus id when `CONFIG_MODEL` failed to parse out of `aeon.yml`, diverging from both the `aeon.yml` default (`claude-sonnet-4-6`) and `apps/dashboard/lib/config.ts`'s absent-model default (also sonnet-4-6). This points them at `claude-sonnet-4-6` so the degraded-parse backstop matches the real default.

**Changed**
- `.github/workflows/aeon.yml:373`
- `.github/workflows/messages.yml:445`

Only fires on the degraded-parse path; normal runs already resolve `claude-sonnet-4-6` from config. Per-run health scorer + `notify-jsonrender` stay on Haiku (deliberate cheap tier); gateway tier maps and `config.test.ts` untouched. actionlint passes.