### PR TITLE
docs: refresh stale references across user-facing docs (catalog move + webhook secret)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -77,10 +77,15 @@ mcp: [base]
 
 A gateway is wired through **five files** — copy an entry of the same tier
 (*native*: speaks the Anthropic API; *sidecar*: OpenAI-compatible, bridged per
-run): `apps/dashboard/lib/types.ts`, `apps/dashboard/lib/auth-provider.mjs`,
-`apps/dashboard/app/api/secrets/route.ts`, `scripts/llm-gateway.sh`, and the
-workflow `env:`. Then add a row to the gateway table in the README and verify a
-run logs `gateway=auto resolved to <slug>`.
+run). `apps/dashboard/lib/gateway-registry.ts` is the **single source of truth**
+(it auto-flows into `lib/types.ts`, `lib/constants.ts`, the secrets route, and
+`lib/auth-provider.ts`), so the files you hand-edit are:
+`apps/dashboard/lib/gateway-registry.ts`, `apps/dashboard/components/AuthModal.tsx`,
+`apps/dashboard/lib/secrets-catalog.ts`, `scripts/llm-gateway.sh`, and the workflow
+`env:` (`.github/workflows/aeon.yml` + `messages.yml`). The README's
+[**Adding a gateway**](README.md#adding-a-gateway) section has the authoritative
+step-by-step. Then add a row to the gateway table in the README and verify a run
+logs `gateway=auto resolved to <slug>`.
 
 ### Listing a community skill pack
 
@@ -125,7 +130,7 @@ committing the regen — run both `generate-*` scripts and commit the result.
 ## Reporting bugs & requesting features
 
 Open an issue. For a bug, include the skill name, the relevant (redacted)
-`memory/logs/` entry, whether the failure was an API or sandbox issue, and whether
+`memory/logs/` entry, whether the failure was an API or permission/secret issue, and whether
 notifications came through. For a feature you'd like Aeon to build itself, label
 the issue `ai-build`.
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -109,11 +109,11 @@ Health skills file issues, repair skills close them. `heartbeat` is the only ski
 
 ### It replicates
 
-Aeon can spawn and manage copies of itself. `spawn-instance` forks the repo into a new specialized instance (`var: "crypto-tracker: monitor DeFi protocols"`), selects relevant skills, and registers it in `memory/instances.json` - no secrets propagated, billing stays isolated. `fleet-control` health-checks and dispatches across instances; `fleet-scorecard` tracks fleet economics.
+Aeon can spawn and manage copies of itself. `spawn-instance` forks the repo into a new specialized instance (`var: "crypto-tracker: monitor DeFi protocols"`), selects relevant skills, and registers it in `memory/instances.json` - no secrets propagated, billing stays isolated. `fleet-control` health-checks and dispatches across instances; its `scorecard` mode tracks fleet economics.
 
 ### It ships real work
 
-`external-feature` ships code to watched repos unprompted. `deploy-prototype` generates and deploys live web apps to Vercel. `vuln-scanner` finds real vulnerabilities and discloses them responsibly. `autoresearch` evolves existing skills through scored variations, and `create-skill` generates new ones from a sentence.
+`feature` ships code unprompted — to your watched repos, or to any repo with `var: external:<owner/repo>`. `deploy-prototype` generates and deploys live web apps to Vercel. `vuln-scanner` finds real vulnerabilities and discloses them responsibly. `autoresearch` evolves existing skills through scored variations, and `create-skill` generates new ones from a sentence.
 
 ### Add more skills
 

--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -6,7 +6,7 @@ The local web UI for running Aeon — enable skills, browse community packs, set
 
 A [Next.js](https://nextjs.org) app that runs on your machine and drives your Aeon fork through the GitHub CLI. Its `/api/*` routes shell out to `gh` for everything that touches your repo — reading and writing secrets, dispatching workflow runs, and committing config changes — so there's no separate backend and no credential custody: the dashboard holds nothing your `gh` login doesn't already grant.
 
-Every change you make in the UI maps to a file in the repo. Toggling a skill flips its `enabled` flag, editing a schedule rewrites its cron, pasting an API key sets a GitHub secret. **Push** commits those changes so Actions picks them up on the next run; **Run now** dispatches a workflow immediately without committing. It's the same `aeon.yml` / `skills.json` / secrets the cron runner reads — the dashboard is just the editor.
+Every change you make in the UI maps to a file in the repo. Toggling a skill flips its `enabled` flag, editing a schedule rewrites its cron, pasting an API key sets a GitHub secret. **Push** commits those changes so Actions picks them up on the next run; **Run now** dispatches a workflow immediately without committing. It's the same `aeon.yml` / `catalog/skills.json` / secrets the cron runner reads — the dashboard is just the editor.
 
 ## Quickstart
 
@@ -74,7 +74,7 @@ The gate also rejects state-changing requests whose `Origin` isn't allowlisted. 
 
 ## How it works
 
-- **Frontend:** Next.js App Router (`app/`) with React client components in `components/`. State is the repo itself — the UI reads `skills.json`, `packs.json`, `aeon.yml`, and `STRATEGY.md`, and writes back through the API.
+- **Frontend:** Next.js App Router (`app/`) with React client components in `components/`. State is the repo itself — the UI reads `catalog/skills.json`, `catalog/packs.json`, `aeon.yml`, and `STRATEGY.md`, and writes back through the API.
 - **API:** route handlers under `app/api/*` are the only place the dashboard touches your repo. They shell out to `gh` (`lib/gh.ts`) for secrets, workflow dispatch, and content reads, and run behind the loopback gate (`proxy.ts`).
 - **Skill output feed:** skill runs drop json-render specs into `outputs/`; the feed renders them as cards via [`@json-render`](https://github.com/json-render). `./notify-jsonrender` (a post-run workflow step) produces those specs.
 - **Deploy:** the repo auto-deploys `apps/dashboard/` to Vercel on push to `main` — no manual step. Most operators run it locally with `./aeon`; the hosted build is the same app.

--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -4,13 +4,13 @@ Expose every Aeon skill as a [Model Context Protocol](https://modelcontextprotoc
 
 ## What it is
 
-The server reads `skills.json` at the repo root and advertises each skill as an MCP tool over stdio. When Claude calls a tool, it spawns `claude -p -` against the matching `skills/<slug>/SKILL.md`, waits for the run to finish (same ~10-minute budget as Actions), and hands the skill's output back as the tool result. It's the bridge that turns "Aeon runs on a schedule in CI" into "Aeon is a set of tools inside my Claude session."
+The server reads `catalog/skills.json` and advertises each skill as an MCP tool over stdio. When Claude calls a tool, it spawns `claude -p -` against the matching `skills/<slug>/SKILL.md`, waits for the run to finish (same ~10-minute budget as Actions), and hands the skill's output back as the tool result. It's the bridge that turns "Aeon runs on a schedule in CI" into "Aeon is a set of tools inside my Claude session."
 
 It's the local, push-button way to run any skill from a Claude client. It spawns the same skill prompt the GitHub Actions runner uses, so behaviour is identical across entry points (cron and Claude).
 
 ## Quickstart
 
-From the **repo root** (the server needs `skills.json` and the `skills/` directory beside it):
+From the **repo root** (the server needs `catalog/skills.json` and the `skills/` directory):
 
 ```bash
 bin/add-mcp                    # build + register with Claude Code
@@ -38,7 +38,7 @@ node dist/index.js           # stdio server; normally launched by the MCP client
 
 ## Tools
 
-Every entry in `skills.json` becomes one tool:
+Every entry in `catalog/skills.json` becomes one tool:
 
 | | |
 |---|---|
@@ -88,7 +88,7 @@ You should see the full `aeon-*` tool list followed by a real skill output. If t
 ## How it works
 
 - **Transport:** stdio (`StdioServerTransport`) using the official `@modelcontextprotocol/sdk`. The MCP client launches `node dist/index.js` as a subprocess and speaks JSON-RPC over stdin/stdout — diagnostics go to stderr (`[aeon-mcp] …`) so they never corrupt the protocol stream.
-- **Skill discovery:** `loadSkills()` parses `skills.json` from the repo root (resolved relative to the compiled file, three levels up from `dist/`). If the manifest is missing the server starts with zero tools rather than crashing.
+- **Skill discovery:** `loadSkills()` parses `catalog/skills.json` (resolved relative to the compiled file, three levels up from `dist/`). If the manifest is missing the server starts with zero tools rather than crashing.
 - **Execution:** each call spawns `claude -p - --output-format json` with `cwd` set to the repo root and a 600 000 ms (10-minute) timeout — the same budget GitHub Actions gives a skill. The JSON envelope is unwrapped to return `result`; raw output is returned as a fallback.
 - **Errors are returned, not thrown:** a missing skill, a missing `claude` CLI (`ENOENT` → install hint), or a non-zero exit all come back as readable tool text so Claude can react instead of the connection dropping.
 

--- a/apps/webhook/README.md
+++ b/apps/webhook/README.md
@@ -32,7 +32,7 @@ npx wrangler deploy
 
 ## Configure
 
-The deploy button prompts for all four values during the wizard (declared in
+The deploy button prompts for all five values during the wizard (declared in
 [`.dev.vars.example`](.dev.vars.example)) and stores them as encrypted Worker
 secrets — the Worker comes out configured. Deploying from a clone instead? Set
 them via the CLI:
@@ -49,6 +49,7 @@ npx wrangler secret put GITHUB_TOKEN              # GitHub PAT (see scopes below
 |--------|----------|-------|
 | `TELEGRAM_BOT_TOKEN` | yes | From [@BotFather](https://t.me/BotFather). |
 | `TELEGRAM_CHAT_ID` | yes | Only messages from this chat are relayed; everything else is dropped. |
+| `TELEGRAM_WEBHOOK_SECRET` | yes | Random string; pass the **same** value to `setWebhook` as `secret_token`. The Worker rejects every update with `403` until it's set. |
 | `GITHUB_REPO` | yes | `owner/repo` of your Aeon fork, e.g. `aaronjmars/aeon` — not the worker repo the deploy button creates. |
 | `GITHUB_TOKEN` | yes | Fine-grained PAT scoped to your fork with **Contents: read/write** and **Actions: read/write**, or a classic token with `repo`. |
 

--- a/apps/webhook/package.json
+++ b/apps/webhook/package.json
@@ -16,6 +16,9 @@
       "TELEGRAM_CHAT_ID": {
         "description": "Your Telegram chat ID — only this chat can command the agent. Message your bot, then open api.telegram.org/bot<TOKEN>/getUpdates and copy chat.id."
       },
+      "TELEGRAM_WEBHOOK_SECRET": {
+        "description": "Random string you choose (any secure value). Pass the SAME value to setWebhook as secret_token — the Worker rejects every update with 403 until it's set."
+      },
       "GITHUB_REPO": {
         "description": "owner/repo of YOUR Aeon fork (where the GitHub Actions run) — not this worker repo."
       },

--- a/apps/webhook/wrangler.toml
+++ b/apps/webhook/wrangler.toml
@@ -8,5 +8,6 @@ compatibility_date = "2025-01-01"
 #
 #   wrangler secret put TELEGRAM_BOT_TOKEN
 #   wrangler secret put TELEGRAM_CHAT_ID
+#   wrangler secret put TELEGRAM_WEBHOOK_SECRET
 #   wrangler secret put GITHUB_REPO
 #   wrangler secret put GITHUB_TOKEN

--- a/bin/add-mcp
+++ b/bin/add-mcp
@@ -79,8 +79,8 @@ if [[ ! -d "$MCP_DIR" ]]; then
   err "apps/mcp-server/ directory not found at $MCP_DIR"
 fi
 
-if [[ ! -f "$DIR/skills.json" ]]; then
-  err "skills.json not found at $DIR/skills.json. Run this script from the repo root."
+if [[ ! -f "$DIR/catalog/skills.json" ]]; then
+  err "catalog/skills.json not found at $DIR/catalog/skills.json. Run this script from the repo root."
 fi
 
 # ── Build ────────────────────────────────────────────────────────────────────
@@ -119,7 +119,7 @@ fi
 
 # ── Count skills ─────────────────────────────────────────────────────────────
 
-SKILL_COUNT=$(node -e "const s=JSON.parse(require('fs').readFileSync('$DIR/skills.json','utf8')); console.log(s.skills.length);" 2>/dev/null || echo "?")
+SKILL_COUNT=$(node -e "const s=JSON.parse(require('fs').readFileSync('$DIR/catalog/skills.json','utf8')); console.log(s.skills.length);" 2>/dev/null || echo "?")
 
 echo ""
 echo "┌──────────────────────────────────────────────────────────┐"

--- a/bin/generate-packs-json
+++ b/bin/generate-packs-json
@@ -5,13 +5,13 @@ set -eo pipefail
 # packs.config.json + skills.json.
 #
 # Usage:
-#   bin/generate-packs-json            Generate packs.json at repo root (compact)
+#   bin/generate-packs-json            Generate the catalog at catalog/packs.json (compact)
 #   bin/generate-packs-json --pretty   Pretty-print the output
 #
 # packs.json is the catalog the dashboard reads to group skills into installable
 # first-party packs. Membership is derived deterministically; every skill in
 # skills.json must land in exactly one pack or this script exits non-zero.
-# Community (external-repo) packs live separately in skill-packs.json.
+# Community (external-repo) packs live separately in catalog/skill-packs.json.
 #
 # A skill's pack IS its `category` (one grouping — see docs/skill-packs.md).
 # Precedence when assigning a skill to a pack:

--- a/bin/generate-skills-json
+++ b/bin/generate-skills-json
@@ -4,7 +4,7 @@ set -eo pipefail
 # generate-skills-json — Build skills.json manifest from all skills/*/SKILL.md files
 #
 # Usage:
-#   bin/generate-skills-json              Generate skills.json at repo root
+#   bin/generate-skills-json              Generate the catalog at catalog/skills.json
 #   bin/generate-skills-json --pretty     Pretty-print the output
 #
 # The manifest enables one-command skill installation and marketplace discovery.

--- a/bin/install-skill-pack
+++ b/bin/install-skill-pack
@@ -118,7 +118,7 @@ Pack manifest:
   for the manifest schema.
 
 Community registry:
-  skill-packs.json at the repo root is the machine-readable index of known
+  catalog/skill-packs.json is the machine-readable index of known
   packs. Use --list (no repo arg) to enumerate it; the script reads the local
   file when available and falls back to the upstream raw URL otherwise.
 

--- a/docs/CORE.md
+++ b/docs/CORE.md
@@ -79,7 +79,7 @@ Three modes via `var`: **Health Check** (default), **Status** (`status`), **Disp
 
 Dispatch mode lets the parent trigger a skill on one child — or all healthy / degraded children at once. State-change-gated notify; bails on missing `gh` auth or low rate limit.
 
-### [`fleet-control`](../skills/fleet-control/SKILL.md) `scorecard` — fleet economics · daily 13:00
+### [`fleet-control`](../skills/fleet-control/SKILL.md) `scorecard` — fleet economics · twice daily (09:00 / 15:00)
 
 The **scorecard view** of `fleet-control` (run with `var: scorecard`; folded in the former standalone `fleet-scorecard`). Discovers the fleet at runtime (self + every non-archived instance — never hardcoded). Data is gathered **in-run** by `node scripts/fleet-scorecard.mjs`, which fetches each repo's runs + token usage from the GitHub API and computes the tables into `/tmp/fleet-scorecard/*`; it reads `GH_READ_PAT` (declared in the skill's `requires:`) from `process.env` so it can reach private fleet members without a secret ever hitting a command line.
 
@@ -87,7 +87,7 @@ Aggregates runs / failures / generations / tokens / est. cost / cache discount (
 
 ### [`distribute-tokens`](../skills/distribute-tokens/SKILL.md) — the pay-your-contributors flywheel
 
-`distribute-tokens` owns the whole flywheel as two phases you can run alone or chained (`var`: empty/`<label>` = send, `plan:` = plan only, `all:` = plan-then-send). The **plan phase** reads the latest `contributor-leaderboard` ranking, scores each contributor against a tier table (rank 1 = 25 USDC … rank 5 = 5, +5 first-PR bonus tracked once-ever per login, eligibility floor score ≥10 + must have an @handle), and writes the plan into `memory/distributions.yml` with a one-command run line. It deliberately **stops short of sending** — keeping a human-visible git diff as the audit trail. (This phase folded in the former standalone `contributor-reward` skill.)
+`distribute-tokens` owns the whole flywheel as two phases you can run alone or chained (`var`: empty/`<label>` = send, `plan:` = plan only, `all:` = plan-then-send). The **plan phase** computes a contributor ranking live from the repo's merged PRs via the GitHub API (no input file or upstream skill), scores each contributor against a tier table (rank 1 = 25 USDC … rank 5 = 5, +5 first-PR bonus tracked once-ever per login, eligibility floor score ≥10 + must have an @handle), and writes the plan into `memory/distributions.yml` with a one-command run line. It deliberately **stops short of sending** — keeping a human-visible git diff as the audit trail. (This phase folded in the former standalone `contributor-reward` skill.)
 
 The **send phase** (the default, empty `var`) does the actual on-chain send via the Bankr Wallet API with serious money-safety engineering: two-phase RESOLVE → EXECUTE (validate config / key / balance, resolve @handles → addresses, build plan; then send), per-recipient idempotency key + txHash so nothing double-sends across re-runs, dry-run mode, and recovery from partial runs. Wallet API for transfers only; read-only keys → 403 guard.
 

--- a/docs/SHOWCASE.md
+++ b/docs/SHOWCASE.md
@@ -47,7 +47,7 @@ Aeon is one of many ways to build agentic systems. Here's where it sits next to 
 | **Scheduling** | Cron, native to runtime | Caller decides | Caller decides | Built-in cron triggers | Caller decides |
 | **Skill format** | Plain Markdown (`SKILL.md`) | Python classes & agents | Python crews & tasks | Visual JSON nodes | Python `StateGraph` |
 | **Persistent memory** | File-based, version-controlled | Per-session unless wired | Per-session unless wired | Per-workflow execution state | Graph state per run |
-| **Self-healing** | Yes — `heartbeat` + `skill-repair` auto-patch failing skills | No | No | No (workflow re-runs) | No |
+| **Self-healing** | Yes — `skill-health` + `skill-repair` auto-patch failing skills | No | No | No (workflow re-runs) | No |
 | **Quality scoring** | Every run scored 1–5 by Haiku | No | No | No | No |
 | **Reactive triggers** | Yes — `schedule: "reactive"` fires on conditions | Event hooks (manual) | No | Webhook nodes | No |
 | **Setup floor** | `git clone` + secrets | `pip install` + write code | `pip install` + write code | Docker or hosted account | `pip install` + write code |

--- a/docs/attestation.md
+++ b/docs/attestation.md
@@ -117,7 +117,7 @@ To make a skill *demand* provenance wherever it's installed, add to its
 
 ```yaml
 ---
-name: disclosure-emailer
+name: vuln-scanner
 category: security
 mode: write
 attest: true          # always attest this skill's output

--- a/docs/community-skill-packs.md
+++ b/docs/community-skill-packs.md
@@ -18,7 +18,7 @@ This page documents the **install protocol** — the `skills-pack.json` manifest
 bin/install-skill-pack --list
 ```
 
-Prints every pack declared in `skill-packs.json` (at the Aeon repo root) — repo, skill count, trust badge, one-line description. Trusted-source packs are marked with `*` (security scan skipped, format check still runs). The script reads the local `skill-packs.json` when present and falls back to fetching the file from `https://raw.githubusercontent.com/aaronjmars/aeon/main/skill-packs.json` when it isn't.
+Prints every pack declared in `catalog/skill-packs.json` — repo, skill count, trust badge, one-line description. Trusted-source packs are marked with `*` (security scan skipped, format check still runs). The script reads the local `catalog/skill-packs.json` when present and falls back to fetching the file from `https://raw.githubusercontent.com/aaronjmars/aeon/main/catalog/skill-packs.json` when it isn't.
 
 Trusted AntFleet packs currently expose both `pr-review-antfleet` for
 installed repos with channel drawdown and `pr-review-antfleet-x402` for
@@ -177,13 +177,13 @@ The operator is always the trust boundary. The install script does not auto-trus
 4. `skills-pack.json` declares every skill the pack intends to install. Skills present in `skills/` but missing from the manifest are not installed.
 5. Optional but encouraged: a `README.md` that names each skill, explains scheduling assumptions, and lists any required environment variables.
 6. Run `./scripts/validate-pack.sh /path/to/your-pack-dir` (from an Aeon checkout) to pre-flight the pack locally — it runs the same structural invariants `install-skill-pack` enforces (valid `skills-pack.json`, clean slugs, no `..` in paths, present per-skill `SKILL.md`, locked-taxonomy capabilities) and exits non-zero on any blocking error. Add `--path <subdir>` if `skills-pack.json` is nested.
-7. Open a PR against `aaronjmars/aeon` that does **two** things in one diff: adds a row to the **Community Skill Packs** table in the project README, AND adds a matching entry to `skill-packs.json` (the machine-readable registry — see schema below).
+7. Open a PR against `aaronjmars/aeon` that does **two** things in one diff: adds a row to the **Community Skill Packs** table in the project README, AND adds a matching entry to `catalog/skill-packs.json` (the machine-readable registry — see schema below).
 
 ---
 
 ## skill-packs.json (community registry)
 
-`skill-packs.json` at the Aeon repo root is the machine-readable mirror of the README's Community Skill Packs table. `bin/install-skill-pack --list` reads it; future tooling (dashboards, third-party indexers) can read it without scraping the README.
+`catalog/skill-packs.json` is the machine-readable mirror of the README's Community Skill Packs table. `bin/install-skill-pack --list` reads it; future tooling (dashboards, third-party indexers) can read it without scraping the README.
 
 ### Registry schema
 

--- a/docs/help.md
+++ b/docs/help.md
@@ -5,7 +5,7 @@ type: Reference
 Aeon — how to use me over Telegram
 
 • Type / to see every skill you have enabled, then tap one to run it.
-• /skillname runs a skill directly (e.g. /rss_digest). Add text after it to
+• /skillname runs a skill directly (e.g. /digest). Add text after it to
   pass an argument, e.g. /article quantum computing.
 • Just message me in plain English and I'll figure out what you want.
 • /settings lists the skills currently enabled.

--- a/docs/telegram-commands.md
+++ b/docs/telegram-commands.md
@@ -56,9 +56,10 @@ again** and **📅 Schedule weekly** — keyed to the running skill (`$SKILL_NAM
 This is a global `notify` feature, not per-skill: `scripts/notify.sh` appends the
 row to any Telegram send. Tapping **Run again** re-dispatches the skill
 (`run:<skill>`); **Schedule weekly** enables it and sets a weekly cron in `aeon.yml`
-(`schedule:<skill>:weekly`), which the router commits. The row is skipped only when
-there is no skill context, or on a force-reply prompt (Telegram forbids inline
-buttons and `force_reply` on the same message).
+(`schedule:<skill>:weekly`), which the caller (the Messages workflow) commits. The
+row is skipped when there is no skill context, when the skill name is too long to
+fit the 64-byte `callback_data` budget, or on a force-reply prompt (Telegram forbids
+inline buttons and `force_reply` on the same message).
 
 ### Custom buttons (`--buttons`)
 

--- a/docs/telegram-instant.md
+++ b/docs/telegram-instant.md
@@ -15,12 +15,14 @@ Cloudflare" button.
 In short:
 
 1. Deploy `webhook/` to your own Cloudflare account (button or `npx wrangler deploy`).
-2. Fill in `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`, `GITHUB_REPO`, and `GITHUB_TOKEN`
-   when the deploy wizard prompts for them (or set them as Worker secrets via
-   `wrangler secret put` when deploying from a clone).
-3. Point your bot at the Worker:
+2. Fill in `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`, `TELEGRAM_WEBHOOK_SECRET`,
+   `GITHUB_REPO`, and `GITHUB_TOKEN` when the deploy wizard prompts for them (or set
+   them as Worker secrets via `wrangler secret put` when deploying from a clone).
+   `TELEGRAM_WEBHOOK_SECRET` is required — the Worker rejects every update with a
+   `403` until it's set.
+3. Point your bot at the Worker, passing the **same** value as `secret_token`:
    ```bash
-   curl "https://api.telegram.org/bot<YOUR_TOKEN>/setWebhook?url=https://your-worker.workers.dev"
+   curl "https://api.telegram.org/bot<YOUR_TOKEN>/setWebhook?url=https://your-worker.workers.dev&secret_token=<YOUR_WEBHOOK_SECRET>"
    ```
 
 Once a webhook is active the poller detects it via `getWebhookInfo` and skips the


### PR DESCRIPTION
## What

Verified **all user-facing docs** against the current repo and fixed the drift. I read all 22 user-facing `.md` files (README, ecosystem, docs/, app READMEs, contributing, security) and cross-checked every count, path, model name, script, and skill slug against the live codebase.

Almost everything traces to two root causes:
1. **The catalog move into `catalog/`** — several docs/scripts still pointed at repo-root `skills.json` / `packs.json` / `skill-packs.json`.
2. **`TELEGRAM_WEBHOOK_SECRET`** was added to the webhook after the setup docs were written.

## Fixes

### 🔴 Broken — following the doc failed
- **`docs/telegram-instant.md`** — add the **required** `TELEGRAM_WEBHOOK_SECRET` to the setup list and `&secret_token=…` to the `setWebhook` call. As written the setup returned `403` on every update (`worker.js:39-42`).
- **`.github/CONTRIBUTING.md`** — the gateway-wiring list pointed at a **non-existent `auth-provider.mjs`** and contradicted the README. Rewrote it around `gateway-registry.ts` as the single source of truth and linked the README's authoritative section.

### 🟠 Stale — catalog moved to `catalog/`
- **`docs/community-skill-packs.md`** — registry is `catalog/skill-packs.json` (including the broken raw-GitHub fallback URL).
- **`apps/mcp-server/README.md`**, **`apps/dashboard/README.md`** — `skills.json`/`packs.json` now under `catalog/`.
- **`docs/CORE.md`** — `fleet-control` scorecard runs 09:00/15:00 (no "daily 13:00"); `distribute-tokens` computes its ranking live from the GitHub API (there is no `contributor-leaderboard` skill).
- **`docs/help.md`** — `/rss_digest` → `/digest` (RSS folded into `digest`).

### 🟡 Minor
- **`.github/README.md`** — `external-feature` → `feature`; `fleet-scorecard` is `fleet-control`'s `scorecard` mode.
- **`docs/SHOWCASE.md`** — self-healing is `skill-health` + `skill-repair` (not `heartbeat`).
- **`docs/attestation.md`** — example skill name → `vuln-scanner` (retired `disclosure-emailer`).
- **`docs/telegram-commands.md`** — the *caller* commits (not the router); note the skill-name-too-long button-skip case.

### 🐛 Code fixes surfaced during verification
- **`apps/webhook/package.json`** + **`wrangler.toml`** — add `TELEGRAM_WEBHOOK_SECRET` to `cloudflare.bindings` and the CLI comment so the deploy wizard actually prompts for it (this was the real gap behind the "four values" doc error).
- **`bin/add-mcp`** — preflight + skill-count now read `catalog/skills.json`; the repo-root path no longer exists, so the documented quickstart failed its own preflight.
- **`bin/install-skill-pack`, `bin/generate-skills-json`, `bin/generate-packs-json`** — header/comment paths corrected to `catalog/`.

## Verified current (no changes needed)
`docs/skill-packs.md`, `docs/status.md`, `docs/ECOSYSTEM.md` (72 partners, no dangling refs), `docs/OKF.md`, `docs/langfuse.md`, `docs/CAPABILITIES.md` (parity check passes), `.github/SECURITY.md`, `apps/cli/README.md`, and the README's counts/models/links/architecture tree (59 skills / 6 packs, default `claude-sonnet-4-6`).

## Validation
- `node scripts/okf-validate.mjs` → OK (95 concepts conform)
- `apps/webhook/package.json` parses (5 bindings)
- `bash -n` passes on all edited shell scripts
- No remaining `SendGrid` / `rss_digest` / repo-root-catalog references in user-facing docs
