### PR TITLE
docs(aeon-setup): name supported agents (Claude Code, Codex, Hermes, OpenClaw)

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -51,7 +51,7 @@ Dashboard views, local dev, env vars, and remote access are documented in [`apps
 
 **Prefer the terminal?** Everything the dashboard does is also a command - `./aeon skills ls`, `./aeon skills enable <name>`, `./aeon secrets set …`, `./aeon runs logs <id>`. Same logic, no browser, scriptable with `--json`. See [Command line](../apps/cli/README.md).
 
-**Drive it from a chat?** This repo ships an **[Aeon setup skill](../docs/aeon-setup.md)** - an agent skill that sets up, schedules, edits, and debugs your instance in plain language. Open the repo folder in [Claude Code](https://claude.com/claude-code) and type `/aeon` (it's already there, zero-install); portable to any agent tool that supports [Agent Skills](https://code.claude.com/docs/en/skills).
+**Drive it from a chat?** This repo ships an **[Aeon setup skill](../docs/aeon-setup.md)** - an agent skill that sets up, schedules, edits, and debugs your instance in plain language. It's a standard [Agent Skill](https://code.claude.com/docs/en/skills), so it works with **Claude Code, Codex, Hermes, or OpenClaw** - open the repo folder in your agent and type `/aeon` (it's already there, zero-install).
 
 <details>
 <summary><strong>No admin rights / can't install <code>gh</code>?</strong></summary>

--- a/docs/aeon-setup.md
+++ b/docs/aeon-setup.md
@@ -8,7 +8,7 @@ description: The operator-facing agent skill that sets up, schedules, edits, and
 
 Aeon ships an **[Agent Skill](https://code.claude.com/docs/en/skills)** (`SKILL.md`) that turns *"how do I set up / schedule / fix this?"* into a guided chat. It's the fastest way to drive your instance — you describe what you want in plain language and it runs the right `./aeon` commands for you, with the silent-failure traps already baked in.
 
-It's a portable skill, not tied to one product: [Claude Code](https://claude.com/claude-code) is the primary host (it auto-loads skills from `.claude/skills/`, so it's zero-install there), but the skill is just a `SKILL.md` in the open Agent Skills format — any agent tool that supports skills can run it.
+It's a portable skill, not tied to one product: [Claude Code](https://claude.com/claude-code) is the primary host (it auto-loads skills from `.claude/skills/`, so it's zero-install there), but the skill is just a `SKILL.md` in the open Agent Skills format — it works with **Claude Code, Codex, Hermes, or OpenClaw**, and any other agent tool that supports skills.
 
 > **This is not an Aeon skill.** The 62 skills under [`skills/`](../skills) run unattended on GitHub Actions. **This** one runs inside *your* agent session on *your* machine — it's the operator's assistant for configuring the instance, not something that runs on a schedule. It doesn't appear in `aeon.yml`, the packs, or the catalog.
 
@@ -51,7 +51,7 @@ Then open **any** directory in Claude Code and type `/aeon`; point it at your in
 
 ### Option C — another agent tool
 
-The skill is a standard `SKILL.md` (plus a `references/` folder). Any agent that supports [Agent Skills](https://code.claude.com/docs/en/skills) can use it — drop `.claude/skills/aeon/` into that tool's skills location. Everything it does is plain `gh` + `./aeon` commands, so nothing about it is Claude-Code-specific beyond where the file is loaded from.
+The skill is a standard `SKILL.md` (plus a `references/` folder). Any agent that supports [Agent Skills](https://code.claude.com/docs/en/skills) — Claude Code, Codex, Hermes, OpenClaw, and others — can use it: drop `.claude/skills/aeon/` into that tool's skills location. Everything it does is plain `gh` + `./aeon` commands, so nothing about it is Claude-Code-specific beyond where the file is loaded from.
 
 ## How it relates to the dashboard & CLI
 


### PR DESCRIPTION
Names the agent tools the Aeon setup skill works with — **Claude Code, Codex, Hermes, or OpenClaw** — in the README Quick start line and the two matching spots in `docs/aeon-setup.md` (intro + Option C), replacing the generic "any agent tool that supports Agent Skills". It's a standard `SKILL.md`, so it runs across all of them.