### PR TITLE
docs(skills): correct /aeon setup skill count 61 -> 62

### DIFF
--- a/.claude/skills/aeon/SKILL.md
+++ b/.claude/skills/aeon/SKILL.md
@@ -248,7 +248,7 @@ requires: [SOME_API_KEY?]
 Today is ${today}. <the prompt — plain instructions, including judgment calls>
 
 ## Steps
-1. <the procedure — 40 of 61 skills lead with this>
+1. <the procedure — 41 of 62 skills lead with this>
 
 ## Network note
 <curl / WebFetch / `./secretcurl` / `gh api` — how this skill fetches>
@@ -308,9 +308,9 @@ Three at a time, not twelve. Every enabled skill is a recurring notification, an
 ./aeon packs ls                  # the six first-party packs
 ```
 
-`ls` footers with `61 skills · 1 enabled` — read it to them before proposing anything. First run installs the CLI runtime (tsx + yaml, ~12MB); the npm noise is one-time and expected. Grep-only equivalents: `references/layout.md`.
+`ls` footers with `62 skills · 1 enabled` — read it to them before proposing anything. First run installs the CLI runtime (tsx + yaml, ~12MB); the npm noise is one-time and expected. Grep-only equivalents: `references/layout.md`.
 
-Packs are a visibility filter, not a runtime switch — revealing one runs nothing. Core (11), Evolution (7) and Basics (15) show by default; Dev (8), Crypto (12) and Productivity (8) are on demand.
+Packs are a visibility filter, not a runtime switch — revealing one runs nothing. Core (11), Evolution (8) and Basics (15) show by default; Dev (8), Crypto (12) and Productivity (8) are on demand.
 
 Reasonable starting sets:
 

--- a/.claude/skills/aeon/references/layout.md
+++ b/.claude/skills/aeon/references/layout.md
@@ -12,7 +12,7 @@ Where everything lives in an Aeon repo, and the fastest way to see what's on.
 ./aeon skills ls --enabled --json # for building the Mode 2 timeline
 ```
 
-`ls` prints `SKILL / ON / SCHEDULE / PACK / DESCRIPTION` and a footer — `61 skills · 1 enabled`. First run installs the CLI runtime (tsx + yaml, ~12MB, one-time); the noise is expected.
+`ls` prints `SKILL / ON / SCHEDULE / PACK / DESCRIPTION` and a footer — `62 skills · 1 enabled`. First run installs the CLI runtime (tsx + yaml, ~12MB, one-time); the noise is expected.
 
 **The `SCHEDULE` column is populated for disabled skills too** — it's their `aeon.yml` entry, not proof anything fires. Only the `●` in `ON` means it runs.
 

--- a/.claude/skills/aeon/references/mcp.md
+++ b/.claude/skills/aeon/references/mcp.md
@@ -7,7 +7,7 @@ Two unrelated things share the name. Get this wrong and nothing works.
 | | |
 |---|---|
 | **`.mcp.json`** — *external MCP servers, called BY Aeon skills* | Wired via the dashboard MCP panel or `./aeon mcp add`. This is what you want when a skill needs a tool. |
-| **`bin/add-mcp`** — *Aeon itself AS an MCP server* | Builds `apps/mcp-server` and registers it with Claude Code / Desktop, so all 61 skills appear as `aeon-*` tools **in your local Claude**. Nothing to do with a skill calling out. |
+| **`bin/add-mcp`** — *Aeon itself AS an MCP server* | Builds `apps/mcp-server` and registers it with Claude Code / Desktop, so all 62 skills appear as `aeon-*` tools **in your local Claude**. Nothing to do with a skill calling out. |
 
 The rest of this doc is the first one. For the second: `bin/add-mcp`, `--desktop` for a Claude Desktop snippet, `--uninstall` to remove, `claude mcp list` to verify.
 

--- a/.claude/skills/aeon/references/skill-anatomy.md
+++ b/.claude/skills/aeon/references/skill-anatomy.md
@@ -1,10 +1,10 @@
 # How Aeon skills are actually written
 
-Surveyed across all 61 skills in `aeonfun/aeon`. Frequencies are real counts — match the dominant convention unless there's a reason not to. Bodies run 133–757 lines (~306 median); a skill is a prompt, not a config file, and reads as prose.
+Surveyed across all 62 skills in `aeonfun/aeon`. Frequencies are real counts — match the dominant convention unless there's a reason not to. Bodies run 133–757 lines (~306 median); a skill is a prompt, not a config file, and reads as prose.
 
 ## Frontmatter
 
-Universal — **all 61 skills** carry these five:
+Universal — **all 62 skills** carry these five:
 
 ```yaml
 type: Skill          # required by ci-okf; every .md under skills/ needs a type:
@@ -114,7 +114,7 @@ There is **no network sandbox** — plain `curl` works for unauthenticated GETs.
 
 `memory/` is the durable state that survives between runs. Four conventions, in order of how often skills touch them:
 
-### `memory/logs/${today}.md` — the run log (57 of 61 skills)
+### `memory/logs/${today}.md` — the run log (58 of 62 skills)
 
 Every skill appends what it did, under **one** heading that is exactly its slug:
 


### PR DESCRIPTION
## What

The `/aeon` operator setup skill (`.claude/skills/aeon/`) still stated **61 skills**, but a 62nd skill shipped in the **evolution** pack. This corrects every stale literal to the live count.

## Why it matters

These counts are hand-maintained literals (unlike the aeon.fun website's live-derived figures), so they silently drift when a skill is added. `catalog/skills.json` `total` is **62** and `ls -d skills/*/ | wc -l` is **62**.

## Changes (counts only, no prose/behavior)

| Surface | Before | After |
|---|---|---|
| `SKILL.md` + `references/layout.md` CLI footer | `61 skills - 1 enabled` | `62 skills - 1 enabled` |
| `SKILL.md` pack breakdown | `Evolution (7)` | `Evolution (8)` (sums to 62) |
| `SKILL.md` survey stat | `40 of 61 skills` lead with Steps | `41 of 62` |
| `references/skill-anatomy.md` | `all 61 skills`, `57 of 61 skills` | `all 62`, `58 of 62` |
| `references/mcp.md` | `all 61 skills` appear as `aeon-*` tools | `all 62` |

All survey numerators were re-verified against the repo (not just denominator-bumped), so "Frequencies are real counts" stays true: `## Steps` present = 41, `memory/logs/${today}` present = 58, `type:` frontmatter = 62/62.

## Note

The same skill is mirrored (hand-copied) to the website at `aeon.fun/skills/aeon.md`; a matching count fix goes out in a separate `aeon-website` PR.
