### PR TITLE
chore(ci): only log the attestation gate when active (attest=true)

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -780,7 +780,12 @@ jobs:
           fi
 
           echo "attest=$ATTEST" >> "$GITHUB_OUTPUT"
-          echo "::notice::attestation gate for ${SKILL_NAME}: attest=$ATTEST"
+          # Only surface the gate when it's actually ON — attest=false is the quiet
+          # default and doesn't need a per-run notice. (if-block, not `[ ] &&`, so a
+          # false condition can't fail this step as its final command under set -e.)
+          if [ "$ATTEST" = "true" ]; then
+            echo "::notice::attestation gate active for ${SKILL_NAME} — signing run provenance"
+          fi
 
       - name: Build run manifest
         id: manifest


### PR DESCRIPTION
chore(ci): only log the attestation gate when it's active (attest=true)

The "Resolve attestation gate" step emitted
`::notice::attestation gate for <skill>: attest=$ATTEST` on every run — noise,
since attest=false is the quiet default. Gate the notice behind attest=true (the
case worth surfacing: the run is being signed for provenance). The machine-readable
`attest=` GITHUB_OUTPUT is untouched.

Used an if-block, not `[ ] &&`, so a false condition can't fail this step as its
final command under set -eo pipefail. actionlint + validate-config green (the
pre-existing shellcheck warnings are in other steps, not this one).
