### PR TITLE
fix(aeon): Run banner names the resolved harness model, not the config-default claude id

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -733,6 +733,7 @@ jobs:
           INPUT_MODEL: ${{ inputs.model }}
           RESOLVED_HARNESS: ${{ steps.harness.outputs.HARNESS }}
           RH_MODEL_ARG: ${{ steps.harness.outputs.MODEL_ARG }}
+          RH_HARNESS_MODEL: ${{ steps.harness.outputs.HARNESS_MODEL }}
           INPUT_CHAIN_CTX: ${{ inputs.chain_context_file }}
         run: |
           TODAY=$(date -u +%Y-%m-%d)
@@ -758,7 +759,16 @@ jobs:
           if [ "$HARNESS" = "grok" ]; then
             case "$MODEL" in claude-*|"") MODEL="grok-4.5" ;; esac
           fi
-          echo "Using harness: $HARNESS  |  model: $MODEL"
+          # Banner must name the model that ACTUALLY runs. For claude/grok that is
+          # $MODEL (their native id). For the adapter harnesses (codex/pi/vibe/kimi)
+          # $MODEL still carries the config-default claude id, which never runs —
+          # the real model is the resolved harness model (HARNESS_MODEL from
+          # "Resolve harness"). Fall back to $MODEL if that output is somehow empty.
+          case "$HARNESS" in
+            claude|grok) BANNER_MODEL="$MODEL" ;;
+            *)           BANNER_MODEL="${RH_HARNESS_MODEL:-$MODEL}" ;;
+          esac
+          echo "Using harness: $HARNESS  |  model: $BANNER_MODEL"
           echo "SKILL_MODEL=$MODEL" >> "$GITHUB_OUTPUT"
           echo "HARNESS=$HARNESS" >> "$GITHUB_OUTPUT"   # read by the post-run scorer / feed-convert steps
 


### PR DESCRIPTION
## What

The **Run** step banner (`Using harness: X | model: …`) printed `$MODEL`, which for the adapter harnesses (**codex / pi / vibe / kimi**) is the *config-default claude id* (e.g. `claude-sonnet-4-6`) — a model that never actually runs on those harnesses. The real model is the one resolved in **Resolve harness** (`HARNESS_MODEL`).

Example (a codex run on OpenRouter):
```
Resolve harness: Harness: codex | model: openai/gpt-5-mini | run-harness --model: openai/gpt-5-mini
Run:             Using harness: codex | model: claude-sonnet-4-6   <-- misleading
```

## Fix

- Expose `steps.harness.outputs.HARNESS_MODEL` to the Run step env as `RH_HARNESS_MODEL`.
- Banner picks the model that actually runs: `$MODEL` for **claude/grok**, `HARNESS_MODEL` for the adapter harnesses (falling back to `$MODEL` if empty).

## Scope

Log-only, cosmetic. The real `--model` passed to `run-harness` was already correct; execution is unchanged. YAML validated. **Verified end-to-end on GitHub Actions** — a codex/OpenRouter run's banner now reads `model: openai/gpt-5-mini`.