### PR TITLE
fix(scorer): flag empty_output only on empty FINAL output, not legitimate no-ops

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -899,6 +899,10 @@ jobs:
 
           Flag any issues from: api_error, empty_output, low_quality, stale_data, generic_content, rate_limited
 
+          Flag strictly against the FINAL output above — not against sources or steps it merely mentions:
+          - empty_output: ONLY when the skill produced no usable result (no report, analysis, or draft). A legitimate no-op — an empty inbox, an empty watchlist, 'nothing met the threshold', a clean scan with no findings — is a COMPLETED task, not empty_output. A run that delivered its output is not empty_output even if its log notes an upstream source came back empty.
+          - api_error / rate_limited: ONLY when the error blocked the skill's output — not for a sub-call that was retried or fell back cleanly.
+
           Skill: $SKILL
           Output (truncated):
           $OUTPUT


### PR DESCRIPTION
## What this fixes

The skill scorer in `.github/workflows/aeon.yml` reads a run's whole log, not just its final output — so it can flag `empty_output` / `api_error` on runs that actually **completed**, whenever the log happens to mention an empty upstream source or a legitimate no-op (an empty inbox, an empty watchlist, "nothing met the threshold", a clean scan with no findings). Those are completed tasks, not empty output, but the flag treats the run as if it failed.

## The fix

Tighten the scorer's flag definitions so `empty_output` / `api_error` / `rate_limited` apply to the **FINAL output only**:
- A legitimate no-op is a **COMPLETED** task, not `empty_output`.
- An upstream sub-source returning empty does not by itself mean the skill's output was empty.

No skill behavior changes — only the scoring rubric the workflow applies to output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
