### PR TITLE
fix(grok): persist rotated OAuth refresh token so GROK_CREDENTIALS survives past 6h

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -220,6 +220,10 @@ jobs:
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           ANTHROPIC_OAUTH_TOKEN: ${{ secrets.ANTHROPIC_OAUTH_TOKEN }}
+          # grok's native auth (X-account OAuth capture > xAI key), so its AUTH_MODE
+          # is detected like the other harnesses instead of defaulting to openrouter.
+          GROK_CREDENTIALS: ${{ secrets.GROK_CREDENTIALS }}
+          XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
         run: |
           # `|| true` on both greps: a repo with no top-level `harness:` key, or a
           # skill absent from aeon.yml's skills map, makes grep exit 1, and under
@@ -266,6 +270,7 @@ jobs:
           # so we forward NO model and let the harness use its own default.
           AUTH_MODE="openrouter"
           case "$HARNESS" in
+            grok)  if [ -n "${GROK_CREDENTIALS:-}" ]; then AUTH_MODE="native-oauth"; elif [ -n "${XAI_API_KEY:-}" ]; then AUTH_MODE="native-key"; fi ;;
             codex) if [ -n "${CODEX_AUTH:-}" ]; then AUTH_MODE="native-oauth"; elif [ -n "${OPENAI_API_KEY:-}" ]; then AUTH_MODE="native-key"; fi ;;
             kimi)  if [ -n "${KIMI_AUTH:-}" ]; then AUTH_MODE="native-oauth"; elif [ -n "${MOONSHOT_API_KEY:-}" ]; then AUTH_MODE="native-key"; fi ;;
             vibe)  if [ -n "${MISTRAL_API_KEY:-}" ]; then AUTH_MODE="native-key"; fi ;;
@@ -352,6 +357,14 @@ jobs:
           # grok auth (staged via run-grok.sh setup): captured X-account OAuth or key.
           GROK_CREDENTIALS: ${{ secrets.GROK_CREDENTIALS }}
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
+          # secrets-write PAT so run-grok.sh setup can PERSIST a rotated grok refresh
+          # token back to GROK_CREDENTIALS - the durable-OAuth-past-6h fix (run-grok.sh §2b).
+          MCP_SECRETS_PAT: ${{ secrets.MCP_SECRETS_PAT }}
+          GH_GLOBAL: ${{ secrets.GH_GLOBAL }}
+          # Optional: seconds-before-expiry that triggers the grok OAuth refresh
+          # (run-grok.sh §2b, default 1800). Set a large value as a repo variable to
+          # force a refresh + persist every run (handy to verify durability in CI).
+          GROK_OAUTH_SKEW: ${{ vars.GROK_OAUTH_SKEW }}
           # Provider credentials. Whichever is set decided AUTH_MODE in "Resolve
           # harness"; here we either RESTORE it (the ChatGPT/Moonshot OAuth
           # captures, which a local `aeon auth --harness …` stored) or write it

--- a/.github/workflows/messages.yml
+++ b/.github/workflows/messages.yml
@@ -435,6 +435,9 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
           GROK_CREDENTIALS: ${{ secrets.GROK_CREDENTIALS }}   # grok harness: X-account OAuth (restored by run-grok.sh)
+          MCP_SECRETS_PAT: ${{ secrets.MCP_SECRETS_PAT }}   # persist rotated grok refresh token → GROK_CREDENTIALS (run-grok.sh §2b)
+          GH_GLOBAL: ${{ secrets.GH_GLOBAL }}
+          GROK_OAUTH_SKEW: ${{ vars.GROK_OAUTH_SKEW }}   # force grok OAuth refresh + persist every run when set large (durability check)
           COINGECKO_API_KEY: ${{ secrets.COINGECKO_API_KEY }}
           ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
           _MSG_SOURCE: ${{ steps.msg.outputs.source }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,20 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 - **Dashboard: per-skill model picker tracks the active harness** — a skill's
   detail panel now offers the selected harness's model ids. (#766)
 
+### Fixed
+
+- **Grok OAuth (`GROK_CREDENTIALS`) now survives past 6h.** The captured
+  X-account session holds a 6h access token plus a refresh token that xAI
+  **rotates and revokes on every refresh**, so a static secret used to break
+  ~6h after Connect (headless runs failed `Not signed in`). `scripts/run-grok.sh`
+  (§2b) now refreshes the access token before each run and **persists the rotated
+  `auth.json` back to the `GROK_CREDENTIALS` secret** - the same durable-refresh
+  contract as MCP OAuth. Persisting reuses the secrets-write PAT
+  (`MCP_SECRETS_PAT` / `GH_GLOBAL`); without it grok warns loudly. Also adds a
+  `grok)` case to the harness AUTH_MODE detection so a Connected X account is
+  labelled `native-oauth` instead of defaulting to `openrouter`. See
+  [docs/harnesses.md](docs/harnesses.md) and [docs/mcp-oauth.md](docs/mcp-oauth.md).
+
 ### Security
 
 - Patched two high-severity CVE classes in the dashboard — `sharp`/`libvips`,

--- a/apps/dashboard/app/page.tsx
+++ b/apps/dashboard/app/page.tsx
@@ -285,7 +285,9 @@ export default function Dashboard() {
 
       {showImport && <ImportModal onClose={() => setShowImport(false)} onImport={importSkill} />}
       {showAuthModal && (harness === 'grok'
-        ? <GrokAuthModal loading={grokLoading} onClose={() => setShowAuthModal(false)} onGrokAuth={(p) => setupGrokAuth(p)} />
+        ? <GrokAuthModal loading={grokLoading} onClose={() => setShowAuthModal(false)} onGrokAuth={(p) => setupGrokAuth(p)}
+            patSet={secrets.some(s => s.isSet && (s.name === 'MCP_SECRETS_PAT' || s.name === 'GH_GLOBAL'))}
+            onGoToSecret={(n) => { setShowAuthModal(false); goToSecret(n) }} />
         : HARNESS_AUTH[harness]
         ? <HarnessAuthModal harness={harness} loading={harnessAuthLoading} onClose={() => setShowAuthModal(false)} onHarnessAuth={(p) => setupHarnessAuth(harness, p)} />
         : <AuthModal loading={authLoading} onClose={() => setShowAuthModal(false)} onAuth={(auth) => setupAuth(auth)} />)}

--- a/apps/dashboard/components/GrokAuthModal.tsx
+++ b/apps/dashboard/components/GrokAuthModal.tsx
@@ -13,9 +13,14 @@ interface GrokAuthModalProps {
   loading: boolean
   onClose: () => void
   onGrokAuth: (payload?: { key: string }) => void
+  // Whether a secrets-write PAT (MCP_SECRETS_PAT / GH_GLOBAL) is
+  // set - the OAuth session rotates its refresh token and only survives past 6h if
+  // the runner can persist each rotation back to GROK_CREDENTIALS. Hides the note once set.
+  patSet: boolean
+  onGoToSecret: (name: string) => void
 }
 
-export function GrokAuthModal({ loading, onClose, onGrokAuth }: GrokAuthModalProps) {
+export function GrokAuthModal({ loading, onClose, onGrokAuth, patSet, onGoToSecret }: GrokAuthModalProps) {
   const [key, setKey] = useState('')
   const submitKey = () => key.trim() && onGrokAuth({ key: key.trim() })
 
@@ -30,6 +35,21 @@ export function GrokAuthModal({ loading, onClose, onGrokAuth }: GrokAuthModalPro
         <button onClick={() => onGrokAuth()} disabled={loading} className="w-full bg-aeon-fg text-aeon-bg text-sm py-3 font-mono uppercase tracking-[2px] hover:opacity-90 transition-opacity disabled:opacity-50">
           {loading ? '...' : 'Connect X account'}
         </button>
+        {/* Secrets-PAT setup note (parallels McpPanel's). The X-account session
+            rotates its refresh token on every run; the runner can only save each
+            rotation back with a secrets-write PAT. Without one, a Connected account
+            works ~6h and then its auth breaks. Hidden once MCP_SECRETS_PAT / GH_GLOBAL
+            is set. */}
+        {!patSet && (
+          <div className="mt-3 border border-[rgba(250,250,250,0.10)] bg-aeon-panel px-[var(--space-md)] py-[var(--space-sm)]">
+            <p className="text-[10px] font-mono uppercase tracking-[0.14em] text-aeon-red mb-1.5">⚠ The X-account session won&apos;t keep working without a secrets PAT</p>
+            <p className="text-[11px] text-primary-40 leading-relaxed">
+              Grok rotates its refresh token on every run, and the runner needs a secrets-write credential to save each rotation - without it a Connected account works once (~6h), then its auth breaks. To set it up: create a fine-grained PAT at <a href="https://github.com/settings/personal-access-tokens" target="_blank" rel="noopener noreferrer" className="text-primary-70 underline decoration-dotted underline-offset-2 hover:text-aeon-fg transition-colors">github.com/settings/personal-access-tokens</a>, add this repo under <span className="text-primary-70">Repository access</span>, grant <span className="text-primary-70">Secrets: Read and write</span>, and save it as{' '}
+              <button onClick={() => onGoToSecret('MCP_SECRETS_PAT')} title="Open in Settings to set this key" className="text-aeon-red-alert underline decoration-dotted underline-offset-2 hover:text-aeon-fg transition-colors">MCP_SECRETS_PAT</button>
+              {' '}in Settings. Already Connected? Re-connect once after adding the PAT.
+            </p>
+          </div>
+        )}
         <div className="my-[var(--space-md)] border-t border-[rgba(250,250,250,0.10)]" />
         <p className="text-xs text-primary-50 font-mono mb-[var(--space-md)]">Or use an xAI API key (no browser flow) - also powers the Grok gateway.</p>
         <input type="password" value={key} onChange={(e) => setKey(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && submitKey()} placeholder="xai-..." className={`${inputCls} mb-[var(--space-md)]`} />

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -121,9 +121,24 @@ exposes differs:
   transparent `char/4` **estimate** of the assembled input + result rather than a
   misleading `0/0/0`; real counts always win if a future build emits them.
 
-The captured OAuth sessions (grok's `GROK_CREDENTIALS`, codex's `CODEX_AUTH`) can
-expire — if unattended runs start failing on auth, re-capture via the dashboard
-(**Connect X account** / **Connect ChatGPT**) or switch to the API-key path.
+The captured OAuth sessions (grok's `GROK_CREDENTIALS`, codex's `CODEX_AUTH`) rotate
+their refresh tokens. **grok's session is kept durable automatically** (mirroring the
+[MCP OAuth](mcp-oauth.md#limits-read-before-relying-on-it) contract): the access token
+in `GROK_CREDENTIALS` lasts only 6h, and xAI **rotates + revokes the refresh token on
+every refresh** (confirmed live - `auth.x.ai` returns `invalid_grant` "Refresh token
+has been revoked"), so a *static* capture self-destructs ~6h after Connect. To fix
+that, `scripts/run-grok.sh` (§2b) refreshes the access token from the refresh token
+before each run and **persists the rotated `auth.json` back to the `GROK_CREDENTIALS`
+secret**. Persisting a secret needs a secrets-write credential - the default
+`GITHUB_TOKEN` cannot - so set a fine-grained PAT with **Secrets: read/write** as
+`MCP_SECRETS_PAT` (or `GH_GLOBAL`). Without the PAT, grok
+warns loudly and auth breaks one run after the first post-expiry refresh. **After
+adding the PAT, re-connect the X account once** to seed a valid refresh token (a token
+already consumed by a prior run can't be revived by the PAT alone). Concurrent grok
+runs that each hit an expired token still race - each refresh revokes the other's
+token - so for high parallelism refresh centrally on a schedule so exactly one run
+mints and persists per interval. codex's `CODEX_AUTH` just expires (no auto-persist
+yet) - re-capture via **Connect ChatGPT** or use the OpenAI key.
 
 ## Capability mode carries over unchanged
 

--- a/scripts/run-grok.sh
+++ b/scripts/run-grok.sh
@@ -26,6 +26,11 @@
 #   GROK_CREDENTIALS      base64 of the X-account OAuth session captured by the
 #                         dashboard (a tar rooted at $HOME, or a single cred file)
 #   GROK_CREDENTIALS_PATH single-file restore target (default ~/.grok/credentials.json)
+#   MCP_SECRETS_PAT       secrets-write PAT (or GH_GLOBAL as the repo-wide fallback)
+#                         used to PERSIST a rotated refresh token back to the
+#                         GROK_CREDENTIALS secret so OAuth auth survives past 6h (§2b);
+#                         without it a rotating provider breaks one run after expiry.
+#   GROK_OAUTH_SKEW       seconds-before-expiry to trigger a refresh (default 1800)
 #   GROK_CLI_VERSION      npm pin override (default below)
 #   Run-shaping knobs (all optional; aeon.yml maps a skill's frontmatter to them):
 #   GROK_MAX_TURNS        agentic-turn cap (default 60; 0/off = uncapped)
@@ -106,6 +111,96 @@ else
   log "::error::grok harness needs auth: set GROK_CREDENTIALS (X-account login via the dashboard) or XAI_API_KEY, or run 'grok login'"
   exit 1
 fi
+
+# --- 2b. keep the OAuth session durable (refresh + persist rotated token) ----
+# The captured GROK_CREDENTIALS holds ~/.grok/auth.json = a 6h access JWT + an
+# offline_access refresh token. xAI ROTATES the refresh token on every refresh and
+# revokes the prior one (confirmed live: auth.x.ai returns invalid_grant "Refresh
+# token has been revoked"), so a STATIC secret self-destructs ~6h after capture: the
+# first post-expiry run refreshes and rotates the token, but grok writes the new one
+# only to the ephemeral runner $HOME - the secret still holds the now-revoked token,
+# and every later run dies "Not signed in". Fix (mirrors scripts/mcp-oauth-refresh.sh):
+# refresh HERE from the refresh token, rewrite auth.json, then PERSIST the rotated
+# file back to the GROK_CREDENTIALS secret via a secrets-write PAT (MCP_SECRETS_PAT /
+# GH_GLOBAL - the default GITHUB_TOKEN cannot write secrets). Only
+# refreshes when the access token is within GROK_OAUTH_SKEW seconds of expiry, so runs
+# inside the window reuse the on-disk token and do not needlessly rotate (fewer
+# concurrent-run races; for high parallelism refresh centrally on a schedule so exactly
+# one run mints per interval - see docs/harnesses.md). Runs on the GitHub runner in
+# plain bash (no Claude bash analyzer), so a normal curl with the token in
+# --data-urlencode is fine; nothing is echoed. This is a no-op unless we authed via
+# GROK_CREDENTIALS (the CI OAuth path) - a local `grok login` session is left untouched.
+grok_oauth_refresh() {
+  local auth="$GROK_HOME/auth.json"
+  [ -f "$auth" ] || return 0
+  command -v jq >/dev/null 2>&1 || { log "::debug::grok oauth: jq missing - skipping refresh"; return 0; }
+  # The credential is a map keyed by "<issuer>::<client_id>"; operate on the first entry.
+  local k iss cid rt exp
+  k=$(jq -r 'keys_unsorted[0] // empty' "$auth" 2>/dev/null)
+  [ -z "$k" ] && return 0
+  iss=$(jq -r --arg k "$k" '.[$k].oidc_issuer   // empty' "$auth" 2>/dev/null)
+  cid=$(jq -r --arg k "$k" '.[$k].oidc_client_id // empty' "$auth" 2>/dev/null)
+  rt=$(jq  -r --arg k "$k" '.[$k].refresh_token  // empty' "$auth" 2>/dev/null)
+  exp=$(jq -r --arg k "$k" '.[$k].expires_at     // empty' "$auth" 2>/dev/null)
+  # No refresh token (API-key path or a stripped file) or no issuer → nothing to keep alive.
+  [ -z "$rt" ] || [ -z "$iss" ] && return 0
+  # Only refresh when the access token is expired or within the skew window.
+  local skew="${GROK_OAUTH_SKEW:-1800}" now_epoch exp_epoch
+  now_epoch=$(jq -rn 'now|floor' 2>/dev/null)
+  exp_epoch=$(jq -rn --arg t "$exp" '($t|sub("\\.[0-9]+Z$";"Z")|fromdateiso8601?) // 0' 2>/dev/null)
+  if [ "${exp_epoch:-0}" -gt 0 ] 2>/dev/null && [ $((exp_epoch - now_epoch)) -gt "$skew" ]; then
+    log "::debug::grok oauth: access token still valid ($((exp_epoch - now_epoch))s left) - skipping refresh"
+    return 0
+  fi
+  local ep="${iss%/}/oauth2/token"
+  log "::debug::grok oauth: refreshing access token via $ep"
+  local resp access new_rt expires_in
+  resp=$(curl -s --max-time 30 -X POST "$ep" \
+    -H 'Accept: application/json' -H 'Content-Type: application/x-www-form-urlencoded' \
+    --data-urlencode 'grant_type=refresh_token' \
+    --data-urlencode "client_id=$cid" \
+    --data-urlencode "refresh_token=$rt" 2>/dev/null)
+  if [ -z "$resp" ]; then
+    log "::warning::grok oauth: refresh request to $ep failed (empty/timeout) - falling through to the on-disk token"; return 0
+  fi
+  access=$(jq -r '.access_token // empty' <<<"$resp" 2>/dev/null)
+  if [ -z "$access" ]; then
+    local oerr; oerr=$(jq -r '[.error,.error_description]|map(select(.!=null and .!=""))|join(": ")' <<<"$resp" 2>/dev/null)
+    log "::warning::grok oauth: refresh failed${oerr:+ ($oerr)} - the stored refresh token was likely rotated/consumed by an earlier run and not saved. Re-connect the X account in the dashboard, and set a secrets-write PAT (MCP_SECRETS_PAT / GH_GLOBAL) so future rotations persist. See docs/harnesses.md."
+    return 0
+  fi
+  new_rt=$(jq -r '.refresh_token // empty' <<<"$resp" 2>/dev/null)
+  expires_in=$(jq -r '.expires_in // 21600' <<<"$resp" 2>/dev/null)   # default 6h
+  # Rewrite auth.json in place: fresh access token, rotated refresh token, new expiry.
+  local new_exp tmp
+  new_exp=$(jq -rn --argjson n "${expires_in:-21600}" '(now + $n)|todate' 2>/dev/null)
+  tmp=$(mktemp)
+  if jq --arg k "$k" --arg a "$access" --arg r "${new_rt:-$rt}" --arg e "$new_exp" \
+        '.[$k].key=$a | .[$k].refresh_token=$r | .[$k].expires_at=$e' "$auth" >"$tmp" 2>/dev/null && [ -s "$tmp" ]; then
+    mv "$tmp" "$auth"; chmod 600 "$auth" 2>/dev/null || true
+    log "::debug::grok oauth: refreshed access token (expires $new_exp)"
+  else
+    rm -f "$tmp"; log "::warning::grok oauth: could not rewrite auth.json after refresh - using the on-disk token"; return 0
+  fi
+  # Persist the rotated refresh token so the NEXT run stays valid. Needs a
+  # secrets-write PAT (the default GITHUB_TOKEN cannot). LOUD on failure - an
+  # unpersisted rotation is exactly what breaks auth one run later.
+  if [ -n "$new_rt" ] && [ "$new_rt" != "$rt" ]; then
+    local pat="${MCP_SECRETS_PAT:-${GH_GLOBAL:-}}"
+    if [ -z "$pat" ]; then
+      log "::warning::grok oauth: refresh token ROTATED but no secrets-write PAT is set, so the rotated token cannot be saved and the NEXT run's refresh WILL fail. Add a fine-grained PAT (Secrets: read/write) as repo secret MCP_SECRETS_PAT (or GH_GLOBAL), then re-connect the X account once."
+    elif ! command -v gh >/dev/null 2>&1; then
+      log "::warning::grok oauth: refresh token rotated but 'gh' is unavailable to persist GROK_CREDENTIALS."
+    elif tar czf - -C "$HOME" .grok/auth.json 2>/dev/null | base64 | GH_TOKEN="$pat" gh secret set GROK_CREDENTIALS >/dev/null 2>&1; then
+      log "grok oauth: persisted rotated GROK_CREDENTIALS (durable refresh active)"
+    else
+      log "::warning::grok oauth: refresh token rotated but persisting GROK_CREDENTIALS FAILED - MCP_SECRETS_PAT/GH_GLOBAL needs 'Secrets: read/write' on this repo. Re-connect the X account once fixed."
+    fi
+  fi
+}
+# Only meaningful on the CI OAuth path (a GROK_CREDENTIALS secret was restored above);
+# a local `grok login` session (no GROK_CREDENTIALS) is deliberately left untouched.
+[ -n "${GROK_CREDENTIALS:-}" ] && grok_oauth_refresh
 
 if [ "$SETUP_ONLY" = 1 ]; then
   log "::debug::grok setup complete (CLI + auth staged); the run itself goes through run-harness grok"

--- a/scripts/tests/test_run_grok.sh
+++ b/scripts/tests/test_run_grok.sh
@@ -185,6 +185,72 @@ TMPD="$(mktemp -d)"
 if grep -q "MCPTool(" "$ARGS_FILE"; then bad "no MCPTool rules without .mcp.json"; else pass "no MCPTool rules without .mcp.json"; fi
 rm -rf "$TMPD"
 
+# --- 10. OAuth durable refresh + persist (§2b) --------------------------------
+# The captured GROK_CREDENTIALS rotates its refresh token on refresh; run-grok.sh
+# must refresh from it AND persist the rotated auth.json back to the secret, or auth
+# breaks ~6h after capture. Fake curl (token endpoint) + fake gh (secret persist),
+# a temp HOME seeded with an EXPIRED grok auth.json, driven through `run-grok.sh setup`.
+OBIN="$(mktemp -d)"; OHOME="$(mktemp -d)"
+cat > "$OBIN/curl" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${CURL_LOG:-/dev/null}"
+if [ -n "${CURL_FAKE_OUT:-}" ]; then printf '%s' "$CURL_FAKE_OUT"
+else printf '%s' '{"access_token":"NEWACCESS","refresh_token":"RT1","expires_in":21600}'; fi
+EOF
+cat > "$OBIN/gh" <<'EOF'
+#!/usr/bin/env bash
+cat >/dev/null                        # consume the piped base64 secret
+printf '%s\n' "$*" >> "${GH_LOG:-/dev/null}"
+exit 0
+EOF
+chmod +x "$OBIN/curl" "$OBIN/gh"
+
+seed_auth() {  # $1 = expires_at → prints a GROK_CREDENTIALS (base64 tar of .grok/auth.json)
+  mkdir -p "$OHOME/.grok"
+  cat > "$OHOME/.grok/auth.json" <<EOF
+{"https://auth.x.ai::CID":{"key":"OLDACCESS","auth_mode":"oidc","refresh_token":"RT0","expires_at":"$1","oidc_issuer":"https://auth.x.ai","oidc_client_id":"CID"}}
+EOF
+  tar czf - -C "$OHOME" .grok/auth.json | base64
+}
+authf() { jq -r ".[\"https://auth.x.ai::CID\"].$1" "$OHOME/.grok/auth.json"; }
+
+# 10a. expired token + PAT → refresh happens AND the rotated secret is persisted
+CREDS="$(seed_auth "2000-01-01T00:00:00.000000Z")"; GH_LOG="$OHOME/gh.log"; : >"$GH_LOG"
+HOME="$OHOME" PATH="$OBIN:$PATH" GROK_CREDENTIALS="$CREDS" MCP_SECRETS_PAT="pat-test" GH_LOG="$GH_LOG" \
+  bash "$RABS" setup >/dev/null 2>"$OHOME/e1"
+{ [ "$(authf key)" = "NEWACCESS" ] && [ "$(authf refresh_token)" = "RT1" ]; } \
+  && pass "oauth: expired token refreshed in auth.json" || bad "oauth refresh (key=$(authf key) rt=$(authf refresh_token); err=$(cat "$OHOME/e1"))"
+grep -q "secret set GROK_CREDENTIALS" "$GH_LOG" \
+  && pass "oauth: rotated refresh token persisted via gh secret set" || bad "oauth persist not called (gh.log: $(cat "$GH_LOG"))"
+
+# 10b. expired token, NO PAT → still refreshes on disk, must NOT persist, warns loudly
+CREDS="$(seed_auth "2000-01-01T00:00:00.000000Z")"; GH_LOG="$OHOME/gh2.log"; : >"$GH_LOG"
+HOME="$OHOME" PATH="$OBIN:$PATH" GROK_CREDENTIALS="$CREDS" GH_LOG="$GH_LOG" \
+  bash "$RABS" setup >/dev/null 2>"$OHOME/e2"
+{ [ "$(authf key)" = "NEWACCESS" ] && ! grep -q "secret set" "$GH_LOG" && grep -q "no secrets-write PAT" "$OHOME/e2"; } \
+  && pass "oauth: no PAT → refreshes but does not persist (warns)" || bad "oauth no-PAT (key=$(authf key); gh=$(cat "$GH_LOG"); err=$(cat "$OHOME/e2"))"
+
+# 10c. token still valid (far-future expiry) → skip refresh, no token-endpoint call
+CREDS="$(seed_auth "2099-01-01T00:00:00.000000Z")"; CURL_LOG="$OHOME/curl.log"; : >"$CURL_LOG"
+HOME="$OHOME" PATH="$OBIN:$PATH" GROK_CREDENTIALS="$CREDS" MCP_SECRETS_PAT="pat-test" CURL_LOG="$CURL_LOG" \
+  bash "$RABS" setup >/dev/null 2>"$OHOME/e3"
+{ [ "$(authf key)" = "OLDACCESS" ] && [ ! -s "$CURL_LOG" ]; } \
+  && pass "oauth: valid token → skips refresh" || bad "oauth skip-when-valid (key=$(authf key); curl=$(cat "$CURL_LOG"))"
+
+# 10d. token endpoint returns invalid_grant → warn, keep on-disk token, exit 0
+CREDS="$(seed_auth "2000-01-01T00:00:00.000000Z")"
+HOME="$OHOME" PATH="$OBIN:$PATH" GROK_CREDENTIALS="$CREDS" MCP_SECRETS_PAT="pat-test" \
+  CURL_FAKE_OUT='{"error":"invalid_grant","error_description":"Refresh token has been revoked"}' \
+  bash "$RABS" setup >/dev/null 2>"$OHOME/e4"; rc=$?
+{ [ "$rc" = 0 ] && [ "$(authf key)" = "OLDACCESS" ] && grep -q "invalid_grant" "$OHOME/e4"; } \
+  && pass "oauth: invalid_grant → warns, keeps token, rc 0" || bad "oauth invalid_grant (rc=$rc key=$(authf key) err=$(cat "$OHOME/e4"))"
+
+# 10e. XAI_API_KEY path (no GROK_CREDENTIALS) → the OAuth refresh never runs
+CURL_LOG="$OHOME/curl2.log"; : >"$CURL_LOG"
+echo p | HOME="$OHOME" PATH="$OBIN:$PATH" XAI_API_KEY=xai-test GROK_FAKE_OUT='{"text":"x"}' MODEL="" SKILL_MODE=write CURL_LOG="$CURL_LOG" bash "$RABS" >/dev/null 2>&1
+[ ! -s "$CURL_LOG" ] && pass "oauth: API-key path does not run the OAuth refresh" || bad "oauth refresh wrongly ran on API-key path"
+rm -rf "$OBIN" "$OHOME"
+
 echo "---"
 [ "$fail" = "0" ] && echo "ALL PASS" || echo "SOME FAILED"
 exit "$fail"


### PR DESCRIPTION
## What

Makes the grok harness's captured X-account OAuth session (`GROK_CREDENTIALS`) durable past its 6h access-token lifetime.

## Why

The captured `GROK_CREDENTIALS` holds a 6h access token plus a refresh token. xAI **rotates and revokes the refresh token on every refresh** (confirmed live - `auth.x.ai` returns `invalid_grant` "Refresh token has been revoked"). So a *static* secret self-destructs ~6h after Connect: the first post-expiry run refreshes and rotates the token, but grok writes the new one only to the ephemeral runner `$HOME`; the secret still holds the now-revoked token, and every later headless run fails `Not signed in`.

## How

Mirrors the existing `scripts/mcp-oauth-refresh.sh` durable-refresh contract.

- **`scripts/run-grok.sh` (§2b)** refreshes the access token from the refresh token before each run, rewrites `auth.json`, and **persists the rotated file back to the `GROK_CREDENTIALS` secret** via a secrets-write PAT. Reuses the existing **`MCP_SECRETS_PAT`** (or `GH_GLOBAL`) - the default `GITHUB_TOKEN` cannot write secrets. Refreshes only within `GROK_OAUTH_SKEW` seconds of expiry (default 1800). No-op on the `XAI_API_KEY` path and on a local `grok login` session.
- **`aeon.yml`**: adds a `grok)` case to the harness AUTH_MODE detection - grok was defaulting to `openrouter`, so a Connected X account was mislabelled in the banner; now `native-oauth`. Passes `MCP_SECRETS_PAT`/`GH_GLOBAL`/`GROK_OAUTH_SKEW` into the grok install step, and `GROK_CREDENTIALS`/`XAI_API_KEY` into the resolve step so the new case can see them.
- **`messages.yml`**: same grok env on the inbound-message run.
- **dashboard `GrokAuthModal`**: a secrets-PAT setup note (parallels `McpPanel`), hidden once `MCP_SECRETS_PAT`/`GH_GLOBAL` is set.
- **`docs/harnesses.md` + `CHANGELOG`**: document the durable-refresh contract.
- **`scripts/tests/test_run_grok.sh`**: 6 integration tests (refresh+persist, no-PAT warn, skip-when-valid, invalid_grant, API-key path).

## Notes

- This reuses the existing `MCP_SECRETS_PAT` secret rather than introducing a new name. A follow-up PR standardizes both the MCP and grok paths onto a single `GH_SECRETS_PAT` (with `GH_GLOBAL` fallback).
- Concurrent grok runs that each hit an expired token still race (each refresh revokes the other's token); for high parallelism, refresh centrally on a schedule so exactly one run mints per interval. Documented in `docs/harnesses.md`.

## Test

- `bash scripts/tests/test_run_grok.sh` -> ALL PASS (incl. the 6 new OAuth tests)
- `actionlint` clean on both workflows
- Verified end-to-end on a live instance: a forced run logged `grok oauth: persisted rotated GROK_CREDENTIALS (durable refresh active)` and the secret's `updated_at` bumped.
