### PR TITLE
docs(readme): align Proof of work table (strip first-column emoji)

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -137,10 +137,10 @@ Aeon isn't a demo reel — its skills ship real, verifiable output in production
 
 | Skill | In production |
 |-------|---------------|
-| 🛡️ **`vuln-scanner`** | **54 open-source repos secured** — real vulnerabilities found, patched, and responsibly disclosed across projects with **~1.6M combined GitHub stars** (31 rated High/Critical). [Every disclosure →](https://www.aeon.fun/security) |
-| 🌐 **ecosystem** | **72 products & agents** built on Aeon. [`ECOSYSTEM.md`](../docs/ECOSYSTEM.md) |
-| 🛰️ **`fork-fleet`** | **24 active forks** running their own Aeon instances. [`SHOWCASE.md`](../docs/SHOWCASE.md) |
-| 📦 **community** | **10 community skill packs** published to the registry. [`community-skill-packs.md`](../docs/community-skill-packs.md) |
+| **`vuln-scanner`** | **54 open-source repos secured** — real vulnerabilities found, patched, and responsibly disclosed across projects with **~1.6M combined GitHub stars** (31 rated High/Critical). [Every disclosure →](https://www.aeon.fun/security) |
+| **ecosystem** | **72 products & agents** built on Aeon. [`ECOSYSTEM.md`](../docs/ECOSYSTEM.md) |
+| **`fork-fleet`** | **24 active forks** running their own Aeon instances. [`SHOWCASE.md`](../docs/SHOWCASE.md) |
+| **community** | **10 community skill packs** published to the registry. [`community-skill-packs.md`](../docs/community-skill-packs.md) |
 
 <sub>Security figures are a snapshot as of 2026-07-06; the live dashboard updates continuously.</sub>
 


### PR DESCRIPTION
Same emoji glyph-width fix as the pack table (#703), applied to the **Proof of work** table — `🛡️`/`🛰️` carried U+FE0F variation selectors that `🌐`/`📦` didn't, making the column look unevenly spaced. Stripped the four first-column emoji so every row starts at `**Name**`.

Swept the rest of the README: no other emoji-led table cells remain.