### PR TITLE
Community skill pack listing: sparkleware (proof-of-loadout, aeon-pulse, eth-gas-watch)

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -160,7 +160,7 @@ Aeon's skills ship to production. These numbers are live at **[aeon.fun](https:/
 |-------|---------------|
 | **`vuln-scanner`** | **~1.6M GitHub stars secured** - real vulnerabilities found, patched, and responsibly disclosed across 54 open-source projects (31 rated High/Critical). [Every disclosure →](https://www.aeon.fun/security) |
 | **ecosystem** | **72 products & agents** built on Aeon. [`ECOSYSTEM.md`](../docs/ECOSYSTEM.md) |
-| **community** | **10 community skill packs** published to the registry. [`community-skill-packs.md`](../docs/community-skill-packs.md) |
+| **community** | **13 community skill packs** published to the registry. [`community-skill-packs.md`](../docs/community-skill-packs.md) |
 
 **One skill, end to end.** `vuln-scanner` clones a repo from your watchlist, runs Semgrep, OSV, and TruffleHog, then triages the hits hard - a finding ships only if it's exploitable, not theoretical, and you'd defend it to the maintainer's face. Most are discarded. What survives becomes a maintainer-ready report, sent through the repo's private advisory channel with a proposed patch pushed to your fork for the maintainer to cherry-pick. That loop, run across the open-source wild, is what the numbers above are made of.
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -322,6 +322,9 @@ Either way the installer reads the pack's `skills-pack.json` manifest, runs the 
 | [Polymarket Trader by Simmer](https://github.com/SpartanLabsXyz/aeon-skill-pack-polymarket/tree/main/aeon-skill-pack) (`--path aeon-skill-pack`) | 3 | Signal, discovery, and real order-placing on Polymarket (simulate-by-default, live opt-in). |
 | [Charon for AEON](https://github.com/CharonAI-code/charon/tree/main/skills/aeon) (`--path skills/aeon`) | 2 | Repo-local policy enforcement for AEON runs, with natural-language policy management. |
 | [aeon-skill-pack-agentlink](https://github.com/techdigger/aeon-skill-pack-agentlink) | 1 | Verified, human-backed on-chain identity on Base via AgentLink. Read-only, on-demand. |
+| [proof-of-loadout](https://github.com/sparkleware/proof-of-loadout) | 1 | Compose an Aeon loadout for a goal, flag USDC-per-call packs (Charon gate routed), preflight a MiroShark sim. Plan-only by default. |
+| [aeon-pulse](https://github.com/sparkleware/aeon-pulse) | 1 | Daily digest of Aeon upstream: recent commits, release freshness, open issues. Read-only, keyless. |
+| [eth-gas-watch](https://github.com/sparkleware/eth-gas-watch) | 1 | Etherscan gas oracle every 4h: traffic-light status, cheap-window alerts, trend from its own ledger. Read-only. |
 
 **To list a pack here**, open a PR that adds a table row **and** a matching [`catalog/skill-packs.json`](../catalog/skill-packs.json) entry. The full checklist - public repo + license, a per-skill `SKILL.md`, a `skills-pack.json` manifest, the registry schema, and the trust model - is in [`docs/community-skill-packs.md`](../docs/community-skill-packs.md#pack-maintainers-publishing-checklist).
 

--- a/catalog/skill-packs.json
+++ b/catalog/skill-packs.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "updated": "2026-07-03",
+  "updated": "2026-07-15",
   "description": "Machine-readable registry of community skill packs installable via bin/install-skill-pack. Mirrors the human-readable table in README.md.",
   "packs": [
     {
@@ -191,6 +191,66 @@
       ],
       "secrets_required": [
         "AGENT_PRIVATE_KEY"
+      ],
+      "capabilities": [
+        "read_only",
+        "external_api",
+        "sends_notifications"
+      ]
+    },
+    {
+      "repo": "sparkleware/proof-of-loadout",
+      "name": "proof-of-loadout",
+      "description": "Compose an Aeon loadout for a goal from the Sparkleware registry, flag packs that settle real USDC per call (with a Charon policy gate routed), and preflight a MiroShark market simulation — plan-only by default; the $1 x402 run never fires on its own.",
+      "author": "sparkleware",
+      "license": "MIT",
+      "homepage": "https://sparkleware.fun",
+      "category": "dev",
+      "trust_level": "community",
+      "skills": [
+        "proof-of-loadout"
+      ],
+      "secrets_required": [],
+      "capabilities": [
+        "external_api",
+        "writes_external_host",
+        "onchain_writes",
+        "sends_notifications"
+      ]
+    },
+    {
+      "repo": "sparkleware/aeon-pulse",
+      "name": "aeon-pulse",
+      "description": "Daily one-screen digest of Aeon upstream activity — recent commits, release freshness, and open issues from aeonfun/aeon (or any repo passed as var). Read-only, keyless.",
+      "author": "sparkleware",
+      "license": "MIT",
+      "homepage": "https://sparkleware.fun",
+      "category": "dev",
+      "trust_level": "community",
+      "skills": [
+        "aeon-activity"
+      ],
+      "secrets_required": [],
+      "capabilities": [
+        "read_only",
+        "sends_notifications"
+      ]
+    },
+    {
+      "repo": "sparkleware/eth-gas-watch",
+      "name": "eth-gas-watch",
+      "description": "Ethereum gas status every 4 hours from the Etherscan gas oracle — traffic-light classification against your gwei threshold, cheap-window alerts, and a trend line computed from its own grep-able ledger.",
+      "author": "sparkleware",
+      "license": "MIT",
+      "homepage": "https://sparkleware.fun",
+      "category": "crypto",
+      "trust_level": "community",
+      "skills": [
+        "gas-status"
+      ],
+      "secrets_required": [],
+      "secrets_optional": [
+        "ETHERSCAN_API_KEY"
       ],
       "capabilities": [
         "read_only",


### PR DESCRIPTION
## What

Lists three sparkleware community skill packs — one README table row each plus matching `catalog/skill-packs.json` entries.

## Why

These are re-submissions, rebuilt to the current bar after the #600 prune. Every criticism from #600 is addressed, plus the conventions that landed since:

- **`./notify`** — every skill notifies through `./notify`, never a channel API.
- **`mode: read-only`** on all three skills — none of them mutate the repo (their writes go to `output/` and `memory/`, which the read-only guard preserves).
- **Network note** per #692 — `curl` is the primary path everywhere; **WebFetch** only as the flaky-GET fallback; the one optional secret (`ETHERSCAN_API_KEY`) routes through `./secretcurl` with an `{ENV_NAME}` placeholder, never a bare command-line interpolation.
- **`category:`** on every skill (`dev` / `dev` / `crypto`), alongside `tags:`.
- **`capabilities`** declared per skill in each `skills-pack.json` (locked taxonomy) and mirrored pack-level in the catalog entries; `secrets_required` / `secrets_optional` declared.
- **Not thin** — only three of the old seven come back:
  - **proof-of-loadout** — composes an Aeon loadout for a goal from the Sparkleware registry, cross-refs the priced-rail index to flag packs that settle real USDC per call, routes a **Charon** policy gate (`CharonAI-code/charon`, from this catalog) in front of them, and preflights a MiroShark market simulation. Plan-only by default: the $1 x402 run needs `MIROSHARK_PAY=1` **and** an `X402_CMD` and never fires on its own.
  - **aeon-pulse** — a four-endpoint daily digest of this repo's upstream activity (commits, release freshness, open issues), keyless and inside the anonymous rate limit.
  - **eth-gas-watch** — Etherscan gas oracle every 4h with traffic-light classification against a configurable threshold, plus a trend line computed from its own grep-able ledger, so its signal compounds the longer it runs.

  `hn-top`, `morning-briefing`, `registry-watch`, and `demo-pack` are deliberately **not** resubmitted.

```bash
bin/install-skill-pack sparkleware/proof-of-loadout
bin/install-skill-pack sparkleware/aeon-pulse
bin/install-skill-pack sparkleware/eth-gas-watch
```

## Type of change

- [x] Community skill pack listing

## Checklist

- [x] Pack repo is public with a clear license (MIT / Apache-2.0) — MIT, all three
- [x] Pack has a `skills-pack.json` manifest at its root and a `SKILL.md` per skill
- [x] Write / onchain / bet skills are `default_enabled: false` — proof-of-loadout (the only pack with a paid, onchain-adjacent path) is `default_enabled: false`, and its paid run is additionally double-gated behind `MIROSHARK_PAY=1` + `X402_CMD`; aeon-pulse and eth-gas-watch are read-only
- [x] This PR adds **both** a README table row and a matching `skill-packs.json` entry (three of each)
- [x] No monkey-patching of Aeon internals; no private or auth-walled endpoints required to run — all endpoints are public; `ETHERSCAN_API_KEY` is optional

**Validated locally** against `scripts/validate-pack.sh`'s structural invariants (valid manifest, clean slugs, per-skill `SKILL.md` present, locked-taxonomy capabilities, license + recommended fields) — 0 errors, 0 warnings on all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
