### PR TITLE
fix(workflows): stamp OKF type: frontmatter before auto-commit

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -1176,6 +1176,12 @@ jobs:
           git config user.email "aeonframework@proton.me"
           rm -f ./notify ./notify-jsonrender .notify-sent-hashes  # Remove generated notify scripts + dedup log before committing
 
+          # OKF: stamp `type:` frontmatter onto any in-scope markdown the run
+          # created bare (e.g. a fresh memory/logs/ day-file appended via bash by
+          # a read-only skill) — ci-okf gates conformance and the backfill is
+          # idempotent. Best-effort: never fails the commit.
+          [ -f scripts/okf-backfill.mjs ] && node scripts/okf-backfill.mjs || true
+
           # Issues-as-state (hardening §3): cron-state.json was materialized from the
           # pinned Issue for this run's readers — it's a projection, not source of truth.
           # Drop the working-tree change so it isn't committed (that churn is exactly

--- a/.github/workflows/messages.yml
+++ b/.github/workflows/messages.yml
@@ -653,6 +653,10 @@ jobs:
           git config user.email "aeonframework@proton.me"
           rm -f ./notify
 
+          # OKF: stamp `type:` onto any in-scope markdown created bare this run
+          # (idempotent; ci-okf gates it). Best-effort — never fails the commit.
+          [ -f scripts/okf-backfill.mjs ] && node scripts/okf-backfill.mjs || true
+
           CURRENT_BRANCH=$(git branch --show-current)
           SOURCE="$_COMMIT_SOURCE"
 


### PR DESCRIPTION
A skill run can create an in-scope markdown file without frontmatter -
seen live on a fresh instance: a read-only skill appended the first
memory/logs/ entry of the day via bash (Write/Edit are stripped in
read-only mode), producing a bare file that failed ci-okf on the next
in-scope push (okf-validate: 'missing or unparseable YAML frontmatter').

Run scripts/okf-backfill.mjs (idempotent, first-match type rules) at the
top of both auto-commit steps (aeon.yml + messages.yml) so conformance
self-heals instead of depending on each agent remembering the rule.
Best-effort guarded - never fails the commit. actionlint clean.
