### PR TITLE
docs: sync skill-pack counts to catalog (61 skills, Basics 15)

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -84,13 +84,13 @@ The prompt *is* the skill, judgment and all. You schedule it, hand it a `var`, c
 | --- | --- | --- | --- |
 | **Core** - fleet coordination, self-config, liveness; shown by default | `core` | 11 | `fleet-control`, `spawn-instance`, `auto-workflow` |
 | **Evolution** - authors, evolves, installs & heals its own skills; shown by default | `evolution` | 7 | `create-skill`, `autoresearch`, `skill-repair` |
-| **Basics** - simple, immediately-runnable skills; shown by default | `basics` | 13 | `digest`, `token-movers`, `pr-review` |
+| **Basics** - simple, immediately-runnable skills; shown by default | `basics` | 15 | `digest`, `token-movers`, `pr-review` |
 | **Dev & Code** | `dev` | 8 | `github-monitor`, `feature`, `deploy-prototype` |
-| **Crypto & Markets** | `crypto` | 12 | `token-pick`, `defi-overview`, `ctrl` |
+| **Crypto & Markets** | `crypto` | 12 | `token-pick`, `defi-overview`, `robinhood-mcp` |
 | **Productivity** | `productivity` | 8 | `mention-radar`, `send-email`, `okf-export` |
 
 <details>
-<summary><strong>Full catalog (all 59 skills by pack)</strong></summary>
+<summary><strong>Full catalog (all 61 skills by pack)</strong></summary>
 
 Three packs are shown by default (**Core**, **Evolution**, **Basics**); the rest are revealed on demand.
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,6 +1,6 @@
 # Aeon integration examples
 
-Aeon ships an [MCP server](../apps/mcp-server/) so any Claude client can call its 59 skills. The scripts here are the shortest possible "first call works" demos — build the server, run `python <file>`, get a real Aeon output back.
+Aeon ships an [MCP server](../apps/mcp-server/) so any Claude client can call its 61 skills. The scripts here are the shortest possible "first call works" demos — build the server, run `python <file>`, get a real Aeon output back.
 
 | File | Stack | Skill called | What it shows |
 |------|-------|--------------|---------------|

--- a/docs/skill-packs.md
+++ b/docs/skill-packs.md
@@ -4,7 +4,7 @@ type: Reference
 
 # Skill packs
 
-Aeon ships **59 skills**, but most forks only ever run a handful. Packs make
+Aeon ships **61 skills**, but most forks only ever run a handful. Packs make
 that manageable: by default the dashboard shows **Core** (what makes Aeon
 different) and **Basics** (simple skills you can run right now) — everything else
 is grouped into **packs** that stay hidden until you enable them.
@@ -77,7 +77,7 @@ Pack key = category. Six packs, no empties; three are shown by default.
 |---|---|---|
 | **Core** (`core`) | Fleet coordination, self-configuration, liveness, memory + reporting. Shown by default; not removable. | 11 |
 | **Evolution** (`evolution`) | The self-improvement loop — authors, evolves, installs, and heals its own skills. Shown by default. | 7 |
-| **Basics** (`basics`) | Simple, immediately-runnable skills — one approachable entry per area. Shown by default. | 13 |
+| **Basics** (`basics`) | Simple, immediately-runnable skills — one approachable entry per area. Shown by default. | 15 |
 | **Dev & Code** (`dev`) | PR/issue triage, review, merges, changelogs, repo monitoring, security scanning, app deploys. | 8 |
 | **Crypto & Markets** (`crypto`) | Token/DeFi/prediction-market monitoring, narrative tracking, on-chain forensics + automation. | 12 |
 | **Productivity** (`productivity`) | Personal + social ops: routines, ideas, retrospectives, mentions, replies, ads, email, OKF housekeeping. | 8 |


### PR DESCRIPTION
The prose in `.github/README.md`, `docs/skill-packs.md` and `docs/examples/README.md` had drifted from the generated catalog (`catalog/skills.json` = **61**; Basics = **15**):

- "Aeon ships **59 skills**" / "all 59 skills by pack" / "call its 59 skills" → **61**
- Basics pack count `13` → `15` (README summary table + skill-packs table)
- Phantom `ctrl` example → real `robinhood-mcp` (README crypto row)

README line 101 already listed Basics as 15, so the file was internally inconsistent — now aligned. The six pack counts sum to 61 (11+7+15+8+12+8). `CHANGELOG.md` ("60 core skills") left as a historical entry; generated `catalog/*.json` and `AGENTS.md` untouched.