### PR TITLE
docs(mcp-catalog): record Robinhood OAuth mechanics + why no offline_access

### DIFF
--- a/apps/dashboard/lib/frontmatter.test.ts
+++ b/apps/dashboard/lib/frontmatter.test.ts
@@ -132,12 +132,12 @@ requires: [GOOD_KEY, , lowercase, 123BAD]
 name: Base MCP
 description: onchain
 tags: [crypto]
-mcp: [base, ctrl?]
+mcp: [base, glim?]
 ---`;
     const result = parseFrontmatter(content);
     assert.deepEqual(result.mcp, [
       { slug: "base", optional: false },
-      { slug: "ctrl", optional: true },
+      { slug: "glim", optional: true },
     ]);
   });
 

--- a/apps/dashboard/lib/frontmatter.ts
+++ b/apps/dashboard/lib/frontmatter.ts
@@ -69,7 +69,7 @@ export function parseFrontmatter(content: string): Frontmatter {
   // `mcp:` declares the MCP servers a skill needs. Same shape/semantics as
   // `requires:` (trailing `?` = "works better with"), but slugs reference the
   // MCP catalog (lib/mcp-catalog.ts) surfaced on the dashboard's MCP page.
-  //   mcp: [base, ctrl?]
+  //   mcp: [base, glim?]
   const mcp: SkillMcpRef[] = parseList(block.match(/mcp:\s*\[([^\]]*)\]/)?.[1])
     .map(raw => {
       const optional = raw.endsWith('?')

--- a/apps/dashboard/lib/mcp-catalog.ts
+++ b/apps/dashboard/lib/mcp-catalog.ts
@@ -48,6 +48,15 @@ export const MCP_CATALOG: McpCatalogEntry[] = [
     url: 'https://agent.robinhood.com/mcp/trading',
     logo: 'https://pbs.twimg.com/profile_images/1844399977482813442/1fTlYz2c_400x400.png',
     description: 'Robinhood Agentic Trading - read your portfolio, buying power, positions, and order history, and place trades from your agent. Remote HTTP MCP with OAuth; trades execute in a dedicated Agentic brokerage account you authorize. You are responsible for every order your agent places.',
+    // Standard OAuth, self-issuing: PRM (well-known path) names the MCP URL itself
+    // as the authorization server, AS metadata at agent.robinhood.com/.well-known/
+    // oauth-authorization-server/mcp/trading. Supports authorization_code +
+    // refresh_token grants, PKCE S256, DCR (registration_endpoint), public client
+    // (auth method "none"). Its ONLY advertised scope is "internal" — do NOT request
+    // offline_access here (glim needs it, Robinhood doesn't have it and would reject
+    // it); refresh tokens come from the refresh_token grant by default. Durable
+    // refresh (rotated-token persistence via MCP_SECRETS_PAT) is handled generically
+    // by scripts/mcp-oauth-refresh.sh — see docs/mcp-oauth.md.
     oauth: true,
   },
   {

--- a/bin/generate-skills-json
+++ b/bin/generate-skills-json
@@ -95,7 +95,7 @@ for skill_dir in "$SKILLS_DIR"/*/; do
   fi
   requires_json+="]"
 
-  # mcp: [base, ctrl?]  →  [{"slug":"base","optional":false},{"slug":"ctrl","optional":true}]
+  # mcp: [base, glim?]  →  [{"slug":"base","optional":false},{"slug":"glim","optional":true}]
   mcp_raw=$(awk '/^---$/{n++; next} n==1 && /^mcp:/{sub(/^mcp: *\[/, ""); sub(/\].*/, ""); print; exit}' "$skill_file")
   mcp_json="["
   if [[ -n "$mcp_raw" ]]; then


### PR DESCRIPTION
Follow-up to #732. Probed Robinhood's MCP OAuth live to answer "does it need the same treatment?"

**Findings** (`agent.robinhood.com/.well-known/oauth-authorization-server/mcp/trading`):
- Self-issuing AS (PRM at the well-known path names the MCP URL as its own authorization server).
- `grant_types_supported`: `authorization_code`, **`refresh_token`** ✓
- PKCE `S256`, DCR present (`registration_endpoint`), public client (`token_endpoint_auth_methods_supported: ["none"]`).
- `scopes_supported`: **`["internal"]` only** — no `offline_access`.

**Conclusion — no functional change needed:**
1. Durable rotated-token refresh is already provider-generic (PR #732 persists any rotation via `MCP_SECRETS_PAT`), so Robinhood is covered whether or not it rotates.
2. **Must NOT add `offline_access`** the way glim does — Robinhood doesn't advertise it and would reject it; refresh tokens come from the `refresh_token` grant by default. Leaving `oauthScopes` unset is correct.

This PR just records those mechanics as a comment on the Robinhood catalog entry (base and glim already have equivalent comments), so nobody re-probes. Comment-only; `tsc --noEmit` clean.

Note: like base/glim, an actual Connect against a real Robinhood account is still the final confirmation — this establishes it *should* work durably.