### PR TITLE
fix(config): enable/schedule create a missing aeon.yml entry, and quote generated crons

### DIFF
--- a/apps/cli/src/commands/skills.ts
+++ b/apps/cli/src/commands/skills.ts
@@ -1,6 +1,6 @@
 import { parseArgs } from 'node:util'
 import { getSkills } from '../../../dashboard/lib/skills.ts'
-import { updateSkillInConfig, removeSkillFromConfig } from '../../../dashboard/lib/config.ts'
+import { updateSkillInConfig, upsertSkillInConfig, removeSkillFromConfig } from '../../../dashboard/lib/config.ts'
 import { getFileContent, saveFile, deleteDirectory, commitAndPush } from '../../../dashboard/lib/github.ts'
 import { runSkill, buildSkillRunArgs } from '../../../dashboard/lib/run-skill.ts'
 import type { Skill } from '../../../dashboard/lib/types.ts'
@@ -55,17 +55,36 @@ function requireName(args: string[]): string {
   return name
 }
 
+// Guard the upsert path: `upsertSkillInConfig` creates a missing entry, so a
+// typo'd name would otherwise write a bogus skill into aeon.yml. Skills are
+// enumerated from disk, so this is the authoritative check.
+async function requireInstalled(name: string) {
+  const { skills } = await getSkills()
+  if (!skills.some(s => s.name === name)) {
+    fail(`unknown skill: ${name} — no skills/${name}/SKILL.md. Run \`aeon skills ls\` to see what's installed.`)
+  }
+}
+
 async function toggle(args: string[], enabled: boolean) {
   const name = requireName(args)
-  const res = await applyConfig(raw => updateSkillInConfig(raw, name, { enabled }), `chore: ${enabled ? 'enable' : 'disable'} ${name}`)
-  reportConfig(res, `${enabled ? 'enable' : 'disable'} ${name}`)
+  // Enabling upserts (a new skill has no entry yet); disabling only edits an
+  // existing entry — no entry already means disabled, so there's nothing to write.
+  if (!enabled) {
+    const res = await applyConfig(raw => updateSkillInConfig(raw, name, { enabled }), `chore: disable ${name}`)
+    reportConfig(res, `disable ${name}`)
+    return
+  }
+  await requireInstalled(name)
+  const res = await applyConfig(raw => upsertSkillInConfig(raw, name, { enabled }), `chore: enable ${name}`)
+  reportConfig(res, `enable ${name}`)
 }
 
 async function schedule(args: string[]) {
   const name = requireName(args)
   const cron = args.filter(a => !a.startsWith('-') && a !== name)[0]
   if (!cron) fail('usage: aeon skills schedule <name> "<cron>"')
-  const res = await applyConfig(raw => updateSkillInConfig(raw, name, { schedule: cron }), `chore: schedule ${name}`)
+  await requireInstalled(name)
+  const res = await applyConfig(raw => upsertSkillInConfig(raw, name, { schedule: cron }), `chore: schedule ${name}`)
   reportConfig(res, `schedule ${name} → ${cron}`)
 }
 
@@ -82,7 +101,8 @@ async function setFields(args: string[]) {
   if (typeof values.model === 'string') updates.model = values.model
   if (typeof values.harness === 'string') updates.harness = values.harness
   if (Object.keys(updates).length === 0) fail('nothing to set — pass --var, --model, or --harness')
-  const res = await applyConfig(raw => updateSkillInConfig(raw, name, updates), `chore: update ${name} config`)
+  await requireInstalled(name)
+  const res = await applyConfig(raw => upsertSkillInConfig(raw, name, updates), `chore: update ${name} config`)
   reportConfig(res, `set ${name} ${Object.entries(updates).map(([k, v]) => `${k}=${v || '(clear)'}`).join(' ')}`)
 }
 

--- a/apps/dashboard/app/api/skills/route.ts
+++ b/apps/dashboard/app/api/skills/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server'
 import { errorResponse, syncResult } from '@/lib/http'
 import { getFileContent, updateFile, commitAndPush } from '@/lib/github'
 import {
-  updateSkillInConfig,
+  upsertSkillInConfig,
   updateModelInConfig,
   updateHarnessInConfig,
   updateJsonrenderInConfig,
@@ -42,7 +42,10 @@ export async function PATCH(request: Request) {
     }
 
     if (name && (typeof enabled === 'boolean' || typeof schedule === 'string' || typeof skillVar === 'string' || typeof skillModel === 'string' || typeof skillHarness === 'string')) {
-      updated = updateSkillInConfig(updated, name, {
+      // upsert, not update: the skill list is built from disk, so the UI can
+      // toggle a skill that has no aeon.yml entry yet (a freshly added
+      // SKILL.md). A plain update would silently no-op on it.
+      updated = upsertSkillInConfig(updated, name, {
         ...(typeof enabled === 'boolean' ? { enabled } : {}),
         ...(typeof schedule === 'string' && schedule ? { schedule } : {}),
         ...(typeof skillVar === 'string' ? { var: skillVar } : {}),

--- a/apps/dashboard/lib/config.test.ts
+++ b/apps/dashboard/lib/config.test.ts
@@ -18,6 +18,7 @@ import {
   updateJsonrenderInConfig,
   removeSkillFromConfig,
   addSkillToConfig,
+  upsertSkillInConfig,
 } from "./config";
 
 // ── Minimal valid config ─────────────────────────────────────────────
@@ -358,5 +359,88 @@ describe("round-trip config mutations", () => {
 
     // Model change should not affect skills
     assert.equal(config1.skills["heartbeat"].enabled, true);
+  });
+});
+
+// ── upsertSkillInConfig ──────────────────────────────────────────────
+
+describe("upsertSkillInConfig", () => {
+  it("creates and enables an entry that does not exist yet", () => {
+    // The regression: updateSkillInConfig no-ops here, so `aeon skills enable`
+    // silently did nothing for a freshly created SKILL.md.
+    assert.equal(
+      updateSkillInConfig(MINIMAL_YAML, "brand-new", { enabled: true }),
+      MINIMAL_YAML,
+    );
+
+    const yaml = upsertSkillInConfig(MINIMAL_YAML, "brand-new", { enabled: true });
+    assert.equal(parseConfig(yaml).skills["brand-new"].enabled, true);
+  });
+
+  it("creates with the given schedule rather than the default", () => {
+    const yaml = upsertSkillInConfig(MINIMAL_YAML, "brand-new", { schedule: "0 8 * * 1-5" });
+    const entry = parseConfig(yaml).skills["brand-new"];
+    assert.equal(entry.schedule, "0 8 * * 1-5");
+    // Scheduling alone must not turn the skill on.
+    assert.equal(entry.enabled, false);
+  });
+
+  it("updates an existing entry without duplicating it", () => {
+    const yaml = upsertSkillInConfig(FULL_YAML, "market-pulse", { schedule: "0 6 * * *" });
+    const config = parseConfig(yaml);
+    assert.equal(config.skills["market-pulse"].schedule, "0 6 * * *");
+    // Pre-existing fields survive, and the key appears exactly once.
+    assert.equal(config.skills["market-pulse"].model, "claude-sonnet-4-6");
+    assert.equal(yaml.match(/^\s*market-pulse:/gm)?.length, 1);
+  });
+
+  it("keeps heartbeat last when creating", () => {
+    const yaml = upsertSkillInConfig(MINIMAL_YAML, "brand-new", { enabled: true });
+    const names = [...yaml.matchAll(/^ {2}([a-z][a-z0-9-]*):/gm)].map(m => m[1]);
+    assert.equal(names[names.length - 1], "heartbeat");
+  });
+
+  it("is idempotent", () => {
+    const once = upsertSkillInConfig(MINIMAL_YAML, "brand-new", { enabled: true });
+    const twice = upsertSkillInConfig(once, "brand-new", { enabled: true });
+    assert.equal(once, twice);
+  });
+});
+
+// ── Scheduler parseability ───────────────────────────────────────────
+//
+// .github/workflows/scheduler.yml reads aeon.yml with a bash regex that only
+// matches a DOUBLE-QUOTED cron:
+//     [[ "$INLINE" =~ schedule:\ *\"([^\"]+)\" ]]
+// An unquoted `schedule: 0 12 * * *` is valid YAML but invisible to it, and the
+// empty-schedule guard then skips the skill — it silently never fires. Any
+// function that writes a schedule must emit the quoted form.
+
+describe("generated entries are readable by the scheduler", () => {
+  const SCHEDULER_INLINE_RE = /schedule: *"([^"]+)"/;
+
+  const scheduleLine = (yaml: string, name: string) =>
+    yaml.split("\n").find(l => l.trim().startsWith(`${name}:`)) ?? "";
+
+  it("addSkillToConfig quotes the default schedule", () => {
+    const line = scheduleLine(addSkillToConfig(MINIMAL_YAML, "brand-new"), "brand-new");
+    assert.match(line, SCHEDULER_INLINE_RE);
+  });
+
+  it("addSkillToConfig quotes an explicit schedule", () => {
+    const yaml = addSkillToConfig(MINIMAL_YAML, "brand-new", { schedule: "0 8 * * 1-5" });
+    const line = scheduleLine(yaml, "brand-new");
+    assert.match(line, SCHEDULER_INLINE_RE);
+    assert.equal(line.match(SCHEDULER_INLINE_RE)![1], "0 8 * * 1-5");
+  });
+
+  it("upsertSkillInConfig quotes on create", () => {
+    const yaml = upsertSkillInConfig(MINIMAL_YAML, "brand-new", { schedule: "*/30 * * * *" });
+    assert.match(scheduleLine(yaml, "brand-new"), SCHEDULER_INLINE_RE);
+  });
+
+  it("upsertSkillInConfig keeps the quotes when updating", () => {
+    const yaml = upsertSkillInConfig(FULL_YAML, "market-pulse", { schedule: "0 6 * * *" });
+    assert.match(scheduleLine(yaml, "market-pulse"), SCHEDULER_INLINE_RE);
   });
 });

--- a/apps/dashboard/lib/config.ts
+++ b/apps/dashboard/lib/config.ts
@@ -194,6 +194,15 @@ export function addSkillToConfig(
   // Set flow style to match inline format
   if (isMap(entry)) {
     entry.flow = true
+    // Force the cron to a double-quoted scalar. `0 12 * * *` is a perfectly
+    // valid plain YAML string, but the scheduler parses aeon.yml with a bash
+    // regex that REQUIRES the quotes:
+    //   [[ "$INLINE" =~ schedule:\ *\"([^\"]+)\" ]]   (.github/workflows/scheduler.yml)
+    // An unquoted cron leaves SKILL_SCHEDULE empty, and the empty-schedule
+    // guard then skips the skill — so it silently never fires. Every
+    // hand-written entry is quoted; generated ones must match.
+    const sched = entry.get('schedule', true)
+    if (isScalar(sched)) sched.type = 'QUOTE_DOUBLE'
   }
 
   // Find the fallback skill (heartbeat, last entry) and insert before it
@@ -210,6 +219,31 @@ export function addSkillToConfig(
   }
 
   return doc.toString()
+}
+
+/**
+ * Create the skill's entry if it's missing, then apply `updates` to it.
+ *
+ * `updateSkillInConfig` deliberately no-ops on an unknown skill (it returns
+ * `raw` unchanged), which is right for a blind edit but wrong for the
+ * enable/schedule/set path: skills are enumerated from disk, so a freshly
+ * created `skills/<name>/SKILL.md` has no aeon.yml entry yet and every attempt
+ * to turn it on silently did nothing — while the read path reported it as
+ * merely "disabled", because a missing entry defaults to `enabled: false`.
+ *
+ * Callers must confirm the skill exists on disk first; this will happily
+ * create an entry for a typo'd name.
+ */
+export function upsertSkillInConfig(
+  raw: string,
+  name: string,
+  updates: Partial<SkillConfig>,
+): string {
+  // addSkillToConfig is a no-op when the entry already exists, so composing the
+  // two is safe unconditionally. Seeding it with `updates` means a create lands
+  // the right enabled/schedule immediately rather than writing the defaults and
+  // overwriting them on the next line.
+  return updateSkillInConfig(addSkillToConfig(raw, name, updates), name, updates)
 }
 
 // --- Helpers ---


### PR DESCRIPTION
Two silent bugs found while scripting skill creation against the CLI.

## 1. `enable`/`schedule`/`set` cannot configure a new skill

`aeon skills enable|schedule|set` and the dashboard `PATCH /api/skills` both route through `updateSkillInConfig`, which returns the input unchanged when the skill has no `aeon.yml` entry:

```ts
const skillNode = skillsNode.get(name)
if (!isMap(skillNode)) return raw     // silent no-op
```

Skills are enumerated from **disk**, so a freshly added `skills/<name>/SKILL.md` has no entry yet. The result:

- `aeon skills enable my-skill` → `no change — already in that state`
- `aeon skills my-skill` → reports `disabled`
- `aeon.yml` → no entry at all

The read path defaults a missing entry to `enabled: false` (`lib/skills.ts:87`), so "not configured" and "disabled" are indistinguishable — and `reportConfig` only string-diffs, so it asserts "already in that state" when the truth is "I could not find it". The only way to configure a new skill was to hand-edit the YAML the setup docs tell you not to touch.

The same applies to the dashboard: toggling a skill that has no entry silently does nothing.

**Fix.** Adds `upsertSkillInConfig` (create-if-missing, then update) and uses it on those paths. `addSkillToConfig` is already idempotent, so composing is safe.

- `disable` still uses a plain update — no entry already means disabled, so there is nothing to write and the existing message is accurate.
- The CLI guards the upsert with a disk check, so a typo errors instead of writing a bogus entry:
  `error: unknown skill: foo — no skills/foo/SKILL.md`

## 2. Generated entries are invisible to the scheduler

`addSkillToConfig` wrote the cron as a plain scalar:

```yaml
my-skill: { enabled: false, schedule: 0 12 * * * }
```

Valid YAML — but `scheduler.yml` parses `aeon.yml` with a bash regex that **requires** the quotes:

```bash
[[ "$INLINE" =~ schedule:\ *\"([^\"]+)\" ]]     # .github/workflows/scheduler.yml:130
```

No match leaves `SKILL_SCHEDULE` empty, and `[ -z "$SCHED" ] && continue` skips the skill. It would sit in `aeon.yml` looking correctly configured and never fire.

This is pre-existing and already affects every skill added through `/api/import` and `/api/upload`. Forced to `QUOTE_DOUBLE`.

## Tests

9 new, in `lib/config.test.ts`. Four assert generated entries match the scheduler's own regex, so this cannot regress silently again. Full suite: **165 pass, 0 fail**. `tsc --noEmit` clean. `scripts/validate-config.js` CLEAN.

Verified end to end against a scratch skill:

```
$ aeon skills enable test-upsert --dry-run
dry-run: would enable test-upsert
  + test-upsert: { enabled: true, schedule: "0 12 * * *" }
```