### PR TITLE
feat(mcp): durable OAuth connect for OAuth-gated MCP servers

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -465,6 +465,13 @@ jobs:
           # natively and expands them (run-grok.sh only adds the MCPTool allows).
           MCP_FLAGS=()
           if [ -f .mcp.json ] && jq -e '.mcpServers' .mcp.json >/dev/null 2>&1; then
+            # MCP OAuth (durable): mint a fresh access token from any captured refresh
+            # token (MCP_<SLUG>_OAUTH secret) and export MCP_<SLUG>_TOKEN BEFORE the
+            # ${VAR} loop, so its "already in env" check keeps the live token over the
+            # stored (stale) one. Sourced; never fails the run. See mcp-oauth-refresh.sh.
+            if [ -f "${GITHUB_WORKSPACE}/scripts/mcp-oauth-refresh.sh" ]; then
+              source "${GITHUB_WORKSPACE}/scripts/mcp-oauth-refresh.sh" || true
+            fi
             MCP_MISSING=""
             # ALL_SECRETS is toJSON(secrets). Guard the empty case via a temp var —
             # NOT the inline ${ALL_SECRETS:-{}} form: bash closes ${...} at the first

--- a/.github/workflows/messages.yml
+++ b/.github/workflows/messages.yml
@@ -524,6 +524,12 @@ jobs:
           # skip MCP with a warning rather than break the run on a parse failure.
           MCP_FLAGS=()
           if [ -f .mcp.json ] && jq -e '.mcpServers' .mcp.json >/dev/null 2>&1; then
+            # MCP OAuth (durable): refresh any captured OAuth access token BEFORE the
+            # ${VAR} loop (exports a live MCP_<SLUG>_TOKEN). Sourced; never fails the
+            # run. See scripts/mcp-oauth-refresh.sh.
+            if [ -f "${GITHUB_WORKSPACE}/scripts/mcp-oauth-refresh.sh" ]; then
+              source "${GITHUB_WORKSPACE}/scripts/mcp-oauth-refresh.sh" || true
+            fi
             MCP_MISSING=""
             # ALL_SECRETS is toJSON(secrets). Guard the empty case via a temp var —
             # NOT the inline ${ALL_SECRETS:-{}} form: bash closes ${...} at the first

--- a/apps/dashboard/app/api/mcp-auth/callback/route.ts
+++ b/apps/dashboard/app/api/mcp-auth/callback/route.ts
@@ -1,0 +1,61 @@
+import { exchangeCode } from '@/lib/mcp-oauth'
+import { pendingFlows } from '@/lib/mcp-oauth-server'
+
+// GET /api/mcp-auth/callback — the OAuth redirect target. Matches the ?state to a
+// pending flow (started by POST /api/mcp-auth), exchanges the ?code for tokens
+// with the stored PKCE verifier, and resolves the waiting POST. Renders a tiny
+// self-contained page for the browser tab; the actual secret-storage + .mcp.json
+// wiring happens back in the POST handler once resolve() fires.
+function page(title: string, detail = '', status = 200): Response {
+  const html = `<!doctype html><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${title}</title>
+<body style="font-family:ui-sans-serif,system-ui,sans-serif;background:#0a0a0a;color:#fafafa;display:grid;place-items:center;min-height:100vh;margin:0">
+<div style="text-align:center;max-width:32rem;padding:2rem">
+<h1 style="font-size:1.25rem;margin:0 0 .5rem">${title}</h1>
+<p style="color:#a3a3a3;font-size:.9rem;margin:0">${detail}</p>
+</div></body>`
+  return new Response(html, { status, headers: { 'Content-Type': 'text/html; charset=utf-8' } })
+}
+
+export async function GET(request: Request) {
+  const url = new URL(request.url)
+  const state = url.searchParams.get('state') || ''
+  const code = url.searchParams.get('code')
+  const err = url.searchParams.get('error')
+  const errDesc = url.searchParams.get('error_description') || ''
+
+  const flow = state ? pendingFlows.get(state) : undefined
+  if (!flow) {
+    return page('Unknown or expired request', 'This authorization request is no longer pending. Start again from the dashboard.', 400)
+  }
+  // One-shot: remove it and stop the POST's timeout regardless of outcome.
+  pendingFlows.delete(state)
+  clearTimeout(flow.timer)
+
+  if (err) {
+    flow.reject(new Error(`Authorization error: ${err}${errDesc ? ` (${errDesc})` : ''}`))
+    return page('Authorization denied', errDesc || err, 400)
+  }
+  if (!code) {
+    flow.reject(new Error('No authorization code was returned'))
+    return page('No authorization code', 'The provider returned no code. Try connecting again.', 400)
+  }
+
+  try {
+    const tokens = await exchangeCode({
+      tokenEndpoint: flow.tokenEndpoint,
+      code,
+      verifier: flow.verifier,
+      clientId: flow.clientId,
+      clientSecret: flow.clientSecret,
+      redirectUri: flow.redirectUri,
+      resource: flow.resource,
+    })
+    flow.resolve(tokens)
+    return page('✓ Connected', 'Tokens captured. You can close this tab and return to the dashboard.')
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : 'token exchange failed'
+    flow.reject(e instanceof Error ? e : new Error(msg))
+    return page('Token exchange failed', msg, 500)
+  }
+}

--- a/apps/dashboard/app/api/mcp-auth/route.ts
+++ b/apps/dashboard/app/api/mcp-auth/route.ts
@@ -1,0 +1,84 @@
+import { NextResponse } from 'next/server'
+import { requireGh, errorResponse } from '@/lib/http'
+import { discover, registerClient, makePkce, makeState, authorizeUrl, type TokenSet } from '@/lib/mcp-oauth'
+import { pendingFlows, openBrowser, storeSecrets, OAUTH_TIMEOUT_MS, type PendingFlow } from '@/lib/mcp-oauth-server'
+
+// POST /api/mcp-auth — start (and complete) the OAuth Authorization Code + PKCE
+// flow for an MCP server, mirroring app/api/grok-auth's one-click UX: discover the
+// server's auth endpoints, register a client (or use a provided client_id), open
+// the operator's browser to authorize, wait for the callback to exchange the code,
+// then persist the tokens as repo secrets and wire the server into .mcp.json.
+//
+// Body: { slug, url, name?, scopes?, clientId? }. The request holds open until the
+// browser callback resolves (or OAUTH_TIMEOUT_MS elapses) — same as grok login.
+export async function POST(request: Request) {
+  try {
+    const notReady = requireGh()
+    if (notReady) return notReady
+
+    const body = (await request.json().catch(() => ({}))) as {
+      slug?: string; url?: string; name?: string; scopes?: string[]; clientId?: string
+    }
+    const slug = (body.slug || '').trim()
+    const url = (body.url || '').trim()
+    const name = (body.name || slug).trim()
+    if (!slug || !url) {
+      return NextResponse.json({ error: 'slug and url are required' }, { status: 400 })
+    }
+
+    // 1. Discover the authorization server + endpoints from the MCP URL.
+    const disc = await discover(url)
+
+    // 2. redirect_uri is this dashboard's own callback (local-first origin).
+    const redirectUri = `${new URL(request.url).origin}/api/mcp-auth/callback`
+
+    // 3. Client: a provided client_id (for servers without DCR) wins; else register.
+    let clientId = (body.clientId || '').trim()
+    let clientSecret: string | undefined
+    if (!clientId) {
+      if (!disc.metadata.registration_endpoint) {
+        return NextResponse.json({
+          error: 'This server does not support dynamic client registration. ' +
+            'Register a client with the provider and retry with its client_id.',
+        }, { status: 400 })
+      }
+      const reg = await registerClient(disc.metadata.registration_endpoint, redirectUri)
+      clientId = reg.client_id
+      clientSecret = reg.client_secret
+    }
+
+    // 4. PKCE + state, then open the browser and wait for the callback.
+    const { verifier, challenge } = makePkce()
+    const state = makeState()
+    const scopes = body.scopes?.length ? body.scopes : disc.metadata.scopes_supported
+
+    let flow!: PendingFlow
+    const tokens = await new Promise<TokenSet>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        pendingFlows.delete(state)
+        reject(new Error('Timed out waiting for authorization. Approve in the browser, then click Connect again.'))
+      }, OAUTH_TIMEOUT_MS)
+      flow = {
+        slug, name, url,
+        tokenEndpoint: disc.metadata.token_endpoint,
+        clientId, clientSecret, verifier, redirectUri,
+        resource: disc.resource, resolve, reject, timer,
+      }
+      pendingFlows.set(state, flow)
+      openBrowser(authorizeUrl({ metadata: disc.metadata, clientId, redirectUri, challenge, state, resource: disc.resource, scopes }))
+    })
+
+    // 5. Persist tokens as secrets; hand the server descriptor back for the panel
+    //    to add via its normal save path.
+    const { durable, server } = storeSecrets(flow, tokens)
+    return NextResponse.json({
+      ok: true,
+      slug,
+      server,
+      durable,
+      ...(durable ? {} : { warning: 'No refresh token was granted, so the access token will expire and need reconnecting. The provider may require an offline-access scope.' }),
+    })
+  } catch (error: unknown) {
+    return errorResponse(error, 'Failed to connect the MCP server')
+  }
+}

--- a/apps/dashboard/components/McpPanel.tsx
+++ b/apps/dashboard/components/McpPanel.tsx
@@ -66,6 +66,12 @@ export function McpPanel({ servers, loading, saving, secrets, busy, onSave, onSe
   const [command, setCommand] = useState('npx')
   const [args, setArgs] = useState('')
 
+  // OAuth connect (featured servers flagged `oauth`): the dashboard drives the
+  // browser flow server-side (POST /api/mcp-auth), which captures the tokens as
+  // secrets and returns the server descriptor to add. Per-slug busy + error.
+  const [oauthBusy, setOauthBusy] = useState<string | null>(null)
+  const [oauthError, setOauthError] = useState('')
+
   // The operator never types a secret name. They paste the bearer token (which
   // IS the secret); we derive the env-var to store it under from the server name.
   const slugify = (s: string) => s.trim().toLowerCase().replace(/[^a-z0-9_-]/g, '-').replace(/^-+|-+$/g, '')
@@ -113,12 +119,38 @@ export function McpPanel({ servers, loading, saving, secrets, busy, onSave, onSe
   const isFeaturedInstalled = (url: string) => Object.values(draft).some(s => s.url === url)
   const installFeatured = (f: typeof FEATURED[number]) => {
     if (isFeaturedInstalled(f.url)) return
+    if (f.oauth) { connectOAuth(f); return }
     const slug = draft[f.slug] ? `${f.slug}-mcp` : f.slug
     const server: McpServer = { type: f.transport ?? 'http', url: f.url }
     if (f.authSecret) server.headers = { Authorization: `Bearer \${${f.authSecret}}` }
     const next = { ...draft, [slug]: server }
     setDraft(next)
     onSave(next)
+  }
+
+  // Run the browser OAuth flow for a featured server, then add the returned
+  // descriptor via the normal save path. The tokens are captured + stored
+  // server-side; the panel never sees them.
+  const connectOAuth = async (f: typeof FEATURED[number]) => {
+    const slug = draft[f.slug] ? `${f.slug}-mcp` : f.slug
+    setOauthBusy(f.slug); setOauthError('')
+    try {
+      const res = await fetch('/api/mcp-auth', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ slug, url: f.url, name: f.name, scopes: f.oauthScopes, clientId: f.oauthClientId }),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok || !data.ok) throw new Error(data.error || `Connect failed (${res.status})`)
+      const next = { ...draft, [slug]: data.server as McpServer }
+      setDraft(next)
+      onSave(next)
+      if (data.warning) setOauthError(`Connected, but: ${data.warning}`)
+    } catch (e) {
+      setOauthError(e instanceof Error ? e.message : 'OAuth connect failed')
+    } finally {
+      setOauthBusy(null)
+    }
   }
 
   const removeServer = (n: string) => {
@@ -170,12 +202,15 @@ export function McpPanel({ servers, loading, saving, secrets, busy, onSave, onSe
                 {installed ? (
                   <span className="text-[10px] font-mono uppercase tracking-[0.14em] text-aeon-green shrink-0">✓ installed</span>
                 ) : (
-                  <button onClick={() => installFeatured(f)} disabled={saving} className="btn-mini-go shrink-0">Install</button>
+                  <button onClick={() => installFeatured(f)} disabled={saving || oauthBusy === f.slug} className="btn-mini-go shrink-0" title={f.oauth ? 'Opens your browser to authorize, then stores the tokens' : undefined}>
+                    {oauthBusy === f.slug ? 'Connecting…' : f.oauth ? 'Connect' : 'Install'}
+                  </button>
                 )}
               </div>
             )
           })}
         </div>
+        {oauthError && <p className="mt-3 text-[11px] font-mono text-aeon-red">{oauthError}</p>}
       </section>
 
       <section className="border-t border-[rgba(250,250,250,0.10)] pt-6">

--- a/apps/dashboard/lib/mcp-catalog.ts
+++ b/apps/dashboard/lib/mcp-catalog.ts
@@ -16,6 +16,15 @@ export interface McpCatalogEntry {
   // header referencing this repo secret, and the MCP panel surfaces a paste-token
   // row for it. Omit for public / OAuth / x402 servers (the existing default).
   authSecret?: string
+  // When true, one-click install runs the dashboard OAuth flow (POST /api/mcp-auth)
+  // instead of wiring a static header: it opens the browser to authorize, captures
+  // the tokens into MCP_<slug>_TOKEN + MCP_<slug>_OAUTH, and scripts/mcp-oauth-
+  // refresh.sh mints a fresh access token before each headless run. Optionally pin
+  // oauthScopes / oauthClientId when the provider needs them (no dynamic client
+  // registration). Mutually exclusive with authSecret.
+  oauth?: boolean
+  oauthScopes?: string[]
+  oauthClientId?: string
 }
 
 export const MCP_CATALOG: McpCatalogEntry[] = [
@@ -53,6 +62,7 @@ export const MCP_CATALOG: McpCatalogEntry[] = [
     url: 'https://agent.robinhood.com/mcp/trading',
     logo: 'https://pbs.twimg.com/profile_images/1844399977482813442/1fTlYz2c_400x400.png',
     description: 'Robinhood Agentic Trading - read your portfolio, buying power, positions, and order history, and place trades from your agent. Remote HTTP MCP with OAuth; trades execute in a dedicated Agentic brokerage account you authorize. You are responsible for every order your agent places.',
+    oauth: true,
   },
   {
     slug: 'glim',

--- a/apps/dashboard/lib/mcp-catalog.ts
+++ b/apps/dashboard/lib/mcp-catalog.ts
@@ -57,15 +57,6 @@ export const MCP_CATALOG: McpCatalogEntry[] = [
     logo: 'https://raw.githubusercontent.com/glim-sh/glim-mcp/main/assets/icon-400.png',
     description: 'glim.sh - live data for AI agents: web search, full page extraction, Twitter/X, Reddit, GitHub, Amazon, YouTube transcripts. Pay-per-call with x402 (Base/Solana USDC) or MPP (Tempo), or sign in and draw from a prepaid account balance.',
   },
-  {
-    slug: 'litebeam',
-    name: 'Litebeam',
-    url: 'https://mcp.litebeam.xyz',
-    logo: 'https://pbs.twimg.com/profile_images/2065063781042954241/zcTqmW5j_400x400.jpg',
-    description: 'Litebeam - one MCP connection to every microservice. An AI-microservice routing layer: discover and call paid services through a single endpoint, settled from your agent\'s wallet (managed Litebeam wallet or BYO via x402), with budget controls and HITL approvals.',
-    transport: 'sse',
-    authSecret: 'LITEBEAM_API_KEY',
-  },
 ]
 
 export const MCP_BY_SLUG: Record<string, McpCatalogEntry> =

--- a/apps/dashboard/lib/mcp-catalog.ts
+++ b/apps/dashboard/lib/mcp-catalog.ts
@@ -34,6 +34,13 @@ export const MCP_CATALOG: McpCatalogEntry[] = [
     url: 'https://mcp.base.org',
     logo: 'https://pbs.twimg.com/profile_images/2060695832840556549/R0s33fMN_400x400.jpg',
     description: 'Base Account access - wallet, portfolio, swaps, signing, x402 payments, and batched contract calls.',
+    // Base is its own OAuth authorization server: no Protected Resource Metadata,
+    // but full AS metadata (+ DCR) at https://mcp.base.org/.well-known/oauth-authorization-server.
+    // discover() falls back to the MCP origin, so Connect works one-click. We request
+    // only the least-privilege transact scope by default; `agent_wallet:escalate` is
+    // also offered by the server for elevated actions.
+    oauth: true,
+    oauthScopes: ['agent_wallet:transact'],
   },
   {
     slug: 'ctrl',

--- a/apps/dashboard/lib/mcp-catalog.ts
+++ b/apps/dashboard/lib/mcp-catalog.ts
@@ -43,27 +43,6 @@ export const MCP_CATALOG: McpCatalogEntry[] = [
     oauthScopes: ['agent_wallet:transact'],
   },
   {
-    slug: 'ctrl',
-    name: 'Ctrl',
-    url: 'https://www.ctrl.build/mcp',
-    logo: 'https://pbs.twimg.com/profile_images/2039734967681597440/Hh_-fXR8_400x400.jpg',
-    description: 'Ctrl MCP server.',
-  },
-  {
-    slug: 'rootai',
-    name: 'RootAI',
-    url: 'https://mcp.rootedge.ai/pro',
-    logo: 'https://pbs.twimg.com/profile_images/2070604629688070144/xNwUGHgX_400x400.jpg',
-    description: 'RootAI Edge MCP - crypto market intelligence across Hyperliquid, Base & Paradex: funding-arbitrage scans, cross-exchange spreads, and best-execution routing. Discovery and free tools are no-cost; premium tools settle per-call in USDC via x402.',
-  },
-  {
-    slug: 'blueagent',
-    name: 'BlueAgent',
-    url: 'https://blueagent.dev/api/mcp',
-    logo: 'https://pbs.twimg.com/profile_images/2047719472455438336/CFrEyoNZ_400x400.jpg',
-    description: 'BlueAgent - the AI founder console for Base builders: idea, build, audit, ship, and raise, from concept to deployment.',
-  },
-  {
     slug: 'robinhood-trading',
     name: 'Robinhood Trading',
     url: 'https://agent.robinhood.com/mcp/trading',

--- a/apps/dashboard/lib/mcp-oauth-server.ts
+++ b/apps/dashboard/lib/mcp-oauth-server.ts
@@ -1,0 +1,80 @@
+// Server-only glue for the MCP OAuth flow: the shared pending-flow store (bridges
+// the POST that starts the flow and the GET callback), opening the operator's
+// browser, and persisting the captured tokens as repo secrets + wiring the server
+// into .mcp.json. Kept out of lib/mcp-oauth.ts so that module stays pure/fetch-only
+// and unit-testable; this one imports gh + the child_process/github helpers.
+import { execFile, execFileSync } from 'child_process'
+import { ghArgsRepo } from './gh'
+import type { McpServer } from './types'
+import { tokenVar, oauthVar, type TokenSet } from './mcp-oauth'
+
+export interface PendingFlow {
+  slug: string
+  name: string
+  url: string
+  tokenEndpoint: string
+  clientId: string
+  clientSecret?: string
+  verifier: string
+  redirectUri: string
+  resource: string
+  resolve: (t: TokenSet) => void
+  reject: (e: Error) => void
+  timer: ReturnType<typeof setTimeout>
+}
+
+// Module-level singleton, keyed by the OAuth `state`. The dashboard is local-first
+// and single-process (same assumption as app/api/grok-auth's spawn-based flow), so
+// the POST that opens the browser and the GET callback share this map. A
+// multi-instance/serverless deploy would need external state instead.
+export const pendingFlows = new Map<string, PendingFlow>()
+
+// Ample time for the operator to approve in the browser, under Node's request cap.
+export const OAUTH_TIMEOUT_MS = 240_000
+
+// Fire-and-forget browser open (identical approach to app/api/grok-auth). A
+// failure to auto-open isn't fatal — the auth URL is also returned to the panel.
+export function openBrowser(url: string): void {
+  const cmd = process.platform === 'darwin' ? 'open'
+    : process.platform === 'win32' ? 'cmd'
+    : 'xdg-open'
+  const args = process.platform === 'win32' ? ['/c', 'start', '', url] : [url]
+  execFile(cmd, args, () => {})
+}
+
+function ghSecretSet(name: string, value: string): void {
+  execFileSync('gh', ['secret', 'set', name, ...ghArgsRepo()], {
+    input: value,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  })
+}
+
+// Persist the captured tokens as repo secrets and return the .mcp.json server
+// descriptor for the caller (the panel) to add via its normal save path — keeping
+// .mcp.json single-writer and the panel state in sync without a reload:
+//   - MCP_<SLUG>_TOKEN  = the (short-lived) access token, referenced by the header.
+//   - MCP_<SLUG>_OAUTH  = the refresh material scripts/mcp-oauth-refresh.sh needs.
+// The tokens themselves are stored server-side (they never reach the browser).
+// Returns whether durable (refresh-token) auth was captured, plus the server to add.
+export function storeSecrets(flow: PendingFlow, tokens: TokenSet): { durable: boolean; server: McpServer } {
+  ghSecretSet(tokenVar(flow.slug), tokens.access_token)
+
+  const durable = Boolean(tokens.refresh_token)
+  if (durable) {
+    ghSecretSet(oauthVar(flow.slug), JSON.stringify({
+      token_endpoint: flow.tokenEndpoint,
+      client_id: flow.clientId,
+      ...(flow.clientSecret ? { client_secret: flow.clientSecret } : {}),
+      refresh_token: tokens.refresh_token,
+      ...(tokens.scope ? { scope: tokens.scope } : {}),
+      slug: flow.slug,
+    }))
+  }
+
+  const server: McpServer = {
+    type: 'http',
+    url: flow.url,
+    headers: { Authorization: `Bearer \${${tokenVar(flow.slug)}}` },
+  }
+  return { durable, server }
+}

--- a/apps/dashboard/lib/mcp-oauth.test.ts
+++ b/apps/dashboard/lib/mcp-oauth.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import { createHash } from 'crypto'
-import { tokenVar, oauthVar, makePkce, makeState, authorizeUrl } from './mcp-oauth'
+import { tokenVar, oauthVar, makePkce, makeState, authorizeUrl, discover } from './mcp-oauth'
 
 function b64url(buf: Buffer): string {
   return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
@@ -49,6 +49,43 @@ test('authorizeUrl builds a spec-correct authorization request', () => {
   assert.equal(u.searchParams.get('state'), 'STATE')
   assert.equal(u.searchParams.get('resource'), 'https://mcp.example')
   assert.equal(u.searchParams.get('scope'), 'a b')
+})
+
+test('discover falls back to origin AS metadata when there is no Protected Resource Metadata (the Base case)', async () => {
+  // Base: no /.well-known/oauth-protected-resource, but full AS metadata at the origin.
+  const asMeta = {
+    issuer: 'https://mcp.base.org',
+    authorization_endpoint: 'https://mcp.base.org/authorize',
+    token_endpoint: 'https://mcp.base.org/token',
+    registration_endpoint: 'https://mcp.base.org/register',
+    scopes_supported: ['agent_wallet:transact', 'agent_wallet:escalate'],
+  }
+  const orig = globalThis.fetch
+  globalThis.fetch = (async (u: string | URL) => {
+    const url = String(u)
+    if (url.includes('oauth-protected-resource')) return { ok: false, status: 404, json: async () => ({}) } as Response
+    if (url.includes('oauth-authorization-server')) return { ok: true, json: async () => asMeta } as Response
+    return { ok: false, status: 404, json: async () => ({}) } as Response
+  }) as typeof fetch
+  try {
+    const d = await discover('https://mcp.base.org')
+    assert.equal(d.authServer, 'https://mcp.base.org', 'falls back to the MCP origin as the auth server')
+    assert.equal(d.resource, 'https://mcp.base.org')
+    assert.equal(d.metadata.authorization_endpoint, 'https://mcp.base.org/authorize')
+    assert.equal(d.metadata.registration_endpoint, 'https://mcp.base.org/register')
+  } finally {
+    globalThis.fetch = orig
+  }
+})
+
+test('discover throws a clear error when a server advertises no OAuth metadata at all', async () => {
+  const orig = globalThis.fetch
+  globalThis.fetch = (async () => ({ ok: false, status: 404, json: async () => ({}) } as Response)) as typeof fetch
+  try {
+    await assert.rejects(discover('https://static-bearer.example'), /No OAuth metadata found/)
+  } finally {
+    globalThis.fetch = orig
+  }
 })
 
 test('authorizeUrl omits scope when none given', () => {

--- a/apps/dashboard/lib/mcp-oauth.test.ts
+++ b/apps/dashboard/lib/mcp-oauth.test.ts
@@ -1,0 +1,60 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { createHash } from 'crypto'
+import { tokenVar, oauthVar, makePkce, makeState, authorizeUrl } from './mcp-oauth'
+
+function b64url(buf: Buffer): string {
+  return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+test('tokenVar / oauthVar derive uppercased, sanitized secret names from a slug', () => {
+  assert.equal(tokenVar('robinhood-trading'), 'MCP_ROBINHOOD_TRADING_TOKEN')
+  assert.equal(oauthVar('robinhood-trading'), 'MCP_ROBINHOOD_TRADING_OAUTH')
+  assert.equal(tokenVar('glim'), 'MCP_GLIM_TOKEN')
+  // Non-alphanumerics collapse to underscores (matches the runtime script's suffix strip).
+  assert.equal(tokenVar('a.b c'), 'MCP_A_B_C_TOKEN')
+})
+
+test('makePkce produces a base64url verifier and its S256 challenge', () => {
+  const { verifier, challenge } = makePkce()
+  assert.match(verifier, /^[A-Za-z0-9_-]+$/, 'verifier is base64url')
+  assert.ok(verifier.length >= 43 && verifier.length <= 128, 'verifier within RFC 7636 length')
+  assert.equal(challenge, b64url(createHash('sha256').update(verifier).digest()), 'challenge = S256(verifier)')
+  // Two calls differ (randomness).
+  assert.notEqual(makePkce().verifier, makePkce().verifier)
+})
+
+test('makeState is random base64url', () => {
+  assert.match(makeState(), /^[A-Za-z0-9_-]+$/)
+  assert.notEqual(makeState(), makeState())
+})
+
+test('authorizeUrl builds a spec-correct authorization request', () => {
+  const url = authorizeUrl({
+    metadata: { authorization_endpoint: 'https://as.example/authorize', token_endpoint: 'https://as.example/token' },
+    clientId: 'client-123',
+    redirectUri: 'http://localhost:3000/api/mcp-auth/callback',
+    challenge: 'CHAL',
+    state: 'STATE',
+    resource: 'https://mcp.example',
+    scopes: ['a', 'b'],
+  })
+  const u = new URL(url)
+  assert.equal(u.origin + u.pathname, 'https://as.example/authorize')
+  assert.equal(u.searchParams.get('response_type'), 'code')
+  assert.equal(u.searchParams.get('client_id'), 'client-123')
+  assert.equal(u.searchParams.get('redirect_uri'), 'http://localhost:3000/api/mcp-auth/callback')
+  assert.equal(u.searchParams.get('code_challenge'), 'CHAL')
+  assert.equal(u.searchParams.get('code_challenge_method'), 'S256')
+  assert.equal(u.searchParams.get('state'), 'STATE')
+  assert.equal(u.searchParams.get('resource'), 'https://mcp.example')
+  assert.equal(u.searchParams.get('scope'), 'a b')
+})
+
+test('authorizeUrl omits scope when none given', () => {
+  const url = authorizeUrl({
+    metadata: { authorization_endpoint: 'https://as.example/authorize', token_endpoint: 'https://as.example/token' },
+    clientId: 'c', redirectUri: 'http://localhost/cb', challenge: 'x', state: 's', resource: 'https://r',
+  })
+  assert.equal(new URL(url).searchParams.get('scope'), null)
+})

--- a/apps/dashboard/lib/mcp-oauth.ts
+++ b/apps/dashboard/lib/mcp-oauth.ts
@@ -1,0 +1,228 @@
+// MCP OAuth (Authorization Code + PKCE) helper — the core of the dashboard's
+// "Connect" flow for OAuth-gated MCP servers. Because the dashboard runs on the
+// operator's own machine (same assumption as app/api/grok-auth), it can open the
+// browser for the authorization step and store the resulting tokens as repo
+// secrets, exactly parallel to how "Connect X account" captures GROK_CREDENTIALS.
+//
+// The durable part: we persist the *refresh* token (+ token endpoint + client id)
+// in an MCP_<SLUG>_OAUTH secret, and scripts/mcp-oauth-refresh.sh mints a fresh
+// access token before every headless run. .mcp.json only ever references the
+// short-lived access token as `Authorization: Bearer ${MCP_<SLUG>_TOKEN}`.
+//
+// Spec basis: OAuth 2.0 Authorization Code + PKCE (RFC 7636), Protected Resource
+// Metadata (RFC 9728), Authorization Server Metadata (RFC 8414 / OIDC discovery),
+// and Dynamic Client Registration (RFC 7591) — the set the MCP Authorization spec
+// builds on. Every network hop is best-effort with clear errors: a server that
+// advertises none of this simply can't be auto-connected, and we say so.
+import { randomBytes, createHash } from 'crypto'
+
+// --- secret names (kept in lockstep with McpPanel's tokenVar) ---------------
+// A server's access token and its OAuth refresh material derive their secret
+// names from the slug, so the operator never types a secret name.
+export function tokenVar(slug: string): string {
+  return 'MCP_' + slug.toUpperCase().replace(/[^A-Z0-9_]/g, '_') + '_TOKEN'
+}
+export function oauthVar(slug: string): string {
+  return 'MCP_' + slug.toUpperCase().replace(/[^A-Z0-9_]/g, '_') + '_OAUTH'
+}
+
+// --- PKCE + state -----------------------------------------------------------
+function base64url(buf: Buffer): string {
+  return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+export function makePkce(): { verifier: string; challenge: string } {
+  const verifier = base64url(randomBytes(32)) // 43 chars, within RFC 7636's 43–128
+  const challenge = base64url(createHash('sha256').update(verifier).digest())
+  return { verifier, challenge }
+}
+export function makeState(): string {
+  return base64url(randomBytes(16))
+}
+
+// --- discovery --------------------------------------------------------------
+export interface AsMetadata {
+  issuer?: string
+  authorization_endpoint: string
+  token_endpoint: string
+  registration_endpoint?: string
+  scopes_supported?: string[]
+  code_challenge_methods_supported?: string[]
+}
+
+// The `resource` value (RFC 8707) the MCP server identifies itself by, plus the
+// resolved authorization-server metadata used to drive the flow.
+export interface Discovery {
+  resource: string
+  authServer: string
+  metadata: AsMetadata
+}
+
+async function fetchJson(url: string, init?: RequestInit): Promise<unknown> {
+  const res = await fetch(url, { ...init, headers: { Accept: 'application/json', ...(init?.headers ?? {}) } })
+  if (!res.ok) throw new Error(`${init?.method ?? 'GET'} ${url} → ${res.status}`)
+  return res.json()
+}
+
+// Resolve a URL against a well-known suffix, preserving any resource path per
+// RFC 9728 (`/.well-known/oauth-protected-resource` MAY carry the resource path).
+function wellKnown(base: string, suffix: string): string {
+  const u = new URL(base)
+  const path = u.pathname.replace(/\/$/, '')
+  return `${u.origin}/.well-known/${suffix}${path && path !== '' ? path : ''}`
+}
+
+// Given an MCP server URL, discover its authorization server + endpoints.
+export async function discover(mcpUrl: string): Promise<Discovery> {
+  // 1. Protected Resource Metadata (RFC 9728) — try path-scoped then origin-scoped.
+  let prm: { authorization_servers?: string[]; resource?: string } | undefined
+  for (const url of [wellKnown(mcpUrl, 'oauth-protected-resource'), `${new URL(mcpUrl).origin}/.well-known/oauth-protected-resource`]) {
+    try { prm = (await fetchJson(url)) as typeof prm; if (prm?.authorization_servers?.length) break } catch { /* try next */ }
+  }
+  const authServer = prm?.authorization_servers?.[0]
+  const resource = prm?.resource ?? new URL(mcpUrl).origin
+  if (!authServer) {
+    throw new Error(
+      'This MCP server does not advertise OAuth Protected Resource Metadata ' +
+      '(/.well-known/oauth-protected-resource). It may use a static bearer token instead — ' +
+      'paste that token on the server row, or check the provider docs.',
+    )
+  }
+
+  // 2. Authorization Server Metadata (RFC 8414), falling back to OIDC discovery.
+  let meta: AsMetadata | undefined
+  for (const url of [
+    wellKnown(authServer, 'oauth-authorization-server'),
+    `${new URL(authServer).origin}/.well-known/oauth-authorization-server`,
+    `${authServer.replace(/\/$/, '')}/.well-known/openid-configuration`,
+  ]) {
+    try {
+      const m = (await fetchJson(url)) as AsMetadata
+      if (m?.authorization_endpoint && m?.token_endpoint) { meta = m; break }
+    } catch { /* try next */ }
+  }
+  if (!meta) throw new Error(`Could not load authorization-server metadata for ${authServer}`)
+  return { resource, authServer, metadata: meta }
+}
+
+// --- dynamic client registration (RFC 7591) ---------------------------------
+export interface ClientCreds { client_id: string; client_secret?: string }
+
+export async function registerClient(
+  registrationEndpoint: string,
+  redirectUri: string,
+  clientName = 'Aeon Dashboard',
+): Promise<ClientCreds> {
+  const body = {
+    client_name: clientName,
+    redirect_uris: [redirectUri],
+    grant_types: ['authorization_code', 'refresh_token'],
+    response_types: ['code'],
+    token_endpoint_auth_method: 'none', // public client (PKCE); AS may override
+  }
+  const reg = (await fetchJson(registrationEndpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })) as ClientCreds
+  if (!reg.client_id) throw new Error('Dynamic client registration returned no client_id')
+  return { client_id: reg.client_id, client_secret: reg.client_secret }
+}
+
+// --- authorization URL ------------------------------------------------------
+export function authorizeUrl(opts: {
+  metadata: AsMetadata
+  clientId: string
+  redirectUri: string
+  challenge: string
+  state: string
+  resource: string
+  scopes?: string[]
+}): string {
+  const u = new URL(opts.metadata.authorization_endpoint)
+  u.searchParams.set('response_type', 'code')
+  u.searchParams.set('client_id', opts.clientId)
+  u.searchParams.set('redirect_uri', opts.redirectUri)
+  u.searchParams.set('code_challenge', opts.challenge)
+  u.searchParams.set('code_challenge_method', 'S256')
+  u.searchParams.set('state', opts.state)
+  u.searchParams.set('resource', opts.resource) // RFC 8707 audience binding
+  if (opts.scopes?.length) u.searchParams.set('scope', opts.scopes.join(' '))
+  return u.toString()
+}
+
+// --- token endpoint (exchange + refresh) ------------------------------------
+export interface TokenSet {
+  access_token: string
+  refresh_token?: string
+  expires_in?: number
+  token_type?: string
+  scope?: string
+}
+
+function tokenForm(params: Record<string, string | undefined>): URLSearchParams {
+  const f = new URLSearchParams()
+  for (const [k, v] of Object.entries(params)) if (v) f.set(k, v)
+  return f
+}
+
+async function postToken(tokenEndpoint: string, form: URLSearchParams, clientSecret?: string): Promise<TokenSet> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/x-www-form-urlencoded', Accept: 'application/json' }
+  // Confidential clients authenticate with HTTP Basic; public (PKCE) clients pass client_id in the body.
+  if (clientSecret) {
+    const clientId = form.get('client_id') ?? ''
+    headers.Authorization = 'Basic ' + Buffer.from(`${clientId}:${clientSecret}`).toString('base64')
+    form.delete('client_secret')
+  }
+  const res = await fetch(tokenEndpoint, { method: 'POST', headers, body: form.toString() })
+  const text = await res.text()
+  if (!res.ok) throw new Error(`token endpoint → ${res.status}: ${text.slice(0, 200)}`)
+  const tok = JSON.parse(text) as TokenSet
+  if (!tok.access_token) throw new Error('token endpoint returned no access_token')
+  return tok
+}
+
+export async function exchangeCode(opts: {
+  tokenEndpoint: string
+  code: string
+  verifier: string
+  clientId: string
+  clientSecret?: string
+  redirectUri: string
+  resource: string
+}): Promise<TokenSet> {
+  return postToken(opts.tokenEndpoint, tokenForm({
+    grant_type: 'authorization_code',
+    code: opts.code,
+    code_verifier: opts.verifier,
+    client_id: opts.clientId,
+    client_secret: opts.clientSecret,
+    redirect_uri: opts.redirectUri,
+    resource: opts.resource,
+  }), opts.clientSecret)
+}
+
+export async function refreshToken(opts: {
+  tokenEndpoint: string
+  refreshToken: string
+  clientId: string
+  clientSecret?: string
+}): Promise<TokenSet> {
+  return postToken(opts.tokenEndpoint, tokenForm({
+    grant_type: 'refresh_token',
+    refresh_token: opts.refreshToken,
+    client_id: opts.clientId,
+    client_secret: opts.clientSecret,
+  }), opts.clientSecret)
+}
+
+// The JSON blob persisted as the MCP_<SLUG>_OAUTH secret. Everything the runtime
+// refresh (scripts/mcp-oauth-refresh.sh) needs to mint a fresh access token, with
+// no interactive step. Note it carries refresh material — treat as a secret.
+export interface OAuthSecret {
+  token_endpoint: string
+  client_id: string
+  client_secret?: string
+  refresh_token: string
+  scope?: string
+  slug: string
+}

--- a/apps/dashboard/lib/mcp-oauth.ts
+++ b/apps/dashboard/lib/mcp-oauth.ts
@@ -73,20 +73,18 @@ function wellKnown(base: string, suffix: string): string {
 
 // Given an MCP server URL, discover its authorization server + endpoints.
 export async function discover(mcpUrl: string): Promise<Discovery> {
-  // 1. Protected Resource Metadata (RFC 9728) — try path-scoped then origin-scoped.
+  const origin = new URL(mcpUrl).origin
+  // 1. Protected Resource Metadata (RFC 9728) — optional. Try path- then origin-scoped.
   let prm: { authorization_servers?: string[]; resource?: string } | undefined
-  for (const url of [wellKnown(mcpUrl, 'oauth-protected-resource'), `${new URL(mcpUrl).origin}/.well-known/oauth-protected-resource`]) {
+  for (const url of [wellKnown(mcpUrl, 'oauth-protected-resource'), `${origin}/.well-known/oauth-protected-resource`]) {
     try { prm = (await fetchJson(url)) as typeof prm; if (prm?.authorization_servers?.length) break } catch { /* try next */ }
   }
-  const authServer = prm?.authorization_servers?.[0]
-  const resource = prm?.resource ?? new URL(mcpUrl).origin
-  if (!authServer) {
-    throw new Error(
-      'This MCP server does not advertise OAuth Protected Resource Metadata ' +
-      '(/.well-known/oauth-protected-resource). It may use a static bearer token instead — ' +
-      'paste that token on the server row, or check the provider docs.',
-    )
-  }
+  // If PRM names an authorization server, use it. Otherwise fall back to the MCP
+  // server's OWN origin acting as its authorization server — the behavior compliant
+  // clients use for a self-issuing server that skips PRM (e.g. Base: issuer ==
+  // mcp.base.org, AS metadata at the origin well-known). Its metadata is loaded next.
+  const authServer = prm?.authorization_servers?.[0] ?? origin
+  const resource = prm?.resource ?? origin
 
   // 2. Authorization Server Metadata (RFC 8414), falling back to OIDC discovery.
   let meta: AsMetadata | undefined
@@ -100,7 +98,13 @@ export async function discover(mcpUrl: string): Promise<Discovery> {
       if (m?.authorization_endpoint && m?.token_endpoint) { meta = m; break }
     } catch { /* try next */ }
   }
-  if (!meta) throw new Error(`Could not load authorization-server metadata for ${authServer}`)
+  if (!meta) {
+    throw new Error(
+      `No OAuth metadata found for ${mcpUrl} — it advertises neither Protected Resource ` +
+      `Metadata nor Authorization Server Metadata. It likely uses a static bearer token; ` +
+      `paste one on the server row instead.`,
+    )
+  }
   return { resource, authServer, metadata: meta }
 }
 

--- a/docs/mcp-oauth.md
+++ b/docs/mcp-oauth.md
@@ -1,0 +1,74 @@
+---
+type: Reference
+title: MCP OAuth — durable headless auth for OAuth-gated MCP servers
+description: How the dashboard captures an OAuth-gated MCP server's tokens and keeps them fresh for headless runs, the parallel to the grok X-account flow, and the known limits.
+---
+
+# MCP OAuth (durable)
+
+Most MCP servers Aeon can wire with a static bearer token (a repo secret injected
+as `Authorization: Bearer ${VAR}`). **OAuth-gated** servers are different: their
+access tokens are short-lived and minted through a browser flow a headless GitHub
+Actions run can't perform. This is the same problem the grok harness solves for the
+X-account login — and the solution here mirrors it: capture once in the dashboard,
+store as repo secrets, refresh before every run.
+
+## The flow
+
+1. **Connect (dashboard).** In the MCP panel, an OAuth-flagged featured server shows
+   **Connect** instead of Install. Clicking it calls `POST /api/mcp-auth`, which:
+   - discovers the server's auth endpoints — Protected Resource Metadata (RFC 9728)
+     → Authorization Server Metadata (RFC 8414 / OIDC),
+   - registers a client via Dynamic Client Registration (RFC 7591), or uses a
+     pinned `oauthClientId`,
+   - opens your browser to authorize (Authorization Code + PKCE, RFC 7636),
+   - on the `/api/mcp-auth/callback` redirect, exchanges the code for tokens.
+2. **Store.** The dashboard writes two repo secrets (the tokens never reach the
+   browser):
+   - `MCP_<SLUG>_TOKEN` — the (short-lived) access token, referenced by the header.
+   - `MCP_<SLUG>_OAUTH` — the refresh material (`token_endpoint`, `client_id`,
+     optional `client_secret`, `refresh_token`, `scope`) the runtime refresh needs.
+   The server is added to `.mcp.json` with `Authorization: Bearer ${MCP_<SLUG>_TOKEN}`.
+3. **Refresh (every run).** Before resolving `.mcp.json`'s `${VAR}`s, both workflows
+   source [`scripts/mcp-oauth-refresh.sh`](../scripts/mcp-oauth-refresh.sh). For each
+   `MCP_<SLUG>_OAUTH` secret it mints a fresh access token via the `refresh_token`
+   grant and exports `MCP_<SLUG>_TOKEN`, so the header resolves to a live token. It
+   is sourced, never fails the run, and never prints a token (masked with
+   `::add-mask::`). Covers both harnesses (Claude via `--mcp-config`, grok natively).
+
+## Code map
+
+| Piece | File |
+|---|---|
+| OAuth core (PKCE, discovery, DCR, exchange/refresh — pure, unit-tested) | `apps/dashboard/lib/mcp-oauth.ts` |
+| Server glue (pending-flow store, browser open, secret storage) | `apps/dashboard/lib/mcp-oauth-server.ts` |
+| Start + callback routes | `apps/dashboard/app/api/mcp-auth/{route,callback/route}.ts` |
+| Panel Connect button | `apps/dashboard/components/McpPanel.tsx` |
+| Catalog `oauth` flag | `apps/dashboard/lib/mcp-catalog.ts` |
+| Runtime refresh (sourced by both workflows) | `scripts/mcp-oauth-refresh.sh` |
+
+## Limits (read before relying on it)
+
+- **Local-first dashboard.** The flow opens your browser and shares the pending
+  request in-process (same assumption as `app/api/grok-auth`). It works when the
+  dashboard runs on your machine; a multi-instance serverless deploy would need
+  external state.
+- **Dynamic Client Registration required for one-click.** A server without DCR
+  needs a pre-registered `client_id` (set `oauthClientId` on the catalog entry).
+- **Rotating refresh tokens.** If a provider rotates the refresh token on each use,
+  the new one can't be persisted from a headless run (the default `GITHUB_TOKEN`
+  can't write secrets), so auth eventually breaks and you re-connect. Providers with
+  stable refresh tokens (the common case) work indefinitely.
+- **No offline scope, no refresh.** If the provider doesn't return a refresh token
+  (e.g. it needs an explicit offline-access scope), only the access token is stored
+  and it will expire — the panel warns when this happens.
+
+## Testing it
+
+The pure OAuth helpers and the refresh script are unit-tested
+(`apps/dashboard/lib/mcp-oauth.test.ts`, `scripts/tests/test_mcp_oauth_refresh.sh`).
+The end-to-end browser flow needs a real OAuth MCP server (e.g. Robinhood): run the
+dashboard locally, click **Connect**, approve in the browser, confirm
+`MCP_<SLUG>_TOKEN` + `MCP_<SLUG>_OAUTH` appear as repo secrets and the server lands
+in `.mcp.json`, then dispatch a skill that calls it and confirm the refresh step
+logs `refreshed MCP_<SLUG>_TOKEN` (with step debug logging on).

--- a/docs/mcp-oauth.md
+++ b/docs/mcp-oauth.md
@@ -18,7 +18,9 @@ store as repo secrets, refresh before every run.
 1. **Connect (dashboard).** In the MCP panel, an OAuth-flagged featured server shows
    **Connect** instead of Install. Clicking it calls `POST /api/mcp-auth`, which:
    - discovers the server's auth endpoints — Protected Resource Metadata (RFC 9728)
-     → Authorization Server Metadata (RFC 8414 / OIDC),
+     → Authorization Server Metadata (RFC 8414 / OIDC). A **self-issuing** server that
+     skips PRM (e.g. Base, whose issuer *is* `mcp.base.org`) is handled by falling back
+     to AS metadata at the MCP origin's well-known — what compliant clients do,
    - registers a client via Dynamic Client Registration (RFC 7591), or uses a
      pinned `oauthClientId`,
    - opens your browser to authorize (Authorization Code + PKCE, RFC 7636),

--- a/scripts/mcp-oauth-refresh.sh
+++ b/scripts/mcp-oauth-refresh.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# mcp-oauth-refresh.sh — SOURCE me (do not execute). The durable half of the
+# dashboard's MCP OAuth flow (apps/dashboard/lib/mcp-oauth.ts): the dashboard
+# captured a refresh token into an MCP_<SLUG>_OAUTH secret; before each headless
+# run we mint a *fresh* access token from it and export MCP_<SLUG>_TOKEN, so
+# .mcp.json's `Authorization: Bearer ${MCP_<SLUG>_TOKEN}` resolves to a live token.
+#
+# Source this immediately BEFORE the .mcp.json ${VAR} resolution loop: that loop
+# keeps any var already in the environment (`[ -n "${!v:-}" ] && continue`), so a
+# token we export here wins over the (possibly stale) stored access-token secret.
+#
+# Contract:
+#   - Sourced, so it NEVER exits and must never abort the caller's run step. It
+#     toggles errexit off for its body and restores it, and guards every command.
+#   - Reads secrets from ALL_SECRETS (toJSON(secrets)); needs jq + curl.
+#   - A server whose refresh fails is simply left without a fresh token — the MCP
+#     preflight then skips it (or falls back to the stored access token), never
+#     breaking the run.
+#   - Never prints a token: the fresh access token is masked with ::add-mask::.
+
+# Preserve the caller's errexit, then disable it for our body (we handle every
+# error explicitly). Restored at the end.
+case $- in *e*) _mcp_oe_was_set=1 ;; *) _mcp_oe_was_set=0 ;; esac
+set +e
+
+_mcp_oauth_refresh_one() {
+  local oauth_var="$1" json="$2"
+  local token_var="${oauth_var%_OAUTH}_TOKEN"
+  local ep cid csec rt
+  ep=$(jq -r '.token_endpoint // empty' <<<"$json" 2>/dev/null)
+  cid=$(jq -r '.client_id // empty' <<<"$json" 2>/dev/null)
+  csec=$(jq -r '.client_secret // empty' <<<"$json" 2>/dev/null)
+  rt=$(jq -r '.refresh_token // empty' <<<"$json" 2>/dev/null)
+  if [ -z "$ep" ] || [ -z "$rt" ]; then
+    echo "::warning::MCP OAuth: $oauth_var is missing token_endpoint/refresh_token — skipping (re-connect it in the dashboard)"
+    return 0
+  fi
+
+  # Refresh request. A confidential client (has client_secret) authenticates with
+  # HTTP Basic; a public/PKCE client passes client_id in the body. This runs on
+  # the GitHub runner (plain bash — no Claude bash analyzer), so a normal request
+  # with the secret in --data-urlencode is fine; nothing is echoed (set +e, no -x).
+  local args=(-s --max-time 30 -X POST "$ep"
+    -H "Accept: application/json"
+    -H "Content-Type: application/x-www-form-urlencoded"
+    --data-urlencode "grant_type=refresh_token"
+    --data-urlencode "refresh_token=$rt")
+  if [ -n "$csec" ]; then
+    args+=(-u "$cid:$csec")
+  else
+    args+=(--data-urlencode "client_id=$cid")
+  fi
+
+  local resp access new_rt
+  resp=$(curl "${args[@]}" 2>/dev/null)
+  if [ $? -ne 0 ] || [ -z "$resp" ]; then
+    echo "::warning::MCP OAuth: refresh request to the token endpoint failed for $oauth_var"
+    return 0
+  fi
+  access=$(jq -r '.access_token // empty' <<<"$resp" 2>/dev/null)
+  if [ -z "$access" ]; then
+    echo "::warning::MCP OAuth: no access_token in the refresh response for $oauth_var — re-connect it in the dashboard"
+    return 0
+  fi
+
+  echo "::add-mask::$access"
+  export "$token_var=$access"
+  echo "::debug::MCP OAuth: refreshed $token_var"
+
+  # Rotated refresh token? Persist it so the NEXT run stays valid. Best-effort:
+  # writing a secret needs a secrets-scoped token (the default GITHUB_TOKEN can't),
+  # so a failure is a debug note, not a warning — most providers don't rotate.
+  new_rt=$(jq -r '.refresh_token // empty' <<<"$resp" 2>/dev/null)
+  if [ -n "$new_rt" ] && [ "$new_rt" != "$rt" ]; then
+    local updated
+    updated=$(jq -c --arg rt "$new_rt" '.refresh_token=$rt' <<<"$json" 2>/dev/null)
+    if [ -n "$updated" ] && command -v gh >/dev/null 2>&1 \
+       && printf '%s' "$updated" | gh secret set "$oauth_var" >/dev/null 2>&1; then
+      echo "::debug::MCP OAuth: persisted rotated refresh token for $oauth_var"
+    else
+      echo "::debug::MCP OAuth: $oauth_var rotated its refresh token but it could not be persisted (needs a secrets-scoped token) — re-connect in the dashboard if auth later fails"
+    fi
+  fi
+  return 0
+}
+
+mcp_oauth_refresh() {
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "::warning::MCP OAuth: jq not found — skipping token refresh"; return 0
+  fi
+  if ! command -v curl >/dev/null 2>&1; then
+    echo "::warning::MCP OAuth: curl not found — skipping token refresh"; return 0
+  fi
+  local secrets="${ALL_SECRETS:-}"; [ -z "$secrets" ] && secrets='{}'
+  local names
+  names=$(jq -r 'keys[] | select(startswith("MCP_") and endswith("_OAUTH"))' <<<"$secrets" 2>/dev/null)
+  [ -z "$names" ] && return 0
+  local n json
+  while IFS= read -r n; do
+    [ -z "$n" ] && continue
+    # The secret VALUE is the OAuthSecret JSON *as a string*; -r unwraps it.
+    json=$(jq -r --arg k "$n" '.[$k] // empty' <<<"$secrets" 2>/dev/null)
+    [ -z "$json" ] && continue
+    _mcp_oauth_refresh_one "$n" "$json"
+  done <<< "$names"
+  return 0
+}
+
+mcp_oauth_refresh
+
+# Restore the caller's errexit setting; leave the shell as we found it.
+if [ "$_mcp_oe_was_set" = 1 ]; then set -e; fi
+unset _mcp_oe_was_set

--- a/scripts/tests/test_mcp_oauth_refresh.sh
+++ b/scripts/tests/test_mcp_oauth_refresh.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Tests for scripts/mcp-oauth-refresh.sh — the durable MCP OAuth token refresh.
+# The script is SOURCED (exports MCP_<SLUG>_TOKEN into the shell), so each case runs
+# in an isolated `bash -c` that defines a stub `curl`, sets ALL_SECRETS, sources the
+# script, and reports the resulting env. No network.
+set -uo pipefail
+R="$(cd "$(dirname "$0")/../.." && pwd)/scripts/mcp-oauth-refresh.sh"
+FAILED=0
+pass() { echo "ok   - $1"; }
+bad()  { echo "FAIL - $1"; FAILED=1; }
+
+# Helper: run the script with a given ALL_SECRETS and stub curl response, echo the
+# resulting MCP_FOO_TOKEN (empty if unset). $1=ALL_SECRETS json, $2=curl stdout.
+run_case() {
+  ALL_SECRETS="$1" CURL_OUT="$2" bash -c '
+    curl() { printf "%s" "$CURL_OUT"; }   # stub: ignore args, emit canned token JSON
+    source "'"$R"'" 2>/dev/null
+    printf "TOKEN=[%s]\n" "${MCP_FOO_TOKEN:-}"
+  '
+}
+
+OAUTH_OK='{"MCP_FOO_OAUTH":"{\"token_endpoint\":\"https://as.example/token\",\"client_id\":\"cid\",\"refresh_token\":\"rt-1\",\"slug\":\"foo\"}"}'
+
+# 1. Valid oauth secret + a good refresh response → fresh token exported.
+out=$(run_case "$OAUTH_OK" '{"access_token":"fresh-123","token_type":"Bearer","expires_in":3600}')
+echo "$out" | grep -qx 'TOKEN=\[fresh-123\]' && pass "refresh exports MCP_FOO_TOKEN with the fresh access token" || bad "refresh exports token (got: $out)"
+
+# 2. Refresh response with no access_token → token NOT exported (stays empty).
+out=$(run_case "$OAUTH_OK" '{"error":"invalid_grant"}')
+echo "$out" | grep -qx 'TOKEN=\[\]' && pass "no access_token in response → token left unset" || bad "unset on bad response (got: $out)"
+
+# 3. Missing token_endpoint → skipped, token unset.
+BAD_SECRET='{"MCP_FOO_OAUTH":"{\"client_id\":\"cid\",\"refresh_token\":\"rt-1\"}"}'
+out=$(run_case "$BAD_SECRET" '{"access_token":"nope"}')
+echo "$out" | grep -qx 'TOKEN=\[\]' && pass "missing token_endpoint → skipped" || bad "skip on missing endpoint (got: $out)"
+
+# 4. No MCP_*_OAUTH secrets → clean no-op (token unset, no failure).
+out=$(run_case '{"SOME_OTHER":"x"}' '{"access_token":"nope"}')
+echo "$out" | grep -qx 'TOKEN=\[\]' && pass "no oauth secrets → no-op" || bad "no-op when no oauth secrets (got: $out)"
+
+# 5. Sourced under `set -e`, a failing refresh must NOT abort the caller.
+out=$(ALL_SECRETS="$OAUTH_OK" CURL_OUT='{"error":"x"}' bash -c '
+  set -eo pipefail
+  curl() { printf "%s" "$CURL_OUT"; }
+  source "'"$R"'" 2>/dev/null
+  echo "SURVIVED"
+')
+echo "$out" | grep -qx 'SURVIVED' && pass "failing refresh does not abort a set -e caller" || bad "set -e safety (got: $out)"
+
+# 6. Sourced under `set -e`, errexit is restored afterward (still on).
+out=$(ALL_SECRETS="$OAUTH_OK" CURL_OUT='{"access_token":"z"}' bash -c '
+  set -e
+  curl() { printf "%s" "$CURL_OUT"; }
+  source "'"$R"'" 2>/dev/null
+  case $- in *e*) echo "ERREXIT_ON" ;; *) echo "ERREXIT_OFF" ;; esac
+')
+echo "$out" | grep -qx 'ERREXIT_ON' && pass "errexit restored after sourcing" || bad "errexit restored (got: $out)"
+
+echo "---"
+[ "$FAILED" = 0 ] && echo "ALL PASS" || { echo "SOME FAILED"; exit 1; }


### PR DESCRIPTION
feat(mcp): durable OAuth connect for OAuth-gated MCP servers

Adds a dashboard OAuth flow so OAuth-gated MCP servers (e.g. Robinhood) work
headlessly, mirroring the grok X-account capture: connect once in the browser,
store the tokens as repo secrets, refresh before every run.

Dashboard (capture):
- lib/mcp-oauth.ts — OAuth core: PKCE (RFC 7636), Protected-Resource + AS
  discovery (RFC 9728 / 8414 / OIDC), Dynamic Client Registration (RFC 7591),
  code exchange + refresh. Pure + unit-tested.
- lib/mcp-oauth-server.ts — pending-flow store, browser open, secret storage.
- app/api/mcp-auth/{route,callback/route}.ts — start the flow (discover, register,
  open browser, wait) + the PKCE callback (exchange code, resolve).
- components/McpPanel.tsx — OAuth-flagged featured servers show "Connect"; the
  tokens are captured server-side and never reach the browser.
- lib/mcp-catalog.ts — oauth / oauthScopes / oauthClientId flags; Robinhood marked.

Runtime (the durable half):
- scripts/mcp-oauth-refresh.sh — sourced by aeon.yml + messages.yml right before
  the .mcp.json ${VAR} loop. For each MCP_<SLUG>_OAUTH secret it mints a fresh
  access token via the refresh_token grant and exports MCP_<SLUG>_TOKEN, so the
  header resolves to a live token. Sourced (never exits/fails the run), masks the
  token, restores the caller's errexit. Covers both harnesses.

Validated here: dashboard suite 154 pass (5 new OAuth tests), tsc --noEmit clean;
refresh-script bash tests 6 pass; actionlint, validate-config, okf-validate green.

NOT YET VERIFIED END-TO-END: the browser flow needs a live OAuth MCP server. See
docs/mcp-oauth.md for the test procedure and known limits (rotating refresh tokens,
DCR requirement, local-first single-process). Do not merge before that live test.
