### PR TITLE
fix(skills): one notify call per run in robinhood-mcp + glim-mcp

### DIFF
--- a/skills/glim-mcp/SKILL.md
+++ b/skills/glim-mcp/SKILL.md
@@ -41,6 +41,8 @@ Write the digest: a 2–3 sentence answer up top, then the supporting evidence g
 
 Deliver via `./notify -f` (ordinary Markdown): the answer, the evidence, a `Sources` list of clickable URLs, and a final line `calls: N/<budget>`. This skill is on-demand — a completed run always notifies (unlike monitors, silence isn't signal here).
 
+**Exactly one `./notify` call per run.** Each call overwrites `apps/dashboard/outputs/.pending-<skill>.md` (last-writer-wins), which becomes the chain artifact `output/.chains/glim-mcp.md` that `consume:` steps and the feed read — a follow-up "headline" ping would replace the digest with a stub. Everything goes in the single `-f` file.
+
 ### 5. Log
 
 Append to `memory/logs/${today}.md`:

--- a/skills/robinhood-mcp/SKILL.md
+++ b/skills/robinhood-mcp/SKILL.md
@@ -37,7 +37,7 @@ Operator-initiated only — never trade on a scheduled/default run, and never in
 
 ### 3. Notify
 
-This skill is on-demand — deliver the result via `./notify -f` (ordinary Markdown):
+This skill is on-demand — deliver the result via `./notify -f` (ordinary Markdown), **exactly one `./notify` call per run** (each call overwrites the `.pending-<skill>.md` file the chain artifact is captured from — a second ping would clobber the report):
 
 - **Report branches:** portfolio value + day change, buying power, a positions table, open orders, and one line of what stands out (concentration, a position moving hard). Keep it tight — signal, not a data dump.
 - **Trade branch:** the exact order placed (side, symbol, size, order id, status) — or, on refusal, exactly what was ambiguous and how to restate it. Severity `success` for a placed order, `warn` for a refusal.


### PR DESCRIPTION
A second ./notify call overwrites apps/dashboard/outputs/.pending-<skill>.md
(notify.sh writes it with >, last-writer-wins), which the workflow then
captures as the chain artifact output/.chains/<skill>.md. Seen live on the
aeon-mcp test instance: a follow-up headline ping shrank the captured glim
digest from ~2.2KB to a 56-byte stub. Make the single-notify rule explicit
in both MCP skills. Frontmatter untouched - no catalog regen needed.
