### PR TITLE
docs(harness-adapter): drop pointers to repos that no longer exist

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -243,7 +243,7 @@ jobs:
 
           # Allowlist. Upstream had a claude/grok binary, so ANY other value was
           # silently rewritten to claude. These four are the ones measured end to
-          # end on a real runner (aaronjmars/harness-adapter, Tier 4).
+          # end on a real runner (Tier 4).
           # Deliberately NOT here, each for a measured reason:
           #   opencode — its .result carried the agent's narration instead of the
           #              deliverable (fixed in the adapter, but it still loops to

--- a/harness-adapter/README.md
+++ b/harness-adapter/README.md
@@ -1,14 +1,13 @@
-# harness-adapter — vendored subset
+# harness-adapter
 
 **One Claude Code-shaped contract, six coding-agent harnesses.**
 
-This is a **vendored copy** inside `aeon-openrouter`, trimmed to exactly what the
-workflow runs: the `run-harness` dispatcher and the six adapters aeon can dispatch
-to — **claude, grok, codex, pi, vibe, kimi**. The full project — three more
-harnesses (`opencode`, `copilot`, `agy`), the live test suite, and the
-harness-by-harness research — lives upstream at
-[aaronjmars/harness-adapter](https://github.com/aaronjmars/harness-adapter). Fixes
-land there first and are re-vendored here.
+This directory is exactly what the workflow runs: the `run-harness` dispatcher and
+the six adapters aeon can dispatch to — **claude, grok, codex, pi, vibe, kimi**.
+It is self-contained, so fixes land here directly. Three further harnesses
+(`opencode`, `copilot`, `agy`) were evaluated and deliberately left out; the
+per-harness reasons are recorded in the allowlist comment in
+`.github/workflows/aeon.yml`.
 
 `run-harness` wraps each CLI behind one headless interface — Claude Code's: prompt
 on stdin, flags mirroring `claude -p`, one JSON envelope on stdout. Swap the first
@@ -174,7 +173,6 @@ docs/aeon-integration.md  deployment runbook: wiring the swap into a live aeon
 
 The normalize-to-Claude's-envelope pattern, the grok permission stance, and the
 thought-firewall come from [aeonfun/aeon](https://github.com/aeonfun/aeon)'s
-`run-grok.sh`. The full nine-harness research, sources, and live test suite are in
-the upstream [aaronjmars/harness-adapter](https://github.com/aaronjmars/harness-adapter).
+`run-grok.sh`.
 
 MIT — see [LICENSE](LICENSE).

--- a/harness-adapter/docs/aeon-integration.md
+++ b/harness-adapter/docs/aeon-integration.md
@@ -3,12 +3,10 @@
 A deployment runbook for putting `run-harness` into [aeonfun/aeon](https://github.com/aeonfun/aeon)
 so a skill can run on **codex, pi, vibe, or kimi** instead of only claude/grok.
 
-The reference implementation is `aaronjmars/aeon-harness@harness-swap-4` — a full
-aeon fork with every change below applied and verified on a real GitHub runner
-(6-harness × 3-scenario matrix, verified in the upstream
-[harness-adapter](https://github.com/aaronjmars/harness-adapter) test suite, Tier 4).
-This document is how to reproduce it on a fresh aeon instance, and what each
-change is for so you can review rather than copy blind.
+Every change below was applied to a full aeon fork and verified on a real GitHub
+runner (6-harness × 3-scenario matrix, Tier 4). This document is how to reproduce
+it on a fresh aeon instance, and what each change is for so you can review rather
+than copy blind.
 
 ---
 
@@ -148,8 +146,7 @@ skills are overwhelmingly **research** skills.
 Getting this wrong is silent: three harnesses each lost the network a different
 way, and every failed run was **green** — valid envelope, exit 0, scorer 3–4/5 —
 while committing fabricated or empty output. The fixes are in the adapters
-(pi/vibe/codex) and one compat clause; see the upstream
-[harness-adapter](https://github.com/aaronjmars/harness-adapter) test suite for the full account.
+(pi/vibe/codex) and one compat clause.
 The takeaway for operating an instance: **a green run is not proof the skill did
 its job.** Spot-check committed `output/` content, especially for research skills.
 
@@ -254,9 +251,8 @@ output**:
 - `memory/token-usage.csv` — non-zero tokens, and the model that actually ran
 - `memory/skill-health/<skill>.json` — a real score, not an empty no-op
 
-The reference fork's final grid (all four × three scenarios, verified by output)
-is the "FINAL verified grid" in the upstream
-[harness-adapter](https://github.com/aaronjmars/harness-adapter) test suite.
+The reference fork's final grid covered all four harnesses × three scenarios, each
+verified by committed output rather than by exit code.
 
 ---
 


### PR DESCRIPTION
## The problem

`harness-adapter/` documented a contribution path that cannot be followed. It told contributors:

> Fixes land there first and are re-vendored here.

pointing at `aaronjmars/harness-adapter`, and cited that repo's test suite as the source for three separate verification claims. It also described itself as a vendored copy inside `aeon-openrouter`, and named `aaronjmars/aeon-harness@harness-swap-4` as the reference implementation.

**All three repos 404.** Not under `aaronjmars`, not under `aeonfun`/`MiroShark`/`TelahVC`, absent from an authenticated `user/repos` listing (so not merely private), and not in global search. Seven dead links across three files.

Found while verifying an unrelated claim in #775 - I had justified leaving a stale model id in `adapters/pi.sh` on the grounds that "fixes land upstream first", then checked whether that was actually true.

## What changed

- `README.md`: drops the vendored-subset framing and the upstream pointer. The directory is self-contained and fixes land here. The exclusion of `opencode`/`copilot`/`agy` now points at the allowlist comment in `.github/workflows/aeon.yml`, which already records the measured per-harness reason.
- `docs/aeon-integration.md`: three dead test-suite citations removed. The claims they supported are kept as claims - real runner, 6-harness x 3-scenario matrix, Tier 4 - just without a citation to a repo nobody can open.
- `.github/workflows/aeon.yml`: one comment reference in the harness allowlist.

No behavior change; comments and prose only.

## Verification

- Zero remaining references to any of the three repos
- Every `github.com` link under `harness-adapter/` resolved live: `aeonfun/aeon`, `anthropics/claude-code`, `openai/codex`, `actions/attest-build-provenance` all 200
- `validate-config.js` CLEAN, `actionlint` clean, `test_run_grok.sh` ALL PASS
