### PR TITLE
ci: bump actions/cache@v4 → v6 (drop Node 20 deprecation warning)

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -154,7 +154,7 @@ jobs:
         # ~100% hit after the first run of a version, shared with messages.yml). The
         # restore-keys prefix degrades gracefully on a version bump. Keep the version
         # in the key in sync with the pin below.
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.npm
           key: claude-code-${{ runner.os }}-2.1.168

--- a/.github/workflows/messages.yml
+++ b/.github/workflows/messages.yml
@@ -376,7 +376,7 @@ jobs:
         if: steps.msg.outputs.source != ''
         # Shares the pinned-version cache with aeon.yml so the global install runs
         # offline. Keep the version in the key in sync with the pin below.
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.npm
           key: claude-code-${{ runner.os }}-2.1.168


### PR DESCRIPTION
The heartbeat run's logs flagged: `Node.js 20 is deprecated ... actions/cache@v4 ... forced to run on Node.js 24`. `actions/cache@v4` declares node20; **v6.1.0** (latest) runs natively on node24. Cache API (path/key/restore-keys) unchanged → the two `~/.npm` cache steps (aeon.yml, messages.yml) behave identically. Verified v6 `using: node24`; actionlint clean.

The other heartbeat log lines were **not** issues: grok OAuth restore ✓, grok CLI on-demand install of 0.2.101 ✓ (expected), RESEND_API_KEY optional-not-set → fallbacks ✓. The run itself succeeded.