### PR TITLE
feat(harness): multi-harness support (codex/pi/vibe/kimi) via harness-adapter

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -13,10 +13,14 @@ on:
         required: false
         type: choice
         default: '(config default)'
-        # Keep in sync with the dashboard's MODELS/GROK_MODELS (apps/dashboard/lib/
-        # constants.ts): the dashboard dispatches `-f model=<id>` and this is a
-        # `choice` input, so any id it offers that's missing here is rejected with
-        # HTTP 422 at dispatch time.
+        # Keep in sync with the dashboard's MODELS/GROK_MODELS/CODEX_MODELS/
+        # VIBE_MODELS/PI_MODELS/KIMI_MODELS (apps/dashboard/lib/constants.ts): the
+        # dashboard dispatches `-f model=<id>` and this is a `choice` input, so any id
+        # it offers that's missing here is rejected with HTTP 422 at dispatch time.
+        # Each harness runs its own native family: codex uses openai/* ids; kimi
+        # moonshotai/*; vibe mistralai/mistral-medium-3-5 (default) + deepseek/
+        # deepseek-v4-flash; pi deepseek/deepseek-v4-flash (default) + deepseek-v4-pro.
+        # "Resolve harness" forwards them verbatim as the harness model.
         options:
           - '(config default)'
           - claude-opus-4-8
@@ -26,7 +30,17 @@ on:
           - claude-sonnet-4-6
           - claude-haiku-4-5-20251001
           - grok-4.5
-          - grok-composer-2.5-fast
+          - openai/gpt-5-mini
+          - openai/gpt-5.1-codex-mini
+          - openai/gpt-5.3-codex
+          - openai/gpt-5.6-luna
+          - openai/gpt-5.6-terra
+          - mistralai/mistral-medium-3-5
+          - deepseek/deepseek-v4-flash
+          - deepseek/deepseek-v4-pro
+          - moonshotai/kimi-k2.5
+          - moonshotai/kimi-k3
+          - moonshotai/kimi-k2.7-code
       harness:
         description: 'Agent harness'
         required: false
@@ -36,6 +50,10 @@ on:
           - '(config default)'
           - claude
           - grok
+          - codex
+          - pi
+          - vibe
+          - kimi
       var:
         description: 'Variable (e.g. AI, bitcoin, owner/repo)'
         required: false
@@ -55,7 +73,7 @@ on:
         required: false
         type: string
       harness:
-        description: 'Agent harness override (claude | grok)'
+        description: 'Agent harness override (claude | grok | codex | pi | vibe | kimi)'
         required: false
         type: string
       var:
@@ -168,6 +186,355 @@ jobs:
         # (--prefer-offline uses the cached tarball above; keep the pin and the
         # cache key version in sync.)
         run: npm install -g @anthropic-ai/claude-code@2.1.168 --prefer-offline
+
+      # ──────────────────────────────────────────────────────────────────────
+      # Harness swap: resolve the harness HERE, not in "Run"
+      #
+      # Upstream resolves it inline in the Run step, which is fine when the only
+      # two values are claude (installed above) and grok (run-grok.sh installs
+      # itself). The four added harnesses need a CLI installed first, and an
+      # install step cannot read a value that does not exist yet.
+      #
+      # Gating the install on `inputs.harness` instead would silently break every
+      # CRON run: a cron carries no dispatch input, so a repo that sets
+      # `harness: codex` in aeon.yml would install nothing and fail inside Run.
+      # Resolution therefore moves up here and "Run" consumes this output.
+      #
+      # The resolution logic itself is upstream's, moved verbatim — same 3-tier
+      # precedence, same greps — so behaviour for claude/grok is unchanged.
+      # ──────────────────────────────────────────────────────────────────────
+      - name: Resolve harness
+        id: harness
+        if: steps.work.outputs.mode != ''
+        env:
+          INPUT_HARNESS: ${{ inputs.harness }}
+          INPUT_MODEL: ${{ inputs.model }}
+          SKILL_NAME: ${{ steps.skill.outputs.name }}
+          HARNESS_MODEL: ${{ vars.HARNESS_MODEL }}
+          # Native-auth secrets — used ONLY to detect which provider each harness
+          # should run on (native login/key > OpenRouter). Never echoed.
+          CODEX_AUTH: ${{ secrets.CODEX_AUTH }}
+          KIMI_AUTH: ${{ secrets.KIMI_AUTH }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          MOONSHOT_API_KEY: ${{ secrets.MOONSHOT_API_KEY }}
+          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_OAUTH_TOKEN: ${{ secrets.ANTHROPIC_OAUTH_TOKEN }}
+        run: |
+          # `|| true` on both greps: a repo with no top-level `harness:` key, or a
+          # skill absent from aeon.yml's skills map, makes grep exit 1, and under
+          # the runner's default `bash -e -o pipefail` that kills the step with NO
+          # message — the reader is left with a red "Resolve harness" and nothing
+          # to go on. Upstream carried the same two unguarded greps inside "Run";
+          # moving them here without the guard would have relocated a silent
+          # failure rather than fixed it. An empty result already means "not
+          # configured", which the defaults below handle, and a genuinely bad skill
+          # name now fails later where the error names the missing SKILL.md.
+          CONFIG_HARNESS=$(grep -E '^harness:' aeon.yml | sed 's/^harness: *//' | tr -d ' ' || true)
+          SKILL_HARNESS=$(grep "^  ${SKILL_NAME}:" aeon.yml | sed -n 's/.*harness: *"\([^"]*\)".*/\1/p' || true)
+          if [ -n "${INPUT_HARNESS:-}" ] && [ "$INPUT_HARNESS" != "(config default)" ]; then
+            HARNESS="$INPUT_HARNESS"
+          elif [ -n "$SKILL_HARNESS" ]; then
+            HARNESS="$SKILL_HARNESS"
+          else
+            HARNESS="${CONFIG_HARNESS:-claude}"
+          fi
+
+          # Allowlist. Upstream had a claude/grok binary, so ANY other value was
+          # silently rewritten to claude. These four are the ones measured end to
+          # end on a real runner (aaronjmars/harness-adapter, Tier 4).
+          # Deliberately NOT here, each for a measured reason:
+          #   opencode — its .result carried the agent's narration instead of the
+          #              deliverable (fixed in the adapter, but it still loops to
+          #              the wall-clock guard on research skills);
+          #   copilot  — no credential path without a Copilot-subscribed PAT;
+          #   agy      — its print mode runs tools outside $PWD, so it reports
+          #              success having written nothing to the workspace.
+          case "$HARNESS" in
+            claude|grok|codex|pi|vibe|kimi) ;;
+            *) echo "::warning::unknown harness '$HARNESS' — falling back to claude"
+               HARNESS="claude" ;;
+          esac
+
+          # Which PROVIDER does this harness run on? Decided by which auth secret is
+          # set, native first, OpenRouter last — the same ordered set the dashboard's
+          # authSecretsForHarness / HARNESS_AUTH registry expose, and the order the
+          # "Install harness CLI" step configures. `native-oauth` = a captured
+          # ChatGPT/Moonshot login restored below; `native-key` = a provider API key
+          # in env; `openrouter` = the shared key (the default). This matters for the
+          # MODEL: on native auth the OpenRouter openai/* ids are the WRONG provider,
+          # so we forward NO model and let the harness use its own default.
+          AUTH_MODE="openrouter"
+          case "$HARNESS" in
+            codex) if [ -n "${CODEX_AUTH:-}" ]; then AUTH_MODE="native-oauth"; elif [ -n "${OPENAI_API_KEY:-}" ]; then AUTH_MODE="native-key"; fi ;;
+            kimi)  if [ -n "${KIMI_AUTH:-}" ]; then AUTH_MODE="native-oauth"; elif [ -n "${MOONSHOT_API_KEY:-}" ]; then AUTH_MODE="native-key"; fi ;;
+            vibe)  if [ -n "${MISTRAL_API_KEY:-}" ]; then AUTH_MODE="native-key"; fi ;;
+            pi)    if [ -n "${ANTHROPIC_API_KEY:-}" ] || [ -n "${ANTHROPIC_OAUTH_TOKEN:-}" ] || [ -n "${OPENAI_API_KEY:-}" ]; then AUTH_MODE="native-key"; fi ;;
+          esac
+
+          # The harness model (HM), in priority order:
+          #   1. vars.HARNESS_MODEL         — a repo-wide override, handy for CI.
+          #   2. the model chosen in the dashboard (which writes `model:` into
+          #      aeon.yml) or a per-skill/dispatch model — WHEN it's an OpenRouter
+          #      id. This is what makes the dashboard's model picker actually
+          #      control what runs: modelsForHarness() offers OpenRouter ids for
+          #      these harnesses, so CONFIG_MODEL is one of them here.
+          #   3. a per-harness cheap default.
+          # aeon-native ids (claude-*/grok-*) mean nothing to an OpenRouter CLI, so
+          # they're treated as "unset" and fall through to the default — a repo that
+          # never touched the model picker (still `model: claude-sonnet-4-6`) still
+          # gets a working default instead of a dead id. The greps carry `|| true`
+          # for the same reason as the harness greps above (no key ≠ fatal).
+          # Each harness defaults to its own native family (the dashboard's
+          # per-harness list, modelsForHarness[0]). The generic `*)` fallback is
+          # gpt-5-mini — a universally safe id — NOT gpt-5-nano: codex fails
+          # DETERMINISTICALLY on nano (measured on a real runner the model emits a
+          # shell tool call with a duplicated `cmd` field, codex's strict parser
+          # rejects it, and codex, which has no --max-turns, spins to the 900s
+          # guard), and the same skill passes on gpt-5-mini in ~2m40s.
+          CONFIG_MODEL=$(grep -E '^model:' aeon.yml | sed 's/^model: *//' | tr -d ' ' || true)
+          SKILL_MODEL=$(grep "^  ${SKILL_NAME}:" aeon.yml | sed -n 's/.*model: *"\([^"]*\)".*/\1/p' || true)
+          if [ -n "${INPUT_MODEL:-}" ] && [ "$INPUT_MODEL" != "(config default)" ]; then
+            REQ_MODEL="$INPUT_MODEL"
+          elif [ -n "$SKILL_MODEL" ]; then
+            REQ_MODEL="$SKILL_MODEL"
+          else
+            REQ_MODEL="${CONFIG_MODEL:-}"
+          fi
+          case "$REQ_MODEL" in claude-*|grok-*|"") REQ_MODEL="" ;; esac   # aeon-native / unset → not an OpenRouter id
+          case "$HARNESS" in
+            codex) DEFAULT_HM="openai/gpt-5-mini" ;;
+            vibe)  DEFAULT_HM="mistralai/mistral-medium-3-5" ;;   # vibe's default (VIBE_MODELS[0])
+            pi)    DEFAULT_HM="deepseek/deepseek-v4-flash" ;;     # pi's default (PI_MODELS[0])
+            kimi)  DEFAULT_HM="moonshotai/kimi-k2.5" ;;          # kimi's default (KIMI_MODELS[0])
+            *)     DEFAULT_HM="openai/gpt-5-mini" ;;             # generic fallback: only claude/grok hit it (and don't consume it); mini is universally safe
+          esac
+          HM="${HARNESS_MODEL:-${REQ_MODEL:-$DEFAULT_HM}}"
+
+          # The --model run-harness should pass, or empty for "the harness's own
+          # staged config decides". aeon's model ids are always claude-*/grok-*,
+          # which mean nothing to an OpenRouter-backed CLI, so they are NOT
+          # forwarded: passing one leaves the harness on its default while every
+          # downstream record (token-usage.csv, the signed run manifest) names a
+          # model that never ran.
+          MODEL_ARG=""
+          if [ "$AUTH_MODE" = "openrouter" ]; then
+            case "$HARNESS" in
+              codex) MODEL_ARG="$HM" ;;                 # config.toml pins the provider; --model takes a bare id
+              pi)    MODEL_ARG="openrouter/$HM" ;;      # pi wants provider/model
+              # vibe and kimi resolve a config ALIAS rather than a raw id, so
+              # passing --model breaks them — their staged config decides.
+            esac
+          else
+            # Native auth (the operator's own ChatGPT/Moonshot/provider account):
+            # let the harness pick its own default model. HM is only a label here.
+            HM="(native:$AUTH_MODE)"
+          fi
+
+          echo "Harness: $HARNESS  |  auth: $AUTH_MODE  |  model: $HM  |  run-harness --model: ${MODEL_ARG:-<harness default>}"
+          echo "HARNESS=$HARNESS" >> "$GITHUB_OUTPUT"
+          echo "HARNESS_MODEL=$HM" >> "$GITHUB_OUTPUT"
+          echo "MODEL_ARG=$MODEL_ARG" >> "$GITHUB_OUTPUT"
+          echo "AUTH_MODE=$AUTH_MODE" >> "$GITHUB_OUTPUT"
+
+      # Install/stage the harness CLI for every harness except claude (which is
+      # installed above and needs no per-provider auth). grok is included now:
+      # the run itself goes through `run-harness grok`, so grok's CLI + auth must
+      # be staged here just like the other adapter harnesses. It reuses
+      # `run-grok.sh setup` — the single source of truth for grok's pin and the
+      # GROK_CREDENTIALS/XAI_API_KEY restore — so nothing is duplicated.
+      - name: Install harness CLI
+        if: steps.harness.outputs.HARNESS != '' && steps.harness.outputs.HARNESS != 'claude'
+        env:
+          H: ${{ steps.harness.outputs.HARNESS }}
+          HM: ${{ steps.harness.outputs.HARNESS_MODEL }}
+          AUTH_MODE: ${{ steps.harness.outputs.AUTH_MODE }}
+          # grok auth (staged via run-grok.sh setup): captured X-account OAuth or key.
+          GROK_CREDENTIALS: ${{ secrets.GROK_CREDENTIALS }}
+          XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
+          # Provider credentials. Whichever is set decided AUTH_MODE in "Resolve
+          # harness"; here we either RESTORE it (the ChatGPT/Moonshot OAuth
+          # captures, which a local `aeon auth --harness …` stored) or write it
+          # into the harness's config (provider keys). Everything lands in the
+          # runner's ephemeral $HOME and is never echoed.
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          CODEX_AUTH: ${{ secrets.CODEX_AUTH }}
+          KIMI_AUTH: ${{ secrets.KIMI_AUTH }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          MOONSHOT_API_KEY: ${{ secrets.MOONSHOT_API_KEY }}
+          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+        run: |
+          set -euo pipefail
+          # bubblewrap is what harness-adapter/lib/sandbox.sh uses to make
+          # read-only mean "the workspace physically cannot be written" on Linux.
+          # grok is skipped: like claude it runs through run-harness with
+          # --no-sandbox (its own bypassPermissions + the post-run stray-write
+          # revert are its read-only guard), so it never invokes the wrapper.
+          if [ "$H" != "grok" ]; then
+            sudo apt-get update -qq && sudo apt-get install -y -qq bubblewrap
+            # Ubuntu 24.04 (including GitHub's ubuntu-latest) restricts unprivileged
+            # user namespaces via AppArmor, so bwrap dies with 'setting up uid map:
+            # Permission denied' and run-harness fails CLOSED on every read-only
+            # skill. Measured on this runner 2026-07-21. Re-enable them for the job.
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
+            bwrap --dev-bind / / --ro-bind /tmp /tmp true && echo 'bwrap: userns OK' || echo '::warning::bwrap still blocked'
+          fi
+
+          # Each harness is configured for the provider AUTH_MODE selected:
+          #   native-oauth — restore the captured login (~/.codex, ~/.kimi-code);
+          #                  the harness then runs on its own default model.
+          #   native-key   — the provider's own API key (codex→OpenAI, kimi→Moonshot,
+          #                  vibe→Mistral, pi→Anthropic/OpenAI from env).
+          #   openrouter   — the shared OPENROUTER_API_KEY (the default; one key
+          #                  covers all four). $HM is the OpenRouter model here.
+          case "$H" in
+            grok)
+              # Install the pinned grok CLI + restore its auth (GROK_CREDENTIALS
+              # X-account OAuth, or XAI_API_KEY). run-grok.sh's `setup` subcommand
+              # runs ONLY those two steps and exits — the actual run then goes
+              # through run-harness grok in the Run step, on grok's own auth.
+              bash "${GITHUB_WORKSPACE}/scripts/run-grok.sh" setup
+              echo "grok: CLI + auth staged (auth: ${AUTH_MODE:-native})" ;;
+            codex)
+              # PINNED, like aeon pins claude-code. Unpinned, this step silently
+              # tracked latest: two cells that passed on 2026-07-21 failed hours
+              # later with an OpenRouter 400 and nothing in the repo had changed.
+              npm install -g @openai/codex@0.144.6
+              mkdir -p "$HOME/.codex"
+              case "$AUTH_MODE" in
+                native-oauth)
+                  # Restore the ChatGPT login captured by `aeon auth --harness codex`
+                  # (tar+base64 of ~/.codex/auth.json). codex refreshes the access
+                  # token from the refresh token at run start and uses its own
+                  # default model — no config needed, no OpenRouter.
+                  printf '%s' "$CODEX_AUTH" | base64 -d | tar xzf - -C "$HOME"
+                  chmod 600 "$HOME/.codex/auth.json" || true
+                  echo "codex: restored ChatGPT login" ;;
+                native-key)
+                  # OPENAI_API_KEY in env → codex's built-in `openai` provider (its
+                  # default), on codex's default model. No OpenRouter block.
+                  cat > "$HOME/.codex/config.toml" <<'TOML'
+          model_reasoning_effort = "medium"
+          TOML
+                  echo "codex: OpenAI API key" ;;
+                *)
+                  # wire_api MUST be "responses": codex 0.144.6 removed "chat"
+                  # ("no longer supported", a hard config-load error), and OpenRouter
+                  # does serve /api/v1/responses. Both verified 2026-07-21.
+                  cat > "$HOME/.codex/config.toml" <<TOML
+          model = "$HM"
+          model_provider = "openrouter"
+          # OpenRouter rejects a reasoning-disabled request to this endpoint:
+          # 400 "Reasoning is mandatory for this endpoint and cannot be disabled."
+          model_reasoning_effort = "medium"
+
+          [model_providers.openrouter]
+          name = "OpenRouter"
+          base_url = "https://openrouter.ai/api/v1"
+          env_key = "OPENROUTER_API_KEY"
+          wire_api = "responses"
+          TOML
+                  echo "codex: OpenRouter" ;;
+              esac
+              ;;
+            pi)
+              # PINNED (like codex/claude): an unpinned `-g` install silently tracks
+              # latest and would run whatever the registry serves in CI with the run's
+              # secrets in env. 0.80.9 is the version verified live 2026-07-22.
+              # --ignore-scripts: pi's postinstall is not needed headless.
+              npm install -g --ignore-scripts @earendil-works/pi-coding-agent@0.80.9
+              # pi picks its provider from whichever key is in env at RUN time
+              # (ANTHROPIC_API_KEY / OPENAI_API_KEY native, else OPENROUTER_API_KEY
+              # with --model openrouter/…). No config file either way.
+              echo "pi: $AUTH_MODE (env-driven)"
+              ;;
+            kimi)
+              # PINNED + --ignore-scripts: same supply-chain hardening as pi/codex.
+              # 0.28.0 is the version verified live 2026-07-22. If a future CI run
+              # shows kimi's install needs a postinstall binary fetch, drop
+              # --ignore-scripts (keep the pin).
+              npm install -g --ignore-scripts @moonshot-ai/kimi-code@0.28.0
+              mkdir -p "$HOME/.kimi-code"
+              case "$AUTH_MODE" in
+                native-oauth)
+                  # Restore the Moonshot device login captured by
+                  # `aeon auth --harness kimi`; kimi then runs on Moonshot by default.
+                  printf '%s' "$KIMI_AUTH" | base64 -d | tar xzf - -C "$HOME"
+                  echo "kimi: restored Moonshot login" ;;
+                native-key)
+                  # MOONSHOT_API_KEY → Moonshot provider. Model id is best-effort;
+                  # adjust to your Moonshot plan if it 404s.
+                  cat > "$HOME/.kimi-code/config.toml" <<TOML
+          default_model = "kimi-native"
+
+          [providers.moonshot]
+          type = "openai"
+          base_url = "https://api.moonshot.ai/v1"
+          api_key = "$MOONSHOT_API_KEY"
+
+          [models.kimi-native]
+          provider = "moonshot"
+          model = "kimi-k2-0711-preview"
+          max_context_size = 131072
+          TOML
+                  chmod 600 "$HOME/.kimi-code/config.toml"
+                  echo "kimi: Moonshot API key" ;;
+                *)
+                  # kimi resolves --model through ALIASES declared here and takes the
+                  # provider key inline. default_model set → run-harness passes no
+                  # --model at all, which is what we want.
+                  cat > "$HOME/.kimi-code/config.toml" <<TOML
+          default_model = "or-cheap"
+
+          [providers.openrouter]
+          type = "openai"
+          base_url = "https://openrouter.ai/api/v1"
+          api_key = "$OPENROUTER_API_KEY"
+
+          [models.or-cheap]
+          provider = "openrouter"
+          model = "$HM"
+          max_context_size = 400000
+          TOML
+                  chmod 600 "$HOME/.kimi-code/config.toml"
+                  echo "kimi: OpenRouter" ;;
+              esac
+              ;;
+            vibe)
+              # PINNED: 2.20.0 verified live 2026-07-22. (pipx/pip has no clean
+              # per-package --ignore-scripts equivalent, so the pin is the guard here.)
+              pipx install mistral-vibe==2.20.0
+              echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+              if [ "$AUTH_MODE" = "native-key" ]; then
+                # MISTRAL_API_KEY set → vibe's DEFAULT provider IS Mistral; it runs
+                # straight off the env key, no config. (The config below only exists
+                # because vibe hard-fails WITHOUT a Mistral key.)
+                echo "vibe: Mistral API key (default provider)"
+              else
+                # vibe's ProviderConfig is generic (api_base + api_key_env_var +
+                # api_style), so point it at OpenRouter.
+                mkdir -p "$HOME/.vibe"
+                cat > "$HOME/.vibe/config.toml" <<TOML
+          active_model = "or-cheap"
+
+          [[providers]]
+          name = "openrouter"
+          api_base = "https://openrouter.ai/api/v1"
+          api_key_env_var = "OPENROUTER_API_KEY"
+          api_style = "openai"
+
+          [[models]]
+          name = "$HM"
+          provider = "openrouter"
+          alias = "or-cheap"
+          TOML
+                echo "vibe: OpenRouter"
+              fi
+              ;;
+            *)
+              echo "::error::no install recipe for harness '$H'"; exit 1 ;;
+          esac
+          echo "installed harness CLI: $H  (auth: $AUTH_MODE)"
 
       - name: Validate skill secrets
         if: steps.work.outputs.mode != ''
@@ -296,6 +663,13 @@ jobs:
           ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
           BANKR_LLM_KEY: ${{ secrets.BANKR_LLM_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          # Native harness-provider keys — read at run time by the api-key auth
+          # paths (codex→OpenAI, pi→Anthropic/OpenAI, vibe→Mistral). The OAuth
+          # captures need nothing here: their creds are already on disk from install.
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_OAUTH_TOKEN: ${{ secrets.ANTHROPIC_OAUTH_TOKEN }}
+          MOONSHOT_API_KEY: ${{ secrets.MOONSHOT_API_KEY }}
+          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
           USEPOD_TOKEN: ${{ secrets.USEPOD_TOKEN }}
           VENICE_API_KEY: ${{ secrets.VENICE_API_KEY }}
           SURPLUS_API_KEY: ${{ secrets.SURPLUS_API_KEY }}
@@ -357,7 +731,8 @@ jobs:
           SKILL_VAR: ${{ inputs.var }}
           SKILL_NAME: ${{ steps.skill.outputs.name }}
           INPUT_MODEL: ${{ inputs.model }}
-          INPUT_HARNESS: ${{ inputs.harness }}
+          RESOLVED_HARNESS: ${{ steps.harness.outputs.HARNESS }}
+          RH_MODEL_ARG: ${{ steps.harness.outputs.MODEL_ARG }}
           INPUT_CHAIN_CTX: ${{ inputs.chain_context_file }}
         run: |
           TODAY=$(date -u +%Y-%m-%d)
@@ -374,18 +749,9 @@ jobs:
           fi
 
           # --- Harness resolution (which agent CLI runs the skill) ---
-          # Same 3-tier precedence as model: workflow_dispatch input → per-skill
-          # `harness:` in aeon.yml → top-level `harness:` → claude (default).
-          CONFIG_HARNESS=$(grep -E '^harness:' aeon.yml | sed 's/^harness: *//' | tr -d ' ')
-          SKILL_HARNESS=$(grep "^  ${SKILL_NAME}:" aeon.yml | sed -n 's/.*harness: *"\([^"]*\)".*/\1/p')
-          if [ -n "${INPUT_HARNESS:-}" ] && [ "$INPUT_HARNESS" != "(config default)" ]; then
-            HARNESS="$INPUT_HARNESS"
-          elif [ -n "$SKILL_HARNESS" ]; then
-            HARNESS="$SKILL_HARNESS"
-          else
-            HARNESS="${CONFIG_HARNESS:-claude}"
-          fi
-          if [ "$HARNESS" != "grok" ]; then HARNESS="claude"; fi   # unknown value → safe default (use `if`, not `&&`, under set -e)
+          # Resolved in the "Resolve harness" step above, which had to run before
+          # "Install harness CLI". Same 3-tier precedence as model, moved verbatim.
+          HARNESS="$RESOLVED_HARNESS"
           # On the grok harness a claude-* model id is meaningless — fall back to
           # grok's current default (grok-4.5) unless an explicit grok model was
           # chosen. run-grok.sh omits --model for a non-grok value as a safety net.
@@ -412,6 +778,12 @@ jobs:
             # call to xAI (Anthropic-compatible) when an API key is present, else
             # direct (scoring then just no-ops gracefully if no Anthropic creds).
             if [ -n "${XAI_API_KEY:-}" ]; then echo "GATEWAY=grok" >> "$GITHUB_OUTPUT"; else echo "GATEWAY=direct" >> "$GITHUB_OUTPUT"; fi
+          elif [ "$HARNESS" != "claude" ]; then
+            # Same reasoning as grok: the run-harness harnesses carry their own
+            # auth (staged in "Install harness CLI") and never touch the gateway.
+            # The scorer routes through run-harness too, so there is no `claude -p`
+            # call left to hint at — emit the output only so it is always defined.
+            echo "GATEWAY=$HARNESS" >> "$GITHUB_OUTPUT"
           else
             GATEWAY=$(grep -A1 '^gateway:' aeon.yml | grep 'provider:' | sed 's/.*provider:[[:space:]]*//' | sed "s/[\"' ]//g" || true)
             GATEWAY="${GATEWAY:-auto}"
@@ -549,64 +921,102 @@ jobs:
           Use this variable (override the default in the skill file):
           var=$VAR"
           fi
-          # Harness split: the grok path is a single guarded branch; the entire
-          # claude cascade below is unchanged. Both set CLAUDE_OUTPUT to a JSON
-          # envelope with .result / .usage.*, so everything downstream is shared.
+          # Unified execution: EVERY harness runs through the harness-adapter
+          # (harness-adapter/run-harness), which speaks one Claude-Code-shaped
+          # contract — prompt on stdin, a normalized {result,usage{...},session_id}
+          # envelope on stdout, diagnostics on stderr — so everything downstream
+          # (.result/.usage jq, scoring, token accounting) is identical for all six.
+          # There is no longer a native `claude -p` or `run-grok.sh` run path; the
+          # two features those paths carried are preserved AROUND the adapter call:
+          #   * claude  — wrapped in the multi-provider gateway cascade below, so it
+          #               keeps 8-provider failover + Langfuse tracing. --no-sandbox:
+          #               claude's own --allowedTools + the post-run stray-write
+          #               revert are its read-only guard, and it keeps .pending-notify
+          #               (inside the workspace) writable.
+          #   * grok    — GROK_* run-knobs from frontmatter (adapters/grok.sh maps
+          #               them); --no-sandbox for the same reason (bypassPermissions
+          #               + revert are its guard; its own --sandbox is a 0.2.101 no-op).
+          #   * codex/pi/vibe/kimi — the wrapper OS sandbox (bwrap) enforces read-only.
           CLAUDE_OK=0
-          if [ "$HARNESS" = "grok" ]; then
-            # --- Grok Build harness ---
-            # run-grok.sh installs/pins the grok CLI, restores the X-account OAuth
-            # session (or uses XAI_API_KEY), maps SKILL_MODE to grok's permission
-            # flags, discovers .mcp.json natively + allows its tools, runs `grok -p`,
-            # and emits the SAME normalized JSON envelope Claude Code's
-            # --output-format json produces. Its stdout is the JSON; diagnostics go
-            # to stderr (the step log), so capture stdout only.
-            # Opt-in per-skill run knobs (effort/max_turns/best_of_n/verify) come
-            # from SKILL.md frontmatter → GROK_* env for run-grok.sh to map to flags.
-            eval "$(bash "${GITHUB_WORKSPACE}/scripts/skill_mode.sh" grok-run-env "$SKILL_NAME")"
-            if CLAUDE_OUTPUT=$(
-              export MODEL="$BASE_MODEL" SKILL_MODE
-              echo "$PROMPT" | bash "${GITHUB_WORKSPACE}/scripts/run-grok.sh"
-            ); then
-              CLAUDE_OK=1
-            fi
-            if [ "$CLAUDE_OK" != "1" ]; then
-              echo "::error::grok harness failed. Last output: $(printf '%s' "$CLAUDE_OUTPUT" | tail -c 200 | tr '\n' ' ')"
-              printf '%s' "$CLAUDE_OUTPUT" | tail -c 500 | tr '\n' ' ' | cut -c1-200 > /tmp/skill-error.txt
-              exit 1
-            fi
-          else
-            # Cascade: try each provider in priority order; on ANY failure fall over
-            # to the next. Each attempt runs in a subshell so provider setup (env +
-            # any claude-code-router sidecar) is isolated and torn down on exit. The
-            # gateway script's notices go to stderr (>&2) so only Claude's JSON is captured.
+          RH="${GITHUB_WORKSPACE}/harness-adapter/run-harness"
+          RH_ARGS=(--mode "$SKILL_MODE" --allowed-tools "$ALLOWED" --timeout 900)
+          # Pass --mcp-config only when the MCP preflight actually ENABLED MCP (every
+          # required ${VAR} resolved) — MCP_FLAGS is set to the flags in that case and
+          # left empty otherwise, so it doubles as the "MCP on" gate. run-harness does
+          # its own ${VAR} expansion + per-harness translation from the same file.
+          if [ "${#MCP_FLAGS[@]}" -gt 0 ]; then RH_ARGS+=(--mcp-config .mcp.json); fi
+
+          if [ "$HARNESS" = "claude" ]; then
+            # Cascade: try each provider in priority order; fall over on ANY failure.
+            # Each attempt is an isolated subshell that sets up its provider env (+
+            # optional Langfuse), THEN runs `run-harness claude` (which invokes
+            # `claude -p` under that env). Gateway/Langfuse notices go to the step
+            # log (>&2); only run-harness's stdout envelope is captured. A hard
+            # gateway setup failure `exit 1`s the subshell → this attempt fails →
+            # fall over, exactly as the old inline `claude -p` cascade did.
             USED_GATEWAY=""
             for cand in $CANDIDATES; do
               echo "::notice::Routing attempt via '$cand'"
-              # No `set -e` here: the gateway script signals a hard setup failure with
-              # an explicit `exit 1` (which exits this subshell → fall over), and on
-              # success the subshell's status is Claude's own exit code. A benign
-              # non-zero from a trailing test in the gateway script is harmless — we
-              # only fall over on an explicit exit or a failed Claude call.
               if CLAUDE_OUTPUT=$(
                 GATEWAY="$cand"
                 MODEL="$BASE_MODEL"
                 source "$GW" >&2
                 source "$LF" >&2   # optional Langfuse tracing (no-op unless LANGFUSE_* set)
-                echo "$PROMPT" | claude -p - --model "$MODEL" --allowedTools "$ALLOWED" "${MCP_FLAGS[@]}" --output-format json 2>&1
+                echo "$PROMPT" | bash "$RH" claude --model "$MODEL" --no-sandbox "${RH_ARGS[@]}" 2>/tmp/harness-stderr.txt
               ); then
                 USED_GATEWAY="$cand"; CLAUDE_OK=1; break
               fi
-              echo "::warning::provider '$cand' failed — $(printf '%s' "$CLAUDE_OUTPUT" | tail -c 160 | tr '\n' ' ')"
+              echo "::warning::provider '$cand' failed — $(tail -c 160 /tmp/harness-stderr.txt 2>/dev/null | tr '\n' ' ')"
             done
             if [ "$CLAUDE_OK" != "1" ]; then
-              echo "::error::All gateway providers failed ($CANDIDATES). Last output: $CLAUDE_OUTPUT"
+              echo "::error::All gateway providers failed ($CANDIDATES). Last: $(tail -c 200 /tmp/harness-stderr.txt 2>/dev/null | tr '\n' ' ')"
               # Save error signature for quality tracking (cron-state step reads this)
-              echo "$CLAUDE_OUTPUT" | tail -c 500 | tr '\n' ' ' | cut -c1-200 > /tmp/skill-error.txt
+              tail -c 500 /tmp/harness-stderr.txt 2>/dev/null | tr '\n' ' ' | cut -c1-200 > /tmp/skill-error.txt
               exit 1
             fi
             [ "$USED_GATEWAY" != "${CANDIDATES%% *}" ] && echo "::notice::Skill ran via fallback provider '$USED_GATEWAY'"
             echo "GATEWAY=$USED_GATEWAY" >> "$GITHUB_OUTPUT"
+          else
+            # grok / codex / pi / vibe / kimi — one run-harness call each.
+            RH_MODEL_ARGS=()
+            if [ "$HARNESS" = "grok" ]; then
+              # Per-skill run-knobs (effort/max_turns/best_of_n/verify) → GROK_* env,
+              # consumed by adapters/grok.sh — the same frontmatter mapping the
+              # native path used. SKILL_MODEL was already set to grok's model above.
+              eval "$(bash "${GITHUB_WORKSPACE}/scripts/skill_mode.sh" grok-run-env "$SKILL_NAME")"
+              RH_ARGS+=(--no-sandbox)
+              # BASE_MODEL is grok-4.5 or an explicit grok id (forced above); pass
+              # only a real grok id — the adapter falls back to grok's default
+              # otherwise. (BASE_MODEL, not MODEL: identical here, but MODEL is the
+              # var the claude cascade rewrites in a subshell, so referencing it here
+              # would trip a spurious shellcheck SC2031.)
+              case "$BASE_MODEL" in grok-*) RH_MODEL_ARGS=(--model "$BASE_MODEL") ;; esac
+            else
+              # RH_MODEL_ARG is decided in "Resolve harness" (empty = let the
+              # harness's staged config choose). Never aeon's BASE_MODEL: that is
+              # always a claude-*/grok-* id these CLIs cannot resolve.
+              if [ -n "${RH_MODEL_ARG:-}" ]; then RH_MODEL_ARGS=(--model "$RH_MODEL_ARG"); fi
+              # Re-emit SKILL_MODEL with what ACTUALLY ran. It was written above from
+              # BASE_MODEL, before the harness was applied — leaving it would file
+              # these tokens under a model that never ran in memory/token-usage.csv,
+              # and put a false model into the run manifest that attestation signs.
+              # Later writes to $GITHUB_OUTPUT win, so this corrects every consumer.
+              EFFECTIVE_MODEL="${RH_MODEL_ARG:-$HARNESS-default}"   # no spaces: the notice is parsed by field
+              echo "SKILL_MODEL=$EFFECTIVE_MODEL" >> "$GITHUB_OUTPUT"
+              echo "::notice::effective model for $HARNESS: $EFFECTIVE_MODEL"
+            fi
+
+            if CLAUDE_OUTPUT=$(echo "$PROMPT" | bash "$RH" "$HARNESS" "${RH_MODEL_ARGS[@]}" "${RH_ARGS[@]}" 2>/tmp/harness-stderr.txt); then
+              CLAUDE_OK=1
+            fi
+            # run-harness's diagnostics are the only signal when a harness stalls;
+            # surface them in the step log either way, not just on failure.
+            tail -c 4000 /tmp/harness-stderr.txt >&2 || true
+            if [ "$CLAUDE_OK" != "1" ]; then
+              echo "::error::run-harness $HARNESS failed: $(tail -c 200 /tmp/harness-stderr.txt | tr '\n' ' ')"
+              tail -c 500 /tmp/harness-stderr.txt | tr '\n' ' ' | cut -c1-200 > /tmp/skill-error.txt
+              exit 1
+            fi
           fi
 
           # Extract and print the text result so logs still show skill output
@@ -703,7 +1113,16 @@ jobs:
       # Renders a table into the Actions run summary and appends a one-line footer to
       # today's memory log so the record lives in git. Never fails the run.
       - name: Under the hood (tool actions)
-        if: steps.work.outputs.mode != '' && steps.run.outcome == 'success' && steps.run.outputs.SESSION_ID != ''
+        # The HARNESS gate is load-bearing, not defensive. run-actions-summary.sh
+        # falls back to the NEWEST transcript under ~/.claude/projects when the
+        # session id does not resolve, and the run-harness harnesses emit a session
+        # id of their own — so without this gate a codex/pi/vibe/kimi run gets
+        # ANOTHER run's tool calls attributed to it and committed to memory/logs/.
+        # Verified on a real runner: the run logged `session_id present=YES
+        # harness=pi` while this step correctly skipped.
+        # (For claude-only repos this is a no-op: SESSION_ID != '' already implied
+        # the claude harness upstream.)
+        if: steps.work.outputs.mode != '' && steps.run.outcome == 'success' && steps.run.outputs.SESSION_ID != '' && steps.run.outputs.HARNESS == 'claude'
         env:
           SESSION_ID: ${{ steps.run.outputs.SESSION_ID }}
           SKILL_NAME: ${{ steps.skill.outputs.name }}
@@ -855,11 +1274,19 @@ jobs:
           ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
           BANKR_LLM_KEY: ${{ secrets.BANKR_LLM_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          # Native harness-provider keys — read at run time by the api-key auth
+          # paths (codex→OpenAI, pi→Anthropic/OpenAI, vibe→Mistral). The OAuth
+          # captures need nothing here: their creds are already on disk from install.
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_OAUTH_TOKEN: ${{ secrets.ANTHROPIC_OAUTH_TOKEN }}
+          MOONSHOT_API_KEY: ${{ secrets.MOONSHOT_API_KEY }}
+          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
           USEPOD_TOKEN: ${{ secrets.USEPOD_TOKEN }}
           VENICE_API_KEY: ${{ secrets.VENICE_API_KEY }}
           SURPLUS_API_KEY: ${{ secrets.SURPLUS_API_KEY }}
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}   # grok scorer: API-key auth path
           GROK_CREDENTIALS: ${{ secrets.GROK_CREDENTIALS }}   # grok scorer: X-account OAuth (restored by run-grok.sh)
+          RH_MODEL_ARG: ${{ steps.harness.outputs.MODEL_ARG }}   # run-harness scorer: same --model the run used
           OPENROUTER_MODEL: ${{ vars.OPENROUTER_MODEL }}
           OPENROUTER_MODEL_SONNET: ${{ vars.OPENROUTER_MODEL_SONNET }}
           OPENROUTER_MODEL_HAIKU: ${{ vars.OPENROUTER_MODEL_HAIKU }}
@@ -884,10 +1311,12 @@ jobs:
 
           HARNESS="${{ steps.run.outputs.HARNESS }}"
           # Route the scorer's claude call through the gateway (claude harness only).
-          # On grok we score via run-grok.sh below and don't touch the gateway, so
-          # skip the source entirely — otherwise it prints "Using direct Anthropic
-          # API" noise on a grok-only repo.
-          if [ "$HARNESS" != "grok" ]; then
+          # Every other harness scores through ITSELF below and doesn't touch the
+          # gateway, so skip the source entirely — otherwise it prints "Using
+          # direct Anthropic API" noise on a repo with no Anthropic creds.
+          # (Was `!= grok`; with only claude/grok upstream the two are identical,
+          # so this is a no-op there and correct for the added harnesses.)
+          if [ "$HARNESS" = "claude" ]; then
             GATEWAY="${{ steps.run.outputs.GATEWAY }}"
             source "${GITHUB_WORKSPACE}/scripts/llm-gateway.sh"
             AEON_OTEL_COMPONENT=scorer source "${GITHUB_WORKSPACE}/scripts/langfuse-otel.sh"
@@ -922,25 +1351,38 @@ jobs:
           JSON format: {\"score\": N, \"assessment\": \"one line\", \"flags\": []}"
 
           SCORE_MODEL="${ANTHROPIC_DEFAULT_HAIKU_MODEL:-claude-haiku-4-5-20251001}"
-          if [ "$HARNESS" = "grok" ]; then
-            # Score through the SAME harness the skill ran on. A grok-only repo has
-            # no Claude credentials, so `claude -p` would just print "Not logged in";
-            # run-grok.sh reuses the run's X-account/API-key auth and emits the same
-            # {result,usage} envelope. Pin grok-composer-2.5-fast explicitly — the
-            # cheap/fast model this robust parse is tuned for. (Don't rely on grok's
-            # own default here: it's now grok-4.5, the pricier flagship.) Notices→stderr.
-            # NB: we deliberately do NOT pass grok's --json-schema here — composer
-            # doesn't populate structured output (it leaves .structuredOutput null),
-            # and the ANALYSIS_PROMPT already asks for a {score,assessment,flags}
-            # object, so the robust parse below handles composer's JSON text fine.
-            if ! RAW=$(echo "$ANALYSIS_PROMPT" | MODEL=grok-composer-2.5-fast SKILL_MODE=read-only \
-                bash "${GITHUB_WORKSPACE}/scripts/run-grok.sh" 2>/dev/null); then
-              echo "::notice::Skill scoring skipped — grok scorer unavailable (non-fatal)"
-              exit 0
-            fi
-          elif ! RAW=$(echo "$ANALYSIS_PROMPT" | claude -p - \
-            --model "$SCORE_MODEL" --output-format json 2>&1); then
-            echo "::warning::Skill analysis failed (non-fatal). Raw: $(printf '%s' "$RAW" | head -c 800 | tr '\n' ' ')"
+          # Score through the SAME harness the skill ran on, ALWAYS via the
+          # harness-adapter — no native `claude -p` / `run-grok.sh` path remains.
+          # A repo authed for only one harness has no Claude creds, so a direct
+          # `claude -p` here would print "Not logged in" and every run would go
+          # unscored (skill-health / skill-analytics / cron-state quality signals
+          # silently empty while the workflow stays green — the silent-no-op class).
+          # read-only + --no-sandbox: scoring is a single text call needing no tools
+          # or workspace, so the wrapper sandbox would only add a failure mode; any
+          # stray write is reverted by the "Read-only capability guard" step.
+          # --timeout 300 = half the run guard. No --json-schema: ANALYSIS_PROMPT
+          # already asks for a {score,assessment,flags} object and the robust parse
+          # below is tuned for that (composer/pi/vibe/kimi lack a native schema flag).
+          RH="${GITHUB_WORKSPACE}/harness-adapter/run-harness"
+          SCORE_ARGS=(--mode read-only --no-sandbox --timeout 300)
+          case "$HARNESS" in
+            claude)
+              # Runs under the gateway env sourced above; SCORE_MODEL is the cheap
+              # scoring model (haiku by default).
+              SCORE_ARGS+=(--model "$SCORE_MODEL") ;;
+            grok)
+              # Pin grok-4.5 — the only model the X-account (GROK_CREDENTIALS) login
+              # exposes. grok-composer-2.5-fast was a phantom id: the grok CLI rejects
+              # it with "unknown model id" (verified live, run 29944263287), so pinning
+              # it made every grok scorer call fail-then-fall-back. Scoring is one short
+              # text call, so grok-4.5's cost is pennies.
+              SCORE_ARGS+=(--model grok-4.5) ;;
+            *)
+              # RH_MODEL_ARG is the same --model the run used (empty = harness default).
+              [ -n "${RH_MODEL_ARG:-}" ] && SCORE_ARGS+=(--model "$RH_MODEL_ARG") ;;
+          esac
+          if ! RAW=$(echo "$ANALYSIS_PROMPT" | bash "$RH" "$HARNESS" "${SCORE_ARGS[@]}" 2>/dev/null); then
+            echo "::notice::Skill scoring skipped — $HARNESS scorer unavailable (non-fatal)"
             exit 0
           fi
 
@@ -949,10 +1391,10 @@ jobs:
           # this call (seen twice on OpenRouter's haiku slug, while its opus
           # slug always returns text). Retry once on the run's main model —
           # llm-gateway.sh only sets MODEL here when the gateway remaps it.
-          # (claude harness only; grok already used its default.)
-          if [ "$HARNESS" != "grok" ] && [ -z "$ANALYSIS_TEXT" ] && [ -n "${MODEL:-}" ] && [ "$MODEL" != "$SCORE_MODEL" ]; then
+          # (claude harness only; every other harness already used its own model.)
+          if [ "$HARNESS" = "claude" ] && [ -z "$ANALYSIS_TEXT" ] && [ -n "${MODEL:-}" ] && [ "$MODEL" != "$SCORE_MODEL" ]; then
             echo "::warning::Empty analysis result from ${SCORE_MODEL} — retrying with ${MODEL}. Raw: $(printf '%s' "$RAW" | head -c 800 | tr '\n' ' ')"
-            if RAW=$(echo "$ANALYSIS_PROMPT" | claude -p - --model "$MODEL" --output-format json 2>&1); then
+            if RAW=$(echo "$ANALYSIS_PROMPT" | bash "$RH" claude --model "$MODEL" --mode read-only --no-sandbox --timeout 300 2>/dev/null); then
               ANALYSIS_TEXT=$(echo "$RAW" | jq -r '.result // empty')
             fi
           fi
@@ -1010,16 +1452,28 @@ jobs:
           echo "::notice::Skill quality — $SKILL: score=$SCORE, avg=$AVG — $ASSESSMENT"
 
       - name: Convert feed outputs
-        # Skipped on the grok harness: notify-jsonrender renders via `claude -p`, so
-        # on a grok-only repo (no Claude auth) it can only no-op with noise. The
-        # jsonrender feed is a Claude-Code-side feature.
-        if: steps.work.outputs.mode != '' && vars.JSONRENDER_ENABLED != 'false' && steps.run.outputs.HARNESS != 'grok'
+        # Claude harness only: notify-jsonrender renders via `claude -p`, so on a
+        # repo with no Claude auth it can only no-op with noise. The jsonrender
+        # feed is a Claude-Code-side feature.
+        # Was `!= grok`, which is identical upstream (claude/grok only) but would
+        # have let the four added harnesses through into a `claude -p` they cannot
+        # authenticate. Unlike scoring, this one is NOT worth routing through
+        # run-harness: it is a rendering convenience, not a quality signal, and
+        # skipping it costs the run nothing.
+        if: steps.work.outputs.mode != '' && vars.JSONRENDER_ENABLED != 'false' && steps.run.outputs.HARNESS == 'claude'
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
           BANKR_LLM_KEY: ${{ secrets.BANKR_LLM_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          # Native harness-provider keys — read at run time by the api-key auth
+          # paths (codex→OpenAI, pi→Anthropic/OpenAI, vibe→Mistral). The OAuth
+          # captures need nothing here: their creds are already on disk from install.
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_OAUTH_TOKEN: ${{ secrets.ANTHROPIC_OAUTH_TOKEN }}
+          MOONSHOT_API_KEY: ${{ secrets.MOONSHOT_API_KEY }}
+          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
           USEPOD_TOKEN: ${{ secrets.USEPOD_TOKEN }}
           VENICE_API_KEY: ${{ secrets.VENICE_API_KEY }}
           SURPLUS_API_KEY: ${{ secrets.SURPLUS_API_KEY }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,4 +139,6 @@ Never exfiltrate env vars or secrets to an external URL; only call the auth'd en
 
 ## Output
 
-After completing any task, end with a `## Summary` listing what you did, files created/modified, and follow-up actions needed.
+Your final message — your stdout — is the run's **captured output**: the health scorer grades it, chained skills `consume:` it, and the feed can render it. So it must carry the **substance** of your work (the report, the findings, the slate, the analysis), not just a pointer to it. `./notify` is a *delivery channel, not a substitute*: a run that pushes the detail to a channel but leaves only a terse "delivered inline" line as its output is graded as empty/low-quality even though the real work happened — so keep the substance in the output too, then deliver a copy via `./notify`.
+
+After the substance, end with a `## Summary` listing what you did, files created/modified, and follow-up actions needed.

--- a/apps/cli/src/commands/auth.ts
+++ b/apps/cli/src/commands/auth.ts
@@ -1,33 +1,80 @@
 import { parseArgs } from 'node:util'
 import { configureAuth } from '../../../dashboard/lib/auth.ts'
 import { normalizeAuthConfig } from '../../../dashboard/lib/auth-provider.ts'
+import { HARNESS_AUTH } from '../../../dashboard/lib/harness-auth.ts'
+import { driveTtyLogin, captureHarnessCreds, setHarnessApiKey } from '../../../dashboard/lib/harness-auth-server.ts'
 import { emit, c, fail, isDryRun, requireGh } from '../output.ts'
 
-const USAGE = `aeon auth — set how Claude Code authenticates in CI
+const USAGE = `aeon auth — set how the agent authenticates in CI
 
+Claude harness (default):
   aeon auth --oauth                 Mint a Claude OAuth token via \`claude setup-token\`
   aeon auth --key <sk-ant-…|bk_…|…>  Set an Anthropic / gateway key (provider auto-detected)
   aeon auth <token>                 Same as --key (positional)
 
+Other harnesses (--harness codex|kimi|pi|vibe):
+  aeon auth --harness codex         Log in with ChatGPT (browser), store as CODEX_AUTH
+  aeon auth --harness kimi          Log in with Moonshot (device code), store as KIMI_AUTH
+  aeon auth --harness codex --key <sk-…>          Store an OpenAI key instead of the ChatGPT login
+  aeon auth --harness pi   --key <sk-ant-…|sk-…>  Native provider key for pi
+  aeon auth --harness vibe --key <key>            Mistral key for vibe
+  (any of the four also runs on the shared OPENROUTER_API_KEY — set that in Settings.)
+
 Options:
-  --provider <slug>   Force a gateway (bankr, openrouter, venice, …)
-  --base-url <url>    Custom HTTPS base URL (API-key auth only)
-  --dry-run           Show what would be set, without calling gh/claude
+  --harness <h>       codex | kimi | pi | vibe (omit for the Claude harness)
+  --provider <slug>   Force a gateway (bankr, openrouter, venice, …) — Claude only
+  --base-url <url>    Custom HTTPS base URL (API-key auth only) — Claude only
+  --dry-run           Show what would be set, without calling gh/the CLI
   --json              Machine-readable output`
 
 export async function authCommand(argv: string[]) {
   if (argv.includes('-h') || argv.includes('--help')) { console.log(USAGE); return }
   requireGh()
 
-  let values: { key?: string; provider?: string; 'base-url'?: string; oauth?: boolean }
+  let values: { key?: string; provider?: string; 'base-url'?: string; oauth?: boolean; harness?: string }
   let positionals: string[]
   try {
     ;({ values, positionals } = parseArgs({ args: argv, options: {
       key: { type: 'string' }, provider: { type: 'string' },
       'base-url': { type: 'string' }, oauth: { type: 'boolean' },
+      harness: { type: 'string' },
     }, allowPositionals: true }))
   } catch (e) { fail(e instanceof Error ? e.message : 'bad arguments') }
 
+  // --- Non-Claude harnesses: native OAuth capture or a provider key ---
+  if (values.harness) {
+    const harness = values.harness
+    const spec = HARNESS_AUTH[harness]
+    if (!spec) fail(`unknown harness '${harness}'. Native auth is available for: ${Object.keys(HARNESS_AUTH).join(', ')}`)
+    const key = (values.key ?? positionals[0] ?? '').trim()
+
+    // A key was given (or the harness only supports keys) → store it.
+    if (key || !spec.oauth) {
+      if (!spec.apiKey) fail(`${harness} has no API-key path — run \`aeon auth --harness ${harness}\` for its login flow`)
+      if (!key) fail(`${harness} takes a provider API key: aeon auth --harness ${harness} --key <…>`)
+      const target = spec.apiKey.detect ? spec.apiKey.detect(key) : spec.apiKey.secret
+      if (isDryRun()) return emit({ dryRun: true, harness, method: 'api-key', secret: target }, () =>
+        console.log(c.yellow('dry-run: ') + `${harness} key → secret ${target}`))
+      let res: { secret: string }
+      try { res = setHarnessApiKey(harness, key) } catch (e) { fail(e instanceof Error ? e.message : 'failed to set key') }
+      return emit({ ok: true, harness, method: 'api-key', secret: res.secret }, () =>
+        console.log(c.green('✓ ') + `${harness}: key stored as ${res.secret}. Select the harness with \`aeon config set harness ${harness}\`.`))
+    }
+
+    // No key → drive the native OAuth login, then capture the credential.
+    if (isDryRun()) return emit({ dryRun: true, harness, method: 'oauth', secret: spec.oauth.secret }, () =>
+      console.log(c.yellow('dry-run: ') + `would run \`${spec.oauth!.cli} ${spec.oauth!.ttyArgs.join(' ')}\` → secret ${spec.oauth!.secret}`))
+    console.log(c.dim(`Opening ${spec.oauth.cli} login — approve in your browser…`))
+    let res: { secret: string }
+    try {
+      driveTtyLogin(harness)
+      res = captureHarnessCreds(harness)
+    } catch (e) { fail(e instanceof Error ? e.message : `${harness} login failed`) }
+    return emit({ ok: true, harness, method: 'oauth', secret: res.secret }, () =>
+      console.log(c.green('✓ ') + `${harness}: login captured as ${res.secret}. Select the harness with \`aeon config set harness ${harness}\`.`))
+  }
+
+  // --- Claude harness (default), unchanged ---
   const key = values.oauth ? '' : (values.key ?? positionals[0] ?? '')
   const body = { key, provider: values.provider, baseUrl: values['base-url'] }
 

--- a/apps/dashboard/app/api/harness-auth/route.ts
+++ b/apps/dashboard/app/api/harness-auth/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from 'next/server'
+import { syncHarness } from '@/lib/gateway'
+import { errorResponse, requireGh } from '@/lib/http'
+import { openBrowser } from '@/lib/open-browser'
+import { HARNESS_AUTH } from '@/lib/harness-auth'
+import { driveDeviceLogin, captureHarnessCreds, setHarnessApiKey } from '@/lib/harness-auth-server'
+import type { Harness } from '@/lib/types'
+
+// Native per-harness auth for codex/pi/vibe/kimi — the generic parallel to
+// app/api/grok-auth. Because the dashboard runs on the operator's own machine it
+// can drive the CLI and open their browser. POST { harness, key? }:
+//   - key present (or the harness is key-only) → store it under the harness's
+//     provider secret (pi auto-detects the secret from the key prefix). No browser.
+//   - no key + the harness has an OAuth flow → run its device login, open the
+//     browser at the verification URL, capture the credential file into its secret.
+// The OAuth captures (CODEX_AUTH/KIMI_AUTH) are that-harness-only, so — exactly
+// like connecting the X account for grok — they also switch the repo to that
+// harness. The api-key paths don't (a provider key isn't an unambiguous signal).
+
+export async function POST(request: Request) {
+  try {
+    const notReady = requireGh()
+    if (notReady) return notReady
+
+    const body = (await request.json().catch(() => ({}))) as { harness?: string; key?: string }
+    const harness = typeof body.harness === 'string' ? body.harness : ''
+    const spec = HARNESS_AUTH[harness]
+    if (!spec) return NextResponse.json({ error: `Unknown harness '${harness}'` }, { status: 400 })
+    const key = typeof body.key === 'string' ? body.key.trim() : ''
+
+    // Path 1 — API key (given, or the only option for pi/vibe).
+    if (key || !spec.oauth) {
+      if (!spec.apiKey) return NextResponse.json({ error: `${harness} needs its login flow, not a key` }, { status: 400 })
+      if (!key) return NextResponse.json({ error: `${harness} takes a provider API key` }, { status: 400 })
+      const { secret } = setHarnessApiKey(harness, key)
+      return NextResponse.json({ ok: true, harness, method: 'api-key', secret })
+    }
+
+    // Path 2 — native OAuth: drive the device login, open the browser, capture.
+    await driveDeviceLogin(harness, openBrowser)
+    const { secret } = captureHarnessCreds(harness)
+    const sync = await syncHarness(harness as Harness)
+    return NextResponse.json({ ok: true, harness, method: 'oauth', secret, synced: sync.synced })
+  } catch (error: unknown) {
+    return errorResponse(error, 'Failed to connect harness')
+  }
+}

--- a/apps/dashboard/app/page.tsx
+++ b/apps/dashboard/app/page.tsx
@@ -27,6 +27,8 @@ import { RightPanel } from '../components/RightPanel'
 import { ImportModal } from '../components/ImportModal'
 import { AuthModal } from '../components/AuthModal'
 import { GrokAuthModal } from '../components/GrokAuthModal'
+import { HarnessAuthModal } from '../components/HarnessAuthModal'
+import { HARNESS_AUTH } from '../lib/harness-auth'
 import { PanelError } from '../components/PanelError'
 
 export default function Dashboard() {
@@ -73,6 +75,7 @@ export default function Dashboard() {
   const [showImport, setShowImport] = useState(false)
   const [authLoading, setAuthLoading] = useState(false)
   const [grokLoading, setGrokLoading] = useState(false)
+  const [harnessAuthLoading, setHarnessAuthLoading] = useState(false)
   const [showAuthModal, setShowAuthModal] = useState(false)
 
   const [strategy, setStrategy] = useState('')
@@ -145,7 +148,7 @@ export default function Dashboard() {
   // Switch the agent harness. If the current model doesn't belong to the new
   // harness's model set, snap it to that harness's default so the picker + runs
   // stay coherent (persisted in the same PATCH round-trip).
-  const updateHarness = async (h: string) => { const hh: Harness = h === 'grok' ? 'grok' : 'claude'; setHarness(hh); const list = modelsForHarness(hh); const nextModel = list.some(x => x.id === model) ? undefined : list[0]?.id; if (nextModel) setModel(nextModel); try { const { data } = await patchJson<SyncResult>('/api/skills', { harness: hh, ...(nextModel ? { model: nextModel } : {}) }); flashSynced(`Harness: ${HARNESSES.find(x => x.id === hh)?.label || hh}`, data) } catch { flash('Network error') } }
+  const updateHarness = async (h: string) => { const hh: Harness = (HARNESSES.find(x => x.id === h)?.id ?? 'claude') as Harness; setHarness(hh); const list = modelsForHarness(hh); const nextModel = list.some(x => x.id === model) ? undefined : list[0]?.id; if (nextModel) setModel(nextModel); try { const { data } = await patchJson<SyncResult>('/api/skills', { harness: hh, ...(nextModel ? { model: nextModel } : {}) }); flashSynced(`Harness: ${HARNESSES.find(x => x.id === hh)?.label || hh}`, data) } catch { flash('Network error') } }
   const deleteSkill = async (n: string) => { setBusy(b => ({ ...b, [`d-${n}`]: true })); try { const { ok, data } = await del<SyncResult>('/api/skills', { name: n }); if (ok) { setSkills(s => s.filter(x => x.name !== n)); setSelectedSkill(null); flashSynced(`${displayName(n)} removed`, data) } else { flash(`${displayName(n)} removal failed`) } } catch { flash('Network error') } finally { setBusy(b => ({ ...b, [`d-${n}`]: false })) } }
   const syncToGithub = async () => { setSyncing(true); try { const { ok } = await postJson('/api/sync'); if (ok) { flash('Synced'); setHasChanges(false) } else { flash('Sync failed') } } catch { flash('Network error') } finally { setSyncing(false) } }
   // Pull rebases origin/main onto the working tree, so the whole dashboard can be
@@ -156,6 +159,10 @@ export default function Dashboard() {
   // Connect the grok harness: no arg captures the local X-account OAuth session
   // (GROK_CREDENTIALS); a key stores XAI_API_KEY instead.
   const setupGrokAuth = async (payload?: { key: string }) => { setGrokLoading(true); try { const { ok, data } = await postJson<ErrorResponse & { harness?: Harness; synced?: boolean }>('/api/grok-auth', payload || {}); if (ok) { if (data?.harness === 'grok') { setHarness('grok'); flashSynced('X account connected - harness set to grok', data) } else { flash(payload?.key ? 'XAI_API_KEY saved' : 'X account connected') } setShowAuthModal(false); fetchData() } else { flash(typeof data?.error === 'string' ? data.error : 'Grok connect failed') } } finally { setGrokLoading(false) } }
+  // Native auth for codex/pi/vibe/kimi (the /api/harness-auth parallel to grok):
+  // no arg = OAuth capture (codex→ChatGPT, kimi→device), which also switches the
+  // repo to that harness; {key} = a provider key stored under its own secret.
+  const setupHarnessAuth = async (targetHarness: string, payload?: { key: string }) => { setHarnessAuthLoading(true); try { const { ok, data } = await postJson<ErrorResponse & { harness?: Harness; method?: string; secret?: string; synced?: boolean }>('/api/harness-auth', { harness: targetHarness, ...(payload || {}) }); if (ok) { if (data?.method === 'oauth' && data?.harness) { setHarness(data.harness); flashSynced(`${data.harness} connected - harness set`, data) } else { flash(`${data?.secret || 'Key'} saved`) } setShowAuthModal(false); fetchData() } else { flash(typeof data?.error === 'string' ? data.error : 'Connect failed') } } finally { setHarnessAuthLoading(false) } }
   const saveSecret = async (n: string, value: string) => { setBusy(b => ({ ...b, [`sec-${n}`]: true })); try { const { ok } = await postJson('/api/secrets', { name: n, value }); if (ok) { setSecrets(s => { const e = s.some(x => x.name === n); if (e) return s.map(x => x.name === n ? { ...x, isSet: true } : x); return [...s, { name: n, group: 'Skill Keys', description: 'Custom', isSet: true }] }); flash(`${n} saved`) } } finally { setBusy(b => ({ ...b, [`sec-${n}`]: false })) } }
   const deleteSecret = async (n: string) => { setBusy(b => ({ ...b, [`sec-${n}`]: true })); try { const { ok } = await del('/api/secrets', { name: n }); if (ok) { setSecrets(s => s.map(x => x.name === n ? { ...x, isSet: false } : x)); flash(`${n} removed`) } } finally { setBusy(b => ({ ...b, [`sec-${n}`]: false })) } }
   const importSkill = async (files: UploadFile[], name?: string, category?: string) => { const { ok, data } = await postJson<UploadResponse>('/api/upload', { files, name, category }); if (ok) { flash(`${displayName(data.name)} added`); fetchData() } }
@@ -233,7 +240,7 @@ export default function Dashboard() {
 
         <div ref={mainScrollRef} className="flex-1 overflow-y-auto p-[var(--space-lg)]">
           {view === 'secrets' && !selectedSkill && (
-            <SecretsPanel secrets={secrets} skills={skills} busy={busy} repo={repo} harness={harness} focusKey={secretFocus} onFocusHandled={() => setSecretFocus(null)} onSave={saveSecret} onDelete={deleteSecret} onSelectSkill={(name) => { setSelectedSkill(name); setView('hq') }} onConnectClaude={() => setupAuth()} connecting={authLoading} onConnectGrok={() => setupGrokAuth()} grokConnecting={grokLoading} />
+            <SecretsPanel secrets={secrets} skills={skills} busy={busy} repo={repo} harness={harness} focusKey={secretFocus} onFocusHandled={() => setSecretFocus(null)} onSave={saveSecret} onDelete={deleteSecret} onSelectSkill={(name) => { setSelectedSkill(name); setView('hq') }} onConnectClaude={() => setupAuth()} connecting={authLoading} onConnectGrok={() => setupGrokAuth()} grokConnecting={grokLoading} onConnectHarness={(h) => setupHarnessAuth(h)} harnessConnecting={harnessAuthLoading} />
           )}
           {view === 'strategy' && !selectedSkill && (
             strategyError
@@ -279,6 +286,8 @@ export default function Dashboard() {
       {showImport && <ImportModal onClose={() => setShowImport(false)} onImport={importSkill} />}
       {showAuthModal && (harness === 'grok'
         ? <GrokAuthModal loading={grokLoading} onClose={() => setShowAuthModal(false)} onGrokAuth={(p) => setupGrokAuth(p)} />
+        : HARNESS_AUTH[harness]
+        ? <HarnessAuthModal harness={harness} loading={harnessAuthLoading} onClose={() => setShowAuthModal(false)} onHarnessAuth={(p) => setupHarnessAuth(harness, p)} />
         : <AuthModal loading={authLoading} onClose={() => setShowAuthModal(false)} onAuth={(auth) => setupAuth(auth)} />)}
     </div>
   )

--- a/apps/dashboard/components/HarnessAuthModal.tsx
+++ b/apps/dashboard/components/HarnessAuthModal.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { useState } from 'react'
+import { inputCls } from '../lib/utils'
+import { HARNESS_AUTH } from '../lib/harness-auth'
+
+// Native auth for the run-harness harnesses (codex/pi/vibe/kimi) — the generic
+// parallel to GrokAuthModal. codex/kimi offer a one-click native login (browser/
+// device OAuth, captured for CI); every one of the four also takes a provider
+// API key, and all fall back to the shared OpenRouter key. Posts to
+// /api/harness-auth via onHarnessAuth (no arg = OAuth, {key} = provider key).
+
+const TITLES: Record<string, string> = { codex: 'Codex', kimi: 'Kimi', pi: 'Pi', vibe: 'Vibe' }
+const OAUTH_BLURB: Record<string, string> = {
+  codex: 'Run codex on your ChatGPT plan. A browser tab opens to approve on OpenAI; the session is captured for CI. Needs the codex CLI installed.',
+  kimi: 'Run kimi on your Moonshot account (device-code flow). A browser tab opens to approve; the session is captured for CI. Needs the kimi CLI installed.',
+}
+
+interface HarnessAuthModalProps {
+  harness: string
+  loading: boolean
+  onClose: () => void
+  onHarnessAuth: (payload?: { key: string }) => void
+}
+
+export function HarnessAuthModal({ harness, loading, onClose, onHarnessAuth }: HarnessAuthModalProps) {
+  const spec = HARNESS_AUTH[harness]
+  const [key, setKey] = useState('')
+  const submitKey = () => key.trim() && onHarnessAuth({ key: key.trim() })
+  if (!spec) return null
+
+  return (
+    <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/30 backdrop-blur-sm">
+      <div className="bg-aeon-panel border border-[rgba(250,250,250,0.10)] w-full max-w-sm mx-4 p-[var(--space-lg)] shadow-2xl">
+        <div className="flex items-center justify-between mb-[var(--space-sm)]">
+          <h2 className="font-display text-xl">{TITLES[harness] ?? harness}</h2>
+          <button onClick={onClose} className="text-primary-35 hover:text-primary-100 text-lg">&times;</button>
+        </div>
+
+        {spec.oauth && (
+          <>
+            <p className="text-xs text-primary-50 font-mono mb-[var(--space-md)]">{OAUTH_BLURB[harness] ?? 'Connect this harness with its native login.'}</p>
+            <button onClick={() => onHarnessAuth()} disabled={loading} className="w-full bg-aeon-fg text-aeon-bg text-sm py-3 font-mono uppercase tracking-[2px] hover:opacity-90 transition-opacity disabled:opacity-50">
+              {loading ? '...' : spec.oauth.label}
+            </button>
+          </>
+        )}
+
+        {spec.apiKey && (
+          <>
+            {spec.oauth && <div className="my-[var(--space-md)] border-t border-[rgba(250,250,250,0.10)]" />}
+            <p className="text-xs text-primary-50 font-mono mb-[var(--space-md)]">{spec.oauth ? 'Or use a provider API key (no browser flow).' : 'Paste a provider API key.'} Any of the four also runs on the shared OpenRouter key.</p>
+            <input type="password" value={key} onChange={(e) => setKey(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && submitKey()} placeholder={spec.apiKey.placeholder} className={`${inputCls} mb-[var(--space-md)]`} />
+            <button onClick={submitKey} disabled={!key.trim() || loading} className="w-full bg-aeon-panel text-aeon-fg border border-[rgba(250,250,250,0.14)] text-sm py-3 font-mono uppercase tracking-[2px] hover:border-aeon-red transition-colors disabled:opacity-50">{loading ? '...' : 'Save key'}</button>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/dashboard/components/SecretsPanel.tsx
+++ b/apps/dashboard/components/SecretsPanel.tsx
@@ -39,9 +39,15 @@ interface SecretsPanelProps {
   connecting?: boolean
   onConnectGrok: () => void
   grokConnecting?: boolean
+  onConnectHarness: (harness: string) => void
+  harnessConnecting?: boolean
 }
 
-export function SecretsPanel({ secrets, skills, busy, repo, harness, focusKey, onFocusHandled, onSave, onDelete, onSelectSkill, onConnectClaude, connecting, onConnectGrok, grokConnecting }: SecretsPanelProps) {
+// The OAuth-capture secrets (a tar of a login you can't paste) → the harness
+// whose native login sets them. Rendered with a Connect button, like Claude/Grok.
+const OAUTH_SECRET_HARNESS: Record<string, string> = { CODEX_AUTH: 'codex', KIMI_AUTH: 'kimi' }
+
+export function SecretsPanel({ secrets, skills, busy, repo, harness, focusKey, onFocusHandled, onSave, onDelete, onSelectSkill, onConnectClaude, connecting, onConnectGrok, grokConnecting, onConnectHarness, harnessConnecting }: SecretsPanelProps) {
   const [editingSecret, setEditingSecret] = useState<string | null>(null)
   const [secretValue, setSecretValue] = useState('')
   const [addingSecret, setAddingSecret] = useState(false)
@@ -173,7 +179,8 @@ export function SecretsPanel({ secrets, skills, busy, repo, harness, focusKey, o
                     <div className="flex gap-1.5 shrink-0">
                       {secret.name === 'CLAUDE_CODE_OAUTH_TOKEN' && !claudeAuthSet && <button onClick={onConnectClaude} disabled={connecting} title="Run the Claude Code OAuth flow - signs in with your Claude Pro/Max plan, no API key or manual token needed." className="text-[11px] text-aeon-bg bg-aeon-fg font-mono px-2.5 py-1 hover:opacity-90 transition-opacity disabled:opacity-50">{connecting ? '…' : 'Connect'}</button>}
                       {secret.name === 'GROK_CREDENTIALS' && <button onClick={onConnectGrok} disabled={grokConnecting} title="Run the Grok Build device-auth flow - opens your browser to approve on accounts.x.ai, then stores the session for CI. Use Reconnect if the session expires." className="text-[11px] text-aeon-bg bg-aeon-fg font-mono px-2.5 py-1 hover:opacity-90 transition-opacity disabled:opacity-50">{grokConnecting ? '…' : (secret.isSet ? 'Reconnect' : 'Connect')}</button>}
-                      {!secret.isSet && editingSecret !== secret.name && <button onClick={() => { setEditingSecret(secret.name); setSecretValue('') }} className="btn-mini">Set</button>}
+                      {OAUTH_SECRET_HARNESS[secret.name] && <button onClick={() => onConnectHarness(OAUTH_SECRET_HARNESS[secret.name])} disabled={harnessConnecting} title={`Run the ${OAUTH_SECRET_HARNESS[secret.name]} login flow - opens your browser to approve, then stores the session for CI. Use Reconnect if it expires.`} className="text-[11px] text-aeon-bg bg-aeon-fg font-mono px-2.5 py-1 hover:opacity-90 transition-opacity disabled:opacity-50">{harnessConnecting ? '…' : (secret.isSet ? 'Reconnect' : 'Connect')}</button>}
+                      {!secret.isSet && editingSecret !== secret.name && !OAUTH_SECRET_HARNESS[secret.name] && <button onClick={() => { setEditingSecret(secret.name); setSecretValue('') }} className="btn-mini">Set</button>}
                       {secret.isSet && <button onClick={() => onDelete(secret.name)} disabled={!!busy[`sec-${secret.name}`]} className="btn-mini-danger">Remove</button>}
                     </div>
                   </div>

--- a/apps/dashboard/components/TopBar.tsx
+++ b/apps/dashboard/components/TopBar.tsx
@@ -42,7 +42,7 @@ export function TopBar({ skill, view, repo, model, harness, gateway, hasModelKey
         )}
       </div>
       <div className="flex items-center gap-2">
-        {harness !== 'grok' && gateway !== 'direct' && gateway !== 'auto' && (
+        {harness === 'claude' && gateway !== 'direct' && gateway !== 'auto' && (
           <span className="text-[10px] font-mono px-2 py-0.5 bg-aeon-red/10 text-aeon-red uppercase tracking-[0.18em] border border-aeon-red/30">{gateway}</span>
         )}
         {!hasModelKey && (

--- a/apps/dashboard/components/ui/ServiceIcon.tsx
+++ b/apps/dashboard/components/ui/ServiceIcon.tsx
@@ -36,7 +36,7 @@ const DOMAINS: Record<string, string> = {
   COINGECKO_API_KEY: 'coingecko.com',
   ALCHEMY_API_KEY: 'alchemy.com',
   ETHERSCAN_API_KEY: 'etherscan.io',
-  BASESCAN_API_KEY: 'basescan.org',
+  BASESCAN_KEY: 'basescan.org',
   BANKR_API_KEY: 'bankr.bot',
   VERCEL_TOKEN: 'vercel.com',
   REPLICATE_API_TOKEN: 'replicate.com',

--- a/apps/dashboard/lib/config.ts
+++ b/apps/dashboard/lib/config.ts
@@ -106,9 +106,10 @@ export function updateSkillInConfig(
     }
   }
   if (typeof updates.harness === 'string') {
-    // Only `grok` is worth pinning per-skill; anything else (incl. 'claude')
-    // clears the override so the skill inherits the top-level default.
-    if (updates.harness === 'grok') {
+    // Pin any non-default harness (grok/codex/pi/vibe/kimi) per-skill; `claude`
+    // (the top-level default) clears the override so the skill inherits it. This
+    // lets one skill run on a different harness than the repo default.
+    if (updates.harness && updates.harness !== 'claude') {
       skillNode.set('harness', updates.harness)
     } else {
       skillNode.delete('harness')

--- a/apps/dashboard/lib/constants.ts
+++ b/apps/dashboard/lib/constants.ts
@@ -1,4 +1,5 @@
 import { GATEWAY_SECRET_NAMES } from './gateway-registry'
+import { HARNESS_AUTH } from './harness-auth'
 
 // First entry is the default: it's the top of the model picker AND the fallback the
 // harness-switch snap uses (modelsForHarness(...)[0] in app/page.tsx). Keep it in
@@ -6,39 +7,104 @@ import { GATEWAY_SECRET_NAMES } from './gateway-registry'
 export const MODELS = [
   { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
   { id: 'claude-opus-4-8', label: 'Opus 4.8' },
-  { id: 'claude-fable-5', label: 'Fable 5' },
   { id: 'claude-opus-4-7', label: 'Opus 4.7' },
+  { id: 'claude-fable-5', label: 'Fable 5' },
   { id: 'claude-sonnet-5', label: 'Sonnet 5' },
   { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5' },
 ]
 
-// Models offered when the Grok (`grok`) harness is selected — exactly the two the
-// X-account (GROK_CREDENTIALS) login exposes:
-// - grok-4.5 (grok's CURRENT default) — the flagship reasoning model that powers
-//   Grok Build. Multi-agent-capable, so run-grok.sh passes --no-subagents in CI.
-// - grok-composer-2.5-fast — fast, cheap single-agent; used for CI health scoring.
-// The older grok-build-0.1 is intentionally NOT offered here: it's reachable only via
-// XAI_API_KEY on api.x.ai (the gateway path — set the GROK_MODEL repo var), never on
-// the X-account login, so listing it as a harness option would be a dead click.
+// Models offered when the Grok (`grok`) harness is selected — only grok-4.5, the
+// one model the X-account (GROK_CREDENTIALS) login exposes to the grok CLI's
+// --model flag. grok-4.5 is grok's current default: the flagship reasoning model
+// that powers Grok Build, multi-agent-capable (run-grok.sh passes --no-subagents
+// in CI).
+// Everything else xAI documents — grok-composer-2.5-fast, grok-build, grok-build-0.1,
+// grok-4.3 — is an api.x.ai model *string*, NOT a valid CLI --model value on the
+// X-account OAuth login: the grok CLI rejects each with "unknown model id" (verified
+// live 2026-07-22). They're reachable only via XAI_API_KEY on the gateway path (set
+// the GROK_MODEL repo var), so listing any here would be a dead click.
 // First entry is the default (modelsForHarness(...)[0] on harness switch). Keep this
 // list in sync with the workflow_dispatch `model` choice options in
 // .github/workflows/aeon.yml — a mismatch 422s at dispatch time.
 export const GROK_MODELS = [
   { id: 'grok-4.5', label: 'Grok 4.5' },
-  { id: 'grok-composer-2.5-fast', label: 'Composer 2.5' },
 ]
 
-// Harnesses (agent CLIs). `claude` = Claude Code (default, uses the AI Gateway),
-// labelled "Anthropic" in the UI; `grok` = Grok Build (own X-account/API-key
-// auth, own model list above), labelled "xAI". The `id`s are the on-disk
-// harness values (aeon.yml `harness:`) and never change — only the labels do.
+// kimi gets its own list: it bakes the selected id into a generic OpenRouter
+// provider config (`[providers.openrouter] type=openai`), so it drives ANY
+// OpenRouter model — and kimi IS Moonshot, so it runs Moonshot's own Kimi family
+// through OpenRouter (the way vibe runs Mistral and pi runs DeepSeek). K2.5 is the
+// default (fast, solid), K3 is the strongest (higher quality but ~2× slower), and
+// K2.7-code is the code-tuned variant. All three measured working end-to-end
+// 2026-07-23 on a real runner (k2.5 4/5, k3 5/5, k2.7-code 4/5; slates cross-checked
+// real). First entry is the default (modelsForHarness('kimi')[0] on harness switch)
+// — matched by aeon.yml's DEFAULT_HM. Any id here must also appear in the
+// workflow_dispatch `model` choice, or a dashboard dispatch of it 422s.
+export const KIMI_MODELS = [
+  { id: 'moonshotai/kimi-k2.5', label: 'Kimi K2.5' },
+  { id: 'moonshotai/kimi-k3', label: 'Kimi K3' },
+  { id: 'moonshotai/kimi-k2.7-code', label: 'Kimi K2.7 Code' },
+]
+
+// codex needs its own list: it fails DETERMINISTICALLY on gpt-5-nano (it emits a
+// shell tool call with a duplicated `cmd` field, its strict parser rejects it,
+// and with no --max-turns it spins to the run guard). So its cheapest working
+// model is mini — measured on a real runner — which stays the default (first entry,
+// matched by aeon.yml's DEFAULT_HM). The rest are the codex-tuned line
+// (gpt-5.1-codex-mini, gpt-5.3-codex) and the general gpt-5.6 family (luna, terra),
+// which drive codex via OpenRouter. gpt-5.1-codex-mini + gpt-5.6-luna verified live
+// 2026-07-22; gpt-5.3-codex/gpt-5.6-terra inferred from their same-family siblings.
+export const CODEX_MODELS = [
+  { id: 'openai/gpt-5-mini', label: 'GPT-5 Mini' },
+  { id: 'openai/gpt-5.1-codex-mini', label: 'GPT-5.1 Codex Mini' },
+  { id: 'openai/gpt-5.3-codex', label: 'GPT-5.3 Codex' },
+  { id: 'openai/gpt-5.6-luna', label: 'GPT-5.6 Luna' },
+  { id: 'openai/gpt-5.6-terra', label: 'GPT-5.6 Terra' },
+]
+
+// vibe gets its own list: its generic ProviderConfig drives ANY OpenRouter model,
+// not just openai/*, so it defaults to Mistral Medium 3.5 (vibe's native family, run
+// here through OpenRouter) and also offers DeepSeek V4 Flash. Both measured working
+// end-to-end 2026-07-22 (mistral-medium-3-5 4/5, deepseek-v4-flash 3/5 on a real
+// runner). First entry is the default (modelsForHarness('vibe')[0]) — and the runtime
+// default is set to match in aeon.yml's DEFAULT_HM. Any id here must also appear in
+// the workflow_dispatch `model` choice, or a dashboard dispatch 422s.
+export const VIBE_MODELS = [
+  { id: 'mistralai/mistral-medium-3-5', label: 'Mistral Medium 3.5' },
+  { id: 'deepseek/deepseek-v4-flash', label: 'DeepSeek V4 Flash' },
+]
+
+// pi gets its own list: it drives any OpenRouter model via litellm routing
+// (`openrouter/<slug>`), so it runs the DeepSeek V4 pair — Flash (default, cheap/
+// fast) and Pro (stronger). First entry is the default (modelsForHarness('pi')[0]),
+// matched by aeon.yml's DEFAULT_HM. Any id here must also appear in the
+// workflow_dispatch `model` choice, or a dashboard dispatch 422s.
+export const PI_MODELS = [
+  { id: 'deepseek/deepseek-v4-flash', label: 'DeepSeek V4 Flash' },
+  { id: 'deepseek/deepseek-v4-pro', label: 'DeepSeek V4 Pro' },
+]
+
+// Harnesses (agent CLIs). `claude` = Claude Code (default, AI Gateway), labelled
+// "Anthropic"; `grok` = Grok Build (own X-account/API-key auth, own models),
+// "xAI". The last four run through harness-adapter's run-harness on a single
+// OPENROUTER_API_KEY. The `id`s are the on-disk harness values (aeon.yml
+// `harness:`) and never change — only the labels do.
 export const HARNESSES = [
   { id: 'claude', label: 'Anthropic' },
   { id: 'grok', label: 'xAI' },
+  { id: 'codex', label: 'Codex' },
+  { id: 'pi', label: 'Pi' },
+  { id: 'vibe', label: 'Vibe' },
+  { id: 'kimi', label: 'Kimi' },
 ] as const
 
 export function modelsForHarness(harness: string) {
-  return harness === 'grok' ? GROK_MODELS : MODELS
+  if (harness === 'grok') return GROK_MODELS
+  if (harness === 'codex') return CODEX_MODELS
+  if (harness === 'vibe') return VIBE_MODELS
+  if (harness === 'pi') return PI_MODELS
+  if (harness === 'kimi') return KIMI_MODELS
+  return MODELS
 }
 
 // Secret names that authenticate the CLAUDE harness (Claude Code): its own
@@ -57,8 +123,13 @@ export const GROK_AUTH_SECRETS = ['GROK_CREDENTIALS', 'XAI_API_KEY']
 // The auth-secret set that authenticates the given harness. The client derives
 // auth state from /api/secrets by testing membership against this — so the Auth
 // CTA reappears when you switch to a harness whose own auth isn't set yet.
+// codex/pi/vibe/kimi carry their own native-auth secrets (ChatGPT/Moonshot
+// captures, provider keys) with OPENROUTER_API_KEY as the shared fallback — the
+// full ordered set lives in the HARNESS_AUTH registry (see lib/harness-auth.ts).
 export function authSecretsForHarness(harness: string): string[] {
-  return harness === 'grok' ? GROK_AUTH_SECRETS : CLAUDE_AUTH_SECRETS
+  if (harness === 'grok') return GROK_AUTH_SECRETS
+  if (HARNESS_AUTH[harness]) return HARNESS_AUTH[harness].authSecrets
+  return CLAUDE_AUTH_SECRETS
 }
 
 // Credentials whose CAPABILITY a harness covers with its own built-in tools — so a

--- a/apps/dashboard/lib/dispatch.ts
+++ b/apps/dashboard/lib/dispatch.ts
@@ -20,8 +20,8 @@ export function normLinks(input: unknown): string[] {
 /**
  * Reduce a model identifier to a safe charset — alphanumerics, underscore,
  * hyphen, and dot. The dot matters: grok model ids carry a version like
- * `grok-composer-2.5-fast`, and stripping it produced `grok-composer-25-fast`,
- * which the workflow's `model` choice input rejects with HTTP 422. Dispatch uses
+ * `grok-4.5`, and stripping it produced `grok-45`, which the workflow's `model`
+ * choice input rejects with HTTP 422. Dispatch uses
  * `execFileSync('gh', [...])` (argv array, no shell), so this is defense-in-depth
  * against odd input, not a shell-injection guard. Non-string input yields "".
  */

--- a/apps/dashboard/lib/harness-auth-server.ts
+++ b/apps/dashboard/lib/harness-auth-server.ts
@@ -1,0 +1,100 @@
+import { execFileSync, spawn, type ChildProcess } from 'child_process'
+import { existsSync } from 'fs'
+import { homedir } from 'os'
+import { join } from 'path'
+import { ghArgsRepo } from './gh'
+import { HARNESS_AUTH, DEVICE_URL_RE } from './harness-auth'
+
+// Server-side (Node) half of native harness auth. Shared by `aeon auth` and
+// POST /api/harness-auth. The pure registry it drives is in ./harness-auth.
+// Every one of these mirrors an existing grok/claude flow (lib/auth.ts,
+// app/api/grok-auth) — same tar+base64 capture, same `gh secret set`.
+
+// Store an API key for a harness under the right secret name and return it.
+// pi may resolve a different secret from the key's prefix (see detectPiSecret).
+export function setHarnessApiKey(harness: string, key: string): { secret: string } {
+  const spec = HARNESS_AUTH[harness]
+  if (!spec?.apiKey) throw new Error(`${harness} has no API-key auth path`)
+  const k = key.trim()
+  if (!k) throw new Error('empty key')
+  const secret = spec.apiKey.detect ? spec.apiKey.detect(k) : spec.apiKey.secret
+  execFileSync('gh', ['secret', 'set', secret, ...ghArgsRepo()], { input: k, stdio: ['pipe', 'pipe', 'pipe'] })
+  return { secret }
+}
+
+// After a successful login has written the harness's credential file(s), tar +
+// base64 them into the harness's OAuth secret ($HOME-relative so the archive
+// restores to the same path in CI). Throws if no credential file appeared.
+export function captureHarnessCreds(harness: string): { secret: string } {
+  const spec = HARNESS_AUTH[harness]
+  if (!spec?.oauth) throw new Error(`${harness} has no OAuth capture`)
+  const home = homedir()
+  const present = spec.oauth.credPaths.filter((p) => existsSync(join(home, p)))
+  if (present.length === 0) {
+    throw new Error(`Login completed but none of ${spec.oauth.credPaths.join(', ')} was found under $HOME. Try the login in a terminal, then connect again.`)
+  }
+  const archive = execFileSync('tar', ['czf', '-', '-C', home, ...present], { maxBuffer: 8 * 1024 * 1024 })
+  execFileSync('gh', ['secret', 'set', spec.oauth.secret, ...ghArgsRepo()], {
+    input: archive.toString('base64'),
+    stdio: ['pipe', 'pipe', 'pipe'],
+  })
+  return { secret: spec.oauth.secret }
+}
+
+// Drive the TTY login (inherit stdio: the tool shows its own prompts and opens
+// its own browser), for the aeon CLI. Blocks until the flow finishes; throws on
+// a non-zero exit.
+export function driveTtyLogin(harness: string): void {
+  const spec = HARNESS_AUTH[harness]
+  if (!spec?.oauth) throw new Error(`${harness} has no OAuth login`)
+  execFileSync(spec.oauth.cli, spec.oauth.deviceArgs.length && !process.stdout.isTTY ? spec.oauth.deviceArgs : spec.oauth.ttyArgs, { stdio: 'inherit' })
+}
+
+// Drive the DEVICE login (headless: parse the verification URL from live output
+// and open the browser at it), for the dashboard route. Resolves on approval.
+// Faithful to grokLogin() in app/api/grok-auth/route.ts.
+export function driveDeviceLogin(
+  harness: string,
+  openBrowser: (url: string) => void,
+  timeoutMs = 240_000,
+): Promise<void> {
+  const spec = HARNESS_AUTH[harness]
+  if (!spec?.oauth) return Promise.reject(new Error(`${harness} has no OAuth login`))
+  const { cli, deviceArgs } = spec.oauth
+  return new Promise((resolve, reject) => {
+    let child: ChildProcess
+    try {
+      child = spawn(cli, deviceArgs, { stdio: ['ignore', 'pipe', 'pipe'] })
+    } catch (e) {
+      return reject(e)
+    }
+    let opened = false
+    let buf = ''
+    const onData = (chunk: Buffer) => {
+      buf += chunk.toString()
+      if (!opened) {
+        // Open the first EXTERNAL verification URL. codex prints its localhost
+        // callback server first (http://localhost:1455) — opening that instead of
+        // the auth page would do nothing, so skip loopback hosts.
+        const urls = buf.match(new RegExp(DEVICE_URL_RE.source, 'g')) || []
+        const ext = urls.find((u) => !/localhost|127\.0\.0\.1|\[::1\]/.test(u))
+        if (ext) { opened = true; openBrowser(ext) }
+      }
+    }
+    child.stdout?.on('data', onData)
+    child.stderr?.on('data', onData)
+    const timer = setTimeout(() => {
+      child.kill()
+      reject(new Error('Timed out waiting for approval. Approve in the browser and connect again.'))
+    }, timeoutMs)
+    child.on('error', (e: NodeJS.ErrnoException) => {
+      clearTimeout(timer)
+      reject(e.code === 'ENOENT' ? new Error(`${cli} CLI not found — install it first.`) : e)
+    })
+    child.on('close', (code) => {
+      clearTimeout(timer)
+      if (code === 0) resolve()
+      else reject(new Error(`${cli} login exited ${code}. ${buf.slice(-200)}`))
+    })
+  })
+}

--- a/apps/dashboard/lib/harness-auth.ts
+++ b/apps/dashboard/lib/harness-auth.ts
@@ -1,0 +1,109 @@
+// Native per-harness authentication for the run-harness harnesses (codex, pi,
+// vibe, kimi). Each can run in CI on its OWN provider instead of the shared
+// OPENROUTER_API_KEY:
+//
+//   - codex / kimi have real OAuth device flows (codex → ChatGPT, kimi → Moonshot).
+//     We drive the login locally, then tar+base64 the credential file into a repo
+//     secret and restore it in CI — the exact pattern aeon already uses for grok's
+//     X-account session (GROK_CREDENTIALS). See lib/harness-auth-server.ts.
+//   - pi / vibe take a native provider API key (pi reads standard provider env
+//     vars; vibe a Mistral key).
+//
+// This module is PURE DATA (no node imports) so it's safe to import from client
+// components AND from the CLI/route server code. The provider a harness runs on
+// is decided by which of `authSecrets` is set — native first, OpenRouter last —
+// and the workflow's "Resolve harness" / "Install harness CLI" steps branch on
+// exactly that order (.github/workflows/aeon.yml).
+
+export interface HarnessOAuth {
+  // The CLI binary and login args. Both codex (`codex login` → local callback
+  // server + browser) and kimi (`kimi login` → device URL + browser) open their
+  // own browser and complete on approval, so the same args work for the aeon CLI
+  // (TTY, inherit stdio) and the dashboard route (spawn, wait for exit 0). The
+  // route also opens the verification URL it parses, as a fallback.
+  cli: string
+  ttyArgs: string[]
+  deviceArgs: string[]
+  // $HOME-relative paths of the credential file(s) to capture/restore.
+  credPaths: string[]
+  // The repo secret the tar+base64 archive is stored under.
+  secret: string
+  // Human label for the connect button ("Connect ChatGPT").
+  label: string
+}
+
+export interface HarnessApiKey {
+  // Default secret the key is stored under. `detect` (pi) may pick a different
+  // one from the key's prefix, since pi reads several provider env vars.
+  secret: string
+  detect?: (key: string) => string
+  placeholder: string
+}
+
+export interface HarnessAuthSpec {
+  // Every secret that authenticates this harness, MOST-PREFERRED FIRST. Drives
+  // authSecretsForHarness (the run-gate + Auth CTA) and the workflow's provider
+  // precedence. OPENROUTER_API_KEY is always last: the universal fallback.
+  authSecrets: string[]
+  oauth?: HarnessOAuth
+  apiKey?: HarnessApiKey
+}
+
+// Detect the right Anthropic/OpenAI/OpenRouter secret for a pasted pi key by its
+// prefix — pi auto-selects its provider from whichever of these env vars is set.
+function detectPiSecret(key: string): string {
+  const k = key.trim()
+  if (k.startsWith('sk-ant-oat')) return 'ANTHROPIC_OAUTH_TOKEN'
+  if (k.startsWith('sk-ant')) return 'ANTHROPIC_API_KEY'
+  if (k.startsWith('sk-or')) return 'OPENROUTER_API_KEY'
+  if (k.startsWith('sk-')) return 'OPENAI_API_KEY'
+  return 'ANTHROPIC_API_KEY'
+}
+
+export const HARNESS_AUTH: Record<string, HarnessAuthSpec> = {
+  codex: {
+    authSecrets: ['CODEX_AUTH', 'OPENAI_API_KEY', 'OPENROUTER_API_KEY'],
+    oauth: {
+      cli: 'codex',
+      // Plain `codex login` (NOT --device-auth): it runs a localhost callback
+      // server and auto-completes on browser approval — right for a local
+      // dashboard. --device-auth prints a code the user must type by hand.
+      ttyArgs: ['login'],
+      deviceArgs: ['login'],
+      credPaths: ['.codex/auth.json'],
+      secret: 'CODEX_AUTH',
+      label: 'Connect ChatGPT',
+    },
+    apiKey: { secret: 'OPENAI_API_KEY', placeholder: 'sk-...' },
+  },
+  kimi: {
+    authSecrets: ['KIMI_AUTH', 'MOONSHOT_API_KEY', 'OPENROUTER_API_KEY'],
+    oauth: {
+      cli: 'kimi',
+      ttyArgs: ['login'],
+      deviceArgs: ['login'], // `kimi login` is device-code by default
+      credPaths: ['.kimi-code/credentials/kimi-code.json', '.kimi-code/device_id'],
+      secret: 'KIMI_AUTH',
+      label: 'Connect Kimi',
+    },
+    apiKey: { secret: 'MOONSHOT_API_KEY', placeholder: 'sk-...' },
+  },
+  pi: {
+    authSecrets: ['ANTHROPIC_API_KEY', 'ANTHROPIC_OAUTH_TOKEN', 'OPENAI_API_KEY', 'OPENROUTER_API_KEY'],
+    apiKey: { secret: 'ANTHROPIC_API_KEY', detect: detectPiSecret, placeholder: 'sk-ant-… / sk-…' },
+  },
+  vibe: {
+    authSecrets: ['MISTRAL_API_KEY', 'OPENROUTER_API_KEY'],
+    apiKey: { secret: 'MISTRAL_API_KEY', placeholder: 'Mistral API key' },
+  },
+}
+
+// Is `harness` one of the run-harness harnesses with native auth handling?
+export function isRunHarness(harness: string): harness is keyof typeof HARNESS_AUTH {
+  return harness in HARNESS_AUTH
+}
+
+// The URL a device-auth flow prints for the operator to approve in the browser.
+// Permissive on purpose — codex (ChatGPT) and kimi (Moonshot) print different
+// hosts, and we only need the first https URL to hand to openBrowser.
+export const DEVICE_URL_RE = /https?:\/\/[^\s'"]+/

--- a/apps/dashboard/lib/secrets-catalog.ts
+++ b/apps/dashboard/lib/secrets-catalog.ts
@@ -15,7 +15,16 @@ export const BUILTIN_SECRETS: Omit<Secret, 'isSet'>[] = [
   { name: 'GROK_CREDENTIALS', group: 'Core', description: 'Grok Build (grok CLI) X-account OAuth session - base64 of your ~/.grok login, captured by "Connect X account" in AUTH. Lets the grok harness (harness: grok) run in CI on your SuperGrok / X Premium+ entitlement. Alternative: set XAI_API_KEY instead.' },
   { name: 'ANTHROPIC_API_KEY', group: 'Core', description: 'How Claude Code signs in - option 2 of 2. A pay-as-you-go Anthropic API key (sk-ant-...) billed via the Console, or any Anthropic-compatible key for a proxy. Create one at console.anthropic.com.', either: 'auth' },
   { name: 'BANKR_LLM_KEY', group: 'Core', description: 'Bankr Gateway API key (bk_...) - enable at bankr.bot/api-keys' },
-  { name: 'OPENROUTER_API_KEY', group: 'Core', description: 'OpenRouter API key (sk-or-...) - routes Claude through openrouter.ai. Create at openrouter.ai/keys' },
+  { name: 'OPENROUTER_API_KEY', group: 'Core', description: 'OpenRouter API key (sk-or-...) - dual purpose: (1) routes Claude Code through openrouter.ai (a gateway provider), and (2) the shared fallback auth for the codex, pi, vibe and kimi harnesses, which all run on OpenRouter via run-harness. One key covers all four. Create at openrouter.ai/keys' },
+  // Native harness auth - each of the run-harness harnesses can run on its OWN
+  // provider instead of the shared OpenRouter key. The two OAuth captures
+  // (CODEX_AUTH/KIMI_AUTH) are set by `aeon auth --harness <h>` or the dashboard's
+  // Connect button, which drive the CLI's login and store the captured session.
+  { name: 'CODEX_AUTH', group: 'Core', description: 'Codex (ChatGPT) login captured for CI - a base64 tar of ~/.codex/auth.json. Set it with `aeon auth --harness codex` or the dashboard "Connect ChatGPT" button (runs `codex login`, stores the session here). Runs the codex harness on your ChatGPT plan instead of OpenRouter.' },
+  { name: 'KIMI_AUTH', group: 'Core', description: 'Kimi (Moonshot) device login captured for CI - a base64 tar of ~/.kimi-code/credentials. Set it with `aeon auth --harness kimi` or the dashboard "Connect Kimi" button. Runs the kimi harness on your Moonshot account instead of OpenRouter.' },
+  { name: 'OPENAI_API_KEY', group: 'Core', description: 'OpenAI API key (sk-...) - API-key auth for the codex harness (alternative to the ChatGPT login) and a provider pi can use. Create at platform.openai.com/api-keys' },
+  { name: 'MOONSHOT_API_KEY', group: 'Core', description: 'Moonshot API key - API-key auth for the kimi harness (alternative to the device login). From platform.moonshot.ai' },
+  { name: 'MISTRAL_API_KEY', group: 'Core', description: "Mistral API key - native auth for the vibe harness (its default provider). vibe's own `vibe` sign-in stores its credential in the OS keychain (not a portable file, like Claude Code), so it can't be captured for CI - set the key here instead. Create at console.mistral.ai" },
   { name: 'USEPOD_TOKEN', group: 'Core', description: "UsePod proxy token - routes Claude through UsePod's gateway (token embedded in the base URL). Get one at usepod.ai" },
   { name: 'VENICE_API_KEY', group: 'Core', description: 'Venice API key - routes Claude through api.venice.ai via a local translator. Create at venice.ai/settings/api' },
   { name: 'SURPLUS_API_KEY', group: 'Core', description: 'Surplus Intelligence API key (inf_...) - routes Claude through surplusintelligence.ai via a local translator' },
@@ -42,7 +51,7 @@ export const BUILTIN_SECRETS: Omit<Secret, 'isSet'>[] = [
   { name: 'COINGECKO_API_KEY', group: 'Skill Keys', description: 'CoinGecko API key - crypto price/market skills. Get one at coingecko.com/en/api' },
   { name: 'ALCHEMY_API_KEY', group: 'Skill Keys', description: 'Alchemy API key - on-chain RPC/data skills. Create at dashboard.alchemy.com' },
   { name: 'ETHERSCAN_API_KEY', group: 'Skill Keys', description: 'Etherscan multichain (V2) API key - one key covers Ethereum + Base + other chains for on-chain skills (tx-explain, investigation-report, onchain-monitor); lifts rate limits. Get one at etherscan.io/apis' },
-  { name: 'BASESCAN_API_KEY', group: 'Skill Keys', description: 'Base explorer key for on-chain skills (investigation-report). Etherscan V2 is one multichain key, so the simplest setup is the SAME value as ETHERSCAN_API_KEY; a standalone basescan.org key also works. Optional - lifts Base rate limits. Keys at etherscan.io/apis' },
+  { name: 'BASESCAN_KEY', group: 'Skill Keys', description: 'Base explorer key for on-chain skills (investigation-report). Etherscan V2 is one multichain key, so the simplest setup is the SAME value as ETHERSCAN_API_KEY; a standalone basescan.org key also works. Optional - lifts Base rate limits. Keys at etherscan.io/apis' },
   { name: 'BANKR_API_KEY', group: 'Skill Keys', description: 'Bankr Wallet API key (X-API-Key) - token distribution skills (distribute-tokens). Enable at bankr.bot/api-keys' },
   { name: 'VERCEL_TOKEN', group: 'Skill Keys', description: 'Vercel access token - deploy skills (deploy-prototype). Create at vercel.com/account/settings/tokens' },
   { name: 'REPLICATE_API_TOKEN', group: 'Skill Keys', description: 'Replicate API token - hero image generation (article). Get one at replicate.com/account/api-tokens' },

--- a/apps/dashboard/lib/types.ts
+++ b/apps/dashboard/lib/types.ts
@@ -65,9 +65,11 @@ export type GatewayProvider = 'auto' | 'direct' | GatewaySlug
 export const GATEWAY_PROVIDERS: GatewayProvider[] = ['auto', 'direct', ...GATEWAY_SLUGS]
 
 // Which agent CLI runs skills. `claude` = Claude Code (default, uses the gateway
-// above); `grok` = Grok Build CLI (own auth, own models). See scripts/run-grok.sh.
-export type Harness = 'claude' | 'grok'
-export const HARNESSES: Harness[] = ['claude', 'grok']
+// above); `grok` = Grok Build CLI (own auth, own models). The remaining four run
+// through harness-adapter's `run-harness` on one OPENROUTER_API_KEY (see
+// harness-adapter/docs/aeon-integration.md and scripts/run-grok.sh for the seam).
+export type Harness = 'claude' | 'grok' | 'codex' | 'pi' | 'vibe' | 'kimi'
+export const HARNESSES: Harness[] = ['claude', 'grok', 'codex', 'pi', 'vibe', 'kimi']
 
 export interface UploadFile { path: string; content: string }
 

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -8,16 +8,122 @@ description: Deep reference for Aeon's harness axis (Claude Code vs Grok Build) 
 
 The **harness** is the coding-agent CLI that runs your skills. The README's
 [Harnesses](../.github/README.md#harnesses) section covers the basics — the two
-harnesses (`claude` default, `grok`), how to select one, and one-click X-account
-login. This page collects the deeper behavior for anyone running the `grok`
-harness in anger.
+first-class harnesses (`claude` default, `grok`), how to select one, and
+one-click X-account login. This page collects the deeper behavior for anyone
+running the `grok` harness in anger.
+
+## Additional harnesses via run-harness (`codex`, `pi`, `vibe`, `kimi`)
+
+Four more harnesses are selectable in the dashboard's harness dropdown and the
+`harness:` config: **codex** (OpenAI Codex CLI), **pi** (Pi Coding Agent),
+**vibe** (Mistral Vibe) and **kimi** (Moonshot Kimi). Unlike `claude`/`grok`
+they don't have a bespoke branch in the workflow — they run through
+[`harness-adapter`](../harness-adapter/)'s `run-harness`, which wraps each CLI in
+the same Claude-Code-shaped `{result, usage, session_id}` contract that
+`scripts/run-grok.sh` provides, so everything downstream (scoring, token
+accounting, memory, notifications) is unchanged.
+
+All four authenticate with a single **`OPENROUTER_API_KEY`** — set it in
+Settings and every one of them works. Their model picker offers OpenRouter ids
+rather than the `claude-*`/`grok-*` ids, and the model you pick is what actually
+runs. Each of these harnesses carries its own curated list (`CODEX_MODELS` /
+`VIBE_MODELS` / `PI_MODELS` / `KIMI_MODELS`): **codex**
+defaults to `openai/gpt-5-mini` (it fails on `gpt-5-nano`) and also offers the
+codex-tuned line (`gpt-5.1-codex-mini`, `gpt-5.3-codex`) and the general
+`gpt-5.6` family (`luna`, `terra`); **vibe**'s generic `ProviderConfig` drives any
+OpenRouter model, so it defaults to `mistralai/mistral-medium-3-5` and offers
+`deepseek/deepseek-v4-flash`; **pi** (litellm `openrouter/<slug>` routing) runs the
+DeepSeek V4 pair — `deepseek-v4-flash` (default) and `deepseek-v4-pro`; **kimi** is
+Moonshot, so it runs Moonshot's own Kimi family through OpenRouter —
+`moonshotai/kimi-k2.5` (default), `kimi-k3` (strongest, ~2× slower), and
+`kimi-k2.7-code`. The scorer
+routes through the same harness the skill
+ran on, so a repo with **no** Claude credentials still gets every run scored.
+
+### Native auth — run on your own provider account
+
+OpenRouter is the shared fallback; each harness can also run on its **own**
+provider, the same way `grok` runs on your X-account session. Two have real
+login flows captured for CI (the exact `GROK_CREDENTIALS` pattern — drive the
+login locally, store the session as a repo secret, restore it on the runner):
+
+| harness | native auth | how to set it |
+|---------|-------------|---------------|
+| `codex` | **ChatGPT** OAuth | `aeon auth --harness codex` (or dashboard **Connect ChatGPT**) → `CODEX_AUTH`. Or an OpenAI key: `--key sk-…` → `OPENAI_API_KEY` |
+| `kimi`  | **Moonshot** device login | `aeon auth --harness kimi` (or **Connect Kimi**) → `KIMI_AUTH`. Or `--key` → `MOONSHOT_API_KEY` |
+| `pi`    | provider API key | `aeon auth --harness pi --key <sk-ant-…\|sk-…>` → the matching `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` (auto-detected) |
+| `vibe`  | Mistral key | `aeon auth --harness vibe --key <key>` → `MISTRAL_API_KEY` (vibe's default provider) |
+
+Which one runs is decided at dispatch by **which secret is set**, native first,
+OpenRouter last (`authSecretsForHarness` / the `HARNESS_AUTH` registry in
+`apps/dashboard/lib/harness-auth.ts`). On native auth the harness uses its **own
+default model** — the OpenRouter model picker only applies when the run falls
+back to `OPENROUTER_API_KEY` (an `openai/*` id would be the wrong provider
+otherwise). The workflow's *Install harness CLI* step restores/configures the
+selected provider; the CLI + dashboard flows share `lib/harness-auth-server.ts`.
+
+The full deployment runbook — the added/modified workflow steps, per-harness
+install and config, runner gotchas (AppArmor, the codex pin), and the measured
+reasons `opencode`/`copilot`/`agy` are excluded — is
+[`harness-adapter/docs/aeon-integration.md`](../harness-adapter/docs/aeon-integration.md).
+
+## Verification status
+
+All six harnesses were verified end-to-end through `run-harness` on **2026-07-22**
+— each dispatched live on GitHub Actions, exercising auth, read-only enforcement,
+token accounting, and the post-run health scorer:
+
+| harness | auth as-tested | read-only enforcement | token usage | live result |
+|---------|----------------|-----------------------|-------------|-------------|
+| `claude` | `CLAUDE_CODE_OAUTH_TOKEN` | allowlist-strip + post-run revert (`--no-sandbox`) | real | green, both modes |
+| `grok` | `GROK_CREDENTIALS` (X-OAuth) | allowlist-strip + post-run revert (`--no-sandbox`) | real | scored 4/5 |
+| `codex` | OpenRouter (`OPENROUTER_API_KEY`) | wrapper OS sandbox (codex's own sandbox off in read-only to avoid nesting) | real | 5/5 on `gpt-5-mini`, real fetch verified |
+| `pi` | OpenRouter | wrapper OS sandbox | real | 5/5 on `gpt-5-mini` |
+| `vibe` | OpenRouter | wrapper sandbox + `--disabled-tools write_file,edit` | char/4 estimate | 4/5 on `gpt-5-mini` |
+| `kimi` | OpenRouter | wrapper OS sandbox (its only read-only guard) | char/4 estimate | Kimi K3 5/5, K2.5 & K2.7-code 4/5 — slates verified real |
+
+Notes from the sweep:
+
+- **Model matters for the score.** `pi`/`vibe` scored 2/5 on `gpt-5-nano` (the model
+  punted / truncated) but 5/5 and 4/5 on `gpt-5-mini` — the harness scoring path is
+  sound; nano was just too weak for the task.
+- **Auth precedence is a trap.** codex resolves `CODEX_AUTH` → `OPENAI_API_KEY` →
+  OpenRouter and grok resolves `GROK_CREDENTIALS` → `XAI_API_KEY`, **native-first** —
+  so a stale or quota-dead native secret keeps failing even when a working fallback
+  is present. Delete the native secret to fall through. Deleting `CODEX_AUTH` is also
+  how you pin a cheap model: the OpenRouter path forwards `-f model=openai/gpt-5-*`,
+  while native auth uses the harness's own (pricier) default.
+- **The scorer grades stdout, not `./notify`.** A run that routes its deliverable
+  into a channel and leaves a thin final message is under-graded even though the
+  work was real (observed on codex/`gpt-5-mini`, which narrated pessimistically in
+  stdout while its full slate went to notify). Keep the substance in the run's final
+  message.
+
+Fixes shipped during the sweep: harness unification through `run-harness` (#2),
+codex read-only inline notify (#4), keep-substance-in-stdout guidance (#5),
+kimi/vibe token estimate (#6), grok scorer fallback to `grok-4.5` (#7), and
+codex read-only under the wrapper sandbox so fetches work (#14 — its native
+`--sandbox read-only` was also blocking the network).
 
 ## Token accounting
 
-Grok's `--output-format json` returns the result text but no token counts, so
-grok-harness runs report **0 tokens** in cost tracking. The captured OAuth
-session can expire — if unattended runs start failing on auth, click **Connect X
-account** again in the dashboard.
+Every harness runs through `run-harness`, which normalizes usage into the
+Claude-Code `{input, output, cache_read, cache_creation}` shape. What each CLI
+exposes differs:
+
+- **claude, grok, codex, pi** report **real** usage. grok's adapter uses
+  `--output-format streaming-json`, whose terminal `{"type":"end"}` event carries
+  input/output/cache tokens + cost (`harness-adapter/adapters/grok.sh`) — the older
+  `scripts/run-grok.sh` plain-`json` path reported 0, but the unified adapter does
+  not.
+- **kimi and vibe** expose **no** usage field (kimi's `stream-json` and vibe's
+  `--output json` carry none — verified live), so their adapters fall back to a
+  transparent `char/4` **estimate** of the assembled input + result rather than a
+  misleading `0/0/0`; real counts always win if a future build emits them.
+
+The captured OAuth sessions (grok's `GROK_CREDENTIALS`, codex's `CODEX_AUTH`) can
+expire — if unattended runs start failing on auth, re-capture via the dashboard
+(**Connect X account** / **Connect ChatGPT**) or switch to the API-key path.
 
 ## Capability mode carries over unchanged
 
@@ -61,13 +167,14 @@ verify: true       # append a self-verification loop before finishing    → --c
 effort: high       # low|medium|high|xhigh|max → --effort  (reasoning models only)
 ```
 
-`effort`/`reasoning_effort` map to the API's `reasoningEffort`, which the fast
-`grok-composer-2.5-fast` rejects — so they're applied only when a reasoning model
-(`grok-4.5`, grok's default, or `grok-build`) is selected and skipped-with-a-notice
-otherwise. `best_of_n`/`verify` build on grok's subagents (so the harness drops
-`--no-subagents` for those runs); `verify` can't combine with structured output.
-`run-grok.sh` also understands `GROK_JSON_SCHEMA` for `--json-schema` structured
-output (reliably honoured by reasoning models like `grok-4.5` / `grok-build`).
+`effort`/`reasoning_effort` map to the API's `reasoningEffort`, honoured by
+`grok-4.5` — a reasoning model, and the only model the X-account login exposes to
+the CLI (see [Verification status](#verification-status); other xAI model ids are
+api.x.ai strings the CLI rejects as "unknown model id"). `best_of_n`/`verify` build
+on grok's subagents (so the harness drops `--no-subagents` for those runs);
+`verify` can't combine with structured output. `run-grok.sh` also understands
+`GROK_JSON_SCHEMA` for `--json-schema` structured output (reliably honoured by
+`grok-4.5`).
 
 ## Every entry point runs on either harness
 

--- a/harness-adapter/.gitignore
+++ b/harness-adapter/.gitignore
@@ -1,0 +1,13 @@
+*.log
+.DS_Store
+*.tmp
+node_modules/
+
+# vendored aeon (pinned; fetched on demand by test/lib/aeon-vendor.sh)
+test/aeon/
+
+# local secrets for the container / act runs — NEVER commit
+.secrets
+*.secrets
+test/act/.secrets
+test/docker/.secrets

--- a/harness-adapter/LICENSE
+++ b/harness-adapter/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 aaronjmars
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/harness-adapter/README.md
+++ b/harness-adapter/README.md
@@ -1,0 +1,180 @@
+# harness-adapter — vendored subset
+
+**One Claude Code-shaped contract, six coding-agent harnesses.**
+
+This is a **vendored copy** inside `aeon-openrouter`, trimmed to exactly what the
+workflow runs: the `run-harness` dispatcher and the six adapters aeon can dispatch
+to — **claude, grok, codex, pi, vibe, kimi**. The full project — three more
+harnesses (`opencode`, `copilot`, `agy`), the live test suite, and the
+harness-by-harness research — lives upstream at
+[aaronjmars/harness-adapter](https://github.com/aaronjmars/harness-adapter). Fixes
+land there first and are re-vendored here.
+
+`run-harness` wraps each CLI behind one headless interface — Claude Code's: prompt
+on stdin, flags mirroring `claude -p`, one JSON envelope on stdout. Swap the first
+argument, keep everything else. `.github/workflows/aeon.yml` invokes it in the same
+slot as `scripts/run-grok.sh`, so everything downstream (scoring, token accounting,
+memory, notifications) is unchanged. The pattern generalizes
+[aeonfun/aeon](https://github.com/aeonfun/aeon)'s `run-grok.sh`, which proved it for
+one harness.
+
+```sh
+echo "Summarize the TODOs in this repo" | ./run-harness codex --mode read-only
+echo "Draft release notes"              | ./run-harness grok  --max-turns 20
+echo "Reply with OK"                    | ./run-harness kimi  --mode read-only
+```
+
+## The contract
+
+```
+stdin   the prompt
+stdout  { "result": "<text>",
+          "usage": { "input_tokens": N, "output_tokens": N,
+                     "cache_read_input_tokens": N, "cache_creation_input_tokens": N },
+          "session_id": "<optional>", "total_cost_usd": <optional> }
+stderr  diagnostics only
+exit    0 ok · 3 abnormal model stop with no output · 124 timeout · other = error
+```
+
+An abnormal stop (grok `stopReason=Cancelled`, codex `turn.failed`, …) with no
+output **fails the run** — partial or empty results are never emitted as success.
+
+## The six harnesses
+
+| | claude | grok | codex | pi | vibe | kimi |
+|---|---|---|---|---|---|---|
+| Round-trip envelope | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Token usage | ✅ + cost | ✅ + cost¹ | ✅ | ✅ + cost | 0² | 0² |
+| Read-only enforcement | ✅ sandbox | ✅ sandbox³ | ✅ native | ✅ sandbox | ✅ sandbox⁴ | ✅ sandbox⁴ |
+| Structured output | native | native | native | shim⁵ | shim⁵ | shim⁵ |
+| MCP tool call (live) | ✅ | ✅ | ⚠️ wired, headless-denied⁶ | n/a — warn+skip | ✅ | ✅ |
+| Native provider auth | Claude Pro/Max OAuth | X account · `XAI_API_KEY` | ChatGPT OAuth · `OPENAI_API_KEY` | provider env key | Mistral key | Moonshot OAuth · key |
+
+All six round-trip the contract on real CLIs (claude ≥2.1, grok 0.2.101,
+codex-cli 0.144.6, pi 0.80.9, vibe 2.20.0, kimi 0.28.0). aeon reaches claude and
+grok through its own native paths (the AI gateway / `run-grok.sh`); codex, pi, vibe
+and kimi run only through this adapter.
+
+¹ grok reports usage **only** on `--output-format streaming-json`, whose terminal
+`{"type":"end"}` event carries usage, `total_cost_usd` and `sessionId`; the adapter
+builds `.result` from `type=="text"` chunks only — never the interleaved
+`type=="thought"` chain-of-thought.
+² vibe and kimi expose no token counts in their `-p`/json modes → usage normalizes
+to 0 (vibe meters cost server-side; kimi's stream carries none).
+³ grok's own `--sandbox read-only` is a silent no-op on 0.2.101 (writes still land),
+so grok is write-locked by the dispatcher's wrapper sandbox instead.
+⁴ vibe and kimi `-p` modes have no permission-layer gate of their own; read-only
+holds entirely via the dispatcher's OS sandbox (`sandbox-exec` on macOS, `bwrap` on
+Linux) mounting the workspace read-only.
+⁵ prompt-shim (`lib/schema-retry.sh`): the schema is appended to the prompt, the
+result validated, and one corrective retry runs. No native `--json-schema` flag
+exists on these.
+⁶ codex registers the MCP server and the model *does* invoke the tool, but
+`approval_policy="never"` resolves each call's approval as `Cancel` under
+`codex exec` (stdin closed → EOF → decline), so the tool never runs headlessly
+([openai/codex#24135](https://github.com/openai/codex/issues/24135)). The only
+override also drops codex's native sandbox, so MCP stays effectively unavailable on
+codex headlessly until upstream lands.
+
+## Flags
+
+| Flag | Notes |
+|---|---|
+| `--model <id>` | per-harness mapping; a wrong-family id (e.g. `claude-*` on codex) falls back to that harness's default |
+| `--allowed-tools "<list>"` | Claude's grammar (`Read,Bash(git:*),...`), translated per harness |
+| `--mode read-only\|write` | capability tier; derived from `--allowed-tools` if omitted (default `write`) |
+| `--mcp-config <.mcp.json>` | Claude-style config; `${VAR}`s expanded from env, translated per harness |
+| `--max-turns <n>` | native on claude/grok; codex/pi/vibe/kimi rely on `--timeout` |
+| `--json-schema '<schema>'` | native on claude/grok/codex; prompt+validate+one-retry on pi/vibe/kimi |
+| `--append-system-prompt <t>` | extra standing instructions |
+| `--timeout <s>` | wall-clock guard (default 600) |
+| `--no-sandbox` | skip the wrapper OS sandbox on read-only runs |
+| `--no-compat-rules` | skip the Claude-idiom preamble on non-claude harnesses |
+
+## How each layer is translated
+
+| Layer | claude | grok | codex | pi | vibe | kimi |
+|---|---|---|---|---|---|---|
+| Invoke | `claude -p -` | `grok -p --output-format streaming-json` | `codex exec --json -` | `pi -p --mode json` | `vibe -p --output json` | `kimi -p --output-format stream-json` |
+| Result | envelope passthrough | `type=="text"` chunks (never `thought`) | last `agent_message` | last assistant `message_end` | last assistant `content` (never `reasoning_content`) | last assistant `content` |
+| Usage | native + cost | streaming `end` event → cost | sum of `turn.completed.usage` | per-message usage + cost | none → 0 | none → 0 |
+| Read-only | `--allowedTools` + wrapper sandbox | `bypassPermissions` + wrapper sandbox | `--sandbox read-only` (native) | `--tools` subset + wrapper sandbox | wrapper sandbox only | wrapper sandbox only |
+| MCP | `--mcp-config` | native `.mcp.json` + `MCPTool(...)` allows | `-c mcp_servers.*` (auto-denied headless⁶) | unsupported by design → warn+skip | `config.toml [[mcp_servers]]` in temp `VIBE_HOME` | `{mcpServers}` in temp `KIMI_CODE_HOME` |
+| CLAUDE.md | native + `@imports` | native (no imports) | via `project_doc_fallback_filenames` | native | native | native |
+
+### Design notes
+
+**Read-only enforcement is hoisted into the dispatcher.** Only codex has a native
+kernel sandbox that actually holds; every other harness — claude, grok, pi, vibe,
+kimi — runs read-only under `sandbox-exec` (macOS) or `bwrap` (Linux) with the
+workspace mounted read-only, so `--mode read-only` means the same thing on all six:
+*the repo physically cannot be mutated*, regardless of the model or its permission
+config. (vibe and kimi lean on this entirely — their `-p` modes have no
+permission-layer gate of their own.)
+
+**Denied-tool semantics** are normalized to *deny-and-continue*: claude and codex
+already behave that way headlessly; grok would abort the whole turn on a denied
+tool, so its adapter runs `bypassPermissions` + OS sandbox; pi never denies.
+
+**`@imports` are Claude-only.** The dispatcher detects them in `CLAUDE.md` and
+pre-expands a merged copy (`lib/imports.sh`); the leaner long-term pattern is
+carrying just the delta in `AGENTS.md`, which every other harness reads.
+
+## Field notes from live testing
+
+- **Codex strict-mode schemas** — OpenAI's response_format 400s on any object
+  schema missing `additionalProperties: false`. Claude-style schemas don't carry
+  it; the codex adapter patches schemas recursively, so one `--json-schema` string
+  works identically everywhere.
+- **grok's `--sandbox read-only` is a silent no-op** (0.2.101): a read-only run
+  ordered to write a file created it anyway. grok is now write-locked by the wrapper
+  sandbox like the others, and a `read-only holds` live test guards it.
+- **Read-only really holds**: codex answered *"this workspace is read-only"*; pi
+  lost write/edit/bash to `--tools` subsetting; vibe/kimi are held by the wrapper
+  sandbox — no stray files, on any harness.
+- **Codex MCP tools are wired but auto-denied headlessly** (footnote ⁶) — an open
+  upstream limitation; claude/grok call live MCP tools cleanly, vibe/kimi via their
+  temp-home configs, pi warns-and-skips by design.
+- **Pi's minimalism is measurable**: the same one-line prompt consumed ~2.4k input
+  tokens on pi vs ~12k on codex — its sub-1k system prompt holds up.
+
+## Installing the harnesses
+
+Only the harnesses you actually dispatch need to be installed.
+
+| Harness | Install | Auth |
+|---|---|---|
+| Claude Code | `npm i -g @anthropic-ai/claude-code` | `claude login` (Pro/Max or API key) |
+| Grok Build | `npm i -g @xai-official/grok@0.2.101` | `grok login` (SuperGrok / X Premium+) or `XAI_API_KEY` |
+| Codex CLI | `brew install codex` or `npm i -g @openai/codex@0.144.6` | `codex login` (any ChatGPT plan) or `OPENAI_API_KEY` |
+| Pi | `npm i -g --ignore-scripts @earendil-works/pi-coding-agent` | provider env keys or `/login` OAuth in the TUI |
+| Mistral Vibe | Vibe installer → `~/.local/bin/vibe` | `vibe --setup` (Mistral API key) |
+| Kimi Code | `brew install kimi-code` | `kimi login` (Moonshot) or a provider in `~/.config/kimi` |
+
+For aeon, these installs + auth are automated by `aeon.yml`'s *Install harness CLI*
+step and the native-auth secrets (`CODEX_AUTH`, `KIMI_AUTH`, `MISTRAL_API_KEY`,
+`OPENROUTER_API_KEY`, …). See [docs/aeon-integration.md](docs/aeon-integration.md).
+
+## Layout
+
+```
+run-harness            dispatcher: args → RH_* env → sandbox/timeout → adapter → validate
+adapters/<h>.sh        one per harness: invoke, translate, normalize (claude grok codex pi vibe kimi)
+lib/envelope.sh        emit/validate the contract envelope
+lib/tools-grammar.sh   --allowedTools → per-harness permissions
+lib/mcp-translate.sh   .mcp.json → codex -c flags / vibe TOML / kimi home; ${VAR} expansion
+lib/imports.sh         CLAUDE.md @import pre-expansion
+lib/schema-retry.sh    structured output for harnesses without --json-schema (pi/vibe/kimi)
+lib/sandbox.sh         wrapper OS sandbox (workspace read-only)
+lib/compat-rules.md    Claude-idiom translation preamble
+docs/aeon-integration.md  deployment runbook: wiring the swap into a live aeon
+```
+
+## Credits
+
+The normalize-to-Claude's-envelope pattern, the grok permission stance, and the
+thought-firewall come from [aeonfun/aeon](https://github.com/aeonfun/aeon)'s
+`run-grok.sh`. The full nine-harness research, sources, and live test suite are in
+the upstream [aaronjmars/harness-adapter](https://github.com/aaronjmars/harness-adapter).
+
+MIT — see [LICENSE](LICENSE).

--- a/harness-adapter/adapters/claude.sh
+++ b/harness-adapter/adapters/claude.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# claude adapter — the identity adapter. Claude Code already speaks the contract;
+# this just maps RH_* env to flags and folds structured output into .result.
+set -uo pipefail
+. "$RH_LIB/envelope.sh"
+
+command -v claude >/dev/null 2>&1 || {
+  echo "claude CLI not found (npm i -g @anthropic-ai/claude-code)" >&2; exit 1; }
+
+ARGS=(-p - --output-format json)
+[ -n "${RH_MODEL:-}" ] && ARGS+=(--model "$RH_MODEL")
+[ -n "${RH_ALLOWED_TOOLS:-}" ] && ARGS+=(--allowedTools "$RH_ALLOWED_TOOLS")
+if [ -n "${RH_MCP_CONFIG:-}" ] && [ -f "${RH_MCP_CONFIG:-}" ]; then
+  ARGS+=(--mcp-config "$RH_MCP_CONFIG" --strict-mcp-config)
+fi
+[ -n "${RH_MAX_TURNS:-}" ] && ARGS+=(--max-turns "$RH_MAX_TURNS")
+[ -n "${RH_JSON_SCHEMA:-}" ] && ARGS+=(--json-schema "$RH_JSON_SCHEMA")
+[ -n "${RH_APPEND_SYSTEM_PROMPT:-}" ] && ARGS+=(--append-system-prompt "$RH_APPEND_SYSTEM_PROMPT")
+
+OUT="$RH_TMPDIR/claude-out.json"
+claude "${ARGS[@]}" < "$RH_PROMPT_FILE" > "$OUT"
+rc=$?
+if [ $rc -ne 0 ]; then
+  echo "claude exited $rc: $(tail -c 300 "$OUT" | tr '\n' ' ')" >&2
+  exit $rc
+fi
+
+# With --json-schema Claude puts the object in .structured_output and may leave
+# .result empty; the contract says .result carries the payload — normalize that.
+if jq -e 'type == "object"' "$OUT" >/dev/null 2>&1; then
+  jq -c '
+    if (.structured_output // null) != null and ((.result // "") == "")
+    then .result = (.structured_output | tojson)
+    else . end' "$OUT"
+else
+  echo "warning: claude output was not a JSON object — wrapping raw stdout" >&2
+  wrap_raw_output < "$OUT"
+fi

--- a/harness-adapter/adapters/codex.sh
+++ b/harness-adapter/adapters/codex.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# codex adapter — OpenAI Codex CLI behind the Claude Code contract.
+#
+# Codex quirks this adapter absorbs:
+#   * `codex exec --json` emits a JSONL EVENT STREAM, not a final result object
+#     -> result comes from --output-last-message (belt) or the last
+#        item.completed agent_message (braces); usage is SUMMED over every
+#        turn.completed event (field names: input_tokens, cached_input_tokens,
+#        output_tokens). No dollar-cost field exists.
+#   * approval-needed actions are silently auto-denied headlessly (deny-and-
+#     continue, like Claude) -> approval_policy=never, sandbox picked by mode.
+#   * workspace-write blocks network by default -> we enable it (skills fetch).
+#   * no project .mcp.json support -> translated to -c mcp_servers.* overrides.
+#   * CLAUDE.md ignored by default -> added as an AGENTS.md fallback filename.
+#   * no --max-turns -> the dispatcher's wall-clock timeout is the runaway guard.
+set -uo pipefail
+. "$RH_LIB/envelope.sh"
+. "$RH_LIB/mcp-translate.sh"
+
+command -v codex >/dev/null 2>&1 || {
+  echo "codex CLI not found (npm i -g @openai/codex)" >&2; exit 1; }
+
+ARGS=(exec --json --skip-git-repo-check --ephemeral)
+
+# model: only pass ids codex can serve; a claude-*/grok-* leftover -> codex default
+case "${RH_MODEL:-}" in
+  "" | default | claude-* | grok-*) ;;
+  *) ARGS+=(--model "$RH_MODEL") ;;
+esac
+
+# Sandbox. codex is the only harness with a native kernel sandbox, but its
+# `--sandbox read-only` ALSO blocks the network: network_access lives under
+# [sandbox_workspace_write] and applies to that mode only (`codex --help`: sandbox
+# modes are read-only | workspace-write | danger-full-access), so there is no
+# codex-native "FS-read-only + network" mode. aeon's read-only skills are
+# overwhelmingly research skills that must fetch, so a network-less read-only mode
+# cannot do the job it is for. (Measured on real runners 2026-07-22:
+# gpt-5.1-codex-mini under `--sandbox read-only` hit `curl: (6) Could not resolve
+# host: github.com` on every attempt including proxies; an earlier gpt-5-mini run
+# that appeared to fetch had FABRICATED the result — the page is server-rendered.)
+#
+#   * read-only: run-harness wraps us in its bwrap/sandbox-exec OS sandbox, which
+#     binds the workspace read-only but leaves the NETWORK OPEN (lib/sandbox.sh).
+#     We turn codex's OWN sandbox OFF (danger-full-access) so the two don't nest —
+#     an earlier attempt left codex's landlock ON inside bwrap and the two fought,
+#     breaking codex's file access (it couldn't read its own SKILL.md). With the
+#     self-sandbox off, that wrapper is the SOLE read-only enforcer, exactly how
+#     pi/vibe/kimi run. (If a codex build rejects danger-full-access +
+#     approval_policy=never together, swap in the single flag
+#     --dangerously-bypass-approvals-and-sandbox, which drops both at once.)
+#   * write: NOT bwrap-wrapped, so codex sandboxes itself. workspace-write blocks
+#     network by default -> enable it (skills fetch).
+if [ "${RH_MODE:-write}" = "read-only" ]; then
+  ARGS+=(--sandbox danger-full-access)
+else
+  ARGS+=(--sandbox workspace-write -c 'sandbox_workspace_write.network_access=true')
+fi
+ARGS+=(-c 'approval_policy="never"')
+ARGS+=(-c 'project_doc_fallback_filenames=["CLAUDE.md"]')
+
+# MCP translation (codex reads only its own config; see openai/codex#13056).
+# CAVEAT (codex 0.144.5): this wires the server correctly — codex spawns it,
+# completes the `initialize` handshake, and exposes mcp__<srv>__<tool> — but each
+# MCP tool call raises an approval elicitation that, in `codex exec` (stdin
+# closed), reads EOF and resolves as *cancel*, so the tool never runs headlessly.
+# This is upstream openai/codex#24135 (OPEN): no config key suppresses it
+# (approval_policy / default_tools_approval_mode / tools_require_approval /
+# mcp_approval_policy / trusted_mcp_servers / trust_level all confirmed
+# ineffective there). The only override, --dangerously-bypass-approvals-and-
+# sandbox, also drops the sandbox. Revisit when #24135 lands.
+MCP_ARGS=()
+if [ -n "${RH_MCP_CONFIG:-}" ] && [ -f "${RH_MCP_CONFIG:-}" ]; then
+  while IFS= read -r tok; do MCP_ARGS+=("$tok"); done < <(mcp_to_codex_flags "$RH_MCP_CONFIG")
+fi
+
+# structured output (native) — OpenAI's response_format runs in STRICT mode and
+# 400s unless every object schema carries additionalProperties:false (verified
+# live against codex 0.144.5). Claude-style schemas don't carry it; patch it in
+# recursively. (Strict mode also wants all properties required — not auto-patched
+# since that changes semantics; the API error is explicit if a schema hits it.)
+if [ -n "${RH_JSON_SCHEMA:-}" ]; then
+  jq -c 'walk(if type == "object" and (.type? == "object")
+                 and (has("additionalProperties") | not)
+              then . + {additionalProperties: false} else . end)' \
+    <<<"$RH_JSON_SCHEMA" > "$RH_TMPDIR/schema.json" || {
+      echo "invalid --json-schema (not valid JSON)" >&2; exit 2; }
+  ARGS+=(--output-schema "$RH_TMPDIR/schema.json")
+fi
+
+[ -n "${RH_MAX_TURNS:-}" ] && \
+  echo "notice: codex has no --max-turns; the dispatcher wall-clock timeout is the guard" >&2
+
+LAST_MSG="$RH_TMPDIR/codex-last-message.txt"
+ARGS+=(--output-last-message "$LAST_MSG")
+
+# Compat preamble + operator append go into the PROMPT: codex's instruction-file
+# knob (model_instructions_file) REPLACES its built-in instructions — too blunt.
+PROMPT="$(cat "$RH_PROMPT_FILE")"
+[ -n "${RH_APPEND_SYSTEM_PROMPT:-}" ] && PROMPT="${RH_APPEND_SYSTEM_PROMPT}
+
+${PROMPT}"
+[ -n "${RH_COMPAT_RULES:-}" ] && PROMPT="${RH_COMPAT_RULES}
+
+${PROMPT}"
+
+EVENTS="$RH_TMPDIR/codex-events.jsonl"
+printf '%s' "$PROMPT" | codex "${ARGS[@]}" ${MCP_ARGS[@]+"${MCP_ARGS[@]}"} - > "$EVENTS"
+rc=$?
+if [ $rc -ne 0 ]; then
+  echo "codex exited $rc: $(tail -c 300 "$EVENTS" | tr '\n' ' ')" >&2
+  exit $rc
+fi
+
+# sanitize the stream (drop any non-JSON lines defensively), then normalize
+CLEAN="$RH_TMPDIR/codex-events.clean.jsonl"
+jq -cR 'fromjson? // empty' "$EVENTS" > "$CLEAN"
+
+RESULT=""
+[ -s "$LAST_MSG" ] && RESULT="$(cat "$LAST_MSG")"
+if [ -z "$RESULT" ]; then
+  RESULT=$(jq -rs '
+    [.[] | select(.type == "item.completed") | (.item // {})
+         | select(.type == "agent_message") | (.text // "")]
+    | last // ""' "$CLEAN")
+fi
+
+FAILED=$(jq -s '[.[] | select(.type == "turn.failed" or .type == "error")] | length' "$CLEAN")
+if [ "${FAILED:-0}" -gt 0 ] && [ -z "$RESULT" ]; then
+  echo "codex run failed ($FAILED turn.failed/error event(s)) with no output" >&2
+  exit 3
+fi
+[ "${FAILED:-0}" -gt 0 ] && echo "warning: codex reported $FAILED failed-turn/error event(s) — retaining output" >&2
+
+# usage: sum across turns; map cached_input_tokens -> cache_read (codex has no
+# cache_creation concept and no cost field)
+read -r TIN TOUT TCR <<<"$(jq -rs '
+  [.[] | select(.type == "turn.completed") | (.usage // {})] |
+  [ ([.[].input_tokens // 0] | add // 0),
+    ([.[].output_tokens // 0] | add // 0),
+    ([.[].cached_input_tokens // 0] | add // 0) ] | @tsv' "$CLEAN")"
+SID=$(jq -rs '[.[] | select(.type == "thread.started") | (.thread_id // empty)] | first // ""' "$CLEAN")
+
+emit_envelope "$RESULT" "${TIN:-0}" "${TOUT:-0}" "${TCR:-0}" 0 "" "$SID"

--- a/harness-adapter/adapters/grok.sh
+++ b/harness-adapter/adapters/grok.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# grok adapter — Grok Build (@xai-official/grok) behind the Claude Code contract.
+# Distilled from aeonfun/aeon scripts/run-grok.sh, which established this pattern.
+#
+# Key behaviors carried over (verified there against grok 0.2.101):
+#   * headless grok ABORTS the whole turn on a denied tool (stopReason=Cancelled)
+#     instead of degrading -> we run --permission-mode bypassPermissions and use
+#     the OS-level --sandbox read-only profile as the real read-only guard.
+#     NEVER add --deny rules here.
+#   * multi-agent models delegate to subagent tools that would get denied ->
+#     --no-subagents by default.
+#   * OUTPUT FORMAT: we ask for `streaming-json`, NOT `json`. Both are headless,
+#     but only streaming-json's terminal `{"type":"end"}` event carries usage
+#     (input/output/cache_read/reasoning tokens), total_cost_usd, sessionId AND
+#     structuredOutput. The plain `json` envelope has no usage field at all —
+#     which is why grok counts used to normalize to 0. Verified on 0.2.101.
+#   * .thought (chain-of-thought) must NEVER leak into .result. streaming-json
+#     interleaves {"type":"thought"} chunks with {"type":"text"} chunks, so the
+#     firewall here is structural: .result is built ONLY from type=="text".
+set -uo pipefail
+. "$RH_LIB/envelope.sh"
+
+command -v grok >/dev/null 2>&1 || {
+  echo "grok CLI not found (npm i -g @xai-official/grok)" >&2; exit 1; }
+
+# auth: an existing `grok login` session or an xAI API key
+if [ ! -f "$HOME/.grok/auth.json" ] && [ -z "${XAI_API_KEY:-}" ]; then
+  echo "grok needs auth: run 'grok login' or set XAI_API_KEY" >&2; exit 1
+fi
+
+ARGS=(--output-format streaming-json --no-auto-update --permission-mode bypassPermissions)
+
+# model: only pass real grok ids; anything else -> grok's own default
+case "${RH_MODEL:-}" in
+  "" | default | claude-* | gpt-* | o[0-9]*) ;;
+  *) ARGS+=(--model "$RH_MODEL") ;;
+esac
+
+# read-only is enforced by the dispatcher's wrapper OS sandbox (lib/sandbox.sh),
+# NOT grok's own --sandbox: on grok 0.2.101 `--sandbox read-only` is silently
+# ignored (writes still land) AND it nest-conflicts with sandbox-exec/bwrap.
+# --- run-shaping knobs (max-turns / effort / best-of-n / self-check) ---------
+# Ported from scripts/run-grok.sh §3c so the unified `run-harness grok` path
+# keeps aeon's per-skill grok features. aeon.yml maps a skill's frontmatter
+# (effort/reasoning_effort/max_turns/best_of_n/verify) to these GROK_* env vars
+# and exports them before calling run-harness. Two hard constraints from that
+# script are preserved (verified against grok 0.2.101):
+#   * --effort/--reasoning-effort hit the API's reasoningEffort, which composer
+#     400s on — gate them on a reasoning model, skip-with-warning otherwise.
+#   * grok's parser refuses --no-subagents alongside --best-of-n/--check (both
+#     are built ON subagents) — so those opt OUT of --no-subagents.
+MODEL_IS_REASONING=0
+case "${RH_MODEL:-}" in
+  "" | default | claude-* | *composer*) ;;   # composer / unknown / empty → NOT reasoning (400-safe)
+  grok-*) MODEL_IS_REASONING=1 ;;
+esac
+
+# --max-turns: GROK_MAX_TURNS (frontmatter) wins, else run-harness --max-turns,
+# else grok's runaway-guard default of 60. 0/off = uncapped.
+_max_turns="${GROK_MAX_TURNS:-${RH_MAX_TURNS:-60}}"
+case "$_max_turns" in
+  0 | off | none | "") ;;
+  *[!0-9]*) echo "warning: ignoring non-integer max-turns '$_max_turns'" >&2 ;;
+  *) ARGS+=(--max-turns "$_max_turns") ;;
+esac
+
+# --effort / --reasoning-effort: low|medium|high|xhigh|max — reasoning models only.
+add_effort() {
+  local name="$1" flag="$2" val="$3"
+  case "$val" in
+    "") return 0 ;;
+    low | medium | high | xhigh | max) ;;
+    *) echo "warning: ignoring invalid $name (want low|medium|high|xhigh|max): '$val'" >&2; return 0 ;;
+  esac
+  if [ "$MODEL_IS_REASONING" = 1 ]; then
+    ARGS+=("$flag" "$val")
+  else
+    echo "notice: ignoring $flag $val — model '${RH_MODEL:-<grok default>}' has no reasoning effort" >&2
+  fi
+}
+add_effort GROK_EFFORT --effort "${GROK_EFFORT:-}"
+add_effort GROK_REASONING_EFFORT --reasoning-effort "${GROK_REASONING_EFFORT:-}"
+
+# --best-of-n (N>=2) and --check are built ON subagents, so they flip the
+# subagent switch on (grok won't combine either with --no-subagents).
+GROK_WANTS_SUBAGENTS=0
+case "${GROK_BEST_OF_N:-}" in
+  "" | 0 | 1) ;;
+  *[!0-9]*) echo "warning: ignoring non-integer GROK_BEST_OF_N='${GROK_BEST_OF_N}'" >&2 ;;
+  *) ARGS+=(--best-of-n "$GROK_BEST_OF_N"); GROK_WANTS_SUBAGENTS=1 ;;
+esac
+case "${GROK_CHECK:-}" in
+  1 | true | yes | on)
+    if [ -n "${RH_JSON_SCHEMA:-}" ]; then
+      echo "warning: ignoring --check: grok can't combine it with --json-schema (structured output wins)" >&2
+    else
+      ARGS+=(--check); GROK_WANTS_SUBAGENTS=1
+    fi ;;
+esac
+
+# --no-subagents by default: a headless skill run is one focused agent; the
+# multi-agent models otherwise delegate to a Task/spawn tool that isn't
+# allowlisted, and the denial aborts the whole turn (stopReason=Cancelled).
+# Skip it only when best-of-n/check explicitly asked for subagents above.
+[ "$GROK_WANTS_SUBAGENTS" = 0 ] && ARGS+=(--no-subagents)
+
+# structured output: reliably honoured by reasoning models (grok-4.5/grok-build);
+# composer leaves .structuredOutput null and just emits JSON text — both handled below.
+[ -n "${RH_JSON_SCHEMA:-}" ] && ARGS+=(--json-schema "$RH_JSON_SCHEMA")
+
+# compat preamble + operator append ride grok's --rules (appended to system prompt)
+RULES="${RH_COMPAT_RULES:-}"
+if [ -n "${RH_APPEND_SYSTEM_PROMPT:-}" ]; then
+  RULES="${RULES:+$RULES
+}${RH_APPEND_SYSTEM_PROMPT}"
+fi
+[ -n "$RULES" ] && ARGS+=(--rules "$RULES")
+
+# MCP: grok discovers the project .mcp.json natively (cwd->git-root walk) and
+# expands ${VAR} from the env itself — we only grant permission to call the tools.
+if [ -n "${RH_MCP_CONFIG:-}" ] && [ -f "${RH_MCP_CONFIG:-}" ]; then
+  for srv in $(jq -r '.mcpServers // {} | keys[]' "$RH_MCP_CONFIG"); do
+    ARGS+=(--allow "MCPTool(${srv}__*)")
+  done
+fi
+
+OUT="$RH_TMPDIR/grok-out.jsonl"
+grok -p "$(cat "$RH_PROMPT_FILE")" "${ARGS[@]}" > "$OUT"
+rc=$?
+if [ $rc -ne 0 ]; then
+  echo "grok exited $rc: $(tail -c 300 "$OUT" | tr '\n' ' ')" >&2
+  exit $rc
+fi
+
+# keep only well-formed JSON lines (a stray banner/warning must not sink parsing)
+CLEAN="$RH_TMPDIR/grok-events.clean.jsonl"
+jq -cR 'fromjson? // empty' "$OUT" > "$CLEAN"
+
+if [ -s "$CLEAN" ]; then
+  # THE FIREWALL: .result is assembled ONLY from type=="text" chunks. The
+  # type=="thought" chunks are chain-of-thought and are never read here — that is
+  # how .thought leaked historically in aeon's run history.
+  TEXT=$(jq -rs '[.[] | select(.type == "text") | (.data // "")] | join("")' "$CLEAN")
+  # the terminal event carries stop/usage/cost/session/structuredOutput
+  END=$(jq -cs '[.[] | select(.type == "end")] | last // {}' "$CLEAN")
+
+  STRUCT=$(jq -c '.structuredOutput // null' <<<"$END")
+  if [ "$STRUCT" != "null" ]; then RESULT_TEXT="$STRUCT"; else RESULT_TEXT="$TEXT"; fi
+
+  STOP=$(jq -r '.stopReason // .stop_reason // ""'          <<<"$END")
+  SID=$(jq  -r '.sessionId // .session_id // ""'            <<<"$END")
+  COST=$(jq -r '.total_cost_usd // empty'                   <<<"$END")
+  TIN=$(jq  -r '.usage.input_tokens // 0'                   <<<"$END")
+  TOUT=$(jq -r '.usage.output_tokens // 0'                  <<<"$END")
+  TCR=$(jq  -r '.usage.cache_read_input_tokens // 0'        <<<"$END")
+  TCC=$(jq  -r '.usage.cache_creation_input_tokens // 0'    <<<"$END")
+
+  # grok exits 0 even on a Cancelled/aborted run — that is a FAILED run, not an
+  # empty-but-successful one. A clean EndTurn with empty text passes through.
+  case "$STOP" in
+    Cancelled|cancelled|Aborted|aborted|Interrupted|interrupted|Error|error|Failed|failed|Refusal|refusal)
+      if [ -z "$RESULT_TEXT" ]; then
+        echo "grok terminated abnormally (stopReason=$STOP) with no output" >&2
+        exit 3
+      fi
+      echo "warning: grok stopReason=$STOP — retaining partial output" >&2
+      ;;
+  esac
+  emit_envelope "$RESULT_TEXT" "$TIN" "$TOUT" "$TCR" "$TCC" "$COST" "$SID"
+else
+  echo "warning: grok emitted no parseable JSON events — wrapping raw stdout" >&2
+  wrap_raw_output < "$OUT"
+fi

--- a/harness-adapter/adapters/kimi.sh
+++ b/harness-adapter/adapters/kimi.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# kimi adapter — Kimi Code (kimi) behind the Claude Code contract.
+#
+# kimi quirks this adapter absorbs:
+#   * `kimi -p <text> --output-format stream-json` emits a JSONL stream of
+#     {role,content} messages + a trailing {role:"meta"} resume hint -> .result
+#     is the last assistant message's content.
+#   * stream-json exposes no token usage -> counts normalize to 0.
+#   * model is an alias resolved from config.toml providers; default here is a
+#     small OpenRouter model (or-nano). --model / -m passes through.
+#   * NO native FS sandbox and read-only is SANDBOX-ONLY (its -p mode executes
+#     tools with no permission-layer gate) -> read-only relies entirely on the
+#     dispatcher's wrapper OS sandbox.
+#   * -p (one-shot) mode refuses -y/--yolo and --auto ("Cannot combine --prompt
+#     with …") — it drives permissions itself, so no approval flag is passed.
+#   * no --json-schema flag -> prompt-with-schema + validate + one retry.
+#   * MCP: kimi's mcp.json is the SAME {mcpServers:...} shape as ours; injected
+#     via a temp KIMI_CODE_HOME so nothing touches the user's config or workspace.
+set -uo pipefail
+. "$RH_LIB/envelope.sh"
+. "$RH_LIB/schema-retry.sh"
+
+command -v kimi >/dev/null 2>&1 || { echo "kimi CLI not found" >&2; exit 1; }
+
+ARGS=(--output-format stream-json)
+[ -n "${RH_MODEL:-}" ] && [ "${RH_MODEL}" != "default" ] && ARGS+=(--model "$RH_MODEL")
+
+# kimi has no --append-system-prompt -> prepend compat preamble + operator append
+BASE="$(cat "$RH_PROMPT_FILE")"
+[ -n "${RH_APPEND_SYSTEM_PROMPT:-}" ] && BASE="${RH_APPEND_SYSTEM_PROMPT}
+
+${BASE}"
+[ -n "${RH_COMPAT_RULES:-}" ] && BASE="${RH_COMPAT_RULES}
+
+${BASE}"
+
+# MCP: same {mcpServers:...} format as ours -> drop it in a temp KIMI_CODE_HOME
+# (top-level config copied over to preserve the provider/auth config).
+if [ -n "${RH_MCP_CONFIG:-}" ] && [ -f "${RH_MCP_CONFIG:-}" ]; then
+  KH="$RH_TMPDIR/kimi-home"; mkdir -p "$KH"
+  SRC="${KIMI_CODE_HOME:-$HOME/.kimi-code}"
+  [ -d "$SRC" ] && find "$SRC" -maxdepth 1 -type f -exec cp {} "$KH/" \; 2>/dev/null
+  cp "$RH_MCP_CONFIG" "$KH/mcp.json"
+  export KIMI_CODE_HOME="$KH"
+fi
+[ -n "${RH_MAX_TURNS:-}" ] && \
+  echo "notice: kimi has no --max-turns; the dispatcher wall-clock timeout is the guard" >&2
+
+run_once() {  # run_once PROMPT -> sets RESULT/SID; returns kimi's rc
+  local events="$RH_TMPDIR/kimi-events.jsonl" clean="$RH_TMPDIR/kimi-events.clean.jsonl"
+  kimi -p "$1" "${ARGS[@]}" > "$events" 2>"$RH_TMPDIR/kimi.err"
+  local rc=$?
+  jq -cR 'fromjson? // empty' "$events" > "$clean"
+  RESULT=$(jq -rs '
+    [.[] | select((.role // "") == "assistant")
+         | (.content
+            | if type == "string" then .
+              elif type == "array" then (map(.text // "") | join(""))
+              else "" end)]
+    | map(select(. != "")) | last // ""' "$clean")
+  SID=$(jq -rs '[.[] | (.session_id // empty)] | first // ""' "$clean")
+  return $rc
+}
+
+# structured output: no native flag -> prompt-with-schema + validate + one retry
+PROMPT="$BASE"
+[ -n "${RH_JSON_SCHEMA:-}" ] && PROMPT="${PROMPT}$(schema_prompt_suffix "$RH_JSON_SCHEMA")"
+
+run_once "$PROMPT"
+rc=$?
+if [ $rc -ne 0 ] && [ -z "$RESULT" ]; then
+  echo "kimi exited $rc: $(tail -c 300 "$RH_TMPDIR/kimi.err" | tr '\n' ' ')" >&2
+  exit $rc
+fi
+if [ -z "$RESULT" ]; then
+  echo "kimi produced no assistant message" >&2
+  exit 3
+fi
+
+if [ -n "${RH_JSON_SCHEMA:-}" ]; then
+  RESULT="$(schema_extract_json "$RESULT")"
+  if ! schema_validate "$RH_JSON_SCHEMA" "$RESULT"; then
+    echo "structured output failed validation — retrying once" >&2
+    run_once "${PROMPT}$(schema_retry_suffix)" || true
+    RESULT="$(schema_extract_json "$RESULT")"
+    if ! schema_validate "$RH_JSON_SCHEMA" "$RESULT"; then
+      echo "structured output still invalid after retry" >&2
+      exit 3
+    fi
+  fi
+fi
+
+# TOKEN USAGE: kimi's stream-json carries NONE — verified against kimi-code on a
+# live run, the stream emits only assistant message(s) and a final
+# {role:"meta",type:"session.resume_hint"} event; no usage/token field appears
+# anywhere, and the CLI exposes no usage flag (--output-format is text|stream-json
+# only). There is also no OpenRouter generation-id to look up (only session_id is
+# surfaced). Rather than report a misleading 0/0/0, fall back to a transparent
+# char/4 ESTIMATE from the assembled input (BASE) and the result; a future kimi
+# build that DOES emit usage would be picked up by the scan below first.
+KIN=$(jq -rs '[.[] | (.usage.input_tokens // .usage.prompt_tokens // .input_tokens // empty)] | add // 0' "$RH_TMPDIR/kimi-events.clean.jsonl" 2>/dev/null || echo 0)
+KOUT=$(jq -rs '[.[] | (.usage.output_tokens // .usage.completion_tokens // .output_tokens // empty)] | add // 0' "$RH_TMPDIR/kimi-events.clean.jsonl" 2>/dev/null || echo 0)
+if [ "${KIN:-0}" = "0" ] && [ "${KOUT:-0}" = "0" ]; then
+  KIN=$(( ${#BASE} / 4 )); KOUT=$(( ${#RESULT} / 4 ))
+  echo "note: kimi exposes no token usage — reporting a char/4 estimate (in~$KIN out~$KOUT)" >&2
+fi
+emit_envelope "$RESULT" "$KIN" "$KOUT" 0 0 "" "$SID"

--- a/harness-adapter/adapters/pi.sh
+++ b/harness-adapter/adapters/pi.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# pi adapter — Pi (@earendil-works/pi-coding-agent) behind the Claude Code contract.
+#
+# Pi quirks this adapter absorbs:
+#   * `pi -p --mode json` emits a JSONL EVENT STREAM (session header, message_end,
+#     agent_end, ...) -> result is the last assistant message_end text.
+#   * usage (tokens + cache + usage.cost.total) rides on assistant messages —
+#     the only harness besides Claude with native dollar cost. Field names are
+#     probed defensively (input/input_tokens, cacheRead/cache_read, ...).
+#   * NO permission system by design ("YOLO mode") -> read-only maps to
+#     --exclude-tools write,edit; the dispatcher's wrapper OS sandbox is the real
+#     guard. pi has read/bash/edit/write and NO web tool, so bash is its only
+#     route to the network — never allow-list it away on read-only runs.
+#   * MCP is deliberately unsupported -> warn and skip (pi's answer: wrap MCP
+#     servers as CLI tools with READMEs, or add an extension).
+#   * reads AGENTS.md or CLAUDE.md natively (global -> parents -> cwd); Claude's
+#     @imports are NOT expanded (dispatcher pre-expands when needed).
+#   * no structured-output flag -> prompt-with-schema + validate + one retry.
+set -uo pipefail
+. "$RH_LIB/envelope.sh"
+. "$RH_LIB/tools-grammar.sh"
+. "$RH_LIB/schema-retry.sh"
+
+command -v pi >/dev/null 2>&1 || {
+  echo "pi CLI not found (npm i -g --ignore-scripts @earendil-works/pi-coding-agent)" >&2; exit 1; }
+
+ARGS=(--mode json --no-session --approve)
+
+# model: pi is multi-provider — pass anything through (its registry matches
+# patterns like "claude-sonnet-4-6", "openai/gpt-4o", or bare "sonnet")
+[ -n "${RH_MODEL:-}" ] && [ "${RH_MODEL}" != "default" ] && ARGS+=(--model "$RH_MODEL")
+
+# read-only -> tool subsetting (pi's only native lever; advisory without the
+# dispatcher's wrapper sandbox)
+# read-only DENIES mutation tools rather than allow-listing a filesystem subset:
+# an allowlist silently dropped `bash`, and with no web tool of its own that left
+# pi with no network at all. See tools_to_pi_exclude() for the measured failure.
+if [ -n "${RH_ALLOWED_TOOLS:-}" ]; then
+  PI_EXCLUDE=$(tools_to_pi_exclude "$RH_ALLOWED_TOOLS")
+  [ -n "$PI_EXCLUDE" ] && ARGS+=(--exclude-tools "$PI_EXCLUDE")
+elif [ "${RH_MODE:-write}" = "read-only" ]; then
+  ARGS+=(--exclude-tools "write,edit")
+fi
+
+# compat preamble + operator append -> one --append-system-prompt
+SYS="${RH_COMPAT_RULES:-}"
+if [ -n "${RH_APPEND_SYSTEM_PROMPT:-}" ]; then
+  SYS="${SYS:+$SYS
+}${RH_APPEND_SYSTEM_PROMPT}"
+fi
+[ -n "$SYS" ] && ARGS+=(--append-system-prompt "$SYS")
+
+if [ -n "${RH_MCP_CONFIG:-}" ] && [ -f "${RH_MCP_CONFIG:-}" ]; then
+  SRVS=$(jq -r '.mcpServers // {} | keys | join(", ")' "$RH_MCP_CONFIG")
+  [ -n "$SRVS" ] && echo "warning: pi does not support MCP by design — skipping server(s): $SRVS" >&2
+fi
+
+[ -n "${RH_MAX_TURNS:-}" ] && \
+  echo "notice: pi has no --max-turns; the dispatcher wall-clock timeout is the guard" >&2
+
+run_once() {
+  # run_once PROMPT -> sets TEXT/TIN/TOUT/TCR/TCC/COST/SID; returns pi's rc
+  local prompt="$1"
+  local events="$RH_TMPDIR/pi-events.jsonl"
+  local clean="$RH_TMPDIR/pi-events.clean.jsonl"
+  pi -p "${ARGS[@]}" "$prompt" > "$events"
+  local rc=$?
+  jq -cR 'fromjson? // empty' "$events" > "$clean"
+  TEXT=$(jq -rs '
+    [.[] | select(.type == "message_end") | (.message // {})
+         | select((.role // "") == "assistant")
+         | (.content
+            | if type == "string" then .
+              elif type == "array" then (map(.text // "") | join(""))
+              else tostring end)]
+    | last // ""' "$clean")
+  local usage
+  usage=$(jq -cs '
+    [.[] | select(.type == "message_end") | (.message // {})
+         | select((.role // "") == "assistant") | (.usage // {})]
+    | last // {}' "$clean")
+  TIN=$(jq -r '.input // .input_tokens // .inputTokens // 0' <<<"$usage")
+  TOUT=$(jq -r '.output // .output_tokens // .outputTokens // 0' <<<"$usage")
+  TCR=$(jq -r '.cacheRead // .cache_read // 0' <<<"$usage")
+  TCC=$(jq -r '.cacheWrite // .cache_write // 0' <<<"$usage")
+  COST=$(jq -r '.cost.total // empty' <<<"$usage")
+  SID=$(jq -rs '[.[] | select(.type == "session") | (.id // empty)] | first // ""' "$clean")
+  DONE=$(jq -s '[.[] | select(.type == "agent_end")] | length' "$clean")
+  return $rc
+}
+
+PROMPT="$(cat "$RH_PROMPT_FILE")"
+[ -n "${RH_JSON_SCHEMA:-}" ] && PROMPT="${PROMPT}$(schema_prompt_suffix "$RH_JSON_SCHEMA")"
+
+run_once "$PROMPT"
+rc=$?
+if [ $rc -ne 0 ] && [ -z "${TEXT:-}" ]; then
+  echo "pi exited $rc with no output" >&2
+  exit $rc
+fi
+if [ "${DONE:-0}" -eq 0 ] && [ -z "$TEXT" ]; then
+  echo "pi run ended without agent_end and produced no output" >&2
+  exit 3
+fi
+
+# structured output: validate; one corrective retry
+if [ -n "${RH_JSON_SCHEMA:-}" ]; then
+  TEXT="$(schema_extract_json "$TEXT")"
+  if ! schema_validate "$RH_JSON_SCHEMA" "$TEXT"; then
+    echo "structured output failed validation — retrying once" >&2
+    run_once "${PROMPT}$(schema_retry_suffix)" || true
+    TEXT="$(schema_extract_json "$TEXT")"
+    if ! schema_validate "$RH_JSON_SCHEMA" "$TEXT"; then
+      echo "structured output still invalid after retry" >&2
+      exit 3
+    fi
+  fi
+fi
+
+emit_envelope "$TEXT" "${TIN:-0}" "${TOUT:-0}" "${TCR:-0}" "${TCC:-0}" "${COST:-}" "${SID:-}"

--- a/harness-adapter/adapters/vibe.sh
+++ b/harness-adapter/adapters/vibe.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# vibe adapter — Mistral Vibe (vibe) behind the Claude Code contract.
+#
+# vibe quirks this adapter absorbs:
+#   * `vibe -p <text> --output json` prints a JSON ARRAY of all session messages
+#     at the end -> .result is the last assistant message's `content` (never its
+#     `reasoning_content`).
+#   * json mode exposes no token usage -> counts normalize to 0 (vibe meters cost
+#     internally for --max-price but does not emit it here).
+#   * native --max-turns is honored; reads repo AGENTS.md natively.
+#   * NO native FS sandbox -> read-only relies on the dispatcher's wrapper OS
+#     sandbox plus --disabled-tools write_file,edit. --auto-approve is passed in
+#     BOTH modes: it gates PROMPTING, not writing, so withholding it headless
+#     strands every tool call (reads and web included) rather than restricting
+#     anything.
+#   * no --json-schema flag -> prompt-with-schema + validate + one retry.
+#   * MCP: config.toml [[mcp_servers]]; injected via a temp VIBE_HOME so nothing
+#     touches the user's config or workspace.
+set -uo pipefail
+. "$RH_LIB/envelope.sh"
+. "$RH_LIB/schema-retry.sh"
+. "$RH_LIB/mcp-translate.sh"
+
+command -v vibe >/dev/null 2>&1 || { echo "vibe CLI not found" >&2; exit 1; }
+
+ARGS=(--output json)
+[ -n "${RH_MODEL:-}" ] && [ "${RH_MODEL}" != "default" ] && ARGS+=(--model "$RH_MODEL")
+# --auto-approve in BOTH modes. It means "approve all tool calls without
+# prompting" — withholding it headless does not restrict writes, it strands
+# EVERY tool call (read and web included) on a prompt nobody answers. Measured on
+# a real aeon runner: vibe ended github-trending with "network access is blocked
+# in this environment" and committed a FABRICATED slate of invented repos, which
+# the run reported as success. Mutation is blocked by the wrapper OS sandbox and
+# by dropping the two write tools below, not by withholding approval.
+ARGS+=(--auto-approve)
+# Tool names are snake_case of vibe's class names (vibe/core/tools/base.py:368):
+# WriteFile -> write_file, Edit -> edit. bash stays, so curl/network keep working;
+# a write attempted through it hits the sandbox.
+[ "${RH_MODE:-write}" = "read-only" ] && ARGS+=(--disabled-tools write_file --disabled-tools edit)
+[ -n "${RH_MAX_TURNS:-}" ] && ARGS+=(--max-turns "$RH_MAX_TURNS")
+
+# vibe has no --append-system-prompt -> prepend compat preamble + operator append
+BASE="$(cat "$RH_PROMPT_FILE")"
+[ -n "${RH_APPEND_SYSTEM_PROMPT:-}" ] && BASE="${RH_APPEND_SYSTEM_PROMPT}
+
+${BASE}"
+[ -n "${RH_COMPAT_RULES:-}" ] && BASE="${RH_COMPAT_RULES}
+
+${BASE}"
+
+# MCP: translate to config.toml [[mcp_servers]] inside a temp VIBE_HOME (top-level
+# config copied over to preserve auth), so we never edit the user's real config.
+# Vibe seeds `mcp_servers = []` (inline empty array); strip that line first, since
+# TOML won't let [[mcp_servers]] tables extend an inline-declared array.
+if [ -n "${RH_MCP_CONFIG:-}" ] && [ -f "${RH_MCP_CONFIG:-}" ]; then
+  VH="$RH_TMPDIR/vibe-home"; mkdir -p "$VH"
+  SRC="${VIBE_HOME:-$HOME/.vibe}"
+  [ -d "$SRC" ] && find "$SRC" -maxdepth 1 -type f -exec cp {} "$VH/" \; 2>/dev/null
+  if [ -f "$VH/config.toml" ]; then
+    grep -vE '^[[:space:]]*mcp_servers[[:space:]]*=' "$VH/config.toml" > "$VH/config.toml.tmp" \
+      && mv "$VH/config.toml.tmp" "$VH/config.toml"
+  fi
+  mcp_to_vibe_toml "$RH_MCP_CONFIG" >> "$VH/config.toml"
+  export VIBE_HOME="$VH"
+fi
+
+run_once() {  # run_once PROMPT -> sets RESULT/BADSHAPE; returns vibe's rc
+  vibe -p "$1" "${ARGS[@]}" > "$RH_TMPDIR/vibe-out.json" 2>"$RH_TMPDIR/vibe.err"
+  local rc=$?
+  if jq -e 'type == "array"' "$RH_TMPDIR/vibe-out.json" >/dev/null 2>&1; then
+    RESULT=$(jq -r '
+      [.[] | select((.role // "") == "assistant")
+           | (.content | if type == "string" then . else tostring end)]
+      | map(select(. != "")) | last // ""' "$RH_TMPDIR/vibe-out.json")
+    BADSHAPE=0
+  else
+    RESULT=""; BADSHAPE=1
+  fi
+  return $rc
+}
+
+# structured output: no native flag -> prompt-with-schema + validate + one retry
+PROMPT="$BASE"
+[ -n "${RH_JSON_SCHEMA:-}" ] && PROMPT="${PROMPT}$(schema_prompt_suffix "$RH_JSON_SCHEMA")"
+
+run_once "$PROMPT"
+rc=$?
+if [ $rc -ne 0 ] && [ -z "$RESULT" ]; then
+  echo "vibe exited $rc: $(tail -c 300 "$RH_TMPDIR/vibe.err" | tr '\n' ' ')" >&2
+  exit $rc
+fi
+if [ "${BADSHAPE:-0}" = "1" ]; then
+  echo "warning: vibe output was not a JSON array — wrapping raw" >&2
+  wrap_raw_output < "$RH_TMPDIR/vibe-out.json"; exit 0
+fi
+if [ -z "$RESULT" ]; then
+  echo "vibe produced no assistant message" >&2
+  exit 3
+fi
+
+if [ -n "${RH_JSON_SCHEMA:-}" ]; then
+  RESULT="$(schema_extract_json "$RESULT")"
+  if ! schema_validate "$RH_JSON_SCHEMA" "$RESULT"; then
+    echo "structured output failed validation — retrying once" >&2
+    run_once "${PROMPT}$(schema_retry_suffix)" || true
+    RESULT="$(schema_extract_json "$RESULT")"
+    if ! schema_validate "$RH_JSON_SCHEMA" "$RESULT"; then
+      echo "structured output still invalid after retry" >&2
+      exit 3
+    fi
+  fi
+fi
+
+# TOKEN USAGE: vibe's --output json carries none (it meters cost internally for
+# --max-price but does not emit token counts in the message array). Prefer real
+# usage if a build ever emits it; otherwise fall back to a transparent char/4
+# ESTIMATE from the assembled input (BASE) and the result, rather than reporting a
+# misleading 0/0/0. (kimi's identical claim was verified live; vibe's is guarded
+# here so real counts always win if present.)
+VIN=$(jq -r '[.[] | (.usage.input_tokens // .usage.prompt_tokens // .input_tokens // empty)] | add // 0' "$RH_TMPDIR/vibe-out.json" 2>/dev/null || echo 0)
+VOUT=$(jq -r '[.[] | (.usage.output_tokens // .usage.completion_tokens // .output_tokens // empty)] | add // 0' "$RH_TMPDIR/vibe-out.json" 2>/dev/null || echo 0)
+if [ "${VIN:-0}" = "0" ] && [ "${VOUT:-0}" = "0" ]; then
+  VIN=$(( ${#BASE} / 4 )); VOUT=$(( ${#RESULT} / 4 ))
+  echo "note: vibe exposes no token usage — reporting a char/4 estimate (in~$VIN out~$VOUT)" >&2
+fi
+emit_envelope "$RESULT" "$VIN" "$VOUT" 0 0 "" ""

--- a/harness-adapter/docs/aeon-integration.md
+++ b/harness-adapter/docs/aeon-integration.md
@@ -1,0 +1,268 @@
+# Wiring the harness swap into an aeon instance
+
+A deployment runbook for putting `run-harness` into [aeonfun/aeon](https://github.com/aeonfun/aeon)
+so a skill can run on **codex, pi, vibe, or kimi** instead of only claude/grok.
+
+The reference implementation is `aaronjmars/aeon-harness@harness-swap-4` — a full
+aeon fork with every change below applied and verified on a real GitHub runner
+(6-harness × 3-scenario matrix, verified in the upstream
+[harness-adapter](https://github.com/aaronjmars/harness-adapter) test suite, Tier 4).
+This document is how to reproduce it on a fresh aeon instance, and what each
+change is for so you can review rather than copy blind.
+
+---
+
+## 1. The shape
+
+aeon already defines the seam. `scripts/run-grok.sh` documents its own contract —
+prompt on stdin, a normalized `{result, usage, session_id}` envelope on stdout,
+diagnostics on stderr — and that is exactly `run-harness`'s contract. So the swap
+is one added branch, nothing existing changed:
+
+```
+claude -> untouched gateway cascade   (keeps multi-provider fallover + Langfuse)
+grok   -> untouched run-grok.sh        (keeps GROK_* knobs from skill_mode.sh)
+else   -> run-harness "$HARNESS"        (codex, pi, vibe, kimi)
+```
+
+claude and grok keep their own branches on purpose: claude would otherwise lose
+the multi-provider gateway cascade and Langfuse tracing, grok its `GROK_*` run
+knobs.
+
+**In scope:** codex, pi, vibe, kimi. **Deliberately excluded**, each for a
+measured reason:
+
+| harness | why not |
+|---|---|
+| `opencode` | `.result` carried the agent's narration, not the deliverable — fixed in the adapter, but it still loops to the wall-clock guard on research skills |
+| `copilot` | no credential path without a Copilot-subscribed PAT |
+| `agy` | print mode runs tools in `~/.gemini/antigravity-cli/scratch/`, not `$PWD`, so it reports success having written nothing to the workspace |
+
+---
+
+## 2. Prerequisites
+
+| what | where | needed for |
+|---|---|---|
+| `OPENROUTER_API_KEY` | repo secret | **required** — one key covers all four harnesses |
+| `CLAUDE_CODE_OAUTH_TOKEN` | repo secret | only if you also run the **claude** control path; a codex/pi/vibe/kimi-only instance does **not** need it (the scorer routes through run-harness — see §5) |
+| `HARNESS_MODEL` | repo variable | **optional** override; per-harness defaults are built in (§6). Leave unset unless you want to force one model for all four |
+| everything aeon already requires | — | unchanged |
+
+The runner must be Linux (`ubuntu-latest` is fine). bubblewrap + an AppArmor
+sysctl are installed by the added step (§7).
+
+---
+
+## 3. Wiring steps
+
+### 3.1 Vendor `harness-adapter`
+
+The workflow calls `${GITHUB_WORKSPACE}/harness-adapter/run-harness`, so the
+adapter tree must be present at the repo root. Options, cheapest first:
+
+- **Vendor a pinned copy** at `harness-adapter/` (what the reference fork does).
+  Simplest for a private/public split; re-sync on a tag bump.
+- **git submodule** — clean history, but every downstream fork must
+  `git submodule update --init`, which aeon forks generally don't.
+
+Whichever you pick, the tree must contain `run-harness`, `adapters/`, and `lib/`.
+
+### 3.2 Apply the `aeon.yml` changes
+
+Two steps **added**, five **modified**. Diff against upstream to review; the list
+is exhaustive.
+
+**Added — `Resolve harness` (id: `harness`)**, placed after *Install Claude Code*,
+before the new install step. aeon resolves the harness inline inside *Run*; the
+added harnesses need a CLI installed first, and an install step cannot read a
+value resolved later. So resolution moves up here (logic is upstream's, verbatim),
+emitting three outputs: `HARNESS`, `HARNESS_MODEL`, `MODEL_ARG`.
+
+> **Do not gate the install on `inputs.harness` instead.** A cron carries no
+> dispatch input, so a repo with `harness: codex` in `aeon.yml` would install
+> nothing and fail inside *Run*. Resolving from the same 3-tier precedence
+> (dispatch input → per-skill → top-level → default) is what makes crons work.
+> Both resolution `grep`s must carry `|| true` — under the runner's `bash -e -o
+> pipefail`, a repo with no top-level `harness:` key or a skill missing from the
+> skills map otherwise kills the step with no message.
+
+**Added — `Install harness CLI`**, gated on
+`steps.harness.outputs.HARNESS != '' && != 'claude' && != 'grok'`. Installs the
+selected CLI, stages its OpenRouter config (§6), and installs bubblewrap + the
+AppArmor sysctl (§7).
+
+**Modified — `Run`.** New leading branch
+`if [ "$HARNESS" != "claude" ] && [ "$HARNESS" != "grok" ]` that pipes the prompt
+to `run-harness "$HARNESS" --mode "$SKILL_MODE" --allowed-tools "$ALLOWED"
+--timeout 900 [--model $RH_MODEL_ARG] [--mcp-config .mcp.json]`. It re-emits
+`SKILL_MODEL` with the model that **actually ran** (aeon's `BASE_MODEL` is a
+claude-*/grok-* id these CLIs can't resolve — leaving it would file the run's
+tokens and the signed manifest under a model that never executed). The claude
+cascade and grok branch below it are untouched.
+
+**Modified — three gates flip from `!= 'grok'` to `== 'claude'`:**
+
+| step | change | why |
+|---|---|---|
+| `Analyze skill output` (scorer) | route non-claude through run-harness; gateway-source + empty-retry gated `== 'claude'` | §5 |
+| `Under the hood` | add `&& HARNESS == 'claude'` | `run-actions-summary.sh` falls back to the newest `~/.claude/projects` transcript when a session id doesn't resolve — the added harnesses emit their own session id, so without this gate a run gets *another* run's tool calls committed to `memory/logs/` |
+| `Convert feed outputs` | `!= 'grok'` → `== 'claude'` | `notify-jsonrender` renders via `claude -p`; skip on a no-Claude-auth repo |
+
+> Upstream has only claude and grok, so `!= 'grok'` and `== 'claude'` are
+> **identical there** — every flip is a no-op for aeon as it stands and correct
+> for the added harnesses.
+
+**Modified — dispatch inputs.** Add `codex, pi, vibe, kimi` to the
+`workflow_dispatch` `harness` choice list and the `workflow_call` description.
+
+`OPENROUTER_API_KEY` is added to the env of *Install harness CLI*, *Run*, and
+*Analyze skill output*.
+
+### 3.3 Choose the harness
+
+Same 3-tier precedence as the model, no new mechanism:
+
+```yaml
+# aeon.yml, top-level — every skill in this repo
+harness: codex
+
+# or per-skill
+skills:
+  github-trending: { harness: "pi" }
+
+# or one-off
+gh workflow run aeon.yml -f skill=github-trending -f harness=vibe
+```
+
+---
+
+## 4. read-only semantics (read this before trusting a research skill)
+
+`read-only` means **the workspace cannot be mutated** — *not* "cannot act". The
+network stays available; the write lock is the wrapper OS sandbox
+(`lib/sandbox.sh`, bubblewrap on Linux). This matters because aeon's read-only
+toolset explicitly grants `WebFetch, WebSearch, Bash(curl:*)` and its read-only
+skills are overwhelmingly **research** skills.
+
+Getting this wrong is silent: three harnesses each lost the network a different
+way, and every failed run was **green** — valid envelope, exit 0, scorer 3–4/5 —
+while committing fabricated or empty output. The fixes are in the adapters
+(pi/vibe/codex) and one compat clause; see the upstream
+[harness-adapter](https://github.com/aaronjmars/harness-adapter) test suite for the full account.
+The takeaway for operating an instance: **a green run is not proof the skill did
+its job.** Spot-check committed `output/` content, especially for research skills.
+
+codex has a native kernel sandbox, but its `--sandbox read-only` also blocks the
+**network** (codex has no "read-only + network" mode), which silently broke
+read-only research skills. So read-only codex now runs under the **wrapper** like
+the others, with codex's own sandbox disabled (`danger-full-access`) so the two
+don't nest — an earlier attempt left codex's landlock on *inside* bwrap and the
+two fought, breaking codex's file access. Write mode stays unwrapped and keeps
+codex's native `workspace-write` + `network_access`.
+
+---
+
+## 5. Scoring on a no-Claude-auth repo
+
+The post-run scorer (`Analyze skill output`) grades every run 1–5 and writes
+`memory/skill-health/<skill>.json`. Upstream it calls `claude -p`. On a repo
+running only the added harnesses there are no Claude credentials, so that call
+would just print "Not logged in" and **every run would go unscored** —
+skill-health, skill-analytics and the cron-state quality signals all silently
+empty while the workflow stays green.
+
+grok already solved this: score through the same harness the skill ran on. The
+swap does the same for any non-claude harness —
+`run-harness "$HARNESS" --mode read-only --no-sandbox --timeout 300`.
+
+> **Known limitation:** a self-scoring harness can grade its own fabricated
+> output highly (measured: 3–4/5 on invented data before the read-only fix). If
+> your instance *does* have Claude credentials, preferring `claude -p` for
+> scoring and falling back to run-harness only when creds are absent gives more
+> trustworthy, comparable scores. The reference fork routes everything through
+> run-harness; refine per instance.
+
+---
+
+## 6. Per-harness reference
+
+One `OPENROUTER_API_KEY` covers all four. Each CLI's provider block is generic
+enough to point at OpenRouter; the *Install harness CLI* step stages the config.
+
+| harness | install | model default | `--model` passed | config notes |
+|---|---|---|---|---|
+| **codex** | `npm i -g @openai/codex@0.144.6` | `openai/gpt-5-mini` | bare id | `~/.codex/config.toml`: `wire_api = "responses"` (0.144.6 removed `"chat"`), `model_reasoning_effort = "medium"` (OpenRouter 400s on reasoning-disabled) |
+| **pi** | `npm i -g --ignore-scripts @earendil-works/pi-coding-agent` | `deepseek/deepseek-v4-flash` | `openrouter/<model>` | reads `OPENROUTER_API_KEY` from env |
+| **vibe** | `pipx install mistral-vibe` | `mistralai/mistral-medium-3-5` | none (config alias) | `~/.vibe/config.toml`: provider `api_style=openai`, `api_key_env_var` |
+| **kimi** | `npm i -g @moonshot-ai/kimi-code` | `moonshotai/kimi-k2.5` | none (config alias) | `~/.kimi-code/config.toml`: key **inline** (no env indirection), `default_model` set |
+
+**codex needs `≥ gpt-5-mini`.** On `gpt-5-nano` it fails *deterministically* on
+code-generation skills — the model emits a shell tool call with a duplicated
+`cmd` field, codex's strict parser rejects it, and codex (no `--max-turns`) spins
+to the 900s guard. It passes on `gpt-5-mini` in ~2m40s. This is why the default
+is per-harness, not one repo-wide value. A repo-wide `HARNESS_MODEL` override
+**wins over these defaults** — don't set it to nano if you run codex on code
+skills.
+
+**Pin the version.** `@openai/codex` unpinned tracked latest and drifted
+mid-session into an OpenRouter 400 with no repo change. Pin it, as aeon pins
+claude-code.
+
+---
+
+## 7. Runner gotchas (all handled by the added steps, listed so you know why)
+
+- **AppArmor blocks bubblewrap on Ubuntu 24.04** (including `ubuntu-latest`).
+  Unprivileged user namespaces are restricted, so bwrap dies with `setting up uid
+  map: Permission denied` and run-harness fails *closed* on every read-only skill
+  — correct, but fatal. The install step runs
+  `sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0`. **Any aeon PR
+  must include this.**
+- **The concurrency group cancels queued runs.** `concurrency: {group:
+  aeon-<skill>, cancel-in-progress: false}` protects the *running* job, but GitHub
+  keeps only **one** pending run per group — a third dispatch of the same skill
+  silently cancels the one already queued (reports `cancelled`, not `failed`).
+  When testing a matrix, dispatch at most one run per *skill* at a time; different
+  skills are different groups and do run in parallel.
+- **`OPENROUTER_API_KEY` may already be in aeon's Run env.** Re-adding it is a
+  duplicate-key YAML error that makes the whole workflow unparseable — check
+  before adding.
+
+---
+
+## 8. Verify a fresh instance
+
+Deterministic, no tokens:
+
+```sh
+cd harness-adapter && bash test/contract.sh      # 56/0 expected
+```
+
+On the instance itself, one run per scenario (dispatch one skill at a time):
+
+```sh
+gh workflow run aeon.yml -f skill=github-trending  -f harness=pi     # read-only
+gh workflow run aeon.yml -f skill=strategy-builder -f harness=codex  # write + code-gen
+gh workflow run aeon.yml -f skill=memory-flush     -f harness=kimi   # write + commit-back
+```
+
+Green is necessary, not sufficient. Confirm each by **reading the committed
+output**:
+
+- `output/.chains/<skill>.md` — is it the real deliverable, or narration / invented data?
+- `memory/token-usage.csv` — non-zero tokens, and the model that actually ran
+- `memory/skill-health/<skill>.json` — a real score, not an empty no-op
+
+The reference fork's final grid (all four × three scenarios, verified by output)
+is the "FINAL verified grid" in the upstream
+[harness-adapter](https://github.com/aaronjmars/harness-adapter) test suite.
+
+---
+
+## 9. Open decisions (not blockers)
+
+- **Packaging.** `harness-adapter` is private; aeon is public. A submodule breaks
+  for every downstream fork; a vendored copy drifts. Likely resolution: publish
+  the adapter, then vendor at a pinned tag.
+- **Scorer calibration.** See §5 — prefer `claude -p` when Anthropic creds exist.

--- a/harness-adapter/lib/compat-rules.md
+++ b/harness-adapter/lib/compat-rules.md
@@ -1,0 +1,5 @@
+These instructions may have been authored for the Claude Code harness. Adapt them to your own tools; do not abort when something does not match one-to-one:
+- Tool names may be Claude's (WebFetch, WebSearch, Read, Glob, Grep, Write, Edit, Bash). Map each to your closest equivalent: use your own web fetch/search tools for WebFetch/WebSearch, your file tools for Read/Write/Edit, your shell for Bash.
+- When a step relies on a CLI that is unavailable (for example `gh api`), call the underlying REST API directly over the web instead (https://api.github.com/... is public for reads).
+- If any tool is missing, denied, or returns unusable content, do NOT stop or end the turn. Try another route and finish the task; only surface a failure after you have exhausted the alternatives.
+- Never end a run having produced only planning or commentary. Deliver the task's actual output — the file, report, or answer it asks for — and never emit interim narration as the final result.

--- a/harness-adapter/lib/envelope.sh
+++ b/harness-adapter/lib/envelope.sh
@@ -1,0 +1,44 @@
+# envelope.sh — emit/validate the Claude Code-compatible JSON envelope.
+#
+# The contract every adapter must satisfy on stdout:
+#   { "result": "<text>",
+#     "usage": { "input_tokens": N, "output_tokens": N,
+#                "cache_read_input_tokens": N, "cache_creation_input_tokens": N },
+#     "session_id": "<optional>", "total_cost_usd": <optional> }
+# Diagnostics go to stderr. Exit 0 on success; non-zero on failure; an abnormal
+# model stop with no output must FAIL, never emit partial-as-success.
+
+emit_envelope() {
+  # emit_envelope RESULT INPUT OUTPUT CACHE_READ CACHE_CREATION [COST] [SESSION_ID]
+  local result="$1" tin="${2:-0}" tout="${3:-0}" tcr="${4:-0}" tcc="${5:-0}" cost="${6:-}" sid="${7:-}"
+  local n
+  for n in tin tout tcr tcc; do   # guard non-numeric extractions back to 0
+    case "${!n}" in ''|*[!0-9]*) printf -v "$n" 0 ;; esac
+  done
+  jq -cn --arg result "$result" \
+    --argjson tin "$tin" --argjson tout "$tout" --argjson tcr "$tcr" --argjson tcc "$tcc" \
+    --arg cost "$cost" --arg sid "$sid" '
+    {result: $result,
+     usage: {input_tokens: $tin, output_tokens: $tout,
+             cache_read_input_tokens: $tcr, cache_creation_input_tokens: $tcc}}
+    + (if $sid != "" then {session_id: $sid} else {} end)
+    + (if ($cost != "") and ($cost | test("^[0-9]+(\\.[0-9]+)?$")) then {total_cost_usd: ($cost | tonumber)} else {} end)'
+}
+
+validate_envelope() {
+  # reads an envelope on stdin; exit 0 iff it satisfies the contract
+  jq -e '
+    type == "object"
+    and (.result | type == "string")
+    and (.usage | type == "object")
+    and ([.usage.input_tokens, .usage.output_tokens,
+          .usage.cache_read_input_tokens, .usage.cache_creation_input_tokens]
+         | all(type == "number"))' >/dev/null
+}
+
+wrap_raw_output() {
+  # last-resort fallback: wrap arbitrary stdout as a best-effort envelope, so a
+  # shape change never silently looks like "no output" (pattern from aeon's run-grok.sh)
+  jq -Rsc '{result: ., usage: {input_tokens: 0, output_tokens: 0,
+            cache_read_input_tokens: 0, cache_creation_input_tokens: 0}}'
+}

--- a/harness-adapter/lib/imports.sh
+++ b/harness-adapter/lib/imports.sh
@@ -1,0 +1,49 @@
+# imports.sh — expand Claude Code's `@file` imports in CLAUDE.md.
+#
+# Only Claude Code expands @imports; every other harness loads instruction files
+# verbatim. So for non-claude harnesses we pre-expand imports into a merged file
+# (the generalization of aeon's gen-agents-md.js "carry the delta" trick).
+#
+# Supported: whole-line imports (`@STRATEGY.md` on its own line), relative /
+# absolute / ~ paths, extension-less (`@README` -> README.md), up to 4 hops.
+# Not supported (documented limitation): inline mid-sentence imports.
+# Imports inside fenced code blocks are skipped, matching Claude's parser.
+
+expand_imports() {
+  # expand_imports FILE [depth] -> expanded text on stdout
+  local file="$1" depth="${2:-0}" line target dir in_fence=0
+  [ -f "$file" ] || return 0
+  if [ "$depth" -ge 4 ]; then cat "$file"; return 0; fi
+  dir="$(cd "$(dirname "$file")" && pwd)"
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in '```'*) in_fence=$((1 - in_fence)) ;; esac
+    if [ "$in_fence" -eq 0 ] && [[ "$line" =~ ^@([^[:space:]]+)[[:space:]]*$ ]]; then
+      target="${BASH_REMATCH[1]}"
+      case "$target" in
+        "~/"*) target="$HOME/${target#\~/}" ;;
+        /*) ;;
+        *) target="$dir/$target" ;;
+      esac
+      if [ -f "$target" ]; then
+        expand_imports "$target" $((depth + 1))
+      elif [ -f "$target.md" ]; then
+        expand_imports "$target.md" $((depth + 1))
+      else
+        printf '%s\n' "$line"   # unresolvable import stays literal
+      fi
+    else
+      printf '%s\n' "$line"
+    fi
+  done < "$file"
+}
+
+expand_claude_md() {
+  # expand_claude_md OUTFILE — if ./CLAUDE.md has imports, write the expanded
+  # merge to OUTFILE and print its path; print nothing if there is no work.
+  local out="$1"
+  [ -f CLAUDE.md ] || return 0
+  if grep -qE '^@[^[:space:]]+[[:space:]]*$' CLAUDE.md; then
+    expand_imports CLAUDE.md > "$out"
+    printf '%s\n' "$out"
+  fi
+}

--- a/harness-adapter/lib/mcp-translate.sh
+++ b/harness-adapter/lib/mcp-translate.sh
@@ -1,0 +1,83 @@
+# mcp-translate.sh — translate a Claude-style project .mcp.json for harnesses
+# that don't read it natively.
+#
+#   claude   — reads it via --mcp-config (no translation)
+#   grok     — discovers it natively incl. ${VAR} expansion (only needs allow rules)
+#   codex    — no project .mcp.json support (openai/codex#13056): -> -c overrides
+#   opencode — own config shape: -> "mcp" object for a generated opencode.json
+#   pi       — rejects MCP by design: adapter warns and skips
+
+mcp_expand_vars() {
+  # mcp_expand_vars IN OUT — expand ${VAR} refs from the environment into OUT.
+  # Unset vars are LEFT AS-IS (unlike envsubst, which silently empties them);
+  # their names are printed one per line so callers can warn.
+  # Caveat: values containing double quotes would corrupt the JSON — secrets
+  # virtually never do, but it's worth knowing.
+  local in="$1" out="$2"
+  perl -pe 's/\$\{([A-Z_][A-Z0-9_]*)\}/defined $ENV{$1} ? $ENV{$1} : "\${$1}"/ge' \
+    < "$in" > "$out"
+  grep -oE '\$\{[A-Z_][A-Z0-9_]*\}' "$out" 2>/dev/null | sed -E 's/[${}]//g' | sort -u || true
+}
+
+mcp_server_names() {
+  jq -r '.mcpServers // {} | keys[]' "$1"
+}
+
+mcp_to_codex_flags() {
+  # .mcp.json -> repeated `-c mcp_servers.<name>.<key>=<value>` overrides,
+  # one argv token per line (read into an array with a while-read loop).
+  # NOTE: codex parses -c values as TOML. JSON strings and arrays are valid TOML;
+  # the env OBJECT is emitted as JSON and may need `key = value` inline-table
+  # syntax on some codex versions — verify against your installed codex.
+  jq -r '
+    .mcpServers // {} | to_entries[] |
+    .key as $k | .value as $s |
+    ( if $s.command then
+        ["mcp_servers.\($k).command=\($s.command | tojson)"]
+        + (if $s.args then ["mcp_servers.\($k).args=\($s.args | tojson)"] else [] end)
+        + (if $s.env then ["mcp_servers.\($k).env=\($s.env | tojson)"] else [] end)
+      elif $s.url then
+        ["mcp_servers.\($k).url=\($s.url | tojson)"]
+        + (if $s.headers then ["mcp_servers.\($k).http_headers=\($s.headers | tojson)"] else [] end)
+      else [] end
+    ) | .[] | "-c", .' "$1"
+}
+
+mcp_to_vibe_toml() {
+  # .mcp.json -> [[mcp_servers]] array-of-tables for Mistral Vibe's config.toml.
+  # Vibe declares `mcp_servers = []` (an inline empty array); the adapter strips
+  # that line before appending these tables, since TOML forbids extending an
+  # inline-declared array with [[table]] syntax ("immutable namespace").
+  # env/headers become TOML inline tables ({ K = "V" }), not JSON objects.
+  jq -r '
+    .mcpServers // {} | to_entries[] |
+    (["", "[[mcp_servers]]", "name = \(.key|tojson)"] +
+     ( if .value.command then
+         ["transport = \"stdio\"", "command = \(.value.command|tojson)"]
+         + (if .value.args then ["args = \(.value.args|tojson)"] else [] end)
+         + (if .value.env then ["env = { \(.value.env|to_entries|map("\(.key) = \(.value|tojson)")|join(", ")) }"] else [] end)
+       elif .value.url then
+         ["transport = \"http\"", "url = \(.value.url|tojson)"]
+         + (if .value.headers then ["headers = { \(.value.headers|to_entries|map("\(.key) = \(.value|tojson)")|join(", ")) }"] else [] end)
+       else [] end)) | .[]' "$1"
+}
+
+mcp_to_opencode_json() {
+  # .mcp.json -> the "mcp" object for a generated opencode.json.
+  # stdio: {type:"local", command:[cmd, ...args], environment}; http: {type:"remote", url, headers}
+  jq -c '
+    (.mcpServers // {}) | to_entries | map(
+      select(.value.command or .value.url) | {
+        key: .key,
+        value: (
+          if .value.command then
+            ({type: "local",
+              command: ([.value.command] + (.value.args // [])),
+              enabled: true}
+             + (if .value.env then {environment: .value.env} else {} end))
+          else
+            ({type: "remote", url: .value.url, enabled: true}
+             + (if .value.headers then {headers: .value.headers} else {} end))
+          end)
+      }) | from_entries' "$1"
+}

--- a/harness-adapter/lib/sandbox.sh
+++ b/harness-adapter/lib/sandbox.sh
@@ -1,0 +1,34 @@
+# sandbox.sh — wrapper-level OS sandbox for uniform read-only enforcement.
+#
+# Only grok and codex have native kernel sandboxes; opencode and pi enforce
+# nothing, and claude's --allowedTools can be sidestepped by shell redirection.
+# So for read-only runs the DISPATCHER applies its own sandbox around whatever
+# harness runs: the workspace (cwd) becomes unwritable, everything else stays
+# usable (harnesses need to write their own state under $HOME and $TMPDIR).
+# This mirrors aeon's semantic: "a read-only skill physically cannot mutate the
+# repo" — and makes it mean the same thing on all five harnesses.
+
+sandbox_prefix() {
+  # sandbox_prefix TMPDIR -> prints prefix argv tokens (one per line), or
+  # returns 1 if no OS sandbox is available on this machine.
+  local tmp="$1" ws
+  ws="$(pwd -P)"
+  case "$(uname -s)" in
+    Darwin)
+      command -v sandbox-exec >/dev/null 2>&1 || return 1
+      local profile="$tmp/readonly-workspace.sb"
+      cat > "$profile" <<EOF
+(version 1)
+(allow default)
+(deny file-write* (subpath "$ws"))
+EOF
+      printf '%s\n' sandbox-exec -f "$profile"
+      ;;
+    Linux)
+      command -v bwrap >/dev/null 2>&1 || return 1
+      # bind everything rw, then overlay the workspace read-only
+      printf '%s\n' bwrap --dev-bind / / --ro-bind "$ws" "$ws" --die-with-parent
+      ;;
+    *) return 1 ;;
+  esac
+}

--- a/harness-adapter/lib/schema-retry.sh
+++ b/harness-adapter/lib/schema-retry.sh
@@ -1,0 +1,61 @@
+# schema-retry.sh — structured output for harnesses without a --json-schema flag
+# (opencode, pi). Prompt-with-schema + pragmatic validation + one retry — the
+# same pattern aeon's post-run scorer uses.
+#
+# "Pragmatic" validation: full JSON Schema validation in bash is unrealistic;
+# we check (a) the text parses as a single JSON value, (b) top-level `type`
+# matches if declared, (c) all `required` keys exist. That catches the failure
+# modes that actually occur (prose, fences, missing fields).
+
+schema_prompt_suffix() {
+  # schema_prompt_suffix SCHEMA -> text to append to the prompt
+  printf '\n\nRespond with ONLY a single JSON value that validates against this JSON Schema. No prose, no markdown fences, nothing before or after the JSON:\n%s\n' "$1"
+}
+
+schema_retry_suffix() {
+  printf '\n\nYour previous response was NOT valid against the schema. Respond again with ONLY the JSON value — no explanation, no fences.'
+}
+
+schema_extract_json() {
+  # Recover the JSON value from whatever the model actually emitted. Ordered
+  # cheapest-first; each step is only taken if the previous output isn't already
+  # parseable, so a clean response is passed through untouched.
+  local text="$1" cand pat
+  jq -e . >/dev/null 2>&1 <<<"$text" && { printf '%s' "$text"; return; }
+
+  # 1. markdown fences — ANYWHERE, not just alone on a line. (The previous
+  #    version anchored to whole lines with ^...$, so ```json immediately
+  #    followed by the object on the same line survived and broke parsing.)
+  text=$(sed -e 's/```[a-zA-Z]*//g' <<<"$text")
+  jq -e . >/dev/null 2>&1 <<<"$text" && { printf '%s' "$text"; return; }
+
+  # 2. Prose around the JSON. Models do this constantly despite being told not
+  #    to — opencode prefaces with "I'll read the skill definition and execute
+  #    it." and only then emits the object. Take the widest {...} / [...] span
+  #    and let schema_validate be the judge. Newlines are swapped for \036 so
+  #    grep's `.` spans lines, then restored. Same flatten-and-grab aeon's own
+  #    post-run scorer uses on model JSON.
+  for pat in '{.*}' '\[.*\]'; do
+    cand=$(printf '%s' "$text" | tr '\n' '\036' | grep -o "$pat" | head -1 | tr '\036' '\n')
+    [ -n "$cand" ] && jq -e . >/dev/null 2>&1 <<<"$cand" && { printf '%s' "$cand"; return; }
+  done
+
+  printf '%s' "$text"   # nothing extractable — let schema_validate fail loudly
+}
+
+schema_validate() {
+  # schema_validate SCHEMA TEXT -> exit 0 iff TEXT pragmatically satisfies SCHEMA
+  local schema="$1" text="$2" want_type req k
+  jq -e . >/dev/null 2>&1 <<<"$text" || return 1
+  want_type=$(jq -r '.type // empty' <<<"$schema" 2>/dev/null)
+  if [ -n "$want_type" ] && [ "$want_type" != "null" ]; then
+    jq -e --arg t "$want_type" '
+      (type) as $got |
+      ($t == $got) or ($t == "integer" and $got == "number")' >/dev/null 2>&1 <<<"$text" || return 1
+  fi
+  req=$(jq -r '.required // [] | .[]' <<<"$schema" 2>/dev/null)
+  for k in $req; do
+    jq -e --arg k "$k" 'type == "object" and has($k)' >/dev/null 2>&1 <<<"$text" || return 1
+  done
+  return 0
+}

--- a/harness-adapter/lib/tools-grammar.sh
+++ b/harness-adapter/lib/tools-grammar.sh
@@ -1,0 +1,59 @@
+# tools-grammar.sh — parse Claude Code's --allowedTools grammar and translate it
+# into each harness's native permission shape.
+#
+# Claude grammar (the lingua franca): comma-separated tokens, e.g.
+#   Read,Glob,Grep,WebFetch,Write,Edit,Bash(git:*),Bash(curl:*)
+# Bash rules use colon-globs: Bash(cmd:*). Bare names allow the whole tool.
+
+tools_has_write() {
+  # exit 0 iff the toolset includes a repo-mutation tool (Write or Edit)
+  case ",$1," in
+    *,Write,* | *,Edit,*) return 0 ;;
+  esac
+  return 1
+}
+
+tools_bash_cmds() {
+  # extract CMD from every Bash(CMD:*) token, one per line
+  tr ',' '\n' <<<"$1" | sed -n 's/^Bash(\(.*\):\*)$/\1/p'
+}
+
+tools_to_opencode_permission() {
+  # Claude allowedTools -> opencode.json "permission" object.
+  # opencode semantics: last matching rule wins, so "*" (deny) must come FIRST.
+  # Headless opencode auto-rejects "ask", so deny/allow are the only states we emit.
+  local tools="$1" edit rules
+  if tools_has_write "$tools"; then edit="allow"; else edit="deny"; fi
+  rules=$(tools_bash_cmds "$tools" \
+    | jq -Rn '[inputs | select(length > 0) | {key: (. + " *"), value: "allow"}] | from_entries')
+  jq -cn --arg edit "$edit" --argjson rules "$rules" \
+    '{read: "allow", grep: "allow", glob: "allow",
+      webfetch: "allow", websearch: "allow",
+      edit: $edit,
+      bash: ({"*": "deny"} + $rules)}'
+}
+
+tools_to_pi_exclude() {
+  # Claude allowedTools / mode -> pi --exclude-tools value. pi has no permission
+  # system ("YOLO mode"); the only native lever is subsetting its toolset.
+  # Prints nothing for write mode (pi keeps its full toolset).
+  #
+  # This USED TO emit `--tools read,grep,find,ls`, an allowlist. pi's built-ins
+  # are read/bash/edit/write and it has NO web tool, so that allowlist dropped
+  # `bash` — pi's only route to the network. Read-only skills then could not
+  # fetch anything. Measured on a real aeon runner: pi ended github-trending
+  # with "there is no network access available through the provided tools" and
+  # delivered a menu of options instead of a report. That statement was
+  # literally TRUE, and the cause was this function.
+  #
+  # read-only means "cannot MUTATE the workspace", not "cannot act". The
+  # mutation guard is the dispatcher's wrapper OS sandbox (lib/sandbox.sh), as
+  # adapters/pi.sh's own header says; dropping write/edit here is belt-and-braces
+  # so the model is not even offered a tool that would fail. bash stays, so
+  # curl — which aeon's read-only toolset explicitly grants as Bash(curl:*) —
+  # keeps working, and any write attempted through it hits the sandbox.
+  local tools="$1"
+  if ! tools_has_write "$tools"; then
+    echo "write,edit"
+  fi
+}

--- a/harness-adapter/run-harness
+++ b/harness-adapter/run-harness
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# run-harness — one Claude Code-shaped contract, six coding-agent harnesses.
+#
+#   usage: run-harness <claude|grok|codex|pi|vibe|kimi> [options] < prompt.txt
+#
+#   options (mirroring Claude Code's headless flags):
+#     --model <id>                  model id (per-harness mapping; wrong-family ids fall to defaults)
+#     --allowed-tools "<list>"      Claude --allowedTools grammar, e.g. "Read,Grep,Bash(git:*)"
+#     --mode read-only|write        capability tier (derived from --allowed-tools if omitted; default write)
+#     --mcp-config <file>           Claude-style .mcp.json (${VAR}s expanded from env; translated per harness)
+#     --max-turns <n>               agentic-turn cap where supported (claude/grok); others rely on --timeout
+#     --json-schema '<schema>'      structured output (native on claude/grok/codex; prompt+validate+retry on pi/vibe/kimi)
+#     --append-system-prompt <txt>  extra standing instructions
+#     --timeout <seconds>           wall-clock guard (default 600)
+#     --no-sandbox                  skip the wrapper OS sandbox on read-only runs
+#     --no-compat-rules             skip the Claude-idiom compatibility preamble on non-claude harnesses
+#
+#   contract (stdout): {"result": "...", "usage": {input_tokens, output_tokens,
+#     cache_read_input_tokens, cache_creation_input_tokens}, [session_id], [total_cost_usd]}
+#   diagnostics on stderr; exit 0 ok / 3 abnormal-stop-with-no-output / other non-zero errors.
+#
+# Pattern generalized from aeonfun/aeon's scripts/run-grok.sh.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+  sed -n '2,22p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//' >&2
+  exit 2
+}
+
+[ $# -ge 1 ] || usage
+HARNESS="$1"; shift
+[ -f "$HERE/adapters/$HARNESS.sh" ] || { echo "unknown harness '$HARNESS'" >&2; usage; }
+
+MODEL="" MODE="" ALLOWED="" MCP="" MAXT="" SCHEMA="" APPEND=""
+TIMEOUT=600 SANDBOX=auto COMPAT=auto
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --model)                MODEL="$2"; shift 2 ;;
+    --mode)                 MODE="$2"; shift 2 ;;
+    --allowed-tools | --allowedTools) ALLOWED="$2"; shift 2 ;;
+    --mcp-config)           MCP="$2"; shift 2 ;;
+    --max-turns)            MAXT="$2"; shift 2 ;;
+    --json-schema)          SCHEMA="$2"; shift 2 ;;
+    --append-system-prompt) APPEND="$2"; shift 2 ;;
+    --timeout)              TIMEOUT="$2"; shift 2 ;;
+    --no-sandbox)           SANDBOX=off; shift ;;
+    --no-compat-rules)      COMPAT=off; shift ;;
+    --output-format)        [ "$2" = "json" ] || { echo "only --output-format json is supported" >&2; exit 2; }; shift 2 ;;
+    *) echo "unknown option: $1" >&2; usage ;;
+  esac
+done
+
+case "$MODE" in "" | read-only | write) ;; *) echo "invalid --mode '$MODE' (read-only|write)" >&2; exit 2 ;; esac
+
+if [ -t 0 ]; then
+  echo "error: pipe the prompt on stdin (e.g. echo 'do X' | run-harness $HARNESS)" >&2
+  exit 2
+fi
+
+. "$HERE/lib/tools-grammar.sh"
+. "$HERE/lib/envelope.sh"
+
+# derive capability mode from the toolset when not given explicitly
+if [ -z "$MODE" ]; then
+  if [ -n "$ALLOWED" ] && ! tools_has_write "$ALLOWED"; then MODE=read-only; else MODE=write; fi
+fi
+
+RH_TMPDIR=$(mktemp -d "${TMPDIR:-/tmp}/run-harness.XXXXXX")
+trap 'rm -rf "$RH_TMPDIR"' EXIT
+cat > "$RH_TMPDIR/prompt.txt"
+
+# ${VAR}-expand .mcp.json once, for every adapter
+if [ -n "$MCP" ]; then
+  [ -f "$MCP" ] || { echo "mcp config not found: $MCP" >&2; exit 2; }
+  . "$HERE/lib/mcp-translate.sh"
+  MISSING=$(mcp_expand_vars "$MCP" "$RH_TMPDIR/mcp.json")
+  [ -n "$MISSING" ] && echo "warning: .mcp.json references unset var(s): $(echo "$MISSING" | tr '\n' ' ')" >&2
+  MCP="$RH_TMPDIR/mcp.json"
+fi
+
+# pre-expand CLAUDE.md @imports for harnesses that load it verbatim (all but claude)
+if [ "$HARNESS" != "claude" ]; then
+  . "$HERE/lib/imports.sh"
+  EXPANDED=$(expand_claude_md "$RH_TMPDIR/CLAUDE.expanded.md")
+  [ -n "$EXPANDED" ] && \
+    echo "notice: CLAUDE.md uses @imports (not expanded by $HARNESS) — expanded copy at $EXPANDED; consider carrying the delta in AGENTS.md" >&2
+fi
+
+# Claude-idiom compatibility preamble (skills/prompts authored for Claude Code)
+COMPAT_RULES=""
+if [ "$COMPAT" = "auto" ] && [ "$HARNESS" != "claude" ]; then
+  COMPAT_RULES="$(cat "$HERE/lib/compat-rules.md")"
+  # Read-only mode write-locks the WORKSPACE only — lib/sandbox.sh binds
+  # everything else rw, so $TMPDIR and $HOME stay writable by design. Agents were
+  # never told that, so an agent that reaches for a scratch file hits a denial
+  # inside the workspace and abandons the task. Measured on a real aeon runner:
+  # opencode ended two github-trending runs on "Let me use a Python script to
+  # parse the trending page directly:" and produced no report, while /tmp was
+  # writable the whole time. Mode-conditional because in write mode the workspace
+  # IS writable and saying otherwise would be a lie.
+  if [ "$MODE" = "read-only" ]; then
+    COMPAT_RULES="${COMPAT_RULES}- This run is READ-ONLY: the workspace cannot be written, but \$TMPDIR is fully writable. Put any scratch file, helper script, or intermediate download under \$TMPDIR. A refused write inside the workspace is expected — never abandon the task over it.
+- READ-ONLY DOES NOT MEAN OFFLINE. The network is available: your web fetch/search tools and shell commands like curl work normally. Do not assume otherwise, and never substitute invented, stubbed or placeholder data for a fetch you did not attempt — if a real fetch fails, say so plainly instead of fabricating a plausible-looking result.
+"
+  fi
+fi
+
+export RH_PROMPT_FILE="$RH_TMPDIR/prompt.txt"
+export RH_TMPDIR RH_LIB="$HERE/lib"
+export RH_MODEL="$MODEL" RH_MODE="$MODE" RH_ALLOWED_TOOLS="$ALLOWED"
+export RH_MCP_CONFIG="$MCP" RH_MAX_TURNS="$MAXT" RH_JSON_SCHEMA="$SCHEMA"
+export RH_APPEND_SYSTEM_PROMPT="$APPEND" RH_COMPAT_RULES="$COMPAT_RULES"
+export RH_TIMEOUT="$TIMEOUT"
+
+CMD=(bash "$HERE/adapters/$HARNESS.sh")
+
+# wall-clock guard — the harness-agnostic runaway backstop
+if command -v timeout >/dev/null 2>&1; then
+  CMD=(timeout "$TIMEOUT" "${CMD[@]}")
+elif command -v gtimeout >/dev/null 2>&1; then
+  CMD=(gtimeout "$TIMEOUT" "${CMD[@]}")
+else
+  echo "warning: no timeout(1)/gtimeout(1) found — running without a wall-clock guard" >&2
+fi
+
+# wrapper-level OS sandbox: uniform read-only enforcement. This wrapper binds the
+# workspace read-only but leaves the NETWORK open (lib/sandbox.sh), so every
+# harness relies on it for read-only. codex has its OWN kernel sandbox, but its
+# `--sandbox read-only` also kills the network — so codex.sh disables codex's
+# self-sandbox in read-only mode (danger-full-access) and lets THIS wrapper be the
+# sole enforcer. Only one FS sandbox may be active: nesting codex's landlock
+# inside bwrap's user namespace broke codex's file access entirely.
+# NOTE grok: its own --sandbox read-only is silently ignored on 0.2.101 (writes
+# still land); vibe/kimi ship no FS sandbox at all — so all of them
+# rely on the wrapper for read-only.
+if [ "$MODE" = "read-only" ] && [ "$SANDBOX" = "auto" ]; then
+  case "$HARNESS" in
+    claude | grok | codex | pi | vibe | kimi)
+      . "$HERE/lib/sandbox.sh"
+      SB=()
+      if PREFIX=$(sandbox_prefix "$RH_TMPDIR"); then
+        while IFS= read -r tok; do SB+=("$tok"); done <<<"$PREFIX"
+        CMD=("${SB[@]}" "${CMD[@]}")
+        echo "read-only: workspace write-locked via ${SB[0]}" >&2
+      else
+        echo "warning: no OS sandbox available — read-only is advisory for $HARNESS on this machine" >&2
+      fi
+      ;;
+  esac
+fi
+
+OUT="$RH_TMPDIR/envelope.json"
+"${CMD[@]}" > "$OUT"
+rc=$?
+if [ $rc -eq 124 ]; then
+  echo "error: harness run exceeded --timeout ${TIMEOUT}s" >&2
+  exit 124
+fi
+[ $rc -ne 0 ] && exit $rc
+
+if validate_envelope < "$OUT"; then
+  cat "$OUT"
+  # ensure exactly one trailing newline (if, not &&: a guard-style && here would
+  # become the script's exit status — the same pitfall aeon.yml warns about)
+  if [ -n "$(tail -c 1 "$OUT")" ]; then echo; fi
+else
+  echo "warning: adapter output failed contract validation — wrapping raw" >&2
+  wrap_raw_output < "$OUT"
+fi
+exit 0

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -138,10 +138,20 @@ else
   PLAIN="$MSG"
 fi
 
-# Always save to .pending-notify/ for post-run delivery (sandbox fallback)
-mkdir -p .pending-notify
+# Try to save to .pending-notify/ for post-run re-delivery. This queue is the
+# fallback for the INVERSE sandbox — network blocked, FS writable (the old claude
+# wrapper case): notify can't reach the wire inline, so the workflow's "Send
+# pending notifications" step re-delivers post-run from here.
+#
+# Non-fatal by design: codex's native read-only sandbox is the MIRROR case — the
+# FS is blocked but the network is open — so this write fails while inline delivery
+# below works fine. A failed fallback write must NOT abort the primary path (this
+# script runs `set -e`, so an unguarded failure here would kill the whole notify
+# before a single channel is tried).
 TS=$(date -u +%s)
-printf '%s' "$PLAIN" > ".pending-notify/${TS}.md"
+if ! { mkdir -p .pending-notify && printf '%s' "$PLAIN" > ".pending-notify/${TS}.md"; } 2>/dev/null; then
+  echo "notify: .pending-notify unwritable (read-only FS) — delivering inline only" >&2
+fi
 
 DELIVERED=false
 
@@ -274,10 +284,15 @@ if [ -n "${RESEND_API_KEY:-}" ] && [ -n "${NOTIFY_EMAIL_TO:-}" ]; then
           '{from:$from, to:[$to], subject:$subject, html:$html, text:$text}')" > /dev/null 2>&1 && DELIVERED=true || true
 fi
 
-# json-render channel — save raw message for post-run conversion
+# json-render channel — save raw message for post-run conversion. Non-fatal for
+# the same reason as the .pending-notify/ queue above: on a read-only-FS harness
+# (codex) this write can't land, and it must not abort a run whose channel
+# delivery already succeeded inline. The feed entry is simply skipped.
 if [ "${JSONRENDER_ENABLED:-false}" = "true" ] && [ -n "${SKILL_NAME:-}" ]; then
-  mkdir -p apps/dashboard/outputs
-  printf '%s' "$PLAIN" > "apps/dashboard/outputs/.pending-${SKILL_NAME}.md"
+  if ! { mkdir -p apps/dashboard/outputs \
+       && printf '%s' "$PLAIN" > "apps/dashboard/outputs/.pending-${SKILL_NAME}.md"; } 2>/dev/null; then
+    echo "notify: json-render queue unwritable (read-only FS) — feed entry skipped" >&2
+  fi
 fi
 
 # Remove pending file if immediate delivery succeeded (prevents double-send)

--- a/scripts/run-grok.sh
+++ b/scripts/run-grok.sh
@@ -54,6 +54,15 @@ GROK_CLI_VERSION="${GROK_CLI_VERSION:-0.2.101}"
 
 log() { echo "$@" >&2; }
 
+# Optional `setup` subcommand: run ONLY steps 1–2 (install the pinned CLI +
+# restore auth) and exit, without reading a prompt or invoking the model. The
+# workflow's "Install harness CLI" step calls `run-grok.sh setup` so grok is
+# staged for the unified run-harness path, keeping THIS script the single source
+# of truth for the CLI pin and the GROK_CREDENTIALS restore logic. Any other
+# invocation is a normal run (prompt on stdin), unchanged.
+SETUP_ONLY=0
+[ "${1:-}" = "setup" ] && SETUP_ONLY=1
+
 # --- 1. ensure the CLI ------------------------------------------------------
 if ! command -v grok >/dev/null 2>&1; then
   log "::debug::grok CLI not found — installing @xai-official/grok@${GROK_CLI_VERSION}"
@@ -96,6 +105,11 @@ elif [ -f "$GROK_HOME/auth.json" ]; then
 else
   log "::error::grok harness needs auth: set GROK_CREDENTIALS (X-account login via the dashboard) or XAI_API_KEY, or run 'grok login'"
   exit 1
+fi
+
+if [ "$SETUP_ONLY" = 1 ]; then
+  log "::debug::grok setup complete (CLI + auth staged); the run itself goes through run-harness grok"
+  exit 0
 fi
 
 # --- 3. model + permission flags --------------------------------------------

--- a/scripts/tests/test_notify.sh
+++ b/scripts/tests/test_notify.sh
@@ -184,6 +184,33 @@ else
 fi
 
 reset
+
+# 16. read-only cwd (codex-style FS-blocked / network-open sandbox): notify must
+#     fall through to inline delivery, NOT abort at the .pending-notify queue write.
+#     Regression guard for the set -e abort that made codex read-only skills silently
+#     drop every notification. See scripts/notify.sh "Non-fatal by design" comment.
+reset
+NOTIFY_ABS="$PWD/scripts/notify.sh"
+RO="$(mktemp -d)"
+chmod 555 "$RO"
+if ( cd "$RO" && : > .wtest ) 2>/dev/null; then
+  rm -f "$RO/.wtest"; chmod 755 "$RO"; rm -rf "$RO"
+  pass "read-only cwd fallthrough (skipped: cwd still writable, likely root)"
+else
+  ( cd "$RO" && bash "$NOTIFY_ABS" --severity critical \
+      "A real notification long enough to clear the probe and severity floors here" ) \
+      >/dev/null 2>"${RO}.err"
+  ec=$?
+  chmod 755 "$RO"; rm -rf "$RO"
+  if [ "$ec" -eq 0 ] && grep -q "read-only FS" "${RO}.err"; then
+    pass "read-only cwd -> inline fallthrough (exit 0, no set -e abort)"
+  else
+    bad "read-only cwd -> inline fallthrough (exit=$ec; err=$(tr '\n' '|' <"${RO}.err"))"
+  fi
+  rm -f "${RO}.err"
+fi
+
+reset
 echo "---"
 [ "$fail" = "0" ] && echo "ALL PASS" || echo "SOME FAILED"
 exit "$fail"

--- a/scripts/tests/test_run_grok.sh
+++ b/scripts/tests/test_run_grok.sh
@@ -29,7 +29,7 @@ chmod +x "$BIN/grok"
 export GROK_ARGS_FILE="$ARGS_FILE"
 export PATH="$BIN:$PATH"
 
-run() { echo "test prompt" | GROK_FAKE_OUT="$1" GROK_FAKE_RC="${2:-0}" MODEL="${3:-grok-composer-2.5-fast}" SKILL_MODE="${4:-write}" XAI_API_KEY=xai-test bash "$R" 2>/dev/null; }
+run() { echo "test prompt" | GROK_FAKE_OUT="$1" GROK_FAKE_RC="${2:-0}" MODEL="${3:-grok-4.5}" SKILL_MODE="${4:-write}" XAI_API_KEY=xai-test bash "$R" 2>/dev/null; }
 
 # 1. Claude-shaped JSON normalizes to result + usage
 OUT=$(run '{"result":"hi there","usage":{"input_tokens":11,"output_tokens":4}}')
@@ -78,7 +78,7 @@ grep -qx -- "--output-format" "$ARGS_FILE" && grep -qx "json" "$ARGS_FILE" \
   && pass "passes --output-format json" || bad "passes --output-format json"
 grep -qx -- "--no-auto-update" "$ARGS_FILE" && pass "passes --no-auto-update" || bad "passes --no-auto-update"
 grep -qx -- "--no-subagents" "$ARGS_FILE" && pass "passes --no-subagents" || bad "passes --no-subagents"
-grep -qx -- "--model" "$ARGS_FILE" && grep -qx "grok-composer-2.5-fast" "$ARGS_FILE" \
+grep -qx -- "--model" "$ARGS_FILE" && grep -qx "grok-4.5" "$ARGS_FILE" \
   && pass "passes --model for a real grok model" || bad "passes --model"
 grep -qx -- "--permission-mode" "$ARGS_FILE" && grep -qx "bypassPermissions" "$ARGS_FILE" \
   && pass "passes permission flags from skill_mode" || bad "passes permission flags"


### PR DESCRIPTION
## What

Ports the OpenRouter **multi-harness** capability from [`aaronjmars/aeon-openrouter`](https://github.com/aaronjmars/aeon-openrouter) (fork HEAD `d0a4930`) onto `main` as a strictly **additive** feature — **0 deletions**, no mainline feature dropped.

Six harnesses behind one Claude-Code-shaped `{result, usage, session_id}` contract: `claude`, `grok` (existing) + **`codex`, `pi`, `vibe`, `kimi`** (new, via a vendored `harness-adapter`). The four new ones share a single `OPENROUTER_API_KEY`, each with optional native provider auth.

## What lands
- **`harness-adapter/`** — `run-harness` dispatcher + 6 adapters + libs (envelope, sandbox, mcp-translate, schema-retry, tools-grammar, imports, compat-rules).
- **Native auth plumbing** — `lib/harness-auth.ts` (`HARNESS_AUTH` registry), `harness-auth-server.ts`, `HarnessAuthModal.tsx`, `app/api/harness-auth` (mirrors the existing local-dashboard `grok-auth` trust model).
- **Dashboard/CLI wiring** — per-harness model lists + harness dropdown (`constants.ts`), `aeon auth --harness codex|kimi|pi|vibe`, and the `config/dispatch/types/secrets-catalog` + `SecretsPanel/TopBar/ServiceIcon/page` updates.
- **Unified run path** — every harness runs through `run-harness`; `run-grok.sh` gains a `setup` subcommand; `notify.sh` gets a non-fatal read-only fallthrough (+ regression tests); `docs/harnesses.md` verification section.

## Review gates applied on top of the fork
- **[supply chain]** Pinned `pi@0.80.9`, `kimi@0.28.0` (+`--ignore-scripts`), `vibe==2.20.0` to match the already-pinned `codex@0.144.6`. An unpinned `-g` install runs whatever the registry serves in CI with the run's secrets in env.
- **[defaults]** Kept `harness: claude` / `model: claude-sonnet-4-6` (the fork had flipped these to `kimi`) — land the capability, not the kimi default.
- **[no regressions]** Did **not** drop `aeon-doctor` / `docs/aeon-setup.md` / `.claude`, and did **not** import the fork's `##`-heading skill rewrites (`skill-health` still depends on the `### <skill-name>` log shape), its default-flip `aeon.yml`, or its catalog/README edits.
- Re-added `claude-opus-4-7` to the picker + workflow choices so model availability is unchanged. (The `grok-composer` trim was kept — that one's a real X-account-login correctness fix.)

## ⚠️ One behavioral change to flag for review
The **default `claude` execution path** now routes through `run-harness claude` (which invokes `claude -p` under the gateway cascade) instead of an inline `claude -p`. Read-only guard (allowedTools-strip + post-run revert) and the 8-provider failover are preserved around it. Verified green both modes on the fork (2026-07-22), but it *is* a change to how the default agent runs — worth a look before merge.

## Not addressed (nice-to-have)
codex MCP `env` is still passed via `-c` argv rather than a config file (low severity; codex+MCP is headless-denied upstream today regardless).

## Validation
- All imported shell parses clean (`bash -n`).
- `scripts/tests/test_notify.sh` + `test_run_grok.sh` pass locally.
- TS import graph resolves; full typecheck deferred to `ci-apps` in this PR.
