### PR TITLE
chore(grok): quiet benign harness log notices + drop grok-build from picker

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -27,7 +27,6 @@ on:
           - claude-haiku-4-5-20251001
           - grok-4.5
           - grok-composer-2.5-fast
-          - grok-build
       harness:
         description: 'Agent harness'
         required: false
@@ -202,7 +201,7 @@ jobs:
             fi
           done <<< "$SECRETS"
 
-          [ ${#OPTIONAL[@]} -gt 0 ] && echo "::notice::Optional secrets not set: ${OPTIONAL[*]} (skill will use fallbacks)"
+          [ ${#OPTIONAL[@]} -gt 0 ] && echo "::debug::Optional secrets not set: ${OPTIONAL[*]} (skill will use fallbacks)"
           [ ${#MISSING[@]} -gt 0 ] && echo "::warning::Secrets not set: ${MISSING[*]} — skill may fail or produce incomplete results"
           exit 0
 

--- a/aeon.yml
+++ b/aeon.yml
@@ -176,9 +176,8 @@ chains:
 # Default model for all skills. Override per-run via workflow_dispatch.
 # Options: claude-opus-4-8, claude-fable-5, claude-sonnet-5, claude-sonnet-4-6, claude-haiku-4-5-20251001
 # (Grok harness models: grok-4.5 — flagship reasoning model & grok's current default,
-#  run with --no-subagents in CI; grok-composer-2.5-fast — fast/cheap single-agent;
-#  grok-build — older coding model, XAI_API_KEY/api.x.ai only. Use the bare CLI id
-#  `grok-build`, not the API id `grok-build-0.1`.)
+#  run with --no-subagents in CI; grok-composer-2.5-fast — fast/cheap single-agent.
+#  The older grok-build-0.1 is gateway-only, via XAI_API_KEY + the GROK_MODEL var.)
 model: claude-sonnet-4-6
 
 # Agent harness — which coding-agent CLI runs your skills.

--- a/apps/dashboard/lib/constants.ts
+++ b/apps/dashboard/lib/constants.ts
@@ -12,25 +12,20 @@ export const MODELS = [
   { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5' },
 ]
 
-// Models offered when the Grok (`grok`) harness is selected.
+// Models offered when the Grok (`grok`) harness is selected — exactly the two the
+// X-account (GROK_CREDENTIALS) login exposes:
 // - grok-4.5 (grok's CURRENT default) — the flagship reasoning model that powers
-//   Grok Build. Multi-agent-capable, so run-grok.sh passes --no-subagents in CI
-//   (same mitigation as grok-build). This is the default new grok runs get.
+//   Grok Build. Multi-agent-capable, so run-grok.sh passes --no-subagents in CI.
 // - grok-composer-2.5-fast — fast, cheap single-agent; used for CI health scoring.
-// - grok-build — older reasoning/multi-agent coding model (API id grok-build-0.1).
-//   It used to Cancel every run in the Actions sandbox (its subagent-spawn tool was
-//   denied); run-grok.sh now passes --no-subagents by default, so it runs
-//   single-agent in CI. Skills that opt into best_of_n:/verify: get subagents back.
-//   NOTE: grok-build is reachable only via XAI_API_KEY on api.x.ai — the X-account
-//   (GROK_CREDENTIALS) login exposes only grok-4.5 + composer.
-// Use the bare CLI id (grok-build), not the API id (grok-build-0.1).
+// The older grok-build-0.1 is intentionally NOT offered here: it's reachable only via
+// XAI_API_KEY on api.x.ai (the gateway path — set the GROK_MODEL repo var), never on
+// the X-account login, so listing it as a harness option would be a dead click.
 // First entry is the default (modelsForHarness(...)[0] on harness switch). Keep this
 // list in sync with the workflow_dispatch `model` choice options in
 // .github/workflows/aeon.yml — a mismatch 422s at dispatch time.
 export const GROK_MODELS = [
   { id: 'grok-4.5', label: 'Grok 4.5' },
   { id: 'grok-composer-2.5-fast', label: 'Composer 2.5' },
-  { id: 'grok-build', label: 'Grok Build' },
 ]
 
 // Harnesses (agent CLIs). `claude` = Claude Code (default, uses the AI Gateway),

--- a/scripts/run-grok.sh
+++ b/scripts/run-grok.sh
@@ -56,7 +56,7 @@ log() { echo "$@" >&2; }
 
 # --- 1. ensure the CLI ------------------------------------------------------
 if ! command -v grok >/dev/null 2>&1; then
-  log "::notice::grok CLI not found — installing @xai-official/grok@${GROK_CLI_VERSION}"
+  log "::debug::grok CLI not found — installing @xai-official/grok@${GROK_CLI_VERSION}"
   if ! npm install -g "@xai-official/grok@${GROK_CLI_VERSION}" >&2; then
     log "::error::failed to install @xai-official/grok@${GROK_CLI_VERSION}"
     exit 1
@@ -79,20 +79,20 @@ if [ -n "${GROK_CREDENTIALS:-}" ]; then
   # it as the raw auth.json.
   if tar tzf "$tmp_creds" >/dev/null 2>&1; then
     tar xzf "$tmp_creds" -C "$HOME" >&2 || { log "::error::failed to extract GROK_CREDENTIALS"; rm -f "$tmp_creds"; exit 1; }
-    log "::notice::restored grok OAuth session from GROK_CREDENTIALS (archive)"
+    log "::debug::restored grok OAuth session from GROK_CREDENTIALS (archive)"
   else
     dest="${GROK_CREDENTIALS_PATH:-$GROK_HOME/auth.json}"
     mkdir -p "$(dirname "$dest")"
     cp "$tmp_creds" "$dest"; chmod 600 "$dest" 2>/dev/null || true
-    log "::notice::restored grok OAuth session from GROK_CREDENTIALS to ${dest}"
+    log "::debug::restored grok OAuth session from GROK_CREDENTIALS to ${dest}"
   fi
   rm -f "$tmp_creds"
 elif [ -n "${XAI_API_KEY:-}" ]; then
   export XAI_API_KEY
-  log "::notice::authenticating grok with XAI_API_KEY"
+  log "::debug::authenticating grok with XAI_API_KEY"
 elif [ -f "$GROK_HOME/auth.json" ]; then
   # Already signed in on this machine (local run / mcp-server path) — use it.
-  log "::notice::using existing grok session at $GROK_HOME/auth.json"
+  log "::debug::using existing grok session at $GROK_HOME/auth.json"
 else
   log "::error::grok harness needs auth: set GROK_CREDENTIALS (X-account login via the dashboard) or XAI_API_KEY, or run 'grok login'"
   exit 1
@@ -134,7 +134,7 @@ if [ -f .mcp.json ] && jq -e '.mcpServers' .mcp.json >/dev/null 2>&1; then
   for srv in $MCP_SERVERS; do
     MCP_ALLOW+=(--allow "MCPTool(${srv}__*)")
   done
-  log "::notice::MCP: grok loads .mcp.json natively; allowing tools from: $(printf '%s ' $MCP_SERVERS)"
+  log "::debug::MCP: grok loads .mcp.json natively; allowing tools from: $(printf '%s ' $MCP_SERVERS)"
   # A referenced ${VAR} that isn't in the env expands empty → that one server
   # can't authenticate and grok logs a connect error, but the run and the other
   # servers are unaffected. Warn (don't fail) so it's visible without breaking.
@@ -188,7 +188,7 @@ add_effort() {
   if [ "$MODEL_IS_REASONING" = 1 ]; then
     RUN_FLAGS+=("$flag" "$val")
   else
-    log "::notice::ignoring $flag $val — model '${MODEL:-<default composer>}' doesn't support reasoning effort (use a grok-build model)"
+    log "::debug::ignoring $flag $val — model '${MODEL:-<grok default>}' doesn't support reasoning effort (use a reasoning model like grok-4.5)"
   fi
 }
 add_effort GROK_EFFORT --effort "${GROK_EFFORT:-}"


### PR DESCRIPTION
chore(grok): quiet benign harness log notices + drop grok-build from picker

Two cleanups prompted by heartbeat-run log noise:

1. Downgrade routine run-grok.sh + secret-validation `::notice::` lines to
   `::debug::` (hidden unless step debug logging is on). They fire on every clean
   run and were cluttering the log / raising annotations: grok CLI install,
   OAuth-session restore, XAI_API_KEY auth, existing-session reuse, MCP allowlist,
   reasoning-effort skip, and "Optional secrets not set". Real problems
   (`::warning::` / `::error::`) are left exactly as-is.

2. Remove grok-build from GROK_MODELS + the workflow_dispatch dropdown. It's an
   api.x.ai/XAI_API_KEY-only model, absent from the X-account (GROK_CREDENTIALS)
   login catalog, so offering it as a harness option was a dead click. The two real
   options remain: grok-4.5 (default) + grok-composer-2.5-fast. grok-build-0.1 stays
   reachable via the gateway path (the GROK_MODEL repo var).

Also refreshed a stale "(use a grok-build model)" effort hint -> grok-4.5.
Validated: run-grok tests (28 pass), actionlint, validate-config all green.
