### PR TITLE
Make MCP OAuth refresh durable for rotating-token providers

### DIFF
--- a/apps/dashboard/components/McpPanel.tsx
+++ b/apps/dashboard/components/McpPanel.tsx
@@ -211,6 +211,22 @@ export function McpPanel({ servers, loading, saving, secrets, busy, onSave, onSe
           })}
         </div>
         {oauthError && <p className="mt-3 text-[11px] font-mono text-aeon-red">{oauthError}</p>}
+        {/* Durable-refresh note. A connected OAuth server mints a short-lived
+            access token each run; providers that ROTATE their refresh token also
+            need the rotation saved, which needs a secrets-write PAT. Without it,
+            auth breaks one run after Connect. Shown only once an OAuth server is
+            installed; turns green when MCP_SECRETS_PAT (or GH_GLOBAL) is set. */}
+        {FEATURED.some(f => f.oauth && isFeaturedInstalled(f.url)) && (
+          isSecretSet('MCP_SECRETS_PAT') || isSecretSet('GH_GLOBAL') ? (
+            <p className="mt-3 text-[11px] font-mono text-aeon-green">
+              ✓ Durable OAuth refresh active — rotated refresh tokens persist via {isSecretSet('MCP_SECRETS_PAT') ? 'MCP_SECRETS_PAT' : 'GH_GLOBAL'}.
+            </p>
+          ) : (
+            <p className="mt-3 text-[11px] text-primary-40 leading-relaxed">
+              <span className="text-aeon-red">Durable refresh:</span> a connected OAuth server mints a short-lived token each run. Providers that rotate their refresh token (e.g. <span className="text-primary-70">Base</span>, <span className="text-primary-70">glim</span>) need a secrets-write credential to save each rotation — without it, auth breaks one run after you Connect. Add a fine-grained PAT with <span className="text-primary-70">Secrets: read/write</span> on this repo as <span className="text-primary-70">MCP_SECRETS_PAT</span> (in Settings → Secrets), then re-connect the server once. See <span className="text-primary-70">docs/mcp-oauth.md</span>.
+            </p>
+          )
+        )}
       </section>
 
       <section className="border-t border-[rgba(250,250,250,0.10)] pt-6">

--- a/docs/mcp-oauth.md
+++ b/docs/mcp-oauth.md
@@ -58,9 +58,20 @@ store as repo secrets, refresh before every run.
 - **Dynamic Client Registration required for one-click.** A server without DCR
   needs a pre-registered `client_id` (set `oauthClientId` on the catalog entry).
 - **Rotating refresh tokens.** If a provider rotates the refresh token on each use,
-  the new one can't be persisted from a headless run (the default `GITHUB_TOKEN`
-  can't write secrets), so auth eventually breaks and you re-connect. Providers with
-  stable refresh tokens (the common case) work indefinitely.
+  the old one is invalidated the moment it's used, so unless the replacement is
+  saved the *next* headless run's refresh fails (`no access_token` / `invalid_grant`)
+  and auth breaks one run later. Persisting a secret needs a **secrets-write
+  credential** — the default `GITHUB_TOKEN` cannot write secrets. To make refresh
+  durable for rotating providers, add a fine-grained PAT with **Secrets: read/write**
+  on this repo as the secret **`MCP_SECRETS_PAT`** (or a repo-wide `GH_GLOBAL`);
+  `scripts/mcp-oauth-refresh.sh` then saves each rotated refresh token back to its
+  `MCP_<SLUG>_OAUTH` secret and warns loudly when it can't. **After adding the PAT,
+  re-connect the affected server once** to seed a valid refresh token — a refresh
+  token already consumed by a prior run can't be revived by the PAT alone. Providers
+  with stable refresh tokens (the common case) work indefinitely without a PAT.
+  (Note: concurrent runs that each refresh the same rotating token still race — for
+  many-server / high-parallelism setups, refresh centrally on a schedule so exactly
+  one run mints and persists per interval.)
 - **No offline scope, no refresh.** If the provider doesn't return a refresh token
   (e.g. it needs an explicit offline-access scope), only the access token is stored
   and it will expire — the panel warns when this happens.

--- a/scripts/mcp-oauth-refresh.sh
+++ b/scripts/mcp-oauth-refresh.sh
@@ -24,7 +24,7 @@ case $- in *e*) _mcp_oe_was_set=1 ;; *) _mcp_oe_was_set=0 ;; esac
 set +e
 
 _mcp_oauth_refresh_one() {
-  local oauth_var="$1" json="$2"
+  local oauth_var="$1" json="$2" pat="${3:-}"
   local token_var="${oauth_var%_OAUTH}_TOKEN"
   local ep cid csec rt
   ep=$(jq -r '.token_endpoint // empty' <<<"$json" 2>/dev/null)
@@ -59,7 +59,13 @@ _mcp_oauth_refresh_one() {
   fi
   access=$(jq -r '.access_token // empty' <<<"$resp" 2>/dev/null)
   if [ -z "$access" ]; then
-    echo "::warning::MCP OAuth: no access_token in the refresh response for $oauth_var — re-connect it in the dashboard"
+    # Surface the OAuth error (e.g. invalid_grant) so the failure is actionable —
+    # invalid_grant here almost always means an earlier run rotated/consumed the
+    # stored refresh token and could not save the replacement (see persistence
+    # note below). Never echoes the token itself.
+    local oerr
+    oerr=$(jq -r '[.error, .error_description] | map(select(. != null and . != "")) | join(": ")' <<<"$resp" 2>/dev/null)
+    echo "::warning::MCP OAuth: refresh failed for $oauth_var${oerr:+ ($oerr)} — the stored refresh token was likely rotated/consumed by an earlier run and not saved. Re-connect it in the dashboard, and set a secrets-write PAT (MCP_SECRETS_PAT) so future rotations persist. See docs/mcp-oauth.md."
     return 0
   fi
 
@@ -67,18 +73,27 @@ _mcp_oauth_refresh_one() {
   export "$token_var=$access"
   echo "::debug::MCP OAuth: refreshed $token_var"
 
-  # Rotated refresh token? Persist it so the NEXT run stays valid. Best-effort:
-  # writing a secret needs a secrets-scoped token (the default GITHUB_TOKEN can't),
-  # so a failure is a debug note, not a warning — most providers don't rotate.
+  # Rotated refresh token? Persist it so the NEXT run stays valid. Providers that
+  # rotate the refresh token on every refresh invalidate the old one immediately,
+  # so unless the replacement is saved, the next headless run's refresh fails ("no
+  # access_token"). Writing a secret needs a secrets-write credential — the default
+  # GITHUB_TOKEN CANNOT do this — so persistence uses the PAT the caller resolved
+  # (MCP_SECRETS_PAT / GH_GLOBAL). Failures here are LOUD (::warning::), not silent:
+  # an unpersisted rotation is exactly what silently breaks auth one run later.
   new_rt=$(jq -r '.refresh_token // empty' <<<"$resp" 2>/dev/null)
   if [ -n "$new_rt" ] && [ "$new_rt" != "$rt" ]; then
     local updated
     updated=$(jq -c --arg rt "$new_rt" '.refresh_token=$rt' <<<"$json" 2>/dev/null)
-    if [ -n "$updated" ] && command -v gh >/dev/null 2>&1 \
-       && printf '%s' "$updated" | gh secret set "$oauth_var" >/dev/null 2>&1; then
-      echo "::debug::MCP OAuth: persisted rotated refresh token for $oauth_var"
+    if [ -z "$updated" ]; then
+      echo "::warning::MCP OAuth: $oauth_var rotated its refresh token but the updated secret JSON could not be built — re-connect it in the dashboard."
+    elif [ -z "$pat" ]; then
+      echo "::warning::MCP OAuth: $oauth_var uses a ROTATING refresh token but no secrets-write credential is set, so the rotated token cannot be saved and the NEXT run's refresh WILL fail. Add a fine-grained PAT (Secrets: read/write) as repo secret MCP_SECRETS_PAT (or GH_GLOBAL), then re-connect $oauth_var in the dashboard."
+    elif ! command -v gh >/dev/null 2>&1; then
+      echo "::warning::MCP OAuth: $oauth_var rotated its refresh token but 'gh' is unavailable to persist it."
+    elif printf '%s' "$updated" | GH_TOKEN="$pat" gh secret set "$oauth_var" >/dev/null 2>&1; then
+      echo "MCP OAuth: persisted rotated refresh token for $oauth_var (durable refresh active)"
     else
-      echo "::debug::MCP OAuth: $oauth_var rotated its refresh token but it could not be persisted (needs a secrets-scoped token) — re-connect in the dashboard if auth later fails"
+      echo "::warning::MCP OAuth: $oauth_var rotated its refresh token but persisting it FAILED — MCP_SECRETS_PAT/GH_GLOBAL needs 'Secrets: read/write' on this repo. Re-connect in the dashboard once fixed."
     fi
   fi
   return 0
@@ -95,13 +110,19 @@ mcp_oauth_refresh() {
   local names
   names=$(jq -r 'keys[] | select(startswith("MCP_") and endswith("_OAUTH"))' <<<"$secrets" 2>/dev/null)
   [ -z "$names" ] && return 0
+  # Secrets-write credential used to persist ROTATED refresh tokens (see the
+  # persistence note in _mcp_oauth_refresh_one). A dedicated MCP_SECRETS_PAT wins;
+  # GH_GLOBAL is the repo-wide fallback. Masked so it never lands in a log.
+  local pat
+  pat=$(jq -r '.MCP_SECRETS_PAT // .GH_GLOBAL // empty' <<<"$secrets" 2>/dev/null)
+  [ -n "$pat" ] && echo "::add-mask::$pat"
   local n json
   while IFS= read -r n; do
     [ -z "$n" ] && continue
     # The secret VALUE is the OAuthSecret JSON *as a string*; -r unwraps it.
     json=$(jq -r --arg k "$n" '.[$k] // empty' <<<"$secrets" 2>/dev/null)
     [ -z "$json" ] && continue
-    _mcp_oauth_refresh_one "$n" "$json"
+    _mcp_oauth_refresh_one "$n" "$json" "$pat"
   done <<< "$names"
   return 0
 }

--- a/scripts/tests/test_mcp_oauth_refresh.sh
+++ b/scripts/tests/test_mcp_oauth_refresh.sh
@@ -56,5 +56,25 @@ out=$(ALL_SECRETS="$OAUTH_OK" CURL_OUT='{"access_token":"z"}' bash -c '
 ')
 echo "$out" | grep -qx 'ERREXIT_ON' && pass "errexit restored after sourcing" || bad "errexit restored (got: $out)"
 
+# 7. Rotated refresh token + a secrets-write PAT + stubbed gh → token still
+#    exported AND `gh secret set` invoked to persist the new refresh token.
+ROT_SECRET='{"MCP_SECRETS_PAT":"pat-xyz","MCP_FOO_OAUTH":"{\"token_endpoint\":\"https://as.example/token\",\"client_id\":\"cid\",\"refresh_token\":\"rt-1\"}"}'
+out=$(ALL_SECRETS="$ROT_SECRET" CURL_OUT='{"access_token":"fresh-9","refresh_token":"rt-2"}' GHMARK="$(mktemp)" bash -c '
+  curl() { printf "%s" "$CURL_OUT"; }
+  gh() { [ "$1" = "secret" ] && [ "$2" = "set" ] && { echo "GH_TOKEN=$GH_TOKEN NAME=$3" > "$GHMARK"; cat >/dev/null; }; return 0; }
+  export -f gh
+  source "'"$R"'" 2>/dev/null
+  printf "TOKEN=[%s]\n" "${MCP_FOO_TOKEN:-}"
+  printf "PERSIST=[%s]\n" "$(cat "$GHMARK")"
+  rm -f "$GHMARK"
+')
+echo "$out" | grep -qx 'TOKEN=\[fresh-9\]' && pass "rotated token: fresh access token still exported" || bad "rotated token export (got: $out)"
+echo "$out" | grep -q 'PERSIST=\[GH_TOKEN=pat-xyz NAME=MCP_FOO_OAUTH\]' && pass "rotated token: persisted via gh secret set using the PAT" || bad "rotated token persistence (got: $out)"
+
+# 8. Rotated refresh token but NO secrets-write PAT → access token still exported
+#    (run does not break), persistence simply skipped (warned on stderr).
+out=$(run_case "$OAUTH_OK" '{"access_token":"fresh-8","refresh_token":"rt-2"}')
+echo "$out" | grep -qx 'TOKEN=\[fresh-8\]' && pass "rotated token, no PAT: access token still exported" || bad "no-PAT rotation still exports token (got: $out)"
+
 echo "---"
 [ "$FAILED" = 0 ] && echo "ALL PASS" || { echo "SOME FAILED"; exit 1; }


### PR DESCRIPTION
## Problem

The dashboard OAuth **Connect** flow works — but the runtime **refresh** silently broke one run after connecting, for providers that **rotate their refresh token** (Base, glim). The old refresh token is invalidated the moment it's used, and persisting the replacement needs a **secrets-write credential** the default `GITHUB_TOKEN` doesn't have. So the rotation was dropped with a `::debug::` note, and the *next* run's refresh returned `no access_token` → downstream 401.

Verified live on a test fork: a healthy run right after Connect, then a 401 ~5 min later on the following run.

## Fix (code half)

- **Persist rotated refresh tokens** back to `MCP_<SLUG>_OAUTH` using a PAT resolved from `MCP_SECRETS_PAT` (preferred) or `GH_GLOBAL`, masked with `::add-mask::`.
- **Loud, not silent:** an unpersisted rotation and a failed refresh now emit `::warning::` with actionable text (surfacing the OAuth `error`/`invalid_grant`), instead of a hidden `::debug::`.
- **Dashboard MCP page:** surfaces the requirement once an OAuth server is connected — a red "Durable refresh" note pointing at `MCP_SECRETS_PAT`, which turns green (`✓ Durable OAuth refresh active`) once the PAT (or `GH_GLOBAL`) is set.
- **`docs/mcp-oauth.md`:** documents `MCP_SECRETS_PAT` + the one-time reconnect.
- **Tests:** +2 cases (rotation persists via the PAT; rotation without a PAT still exports the access token and doesn't break the run). `bash scripts/tests/test_mcp_oauth_refresh.sh` → **all 9 pass**; dashboard `tsc --noEmit` clean; OKF validate OK.

## Operator half (cannot be done from CI)

1. Add a fine-grained **PAT** with *Secrets: read/write* on this repo as secret **`MCP_SECRETS_PAT`** (or set a repo-wide `GH_GLOBAL`).
2. **Re-connect the affected server once** in the dashboard MCP tab — a refresh token already consumed by a prior run can't be revived by the PAT alone; the PAT keeps the *next* rotation alive.

Providers with **stable** refresh tokens (the common case) already worked indefinitely and need no PAT.

## Not included

Per request, the `mcp-smoke` testing skill from the source PR is **not** ported (and neither are the generated `catalog/*.json` regenerations it triggered) — this PR is the code + docs + UI fix only.
