### PR TITLE
feat(mcp): enable one-click OAuth Connect for glim

### DIFF
--- a/apps/dashboard/lib/mcp-catalog.ts
+++ b/apps/dashboard/lib/mcp-catalog.ts
@@ -56,6 +56,11 @@ export const MCP_CATALOG: McpCatalogEntry[] = [
     url: 'https://glim.sh/mcp',
     logo: 'https://raw.githubusercontent.com/glim-sh/glim-mcp/main/assets/icon-400.png',
     description: 'glim.sh - live data for AI agents: web search, full page extraction, Twitter/X, Reddit, GitHub, Amazon, YouTube transcripts. Pay-per-call with x402 (Base/Solana USDC) or MPP (Tempo), or sign in and draw from a prepaid account balance.',
+    // Standard OAuth (PRM https://glim.sh/api/auth → AS metadata + DCR). Request
+    // offline_access so the token endpoint returns a refresh token (durable headless
+    // auth); openid for identity. Skip profile/email — not needed for API access.
+    oauth: true,
+    oauthScopes: ['openid', 'offline_access'],
   },
 ]
 


### PR DESCRIPTION
glim advertises the full standard OAuth chain (Protected Resource Metadata → AS metadata + DCR, verified live), so it just needs the catalog flag. Requests `openid` + `offline_access` — `offline_access` ensures the token endpoint returns a refresh token for durable headless auth; skips `profile`/`email` (not needed for API access). All three featured servers (Base, Robinhood, glim) are now one-click OAuth. tsc clean, dashboard 156 tests pass.