### PR TITLE
docs: cover the new MCP servers + skills (catalog table, README packs, CONFIGURATION)

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -98,9 +98,9 @@ Three packs are shown by default (**Core**, **Evolution**, **Basics**); the rest
 |------|--------|
 | **Core** (`core`, 11) | `auto-merge`,`auto-workflow`,`fleet-control`,`fork-fleet`,`heartbeat`,`memory-flush`,`narrative-convergence`,`shiplog`,`soul-builder`,`spawn-instance`,`strategy-builder` |
 | **Evolution** (`evolution`, 7) | `autoresearch`,`create-skill`,`install-skill`,`search-skill`,`self-improve`,`skill-health`,`skill-repair` |
-| **Basics** (`basics`, 13) | `action-converter`,`article`,`bd-radar`,`digest`,`fetch-tweets`,`github-trending`,`idea-forge`,`last30`,`pr-review`,`price-alert`,`token-movers`,`tx-explain`,`write-tweet` |
+| **Basics** (`basics`, 15) | `action-converter`,`article`,`bd-radar`,`digest`,`executor-mcp`,`fetch-tweets`,`github-trending`,`glim-mcp`,`idea-forge`,`last30`,`pr-review`,`price-alert`,`token-movers`,`tx-explain`,`write-tweet` |
 | **Dev & Code** (`dev`, 8) | `changelog`,`deploy-prototype`,`feature`,`github-monitor`,`inbox-triage`,`pr-triage`,`vuln-scanner`,`vuln-tracker` |
-| **Crypto & Markets** (`crypto`, 12) | `base-mcp`,`ctrl`,`defi-overview`,`distribute-tokens`,`investigation-report`,`monitor-polymarket`,`narrative-tracker`,`onchain-monitor`,`picks-tracker`,`pm-manipulation`,`token-pick`,`unlock-monitor` |
+| **Crypto & Markets** (`crypto`, 12) | `base-mcp`,`defi-overview`,`distribute-tokens`,`investigation-report`,`monitor-polymarket`,`narrative-tracker`,`onchain-monitor`,`picks-tracker`,`pm-manipulation`,`robinhood-mcp`,`token-pick`,`unlock-monitor` |
 | **Productivity** (`productivity`, 8) | `idea-pipeline`,`mention-radar`,`okf-export`,`okf-ingest`,`operator-scorecard`,`reply-maker`,`schedule-ads`,`send-email` |
 
 Authoritative source: [`skills.json`](../catalog/skills.json) + [`packs.json`](../catalog/packs.json), the dashboard **Packs** view, or `bin/add-skill aeonfun/aeon --list`. A skill's pack comes from its `category:` frontmatter - see [`docs/skill-packs.md`](../docs/skill-packs.md).

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -69,7 +69,7 @@ cp docs/examples/mcp/.mcp.json.example .mcp.json   # then edit, commit, push
 
 The example ships two working servers — `github` (uses the runner's built-in `GITHUB_TOKEN`) and `sequential-thinking` (no-auth stdio). On the next run the runner loads `.mcp.json` and auto-allows every server's tools, so a skill can just say *"use the github MCP server to …"*. Reference a server's secret with `${VAR}` (never commit the value) and set it in the dashboard — the runner resolves it from the repo's secrets with zero workflow editing, and skips a server (with a warning) when its secret is missing rather than breaking the skill.
 
-Or skip the file entirely: the dashboard's **MCP** tab writes `.mcp.json` for you, lists **Featured** servers (e.g. [Base](https://mcp.base.org)) for one-click install, and tells you which secret each server needs.
+Or skip the file entirely: the dashboard's **MCP** tab writes `.mcp.json` for you, lists **Featured** servers ([Base](https://mcp.base.org), [Robinhood Trading](https://agent.robinhood.com), [glim.sh](https://glim.sh), [Executor](https://executor.sh)) for one-click install, and tells you which secret each server needs. The featured servers are OAuth-gated: **Connect** opens your browser to authorize, then keeps the tokens fresh across headless runs — including saving rotated refresh tokens, which needs a secrets-write PAT (`MCP_SECRETS_PAT`). Flow, PAT setup, and limits: [`docs/mcp-oauth.md`](mcp-oauth.md). Each featured server has a matching on-demand skill (`base-mcp`, `robinhood-mcp`, `glim-mcp`, `executor-mcp`) — dispatch it with a `var` to use the server from a run.
 
 ## Cross-repo access
 

--- a/docs/mcp-oauth.md
+++ b/docs/mcp-oauth.md
@@ -38,6 +38,23 @@ store as repo secrets, refresh before every run.
    is sourced, never fails the run, and never prints a token (masked with
    `::add-mask::`). Covers both harnesses (Claude via `--mcp-config`, grok natively).
 
+## Current catalog
+
+The featured OAuth servers (all probed live; the catalog file carries per-server
+discovery notes) and their companion skills:
+
+| Server (slug) | MCP URL | Scopes requested | Rotates refresh token? | Skill |
+|---|---|---|---|---|
+| Base (`base`) | `mcp.base.org` | `agent_wallet:transact` | yes | `base-mcp` |
+| Robinhood Trading (`robinhood-trading`) | `agent.robinhood.com/mcp/trading` | *(default — no `offline_access`; it only advertises `internal`)* | unverified — assume yes | `robinhood-mcp` |
+| glim.sh (`glim`) | `glim.sh/mcp` | `openid offline_access` | yes — **verified live 2026-07-16** | `glim-mcp` |
+| Executor (`executor`) | `executor.sh/mcp` | `openid offline_access` | yes — **verified live 2026-07-16** | `executor-mcp` |
+
+The glim and Executor loops were verified end-to-end on a live instance
+(Connect → per-run refresh → PAT-persisted rotation → refresh off the persisted
+token, no re-connect): every catalog provider rotates, so treat `MCP_SECRETS_PAT`
+as **required** in practice, not optional.
+
 ## Code map
 
 | Piece | File |


### PR DESCRIPTION
- .github/README.md pack table: drop ctrl, add robinhood-mcp (crypto, still
  12) and glim-mcp + executor-mcp (basics, now 15) - matches packs.json
- docs/CONFIGURATION.md: featured-server list is now the 4 OAuth servers
  with the Connect flow, MCP_SECRETS_PAT pointer, and the skill-per-server
  convention
- docs/mcp-oauth.md: new 'Current catalog' section - per-server URL, scopes,
  rotation status (glim + Executor verified live 2026-07-16; Robinhood
  unverified), and companion skill; note that every provider rotates so the
  PAT is required in practice
