### PR TITLE
docs: document the six-harness setup (README + aeon.yml)

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -40,7 +40,7 @@ cd aeon && ./aeon
 
 Open [http://localhost:5555](http://localhost:5555) and follow the four steps:
 
-1. **Authenticate** - connect your Claude Pro/Max subscription or your X account (for the [Grok harness](../docs/harnesses.md)), or paste an API key - Anthropic, Anthropic-compatible, or an [LLM gateway](../docs/CONFIGURATION.md#llm-gateways) key, routed automatically by prefix.
+1. **Authenticate** - connect your Claude Pro/Max subscription or your X account (for the [Grok harness](../docs/harnesses.md)), or paste an API key - Anthropic, Anthropic-compatible, or an [LLM gateway](../docs/CONFIGURATION.md#llm-gateways) key, routed automatically by prefix. A single **OpenRouter** key also unlocks four more [agent harnesses](../docs/harnesses.md) - Codex, Pi, Vibe, and Kimi - each of which can alternatively run on its own native login.
 2. **Add a channel** - [Telegram, Discord, Slack, or email](#notifications) so Aeon can talk to you.
 3. **Pick skills** - toggle what you want, set schedules. Each skill shows the API keys and MCP servers it needs, with one-click setup.
 4. **Run** - hit **Run now** on any skill to try it immediately; API keys and `var` values apply directly, no push needed. When you change config (schedules, toggles), **Push** commits it to GitHub in one click so Actions runs it on cron.
@@ -245,6 +245,8 @@ skills:
   token-movers: { enabled: true, schedule: "30 12 * * *", model: "claude-sonnet-4-6" }
 ```
 
+> These ids apply to the **claude** harness. Each other [harness](../docs/harnesses.md) carries its own model list (Codex `openai/*`, Kimi `moonshotai/*`, Vibe `mistralai/*`, Pi `deepseek/*`), which the dashboard picker swaps in when you select that harness.
+
 ### Authentication
 
 Aeon needs **at least one** way to reach a model. Add any of these in the dashboard's **Authenticate** modal - paste a key and the provider is auto-detected from its prefix (or picked from the dropdown). You can set several: each run resolves the highest-priority one whose key is present, so you don't have to choose just one.
@@ -255,6 +257,9 @@ Aeon needs **at least one** way to reach a model. Add any of these in the dashbo
 | **Anthropic API** | `ANTHROPIC_API_KEY` | Pay-as-you-go · [console.anthropic.com](https://console.anthropic.com) |
 | **LLM gateway** - cheaper / crypto-settled | Bankr `bk_…` · OpenRouter `sk-or-…` · Surplus `inf_…` · Venice / UsePod | see [LLM Gateways](../docs/CONFIGURATION.md#llm-gateways) |
 | **Grok** - via your X account | `GROK_CREDENTIALS` or `XAI_API_KEY` | SuperGrok / X Premium+ · see [Harnesses](../docs/harnesses.md) |
+| **Codex / Pi / Vibe / Kimi** - four more harnesses | `OPENROUTER_API_KEY` (shared), or each harness's own native auth (`CODEX_AUTH`, `KIMI_AUTH`, `OPENAI_API_KEY`, `MOONSHOT_API_KEY`, `MISTRAL_API_KEY`) | OpenRouter or the provider · see [Harnesses](../docs/harnesses.md) |
+
+For the four OpenRouter-backed harnesses, capture a native login from the terminal with `aeon auth --harness codex|kimi|pi|vibe` (or the dashboard's **Connect** buttons); with none set they fall back to the shared `OPENROUTER_API_KEY`.
 
 Prefer the CLI for the subscription token?
 
@@ -355,7 +360,7 @@ Everything above gets you running. The deeper reference lives in [`docs/`](../do
 - **[Configuration & advanced](../docs/CONFIGURATION.md)** - skill chaining, reactive triggers, scheduler frequency, capability modes, MCP in runs, cross-repo tokens, `STRATEGY.md` / soul, Fleet Watcher, remote dashboard, two-repo setup, Actions cost.
 - **[ADK (Aeon Developer Kit)](../docs/ADK.md)** - build products on top of Aeon: authorize access to your users' instances with a GitHub App, drive skills over the GitHub API, and ship your own skills as a pack.
 - **[LLM gateways](../docs/CONFIGURATION.md#llm-gateways)** - eight ways to power Claude Code, resolved by an automatic fail-over cascade.
-- **[Harnesses](../docs/harnesses.md)** - run skills on Claude Code or the Grok CLI; token accounting and per-skill knobs.
+- **[Harnesses](../docs/harnesses.md)** - run skills on any of six agent CLIs (Claude Code, Grok, Codex, Pi, Vibe, Kimi) behind one contract via [`harness-adapter`](../harness-adapter/); auth, token accounting, per-skill knobs, and the live verification matrix.
 - **[Knowledge (OKF)](../docs/OKF.md)** - Aeon's memory is a portable Open Knowledge Format bundle other agents can read.
 - **[Use Aeon's skills from Claude](../apps/mcp-server/README.md)** - every skill as an `aeon-<name>` MCP tool in Claude Desktop and Code.
 - **[Command line](../apps/cli/README.md)** - the whole dashboard as scriptable `./aeon` commands.

--- a/aeon.yml
+++ b/aeon.yml
@@ -181,14 +181,22 @@ chains:
 # (Grok harness models: grok-4.5 — flagship reasoning model & grok's current default,
 #  run with --no-subagents in CI; grok-composer-2.5-fast — fast/cheap single-agent.
 #  The older grok-build-0.1 is gateway-only, via XAI_API_KEY + the GROK_MODEL var.)
+# The non-claude harnesses use their OWN model ids (codex openai/*, kimi moonshotai/*,
+# vibe mistralai/*, pi deepseek/*) — surfaced in the dashboard picker per harness; see
+# docs/harnesses.md. The value below only applies to the claude/grok harnesses.
 model: claude-sonnet-4-6
 
 # Agent harness — which coding-agent CLI runs your skills.
-#   claude (default) — Claude Code (`claude -p`); uses the AI Gateway below.
-#   grok             — Grok Build (`grok`); logs in with your X account
-#                      (GROK_CREDENTIALS, captured in the dashboard) or an
-#                      XAI_API_KEY. Bypasses the gateway (grok has its own auth).
-# Override per-skill with `harness: "grok"` in the skill entry, or per-run via
+#   claude (default)  — Claude Code (`claude -p`); uses the AI Gateway below.
+#   grok              — Grok Build (`grok`); logs in with your X account
+#                       (GROK_CREDENTIALS, captured in the dashboard) or an
+#                       XAI_API_KEY. Bypasses the gateway (grok has its own auth).
+#   codex/pi/vibe/kimi — OpenAI Codex, Pi, Mistral Vibe, Moonshot Kimi — run through
+#                       harness-adapter/run-harness (one Claude-Code-shaped contract).
+#                       A single OPENROUTER_API_KEY drives all four, or each can use
+#                       its own native auth (ChatGPT/Moonshot login, provider key).
+#                       See docs/harnesses.md for models, auth, and verification.
+# Override per-skill with `harness: "<name>"` in the skill entry, or per-run via
 # the workflow_dispatch `harness` input. Default stays claude — everything
 # already configured keeps working unchanged.
 harness: claude


### PR DESCRIPTION
Follow-up to #765/#766. `docs/harnesses.md` already has the full deep-dive (it came over in the merge); this closes the gap in the two surfaces an operator starts from.

**README** (`.github/README.md`)
- Authenticate step now mentions the OpenRouter key unlocking Codex/Pi/Vibe/Kimi.
- New Authentication-table row: `OPENROUTER_API_KEY` (shared) or each harness's native auth, plus an `aeon auth --harness …` note.
- Models section notes each non-claude harness carries its own model ids (`openai/*`, `moonshotai/*`, `mistralai/*`, `deepseek/*`).
- Harnesses docs-index line updated: six agent CLIs behind one `harness-adapter` contract.

**`aeon.yml`**
- `harness:` and `model:` field comments now list all six harnesses and the non-claude model families, pointing to `docs/harnesses.md`.

Docs-only, no behavior change.