### PR TITLE
fix(dashboard): per-skill model picker tracks active harness

### DIFF
--- a/apps/dashboard/components/SkillDetail.tsx
+++ b/apps/dashboard/components/SkillDetail.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import type { Skill, Run, Secret, SkillKeyRef, SkillMcpRef, McpServers } from '../lib/types'
-import { MODELS, keyProvidedByHarness } from '../lib/constants'
+import { modelsForHarness, keyProvidedByHarness } from '../lib/constants'
 import { MCP_BY_SLUG } from '../lib/mcp-catalog'
 import { displayName, getSkillStatus, cronLabel, statusDot, inputCls, runStatusColor } from '../lib/utils'
 import { ScheduleEditor } from './ScheduleEditor'
@@ -125,7 +125,11 @@ function McpRow({ mref, installed, onGoTo }: { mref: SkillMcpRef; installed: boo
 }
 
 export function SkillDetail({ skill, runs, model, harness, secrets, mcpServers, busy, onToggle, onRun, onDelete, onUpdateSchedule, onUpdateVar, onUpdateModel, onGoToSecret, onGoToMcp, onViewRun }: SkillDetailProps) {
-  const modelOptions = MODELS
+  // Per-skill model-override options must track the active harness, like the
+  // global picker (TopBar/page.tsx) — otherwise a non-claude harness only offers
+  // Claude models here, so an operator can't pin a skill to e.g. kimi-k3 and
+  // picking a Claude id would bake a mismatched `model:` into the skill.
+  const modelOptions = modelsForHarness(harness)
   const [editingSchedule, setEditingSchedule] = useState(false)
   const [editingVar, setEditingVar] = useState(false)
   const [varDraft, setVarDraft] = useState('')


### PR DESCRIPTION
Follow-up to #765. `SkillDetail`'s per-skill model-override dropdown was still hardcoded to `MODELS` (Claude ids). On a non-claude harness it would only offer Claude models, and picking one would bake a mismatched `model:` into the skill. Switch to `modelsForHarness(harness)` — matching the global picker in `TopBar`/`page.tsx`.

Two-line change; compiled fine before (`MODELS` still exists) so #765's CI was green — this closes the functional gap the build couldn't catch. Found during a completeness sweep against the fork.