### PR TITLE
feat(dashboard): disable MCP controls on the Codex harness

### DIFF
--- a/apps/dashboard/app/page.tsx
+++ b/apps/dashboard/app/page.tsx
@@ -250,7 +250,7 @@ export default function Dashboard() {
           {view === 'mcp' && !selectedSkill && (
             mcpError
               ? <PanelError label="MCP servers" onRetry={() => { setMcpError(false); setMcpLoaded(false) }} />
-              : <McpPanel servers={mcpServers} loading={!mcpLoaded} saving={mcpSaving} secrets={secrets} busy={busy} onSave={saveMcp} onSetSecret={saveSecret} onDeleteSecret={deleteSecret} onGoToSecret={goToSecret} />
+              : <McpPanel harness={harness} servers={mcpServers} loading={!mcpLoaded} saving={mcpSaving} secrets={secrets} busy={busy} onSave={saveMcp} onSetSecret={saveSecret} onDeleteSecret={deleteSecret} onGoToSecret={goToSecret} />
           )}
           {view === 'soul' && !selectedSkill && (
             soulError

--- a/apps/dashboard/components/McpPanel.tsx
+++ b/apps/dashboard/components/McpPanel.tsx
@@ -4,12 +4,20 @@ import { useState, useEffect } from 'react'
 import { Scramble } from './ui/Animated'
 import { inputCls } from '../lib/utils'
 import { MCP_CATALOG } from '../lib/mcp-catalog'
-import type { Secret, McpServer, McpServers } from '../lib/types'
+import type { Secret, McpServer, McpServers, Harness } from '../lib/types'
 
 // One-click starters - public HTTP MCP servers that install with no token.
 const FEATURED = MCP_CATALOG
 
+// Codex can't call MCP tools in headless runs: under `codex exec` each tool call
+// raises an approval prompt that reads EOF on the closed stdin and resolves as
+// cancel, so the tool never runs (upstream openai/codex#24135). Wiring a server
+// on codex would silently no-op at run time, so the MCP controls are disabled and
+// the operator is told to switch harness. Keep in sync with harness-adapter.
+const MCP_DISABLED_MSG = "Codex can't run MCP tools in headless runs (openai/codex#24135). Switch the harness to claude, grok, kimi or vibe to use MCP."
+
 interface McpPanelProps {
+  harness: Harness
   servers: McpServers
   loading: boolean
   saving: boolean
@@ -44,7 +52,11 @@ function transportOf(server: McpServer): string {
   return typeof server.command === 'string' ? 'stdio' : 'http'
 }
 
-export function McpPanel({ servers, loading, saving, secrets, busy, onSave, onSetSecret, onDeleteSecret, onGoToSecret }: McpPanelProps) {
+export function McpPanel({ harness, servers, loading, saving, secrets, busy, onSave, onSetSecret, onDeleteSecret, onGoToSecret }: McpPanelProps) {
+  // Codex can't use MCP headlessly (see MCP_DISABLED_MSG): grey out every MCP
+  // action so a run isn't configured to use tools it will silently skip.
+  const mcpDisabled = harness === 'codex'
+
   const [draft, setDraft] = useState<McpServers>(servers)
   useEffect(() => { setDraft(servers) }, [servers])
 
@@ -183,6 +195,15 @@ export function McpPanel({ servers, loading, saving, secrets, busy, onSave, onSe
         </div>
       </section>
 
+      {mcpDisabled && (
+        <div className="border border-aeon-red/40 bg-aeon-panel px-[var(--space-md)] py-[var(--space-sm)]">
+          <p className="text-[10px] font-mono uppercase tracking-[0.14em] text-aeon-red mb-1.5">⚠ MCP is unavailable on the Codex harness</p>
+          <p className="text-[11px] text-primary-40 leading-relaxed">
+            {MCP_DISABLED_MSG} You can still view your servers below, but the actions are disabled until you switch harness in the top bar.
+          </p>
+        </div>
+      )}
+
       <section className="border-t border-[rgba(250,250,250,0.10)] pt-6">
         <div className="flex items-center gap-3 mb-4">
           <span className="font-display text-[13px] tracking-[0.18em] text-aeon-red uppercase">Featured</span>
@@ -203,7 +224,7 @@ export function McpPanel({ servers, loading, saving, secrets, busy, onSave, onSe
                 {installed ? (
                   <span className="text-[10px] font-mono uppercase tracking-[0.14em] text-aeon-green shrink-0">✓ installed</span>
                 ) : (
-                  <button onClick={() => installFeatured(f)} disabled={saving || oauthBusy === f.slug} className="btn-mini-go shrink-0" title={f.oauth ? 'Opens your browser to authorize, then stores the tokens' : undefined}>
+                  <button onClick={() => installFeatured(f)} disabled={saving || oauthBusy === f.slug || mcpDisabled} className="btn-mini-go shrink-0" title={mcpDisabled ? MCP_DISABLED_MSG : f.oauth ? 'Opens your browser to authorize, then stores the tokens' : undefined}>
                     {oauthBusy === f.slug ? 'Connecting…' : f.oauth ? 'Connect' : 'Install'}
                   </button>
                 )}
@@ -268,7 +289,7 @@ export function McpPanel({ servers, loading, saving, secrets, busy, onSave, onSe
                                   ) : (
                                     <>
                                       <input type="password" value={secretDraft[r] ?? ''} onChange={e => setSecretDraft(d => ({ ...d, [r]: e.target.value }))} onKeyDown={e => e.key === 'Enter' && saveRowSecret(r)} placeholder="paste bearer token - saved to GitHub & wired in" className="flex-1 min-w-0 bg-aeon-bg border border-[rgba(250,250,250,0.10)] px-2 py-1 text-[11px] font-mono text-primary-100 outline-none focus:border-aeon-red transition-colors cursor-target" />
-                                      <button onClick={() => saveRowSecret(r)} disabled={!(secretDraft[r] ?? '').trim()} className="btn-mini-go shrink-0">Set</button>
+                                      <button onClick={() => saveRowSecret(r)} disabled={!(secretDraft[r] ?? '').trim() || mcpDisabled} title={mcpDisabled ? MCP_DISABLED_MSG : undefined} className="btn-mini-go shrink-0">Set</button>
                                     </>
                                   )}
                                 </div>
@@ -319,7 +340,7 @@ export function McpPanel({ servers, loading, saving, secrets, busy, onSave, onSe
                   </div>
                 </div>
               ) : (
-                <button onClick={() => setAdding(true)} className="w-full text-sm font-mono uppercase tracking-[0.14em] text-primary-60 border border-dashed border-[rgba(250,250,250,0.16)] py-3.5 hover:text-aeon-red hover:border-aeon-red/40 transition-colors">+ Add server</button>
+                <button onClick={() => setAdding(true)} disabled={mcpDisabled} title={mcpDisabled ? MCP_DISABLED_MSG : undefined} className="w-full text-sm font-mono uppercase tracking-[0.14em] text-primary-60 border border-dashed border-[rgba(250,250,250,0.16)] py-3.5 hover:text-aeon-red hover:border-aeon-red/40 transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:text-primary-60 disabled:hover:border-[rgba(250,250,250,0.16)]">+ Add server</button>
               )}
             </div>
 
@@ -333,7 +354,7 @@ export function McpPanel({ servers, loading, saving, secrets, busy, onSave, onSe
             <div className="flex items-center justify-end mt-4">
               <div className="flex items-center gap-2">
                 {dirty && <button onClick={() => setDraft(servers)} className="btn-mini">Revert</button>}
-                <button onClick={() => onSave(draft)} disabled={!dirty || saving} className="btn-mini-go">
+                <button onClick={() => onSave(draft)} disabled={!dirty || saving || mcpDisabled} title={mcpDisabled ? MCP_DISABLED_MSG : undefined} className="btn-mini-go">
                   {saving ? 'Saving…' : 'Save'}
                 </button>
               </div>


### PR DESCRIPTION
## Why

Codex can't call MCP tools in headless runs. Under `codex exec`, each MCP tool call raises an approval prompt that reads EOF on the closed stdin and resolves as **cancel**, so the tool never runs — upstream [openai/codex#24135](https://github.com/openai/codex/issues/24135) (open). Wiring an MCP server while codex is the selected harness silently no-ops at run time.

Hit live in testing: a `glim-mcp` run on a non-claude harness never got the `mcp__glim__*` tools and fell back to WebFetch. The dashboard shouldn't invite users to configure MCP for a harness that can't use it.

## Change

`McpPanel` now receives the selected `harness` (already held in `page.tsx`) and, when it's `codex`:
- shows a banner: *"⚠ MCP is unavailable on the Codex harness — switch to claude, grok, kimi or vibe."*
- greys out every MCP **action**: Connect/Install (featured), per-row **Set** token, **+ Add server**, and **Save** — each with a `title` tooltip.
- servers stay **viewable** (read-only); only actions are disabled.

Matches the codebase idioms: `disabled` prop + `.btn-mini-go:disabled` CSS greying (`disabled:opacity-40` for the one plain-styled button), native `title` tooltips (no Tooltip component), one prop drilled from `page.tsx`.

## Testing

`npm run typecheck` passed on the origin fork; scoped to `page.tsx` (+1 line) + `McpPanel.tsx`; no behavior change for non-codex harnesses. (Remove `mcpDisabled` + banner if codex headless MCP lands upstream, #24135.)