### PR TITLE
fix: surface swallowed errors in mcp CLI + outputs route

### DIFF
--- a/apps/cli/src/commands/mcp.ts
+++ b/apps/cli/src/commands/mcp.ts
@@ -18,11 +18,22 @@ Options:
   --json      Machine-readable output`
 
 async function readServers(): Promise<McpServers> {
+  let content: string
   try {
-    const { content } = await getFileContent('.mcp.json')
-    const parsed = JSON.parse(content) as { mcpServers?: McpServers }
-    return parsed.mcpServers ?? {}
-  } catch { return {} }
+    content = (await getFileContent('.mcp.json')).content
+  } catch {
+    return {} // no .mcp.json yet — an empty server set is the correct default
+  }
+  // A present-but-corrupt file must NOT silently read as empty: `mcp add` would
+  // then overwrite it with only the new server, clobbering the existing config.
+  // Surface the parse error (main()'s catch renders it as a clean CLI error).
+  let parsed: { mcpServers?: McpServers }
+  try {
+    parsed = JSON.parse(content) as { mcpServers?: McpServers }
+  } catch (e) {
+    throw new Error(`.mcp.json is not valid JSON: ${e instanceof Error ? e.message : e}`)
+  }
+  return parsed.mcpServers ?? {}
 }
 
 async function writeServers(servers: McpServers, message: string) {

--- a/apps/dashboard/app/api/outputs/route.ts
+++ b/apps/dashboard/app/api/outputs/route.ts
@@ -58,8 +58,8 @@ export async function GET() {
     )
 
     return NextResponse.json({ outputs: outputs.filter(Boolean) })
-  } catch {
-    return NextResponse.json({ outputs: [] })
+  } catch (e) {
+    return errorResponse(e)
   }
 }
 


### PR DESCRIPTION
The two defensive-code MEDIUMs surfaced (but not auto-applied) by the `/optimize` pass in #715. Both were silent-fallback swallows inconsistent with how the rest of the app handles errors.

## 1. `cli/src/commands/mcp.ts` — corrupt `.mcp.json` no longer swallowed
`readServers()` had one `catch { return {} }` wrapping **both** "file missing" (correct → empty set) and `JSON.parse` failure. A malformed `.mcp.json`:
- made `aeon mcp ls` print "(no servers configured)" — indistinguishable from no config, and
- made `aeon mcp add` **overwrite the broken file with only the new server** → silent loss of the operator's config.

Now the file read and the parse are split: a missing file still returns `{}`, but a parse error throws, and `main()`'s top-level catch renders it as `error: .mcp.json is not valid JSON: …` (exit 1). This matches the dashboard's `api/mcp` route, which already logs + preserves malformed JSON for repair.

## 2. `app/api/outputs/route.ts` — real errors surface instead of an empty feed
The outer `catch { return { outputs: [] } }` returned an empty feed with a `200` on any *unexpected* error, while every other route uses `errorResponse()`. Switched to `catch (e) { return errorResponse(e) }` so a genuine backend failure is a `500` the dashboard can report, not a false "you have no outputs". The inner readdir / per-file fallbacks still handle the expected empty/missing/corrupt-item cases.

## Verification
dashboard `tsc`, cli `tsc`, `next build` all green. Drove the CLI end-to-end against a missing / valid / corrupt `.mcp.json`:
- missing → "(no servers configured)", exit 0 (unchanged)
- valid → server table, exit 0
- corrupt → `error: .mcp.json is not valid JSON: …`, exit 1
- corrupt + `mcp add` → errors and leaves the file **intact** (no clobber)
