### PR TITLE
chore(deps): hold typescript on 6.x for the dashboard (Next 16 + TS7 breaks build)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,6 +42,14 @@ updates:
       dashboard:
         patterns:
           - "*"
+    # Hold TypeScript on the 6.x line. TS 7 (the native/Go port) ships a different
+    # package layout that Next.js 16's build-time TS integration doesn't recognize
+    # yet: `next build` crashes ("The 'id' argument must be of type string") even
+    # though `tsc --noEmit` passes. Minor/patch bumps within 6.x still flow through.
+    # Revisit once Next.js ships TS7 support.
+    ignore:
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   # MCP server — exposes Aeon skills as Claude tools.
   - package-ecosystem: "npm"


### PR DESCRIPTION
## Why

Dependabot PR #720 grouped three dev-dep bumps for `/apps/dashboard`, one of which was **`typescript` 6.0.3 → 7.0.2**. TypeScript 7 is the native/Go port, which ships a different package layout that **Next.js 16.2.10's build-time TypeScript integration doesn't recognize yet**.

Verified with an A/B build (everything else held constant):

| typescript | `tsc --noEmit` | `next build` |
|---|:---:|:---:|
| 7.0.2 (PR #720) | ✅ passes | ❌ **fails** — Next can't detect TS7, tries to reinstall it, then crashes `The "id" argument must be of type string. Received undefined` |
| 6.0.3 (pre-PR) | ✅ passes | ✅ **succeeds** — full route manifest |

`tsc --noEmit` alone is misleading here because the standalone compiler works fine; only Next's build pipeline breaks.

## Change

Adds a Dependabot `ignore` on the `/apps/dashboard` npm entry for `typescript` `version-update:semver-major`. This:

- stops #720 (and future runs) from re-proposing the breaking TS major,
- **still lets the safe bumps in that group through** (`tsx`, `@types/node`, and any typescript 6.x minor/patch).

Revisit and drop the ignore once Next.js ships TS7 support.

## Follow-up

Once this lands, #720 can be closed/recreated so the `tsx 4.23.1` + `@types/node 26.1.1` patches come through without the typescript major.

🤖 Generated with [Claude Code](https://claude.com/claude-code)