### PR TITLE
feat(grok): support Grok 4.5 + migrate deprecated x_search model to grok-4.3

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -25,6 +25,7 @@ on:
           - claude-sonnet-5
           - claude-sonnet-4-6
           - claude-haiku-4-5-20251001
+          - grok-4.5
           - grok-composer-2.5-fast
           - grok-build
       harness:
@@ -387,10 +388,10 @@ jobs:
           fi
           if [ "$HARNESS" != "grok" ]; then HARNESS="claude"; fi   # unknown value → safe default (use `if`, not `&&`, under set -e)
           # On the grok harness a claude-* model id is meaningless — fall back to
-          # grok's default (grok-composer-2.5-fast) unless an explicit grok model
-          # was chosen. run-grok.sh omits --model for a non-grok value as a safety net.
+          # grok's current default (grok-4.5) unless an explicit grok model was
+          # chosen. run-grok.sh omits --model for a non-grok value as a safety net.
           if [ "$HARNESS" = "grok" ]; then
-            case "$MODEL" in claude-*|"") MODEL="grok-composer-2.5-fast" ;; esac
+            case "$MODEL" in claude-*|"") MODEL="grok-4.5" ;; esac
           fi
           echo "Using harness: $HARNESS  |  model: $MODEL"
           echo "SKILL_MODEL=$MODEL" >> "$GITHUB_OUTPUT"
@@ -914,13 +915,14 @@ jobs:
             # Score through the SAME harness the skill ran on. A grok-only repo has
             # no Claude credentials, so `claude -p` would just print "Not logged in";
             # run-grok.sh reuses the run's X-account/API-key auth and emits the same
-            # {result,usage} envelope. MODEL= → grok's default (grok-composer-2.5-fast,
-            # the only grok model that completes in CI). Its notices go to stderr.
+            # {result,usage} envelope. Pin grok-composer-2.5-fast explicitly — the
+            # cheap/fast model this robust parse is tuned for. (Don't rely on grok's
+            # own default here: it's now grok-4.5, the pricier flagship.) Notices→stderr.
             # NB: we deliberately do NOT pass grok's --json-schema here — composer
             # doesn't populate structured output (it leaves .structuredOutput null),
             # and the ANALYSIS_PROMPT already asks for a {score,assessment,flags}
             # object, so the robust parse below handles composer's JSON text fine.
-            if ! RAW=$(echo "$ANALYSIS_PROMPT" | MODEL= SKILL_MODE=read-only \
+            if ! RAW=$(echo "$ANALYSIS_PROMPT" | MODEL=grok-composer-2.5-fast SKILL_MODE=read-only \
                 bash "${GITHUB_WORKSPACE}/scripts/run-grok.sh" 2>/dev/null); then
               echo "::notice::Skill scoring skipped — grok scorer unavailable (non-fatal)"
               exit 0

--- a/.github/workflows/messages.yml
+++ b/.github/workflows/messages.yml
@@ -452,7 +452,7 @@ jobs:
           if [ "$HARNESS" != "grok" ]; then HARNESS="claude"; fi   # unknown → safe default
           # On grok a claude-* model id is meaningless — fall back to grok's default.
           if [ "$HARNESS" = "grok" ]; then
-            case "$MODEL" in claude-*|"") MODEL="grok-composer-2.5-fast" ;; esac
+            case "$MODEL" in claude-*|"") MODEL="grok-4.5" ;; esac
           fi
           echo "Using harness: $HARNESS  |  model: $MODEL"
 

--- a/aeon.yml
+++ b/aeon.yml
@@ -175,9 +175,10 @@ chains:
 
 # Default model for all skills. Override per-run via workflow_dispatch.
 # Options: claude-opus-4-8, claude-fable-5, claude-sonnet-5, claude-sonnet-4-6, claude-haiku-4-5-20251001
-# (Grok harness models: grok-composer-2.5-fast — fast single-agent default;
-#  grok-build — reasoning/multi-agent coding model, run with --no-subagents in CI.
-#  Use the bare CLI id `grok-build`, not the API id `grok-build-0.1`.)
+# (Grok harness models: grok-4.5 — flagship reasoning model & grok's current default,
+#  run with --no-subagents in CI; grok-composer-2.5-fast — fast/cheap single-agent;
+#  grok-build — older coding model, XAI_API_KEY/api.x.ai only. Use the bare CLI id
+#  `grok-build`, not the API id `grok-build-0.1`.)
 model: claude-sonnet-4-6
 
 # Agent harness — which coding-agent CLI runs your skills.

--- a/apps/dashboard/lib/constants.ts
+++ b/apps/dashboard/lib/constants.ts
@@ -13,15 +13,22 @@ export const MODELS = [
 ]
 
 // Models offered when the Grok (`grok`) harness is selected.
-// - grok-composer-2.5-fast (grok's default) — fast single-agent, runs cleanly in CI.
-// - grok-build — reasoning/multi-agent coding model. It used to Cancel every run in
-//   the Actions sandbox (its subagent-spawn tool was denied); run-grok.sh now passes
-//   --no-subagents by default, so it runs single-agent in CI. Skills that opt into
-//   best_of_n:/verify: get subagents back automatically.
+// - grok-4.5 (grok's CURRENT default) — the flagship reasoning model that powers
+//   Grok Build. Multi-agent-capable, so run-grok.sh passes --no-subagents in CI
+//   (same mitigation as grok-build). This is the default new grok runs get.
+// - grok-composer-2.5-fast — fast, cheap single-agent; used for CI health scoring.
+// - grok-build — older reasoning/multi-agent coding model (API id grok-build-0.1).
+//   It used to Cancel every run in the Actions sandbox (its subagent-spawn tool was
+//   denied); run-grok.sh now passes --no-subagents by default, so it runs
+//   single-agent in CI. Skills that opt into best_of_n:/verify: get subagents back.
+//   NOTE: grok-build is reachable only via XAI_API_KEY on api.x.ai — the X-account
+//   (GROK_CREDENTIALS) login exposes only grok-4.5 + composer.
 // Use the bare CLI id (grok-build), not the API id (grok-build-0.1).
-// Keep this list in sync with the workflow_dispatch `model` choice options in
+// First entry is the default (modelsForHarness(...)[0] on harness switch). Keep this
+// list in sync with the workflow_dispatch `model` choice options in
 // .github/workflows/aeon.yml — a mismatch 422s at dispatch time.
 export const GROK_MODELS = [
+  { id: 'grok-4.5', label: 'Grok 4.5' },
   { id: 'grok-composer-2.5-fast', label: 'Composer 2.5' },
   { id: 'grok-build', label: 'Grok Build' },
 ]

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -58,16 +58,16 @@ harness:
 max_turns: 120     # agentic-turn cap (default 60; a runaway/cost guard) → --max-turns
 best_of_n: 3       # run the task 3 ways in parallel, keep the best      → --best-of-n
 verify: true       # append a self-verification loop before finishing    → --check
-effort: high       # low|medium|high|xhigh|max → --effort  (grok-build only)
+effort: high       # low|medium|high|xhigh|max → --effort  (reasoning models only)
 ```
 
-`effort`/`reasoning_effort` map to the API's `reasoningEffort`, which the
-CI-default `grok-composer-2.5-fast` rejects — so they're applied only when a
-reasoning model (`grok-build`) is selected and skipped-with-a-notice otherwise.
-`best_of_n`/`verify` build on grok's subagents (so the harness drops
+`effort`/`reasoning_effort` map to the API's `reasoningEffort`, which the fast
+`grok-composer-2.5-fast` rejects — so they're applied only when a reasoning model
+(`grok-4.5`, grok's default, or `grok-build`) is selected and skipped-with-a-notice
+otherwise. `best_of_n`/`verify` build on grok's subagents (so the harness drops
 `--no-subagents` for those runs); `verify` can't combine with structured output.
 `run-grok.sh` also understands `GROK_JSON_SCHEMA` for `--json-schema` structured
-output (reliably honoured by `grok-build`).
+output (reliably honoured by reasoning models like `grok-4.5` / `grok-build`).
 
 ## Every entry point runs on either harness
 

--- a/scripts/llm-gateway.sh
+++ b/scripts/llm-gateway.sh
@@ -218,7 +218,9 @@ case "${GATEWAY:-direct}" in
     export ANTHROPIC_BASE_URL="${XAI_ANTHROPIC_BASE_URL:-https://api.x.ai}"
     export ANTHROPIC_AUTH_TOKEN="$XAI_API_KEY"   # Bearer; API_KEY must be blank
     unset ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN
-    # Pin every model slot to a grok coding model (GROK_MODEL overrides).
+    # Pin every model slot to a grok coding model. GROK_MODEL overrides — e.g. set it
+    # to grok-4.5 (xAI's current flagship, available on api.x.ai) instead of the
+    # conservative grok-build-0.1 default kept here for backward-compatible behavior.
     grok_model="${GROK_MODEL:-grok-build-0.1}"
     export ANTHROPIC_DEFAULT_OPUS_MODEL="$grok_model"
     export ANTHROPIC_DEFAULT_SONNET_MODEL="$grok_model"

--- a/scripts/run-grok.sh
+++ b/scripts/run-grok.sh
@@ -19,7 +19,7 @@
 #   exit    — 0 on success, non-zero on any grok failure (caller falls to error)
 #
 # Inputs from the environment:
-#   MODEL                 resolved model id (default grok-build-0.1)
+#   MODEL                 resolved model id; empty ⇒ grok's own default (now grok-4.5)
 #   SKILL_MODE            read-only | write (maps to grok --allow/--deny/--sandbox
 #                         via scripts/skill_mode.sh grok-args)
 #   XAI_API_KEY           xAI API key auth (CI-friendly; the simple path)
@@ -50,7 +50,7 @@ set -uo pipefail   # NOT -e: we capture grok's exit code and output explicitly.
 
 # --- pin (single source of truth for the grok CLI version) ------------------
 # Keep this current the same way aeon.yml/messages.yml pin the claude CLI.
-GROK_CLI_VERSION="${GROK_CLI_VERSION:-0.2.82}"
+GROK_CLI_VERSION="${GROK_CLI_VERSION:-0.2.101}"
 
 log() { echo "$@" >&2; }
 
@@ -101,7 +101,7 @@ fi
 # --- 3. model + permission flags --------------------------------------------
 # Only pass --model for a real grok model id; for an empty value or a leftover
 # claude-* id (harness switched but model not), OMIT it so grok uses its own
-# current default (e.g. grok-composer-2.5-fast) rather than a hardcoded id.
+# current default (now grok-4.5) rather than a hardcoded id.
 MODEL="${MODEL:-}"
 SKILL_MODE="${SKILL_MODE:-write}"
 MODEL_FLAG=()
@@ -148,18 +148,19 @@ fi
 # --- 3c. run-shaping flags (structured output / effort / turns / verify) -----
 # Newer grok headless features, all opt-in via env (aeon.yml maps a skill's
 # frontmatter to these). Two hard-won constraints are enforced here, verified
-# against grok 0.2.82 with the CI-default model grok-composer-2.5-fast:
+# against grok 0.2.101:
 #   * --effort / --reasoning-effort map to the API's `reasoningEffort`, which
 #     composer REJECTS with a 400 ("does not support parameter reasoningEffort").
-#     They only work on a reasoning model (grok-build), so we gate them on MODEL
-#     and skip-with-warning on composer rather than hard-fail the run.
+#     They only work on a reasoning model (grok-4.5 / grok-build), so we gate them
+#     on MODEL and skip-with-warning on composer rather than hard-fail the run.
 #   * grok's own arg parser rejects some combinations; those are reconciled below
 #     and again where --no-subagents is chosen (see the run step).
 # Invalid values are warned-and-skipped, never passed through to fail the run.
 RUN_FLAGS=()
 
-# Is the resolved model reasoning-capable? Composer (the default, and the only
-# model that completes in the Actions sandbox) is not; grok-build is.
+# Is the resolved model reasoning-capable? Composer is not; grok-4.5 / grok-build are.
+# Empty MODEL means grok picks its own default (now grok-4.5, a reasoning model), but
+# we can't know that here, so treat empty as non-reasoning to stay 400-safe.
 MODEL_IS_REASONING=0
 case "$MODEL" in
   ""|default|claude-*|*composer*) ;;      # composer / unknown → NOT reasoning

--- a/scripts/tests/test_run_grok.sh
+++ b/scripts/tests/test_run_grok.sh
@@ -91,6 +91,14 @@ if grep -qx -- "--model" "$ARGS_FILE"; then bad "omits --model for claude-* id";
 echo "p" | GROK_FAKE_OUT='{"text":"x"}' MODEL="" SKILL_MODE=write XAI_API_KEY=xai-test bash "$R" >/dev/null 2>&1
 if grep -qx -- "--model" "$ARGS_FILE"; then bad "omits --model for empty model"; else pass "omits --model for empty model"; fi
 
+# 4c. grok-4.5 (grok's current default) is a real grok id → --model is passed through,
+# and it's a reasoning model so GROK_EFFORT maps to --effort (unlike fast composer).
+echo "p" | GROK_FAKE_OUT='{"text":"x"}' MODEL=grok-4.5 SKILL_MODE=write XAI_API_KEY=xai-test GROK_EFFORT=high bash "$R" >/dev/null 2>&1
+grep -qx -- "--model" "$ARGS_FILE" && grep -qx "grok-4.5" "$ARGS_FILE" \
+  && pass "passes --model grok-4.5" || bad "passes --model grok-4.5"
+grep -qx -- "--effort" "$ARGS_FILE" && grep -qx "high" "$ARGS_FILE" \
+  && pass "grok-4.5 is reasoning → GROK_EFFORT maps to --effort" || bad "grok-4.5 reasoning effort"
+
 # 5. read-only mode adds --sandbox read-only
 echo "p" | GROK_FAKE_OUT='{"result":"x"}' MODEL=grok-build-0.1 SKILL_MODE=read-only XAI_API_KEY=xai-test bash "$R" >/dev/null 2>&1
 grep -qx -- "--sandbox" "$ARGS_FILE" && grep -qx "read-only" "$ARGS_FILE" \

--- a/skills/bd-radar/SKILL.md
+++ b/skills/bd-radar/SKILL.md
@@ -79,7 +79,7 @@ For ecosystem/extension repos, note the owner (potential partner).
 FROM_DATE=$(date -u -d "3 days ago" +%Y-%m-%d 2>/dev/null || date -u -v-3d +%Y-%m-%d)
 TERMS="<OR-joined product names + @handles read from memory/products.md>"
 jq -n --arg terms "$TERMS" --arg fd "$FROM_DATE" \
-  '{model:"grok-4-1-fast", input:[{role:"user",content:("Search X since "+$fd+" for posts mentioning any of: "+$terms+". For each post return: @handle, full text, date, whether the author reads as a project or builder (from bio/links), engagement counts, and the direct link https://x.com/handle/status/ID.")}], tools:[{type:"x_search"}]}' \
+  '{model:"grok-4.3", input:[{role:"user",content:("Search X since "+$fd+" for posts mentioning any of: "+$terms+". For each post return: @handle, full text, date, whether the author reads as a project or builder (from bio/links), engagement counts, and the direct link https://x.com/handle/status/ID.")}], tools:[{type:"x_search"}]}' \
   > /tmp/xai-bd-payload.json
 HTTP=$(./secretcurl -s -o /tmp/xai-bd.json -w '%{http_code}' --max-time 150 -X POST "https://api.x.ai/v1/responses" \
   -H "Content-Type: application/json" -H "Authorization: Bearer {XAI_API_KEY}" -d @/tmp/xai-bd-payload.json)

--- a/skills/digest/SKILL.md
+++ b/skills/digest/SKILL.md
@@ -61,7 +61,7 @@ Pull from the source classes selected by `${var}`. Never rely on a single one â€
    TO_DATE=$(date -u +%Y-%m-%d)
    PROMPT="Search X for substantive, recent posts about: ${topic:-the most notable technology, AI, and crypto stories today}. Date range: $FROM_DATE to $TO_DATE. Return up to 10 high-signal posts â€” prioritize verifiable claims, launches, funding, releases, exploits, or hard data over hot takes. For EACH post return: @handle, the full text, date posted, exact engagement counts (likes, retweets, replies; 0 if unknown), and the direct link https://x.com/handle/status/ID. Return a numbered list."
    jq -n --arg p "$PROMPT" --arg fd "$FROM_DATE" --arg td "$TO_DATE" \
-     '{model:"grok-4-1-fast", input:[{role:"user",content:$p}], tools:[{type:"x_search",from_date:$fd,to_date:$td}]}' \
+     '{model:"grok-4.3", input:[{role:"user",content:$p}], tools:[{type:"x_search",from_date:$fd,to_date:$td}]}' \
      > /tmp/xai-digest-payload.json
    HTTP=$(./secretcurl -s -o /tmp/xai-digest.json -w '%{http_code}' --max-time 150 -X POST "https://api.x.ai/v1/responses" \
      -H "Content-Type: application/json" -H "Authorization: Bearer {XAI_API_KEY}" -d @/tmp/xai-digest-payload.json)

--- a/skills/fetch-tweets/SKILL.md
+++ b/skills/fetch-tweets/SKILL.md
@@ -75,7 +75,7 @@ Search X for tweets matching `ARG` and produce a curated digest grouped by sub-n
    FROM_DATE=$(date -u -d "yesterday" +%Y-%m-%d 2>/dev/null || date -u -v-1d +%Y-%m-%d)
    TO_DATE=$(date -u +%Y-%m-%d)
    PROMPT="Search X for tweets about: ${ARG}. Date range: ${FROM_DATE} to ${TO_DATE}. Return at least 15-20 candidate tweets — mix of high-engagement posts and smaller accounts that add a distinct angle. For each tweet include: @handle, the full text, date posted, exact engagement counts (likes, retweets, replies — never N/A; if unknown, say 0), and the direct link (https://x.com/handle/status/ID). Return as a numbered list."
-   jq -n --arg p "$PROMPT" '{model:"grok-4-1-fast", input:[{role:"user",content:$p}], tools:[{type:"x_search"}]}' > /tmp/xai-ft-keyword.json
+   jq -n --arg p "$PROMPT" '{model:"grok-4.3", input:[{role:"user",content:$p}], tools:[{type:"x_search"}]}' > /tmp/xai-ft-keyword.json
    HTTP=$(./secretcurl -s -o /tmp/xai.json -w '%{http_code}' --max-time 150 -X POST "https://api.x.ai/v1/responses" \
      -H "Content-Type: application/json" \
      -H "Authorization: Bearer {XAI_API_KEY}" \
@@ -146,7 +146,7 @@ Gist of the latest X chatter on one or more configurable topics.
    FROM_DATE=$(date -u -d "yesterday" +%Y-%m-%d 2>/dev/null || date -u -v-1d +%Y-%m-%d)
    TO_DATE=$(date -u +%Y-%m-%d)
    PROMPT="Search X for recent tweets about: ${TOPIC}. Date range: ${FROM_DATE} to ${TO_DATE}. Return up to 8 substantive tweets. For each: @handle, full text, date, exact engagement counts (likes, retweets, replies; 0 if unknown), and the direct link https://x.com/handle/status/ID."
-   jq -n --arg p "$PROMPT" '{model:"grok-4-1-fast", input:[{role:"user",content:$p}], tools:[{type:"x_search"}]}' > /tmp/xai-ft-topic.json
+   jq -n --arg p "$PROMPT" '{model:"grok-4.3", input:[{role:"user",content:$p}], tools:[{type:"x_search"}]}' > /tmp/xai-ft-topic.json
    ./secretcurl -s -o /tmp/xai-topic-out.json -X POST "https://api.x.ai/v1/responses" \
      -H "Content-Type: application/json" \
      -H "Authorization: Bearer {XAI_API_KEY}" \
@@ -198,7 +198,7 @@ Two sub-modes: **single handle** (decision-ready gist of one account) vs. **all 
    - **Path A — X.AI API** (primary): search this account's recent tweets via Grok's `x_search`.
      ```bash
      PROMPT="Search X for the latest tweets, replies, and quote tweets from @${ACCOUNT} in the last 2 days. Return each with full text, timestamp, type (original|reply|quote), what it replies to/quotes if any, exact engagement counts (likes, retweets, replies; 0 if unknown), and the permalink https://x.com/${ACCOUNT}/status/ID. Skip retweets of others. Return chronological."
-     jq -n --arg p "$PROMPT" '{model:"grok-4-1-fast", input:[{role:"user",content:$p}], tools:[{type:"x_search"}]}' > /tmp/xai-ft-account.json
+     jq -n --arg p "$PROMPT" '{model:"grok-4.3", input:[{role:"user",content:$p}], tools:[{type:"x_search"}]}' > /tmp/xai-ft-account.json
      ./secretcurl -m 30 -s -o /tmp/xai-account-out.json -X POST "https://api.x.ai/v1/responses" \
        -H "Content-Type: application/json" \
        -H "Authorization: Bearer {XAI_API_KEY}" \
@@ -258,7 +258,7 @@ Use this to answer "what did *these specific people* post" across a watchlist.
    - **Path A — live curl** (primary, `XAI_API_KEY` is injected and set):
      ```bash
      PROMPT="Search X for the latest tweets from:${HANDLE} in the last 3 days. Return the 5 most interesting or substantive tweets. For each: full text, date, direct link (https://x.com/${HANDLE}/status/ID). Skip retweets of others."
-     jq -n --arg p "$PROMPT" '{model:"grok-4-1-fast", input:[{role:"user",content:$p}], tools:[{type:"x_search"}]}' > /tmp/xai-ft-acct1.json
+     jq -n --arg p "$PROMPT" '{model:"grok-4.3", input:[{role:"user",content:$p}], tools:[{type:"x_search"}]}' > /tmp/xai-ft-acct1.json
      ./secretcurl -m 30 -s -o /tmp/xai-acct1-out.json -X POST "https://api.x.ai/v1/responses" \
        -H "Content-Type: application/json" \
        -H "Authorization: Bearer {XAI_API_KEY}" \
@@ -322,7 +322,7 @@ Cross-list narrative resonance + signal-scored top tweets from tracked X lists i
    TO_DATE=$(date -u +%Y-%m-%d)
    PROMPT="Look at X list https://x.com/i/lists/${LIST_ID}. Step 1: report the list name and a one-line description. Step 2: identify the most engaging tweets posted by members of this list between ${FROM_DATE} and ${TO_DATE} UTC. Return the top 12 tweets ranked by engagement (likes, retweets, replies). For EACH tweet you MUST return: (a) @handle, (b) the full tweet text (not a paraphrase), (c) explicit engagement counts as separate fields — likes:N, retweets:N, replies:N, views:N if available, (d) the direct permalink in the form https://x.com/<handle>/status/<id>, (e) media type (image|video|none), (f) one-line context if it's a reply or quote tweet (who/what). Skip retweets of accounts NOT on this list. If a tweet has an image and you can analyze it, include a one-line image description."
    jq -n --arg p "$PROMPT" --arg fd "$FROM_DATE" --arg td "$TO_DATE" \
-     '{model:"grok-4-1-fast", input:[{role:"user",content:$p}], tools:[{type:"x_search", from_date:$fd, to_date:$td, enable_image_understanding:true}]}' \
+     '{model:"grok-4.3", input:[{role:"user",content:$p}], tools:[{type:"x_search", from_date:$fd, to_date:$td, enable_image_understanding:true}]}' \
      > /tmp/xai-ft-list.json
    ./secretcurl -s -o /tmp/xai-list-out.json --max-time 180 -X POST "https://api.x.ai/v1/responses" \
      -H "Content-Type: application/json" \
@@ -402,7 +402,7 @@ A topic-filtered preset: a curated, narrative-aware read on what the AI-agent sc
    ```bash
    PROMPT="Search X from ${FROM_DATE} to ${TO_DATE} for tweets in the AI-agents conversation: autonomous agents, agent frameworks, MCP / agent protocols, agent products, agent benchmarks, agent research papers. Return up to 40 candidates. For EACH candidate you MUST return: @handle, follower_count (integer or null), role_guess (builder|founder|researcher|investor|commentator|anon), one-line claim (what they actually said — not a paraphrase, the thesis), likes (int), retweets (int), replies (int), posted_at (ISO), direct_link (https://x.com/username/status/ID). Prefer builders/founders/researchers. Skip obvious engagement-farming threads (\"RT if you agree\", reply-guy pileons, giveaways)."
    jq -n --arg p "$PROMPT" --arg fd "$FROM_DATE" --arg td "$TO_DATE" \
-     '{model:"grok-4-1-fast", input:[{role:"user",content:$p}], tools:[{type:"x_search", from_date:$fd, to_date:$td}]}' \
+     '{model:"grok-4.3", input:[{role:"user",content:$p}], tools:[{type:"x_search", from_date:$fd, to_date:$td}]}' \
      > /tmp/xai-ft-buzz.json
    ./secretcurl -s -o /tmp/xai-buzz-out.json -X POST "https://api.x.ai/v1/responses" \
      -H "Content-Type: application/json" \

--- a/skills/last30/SKILL.md
+++ b/skills/last30/SKILL.md
@@ -108,7 +108,7 @@ curl -sL -A "$UA" \
 [ -n "$XAI_API_KEY" ] && echo KEY_PRESENT || echo KEY_UNSET   # prints KEY_PRESENT — Path A is required
 # Build the payload to a file with jq --arg (no heredoc into a var) so the ./secretcurl command stays 100% literal:
 jq -n --arg topic "$TOPIC" --arg variants "$SEARCH_VARIANTS" --arg fd "$FROM_DATE" --arg td "$TO_DATE" \
-  '{model:"grok-4-1-fast", input:[{role:"user",content:("Search X for tweets about: "+$topic+" (also try: "+$variants+"). Date range: "+$fd+" to "+$td+". Return 15-25 substantive tweets — mix high-engagement posts with smaller accounts that add a distinct angle. For each: @handle, full text, date posted, exact engagement counts (likes, retweets, replies; 0 if unknown), follower count if available, and the direct link https://x.com/handle/status/ID. Skip retweets and reply-guy near-duplicates.")}], tools:[{type:"x_search",from_date:$fd,to_date:$td}]}' \
+  '{model:"grok-4.3", input:[{role:"user",content:("Search X for tweets about: "+$topic+" (also try: "+$variants+"). Date range: "+$fd+" to "+$td+". Return 15-25 substantive tweets — mix high-engagement posts with smaller accounts that add a distinct angle. For each: @handle, full text, date posted, exact engagement counts (likes, retweets, replies; 0 if unknown), follower count if available, and the direct link https://x.com/handle/status/ID. Skip retweets and reply-guy near-duplicates.")}], tools:[{type:"x_search",from_date:$fd,to_date:$td}]}' \
   > /tmp/xai-last30-topic-payload.json
 HTTP=$(./secretcurl -s -o /tmp/xai-last30-topic.json -w '%{http_code}' --max-time 150 -X POST "https://api.x.ai/v1/responses" \
   -H "Content-Type: application/json" \
@@ -126,7 +126,7 @@ jq -r '.output[]|select(.type=="message")|.content[]|select(.type=="output_text"
 ```bash
 # Build the handle-restricted payload to its own file with jq --arg (keeps the ./secretcurl command literal):
 jq -n --arg topic "$TOPIC" --arg handles "$RESOLVED_HANDLES" --arg fd "$FROM_DATE" --arg td "$TO_DATE" \
-  '{model:"grok-4-1-fast", input:[{role:"user",content:("Search X for tweets from these accounts about "+$topic+": "+$handles+". Date range: "+$fd+" to "+$td+". For each: @handle, full text, date, engagement counts (likes, retweets, replies; 0 if unknown), and the direct link https://x.com/handle/status/ID.")}], tools:[{type:"x_search",from_date:$fd,to_date:$td}]}' \
+  '{model:"grok-4.3", input:[{role:"user",content:("Search X for tweets from these accounts about "+$topic+": "+$handles+". Date range: "+$fd+" to "+$td+". For each: @handle, full text, date, engagement counts (likes, retweets, replies; 0 if unknown), and the direct link https://x.com/handle/status/ID.")}], tools:[{type:"x_search",from_date:$fd,to_date:$td}]}' \
   > /tmp/xai-last30-handles-payload.json
 HTTP=$(./secretcurl -s -o /tmp/xai-last30-handles.json -w '%{http_code}' --max-time 150 -X POST "https://api.x.ai/v1/responses" \
   -H "Content-Type: application/json" \
@@ -365,7 +365,7 @@ For `LAST30_EMPTY` or `LAST30_ERROR`, skip the verdict/narrative lines and inste
 
 ## Fetching
 
-`XAI_API_KEY` is **injected into this skill's environment** (declared in `requires:`) and is present and valid. The **primary** X/Twitter source is a direct `curl` to `https://api.x.ai/v1/responses` with `Authorization: Bearer {XAI_API_KEY}`, model `grok-4-1-fast`, `"tools":[{"type":"x_search"}]`. There is **no** network sandbox blocking this — just make the call (see step 3).
+`XAI_API_KEY` is **injected into this skill's environment** (declared in `requires:`) and is present and valid. The **primary** X/Twitter source is a direct `curl` to `https://api.x.ai/v1/responses` with `Authorization: Bearer {XAI_API_KEY}`, model `grok-4.3`, `"tools":[{"type":"x_search"}]`. There is **no** network sandbox blocking this — just make the call (see step 3).
 
 **You MUST attempt the direct curl before any fallback:**
 1. **Check, don't assume.** `[ -n "$XAI_API_KEY" ] && echo KEY_PRESENT || echo KEY_UNSET`. If `KEY_PRESENT` (it will be), Path A is required.

--- a/skills/mention-radar/SKILL.md
+++ b/skills/mention-radar/SKILL.md
@@ -36,7 +36,7 @@ Read the last 3 days of memory/logs/ to avoid re-surfacing already-noted mention
    TO_DATE=$(date -u +%Y-%m-%d)
    PROMPT="Search X for posts by OTHER people mentioning the project \"${NAME}\" (also its site ${DOMAIN} and repo ${REPO} when given), posted between ${FROM_DATE} and ${TO_DATE}. Exclude posts by the operator @${OPERATOR} and by the project's own accounts. For each mention return: @handle, the full post text, date, exact engagement counts (likes, retweets, replies; 0 if unknown), the poster's approximate follower count if visible, and the direct link https://x.com/handle/status/ID. Prioritize people discovering it for the first time, asking confused questions, hitting friction (setup/docs/missing feature), comparing it to a competitor, or requesting a feature. Return a numbered list; if nobody is talking about it, say so explicitly."
    jq -n --arg p "$PROMPT" --arg fd "$FROM_DATE" --arg td "$TO_DATE" \
-     '{model:"grok-4-1-fast", input:[{role:"user",content:$p}], tools:[{type:"x_search",from_date:$fd,to_date:$td}]}' \
+     '{model:"grok-4.3", input:[{role:"user",content:$p}], tools:[{type:"x_search",from_date:$fd,to_date:$td}]}' \
      > /tmp/xai-mr-payload.json
    HTTP=$(./secretcurl -s -o /tmp/xai-mr.json -w '%{http_code}' --max-time 150 -X POST "https://api.x.ai/v1/responses" \
      -H "Content-Type: application/json" \

--- a/skills/narrative-tracker/SKILL.md
+++ b/skills/narrative-tracker/SKILL.md
@@ -38,7 +38,7 @@ TO_DATE=$(date -u +%Y-%m-%d)
 # The `>` redirect to /tmp is fine in read-only mode (it is not a repo path; nothing reverts it).
 PROMPT="Search X for the dominant crypto and tech narratives from ${FROM_DATE} to ${TO_DATE}. Return 12-15 distinct narrative threads. For each: 1) short label, 2) 3-5 representative @handles driving it, 3) 2-3 tweet permalinks, 4) rough mention-volume descriptor (niche / growing / saturating / cooling), 5) the strongest one-line bear case against it."
 jq -n --arg p "$PROMPT" --arg fd "$FROM_DATE" --arg td "$TO_DATE" \
-  '{model:"grok-4-1-fast", input:[{role:"user",content:$p}], tools:[{type:"x_search",from_date:$fd,to_date:$td}]}' \
+  '{model:"grok-4.3", input:[{role:"user",content:$p}], tools:[{type:"x_search",from_date:$fd,to_date:$td}]}' \
   > /tmp/xai-nt-payload.json
 HTTP=$(./secretcurl -s -o /tmp/xai-nt.json -w '%{http_code}' --max-time 150 -X POST "https://api.x.ai/v1/responses" \
   -H "Content-Type: application/json" \
@@ -138,7 +138,7 @@ Append a `### narrative-tracker` section with the full structured output (not ju
 
 ## Fetching
 
-`XAI_API_KEY` is **injected into this skill's environment** (declared in `requires:`). It is present and valid. **The primary fetch path is a direct `curl` to `https://api.x.ai/v1/responses` with `Authorization: Bearer {XAI_API_KEY}`** (model `grok-4-1-fast`, `"tools":[{"type":"x_search"}]`). There is **no network sandbox** blocking this — earlier versions of this skill claimed there was, and that is stale and false. Just make the call.
+`XAI_API_KEY` is **injected into this skill's environment** (declared in `requires:`). It is present and valid. **The primary fetch path is a direct `curl` to `https://api.x.ai/v1/responses` with `Authorization: Bearer {XAI_API_KEY}`** (model `grok-4.3`, `"tools":[{"type":"x_search"}]`). There is **no network sandbox** blocking this — earlier versions of this skill claimed there was, and that is stale and false. Just make the call.
 
 Rules:
 1. **Check, don't assume.** Run `[ -n "${XAI_API_KEY:+x}" ] && echo KEY_PRESENT || echo KEY_UNSET` (the `${VAR:+x}` form, not bare `$XAI_API_KEY` — the bare form trips the secret-expansion analyzer and falsely reads as unset). If `KEY_PRESENT` (it will be), Path A (the curl in step 1a) is required before any fallback.

--- a/skills/reply-maker/SKILL.md
+++ b/skills/reply-maker/SKILL.md
@@ -100,7 +100,7 @@ jq -r '.output[] | select(.type == "message") | .content[] | select(.type == "ou
 ```bash
 LIST_ID="${var}"
 jq -n --arg list_id "$LIST_ID" --arg from "$FROM_DATE" --arg to "$TO_DATE" '{
-  model: "grok-4-1-fast",
+  model: "grok-4.3",
   input: [{role: "user", content: ("Look at X list https://x.com/i/lists/" + $list_id + ". Return the 12 most reply-worthy original posts (not retweets, not replies) by members of this list between " + $from + " and " + $to + ". Reply-worthy = has a take, claim, question, or framing worth engaging — NOT pure self-promo, breaking news without analysis, or threads already past 500 replies. For each: @handle, full tweet text, tweet URL, posted_at ISO timestamp, like/reply/retweet counts.")}],
   tools: [{type: "x_search", from_date: $from, to_date: $to}]
 }' > /tmp/xai-rm-payload.json
@@ -110,7 +110,7 @@ jq -n --arg list_id "$LIST_ID" --arg from "$FROM_DATE" --arg to "$TO_DATE" '{
 ```bash
 HANDLE="${var}"
 jq -n --arg handle "$HANDLE" --arg from "$FROM_DATE" --arg to "$TO_DATE" '{
-  model: "grok-4-1-fast",
+  model: "grok-4.3",
   input: [{role: "user", content: ("Look at recent original posts (not retweets, not replies) by " + $handle + " on X between " + $from + " and " + $to + ". Return the 12 most reply-worthy. Reply-worthy = has a take, claim, question, or framing worth engaging — NOT pure self-promo, breaking news without analysis, or threads already past 500 replies. For each: @handle, full tweet text, tweet URL, posted_at ISO timestamp, like/reply/retweet counts.")}],
   tools: [{type: "x_search", from_date: $from, to_date: $to}]
 }' > /tmp/xai-rm-payload.json
@@ -120,7 +120,7 @@ jq -n --arg handle "$HANDLE" --arg from "$FROM_DATE" --arg to "$TO_DATE" '{
 ```bash
 TOPIC="${var}"   # when empty, substitute the top 2–3 topics from memory/MEMORY.md
 jq -n --arg topic "$TOPIC" --arg from "$FROM_DATE" --arg to "$TO_DATE" '{
-  model: "grok-4-1-fast",
+  model: "grok-4.3",
   input: [{role: "user", content: ("Search X for the 12 most reply-worthy original posts (not retweets, not replies) about " + $topic + " between " + $from + " and " + $to + ". Reply-worthy = has a take, claim, question, or framing worth engaging — NOT pure self-promo, breaking news without analysis, or threads already past 500 replies. For each: @handle, full tweet text, tweet URL, posted_at ISO timestamp, like/reply/retweet counts.")}],
   tools: [{type: "x_search", from_date: $from, to_date: $to}]
 }' > /tmp/xai-rm-payload.json

--- a/skills/shiplog/SKILL.md
+++ b/skills/shiplog/SKILL.md
@@ -112,7 +112,7 @@ There are two X sources here — the **operator** handle (`$OPERATOR_HANDLE`, th
 
 *Operator posts* (`SRC=operator`):
 ```bash
-jq -n --arg h "$OPERATOR_HANDLE" --arg sd "$SINCE_DATE" --arg td "$TODAY" '{model:"grok-4-1-fast", input:[{role:"user", content:("Search X for posts by @" + $h + " between " + $sd + " and " + $td + ". Return each post with full text, date, type (original|reply|RT — an RT text starts with \"RT @\"), exact engagement counts (likes, retweets, replies; 0 if unknown), and the direct link https://x.com/" + $h + "/status/ID. Return chronological.")}], tools:[{type:"x_search"}]}' > /tmp/xai-shiplog-operator-payload.json
+jq -n --arg h "$OPERATOR_HANDLE" --arg sd "$SINCE_DATE" --arg td "$TODAY" '{model:"grok-4.3", input:[{role:"user", content:("Search X for posts by @" + $h + " between " + $sd + " and " + $td + ". Return each post with full text, date, type (original|reply|RT — an RT text starts with \"RT @\"), exact engagement counts (likes, retweets, replies; 0 if unknown), and the direct link https://x.com/" + $h + "/status/ID. Return chronological.")}], tools:[{type:"x_search"}]}' > /tmp/xai-shiplog-operator-payload.json
 HTTP=$(./secretcurl -s -o /tmp/xai-shiplog-operator.json -w '%{http_code}' --max-time 150 -X POST "https://api.x.ai/v1/responses" \
   -H "Content-Type: application/json" -H "Authorization: Bearer {XAI_API_KEY}" -d @/tmp/xai-shiplog-operator-payload.json)
 echo "xai http=$HTTP bytes=$(wc -c </tmp/xai-shiplog-operator.json)"
@@ -120,7 +120,7 @@ echo "xai http=$HTTP bytes=$(wc -c </tmp/xai-shiplog-operator.json)"
 
 *Product/project accounts* (`SRC=projects`):
 ```bash
-jq -n --arg sd "$SINCE_DATE" --arg td "$TODAY" --arg ph "$PRODUCT_HANDLES" '{model:"grok-4-1-fast", input:[{role:"user", content:("Search X for posts between " + $sd + " and " + $td + " from these accounts: " + $ph + ". Focus on launches, announcements, and any brag about a security fix merged into another project. For each: @handle, full text, date, exact engagement counts (likes, retweets, replies; 0 if unknown), and the direct link https://x.com/handle/status/ID. Skip retweets of others.")}], tools:[{type:"x_search"}]}' > /tmp/xai-shiplog-projects-payload.json
+jq -n --arg sd "$SINCE_DATE" --arg td "$TODAY" --arg ph "$PRODUCT_HANDLES" '{model:"grok-4.3", input:[{role:"user", content:("Search X for posts between " + $sd + " and " + $td + " from these accounts: " + $ph + ". Focus on launches, announcements, and any brag about a security fix merged into another project. For each: @handle, full text, date, exact engagement counts (likes, retweets, replies; 0 if unknown), and the direct link https://x.com/handle/status/ID. Skip retweets of others.")}], tools:[{type:"x_search"}]}' > /tmp/xai-shiplog-projects-payload.json
 HTTP=$(./secretcurl -s -o /tmp/xai-shiplog-projects.json -w '%{http_code}' --max-time 150 -X POST "https://api.x.ai/v1/responses" \
   -H "Content-Type: application/json" -H "Authorization: Bearer {XAI_API_KEY}" -d @/tmp/xai-shiplog-projects-payload.json)
 echo "xai http=$HTTP bytes=$(wc -c </tmp/xai-shiplog-projects.json)"
@@ -140,7 +140,7 @@ From the **operator** text, separate **original posts** from **RTs** (RT text st
 
 - **Ecosystem mentions** — only if `ecosystem_scouts` (`scouts:`) is configured. Fetch with the same **Path A** X.AI curl as Step 3, into its own tmp file (`SRC=ecosystem`):
   ```bash
-  jq -n --arg sd "$SINCE_DATE" --arg td "$TODAY" --arg es "$ECOSYSTEM_SCOUTS" --arg ph "$PRODUCT_HANDLES" '{model:"grok-4-1-fast", input:[{role:"user", content:("Search X between " + $sd + " and " + $td + " for posts from these recap/scout accounts: " + $es + " that mention any of these products: " + $ph + ". Return each mention with @handle, follower_count, full text, date, and the direct link https://x.com/handle/status/ID — recaps, rankings, partner shares.")}], tools:[{type:"x_search"}]}' > /tmp/xai-shiplog-ecosystem-payload.json
+  jq -n --arg sd "$SINCE_DATE" --arg td "$TODAY" --arg es "$ECOSYSTEM_SCOUTS" --arg ph "$PRODUCT_HANDLES" '{model:"grok-4.3", input:[{role:"user", content:("Search X between " + $sd + " and " + $td + " for posts from these recap/scout accounts: " + $es + " that mention any of these products: " + $ph + ". Return each mention with @handle, follower_count, full text, date, and the direct link https://x.com/handle/status/ID — recaps, rankings, partner shares.")}], tools:[{type:"x_search"}]}' > /tmp/xai-shiplog-ecosystem-payload.json
   HTTP=$(./secretcurl -s -o /tmp/xai-shiplog-ecosystem.json -w '%{http_code}' --max-time 150 -X POST "https://api.x.ai/v1/responses" \
     -H "Content-Type: application/json" -H "Authorization: Bearer {XAI_API_KEY}" -d @/tmp/xai-shiplog-ecosystem-payload.json)
   echo "xai http=$HTTP bytes=$(wc -c </tmp/xai-shiplog-ecosystem.json)"

--- a/skills/soul-builder/SKILL.md
+++ b/skills/soul-builder/SKILL.md
@@ -52,7 +52,7 @@ Gather from **every** source provided and **merge** everything useful — more s
    # with -d @file so the secretcurl command itself stays 100% literal (no shell
    # var expansion in the curl argv — the permission analyzer blocks that).
    jq -n --arg h "$HANDLE" '{
-     model: "grok-4-1-fast",
+     model: "grok-4.3",
      input: [{role: "user", content: ("Build a voice and identity profile of X/Twitter account @" + $h + ". Step 1: return their profile — display name, bio/description, location, website, and what they pin or lead with. Step 2: return a WIDE, DIVERSE sample of 40-60 of their OWN ORIGINAL posts across a long window (not just the last day, not only the viral ones): mix short reactions, medium takes, and longer threads; span different topics, tones, and engagement levels; include some high-engagement and some quiet posts so their full range shows. Include representative replies and quote-tweets — they carry voice and opinion — but skip pure retweets of others. For EACH post return: the full text VERBATIM (never a paraphrase), the date, the type (original|reply|quote|thread-part), and the direct permalink https://x.com/" + $h + "/status/ID. Favour breadth of register over recency.")}],
      tools: [{type: "x_search"}]
    }' > /tmp/xai-soul-payload.json
@@ -252,7 +252,7 @@ Append to `memory/logs/${today}.md`:
 
 ## Fetching the X account
 
-`XAI_API_KEY` is **injected into this skill's environment** (declared in `requires:`). When it is present, **the primary way to read the X account is a direct `curl` to `https://api.x.ai/v1/responses` with `Authorization: Bearer {XAI_API_KEY}`** (Grok's `x_search`, model `grok-4-1-fast`). There is no network sandbox blocking this — just make the call. The rules:
+`XAI_API_KEY` is **injected into this skill's environment** (declared in `requires:`). When it is present, **the primary way to read the X account is a direct `curl` to `https://api.x.ai/v1/responses` with `Authorization: Bearer {XAI_API_KEY}`** (Grok's `x_search`, model `grok-4.3`). There is no network sandbox blocking this — just make the call. The rules:
 
 1. **Check, don't assume.** Run `[ -n "$XAI_API_KEY" ] && echo KEY_PRESENT || echo KEY_UNSET`. If `KEY_PRESENT` (it will be on a normal run), you are required to try Path A before any fallback.
 2. **Allow enough time.** The `x_search` call typically takes 30–120s (it searches X live). When you invoke the Bash tool for the curl, **set the tool's `timeout` to at least 180000 (180s)**, and the curl carries **`--max-time 150`** so it fails cleanly instead of hanging. A curl that is slow is **not** a missing key — never treat a timeout as "key unavailable".

--- a/skills/token-movers/SKILL.md
+++ b/skills/token-movers/SKILL.md
@@ -580,7 +580,7 @@ Save to `output/articles/token-report-${today}.md`:
 If `XAI_API_KEY` is set:
 
 ```bash
-jq -n '{model:"grok-4-1-fast", input:[{role:"user",content:"Search X for TOKEN_SYMBOL or CONTRACT_ADDRESS mentions in the last 24 hours with at least 10 likes. Return up to 5 notable tweets with @handle, engagement counts, and a one-line summary of the claim or vibe. Exclude obvious bots and generic shill posts."}], tools:[{type:"x_search"}]}' > /tmp/xai-tm-payload.json
+jq -n '{model:"grok-4.3", input:[{role:"user",content:"Search X for TOKEN_SYMBOL or CONTRACT_ADDRESS mentions in the last 24 hours with at least 10 likes. Return up to 5 notable tweets with @handle, engagement counts, and a one-line summary of the claim or vibe. Exclude obvious bots and generic shill posts."}], tools:[{type:"x_search"}]}' > /tmp/xai-tm-payload.json
 ./secretcurl -s -X POST "https://api.x.ai/v1/responses" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer {XAI_API_KEY}" \

--- a/skills/write-tweet/SKILL.md
+++ b/skills/write-tweet/SKILL.md
@@ -75,7 +75,7 @@ If the topic needs fresher context, use WebSearch to verify or expand.
 
 If `XAI_API_KEY` is set, search X for what people are already saying about the topic. A direct `curl` to the X.AI Responses API is the **primary** path for this X read (see **Fetching**; set the Bash tool `timeout` ≥180000):
 ```bash
-jq -n '{model:"grok-4-1-fast", input:[{role:"user",content:"Search X for what people are saying about TOPIC in the last 24 hours. Return the 5 most notable tweets with @handle and summary."}], tools:[{type:"x_search"}]}' > /tmp/xai-wt-payload.json
+jq -n '{model:"grok-4.3", input:[{role:"user",content:"Search X for what people are saying about TOPIC in the last 24 hours. Return the 5 most notable tweets with @handle and summary."}], tools:[{type:"x_search"}]}' > /tmp/xai-wt-payload.json
 HTTP=$(./secretcurl -s -o /tmp/xai-wt.json -w '%{http_code}' --max-time 150 -X POST "https://api.x.ai/v1/responses" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer {XAI_API_KEY}" \
@@ -425,7 +425,7 @@ Each query must request for every tweet: full text, date posted, engagement stat
 # Replace HANDLE with the resolved handle. Set the Bash tool timeout ≥180000 (see Fetching).
 Q1_PROMPT="Search X for original tweets (exclude replies, retweets, quote tweets) posted by @HANDLE from ${FROM_DATE} to ${TO_DATE}. I want OPINION/TAKE posts — tweets that state a view, principle, or observation (not news announcements, not project updates, not single-link posts). Return up to 15. For each: full tweet text, date (YYYY-MM-DD), likes, retweets, replies, direct link https://x.com/HANDLE/status/ID. Format as numbered list."
 jq -n --arg p "$Q1_PROMPT" --arg fd "$FROM_DATE" --arg td "$TO_DATE" \
-  '{model:"grok-4-1-fast", input:[{role:"user",content:$p}], tools:[{type:"x_search", allowed_x_handles:["HANDLE"], from_date:$fd, to_date:$td}]}' \
+  '{model:"grok-4.3", input:[{role:"user",content:$p}], tools:[{type:"x_search", allowed_x_handles:["HANDLE"], from_date:$fd, to_date:$td}]}' \
   > /tmp/xai-wt-q1-payload.json
 HTTP=$(./secretcurl -s -o /tmp/xai-wt-q1.json -w '%{http_code}' --max-time 150 -X POST "https://api.x.ai/v1/responses" \
   -H "Content-Type: application/json" \
@@ -620,7 +620,7 @@ Append **one** entry to `memory/logs/${today}.md` under a single `### write-twee
 
 ## Fetching
 
-`XAI_API_KEY` is **injected into this skill's environment** (declared in `requires:`). It is present and valid. **The primary way to fetch X/Twitter context — the DRAFTS "what people are saying" search and the REMIX tweet pull — is a direct `curl` to `https://api.x.ai/v1/responses` with `Authorization: Bearer {XAI_API_KEY}`, model `grok-4-1-fast`, and `"tools":[{"type":"x_search"}]`.** There is no network sandbox blocking this; earlier versions of this skill claimed there was — that is stale and wrong. Just make the call.
+`XAI_API_KEY` is **injected into this skill's environment** (declared in `requires:`). It is present and valid. **The primary way to fetch X/Twitter context — the DRAFTS "what people are saying" search and the REMIX tweet pull — is a direct `curl` to `https://api.x.ai/v1/responses` with `Authorization: Bearer {XAI_API_KEY}`, model `grok-4.3`, and `"tools":[{"type":"x_search"}]`.** There is no network sandbox blocking this; earlier versions of this skill claimed there was — that is stale and wrong. Just make the call.
 
 **You MUST attempt the direct curl before any fallback.** The rules:
 


### PR DESCRIPTION
## Support Grok 4.5 + migrate deprecated x_search model

Verified live against the grok CLI **0.2.101** and [docs.x.ai/developers/models](https://docs.x.ai/developers/models). Two related changes.

### 1. Grok 4.5 in the Grok Build harness (`0519002`)

xAI's Grok Build CLI now defaults to **`grok-4.5`** (the flagship reasoning model that powers Grok Build), with `grok-composer-2.5-fast` as the fast/cheap option. Under the X-account (`GROK_CREDENTIALS`) login, those two are the whole catalog; `grok-build` is `XAI_API_KEY`/api.x.ai-only. Aeon's config still assumed `composer` was grok's default and never offered `grok-4.5`.

- `apps/dashboard/lib/constants.ts` — `grok-4.5` added as the first/default `GROK_MODELS` entry; documented `grok-build` as `XAI_API_KEY`-only.
- `.github/workflows/aeon.yml` — added `grok-4.5` to the model dropdown; grok-harness fallback → `grok-4.5`; **pinned the health scorer to `grok-composer-2.5-fast`** (latent bug: it relied on grok's default, which silently became the pricier `grok-4.5`).
- `.github/workflows/messages.yml` — grok-harness fallback → `grok-4.5`.
- `scripts/run-grok.sh` — CLI pin `0.2.82 → 0.2.101`; refreshed stale "composer is the default" comments (`grok-4.5` is reasoning-capable, already covered by the `grok-*` effort gate).
- `scripts/llm-gateway.sh` — documented `grok-4.5` as a `GROK_MODEL` gateway override.
- `aeon.yml`, `docs/harnesses.md` — comment refreshes.
- `scripts/tests/test_run_grok.sh` — added `grok-4.5` passthrough + reasoning-effort tests.

### 2. Migrate deprecated `grok-4-1-fast` → `grok-4.3` for x_search (`60db36f`)

`grok-4-1-fast` is deprecated — off the api.x.ai catalog, and since **2026-05-15** it redirects to `grok-4.3`. `grok-4.3` is xAI's flagship agentic tool-calling model and exactly what `grok-4-1-fast` already resolves to, so this is **behavior-preserving today** — it just drops the deprecated id before the redirect is retired. Migrated all **26 occurrences across 11 skills** (x_search request payloads + prose). `grok-4.5` was deliberately *not* used — that's the coding flagship, not the agentic-search model.

### Validation

run-grok test suite (28 pass, incl. 2 new), `actionlint`, `validate-config.js`, `okf-validate.mjs` — all green.
