### PR TITLE
ci(okf): trigger only on markdown changes under the OKF roots

### DIFF
--- a/.github/workflows/ci-okf.yml
+++ b/.github/workflows/ci-okf.yml
@@ -11,14 +11,22 @@ name: ci-okf
 # over-conformance would fight Aeon's own agents. See docs/OKF.md.
 #
 # Same shape/permissions as ci-skills-json.yml.
-
+#
+# The root globs are '<root>/**.md', not '<root>/**', on purpose. okf-validate
+# walks ONLY markdown (scripts/lib/okf.mjs: `e.name.endsWith('.md')`), so a
+# change to a JSON/CSV/image file under a root cannot alter the result. On a
+# live agent instance those non-markdown writes dominate: the agent rewrites
+# memory/cron-state.json, memory/*.json and memory/token-usage.csv on nearly
+# every run. Measured on aeon-vuln, 63% of this workflow's push triggers
+# touched no .md in scope at all - pure no-op jobs, each billed a full minute
+# on a private fork. Narrowing to .md drops those with zero loss of coverage.
 on:
   pull_request:
     paths:
-      - 'memory/**'
-      - 'output/articles/**'
-      - 'skills/**'
-      - 'docs/**'
+      - 'memory/**.md'
+      - 'output/articles/**.md'
+      - 'skills/**.md'
+      - 'docs/**.md'
       - 'scripts/okf-validate.mjs'
       - 'scripts/okf-index.mjs'
       - 'scripts/okf-config.json'
@@ -26,10 +34,10 @@ on:
   push:
     branches: [main]
     paths:
-      - 'memory/**'
-      - 'output/articles/**'
-      - 'skills/**'
-      - 'docs/**'
+      - 'memory/**.md'
+      - 'output/articles/**.md'
+      - 'skills/**.md'
+      - 'docs/**.md'
       - 'scripts/okf-validate.mjs'
       - 'scripts/okf-index.mjs'
       - 'scripts/okf-config.json'


### PR DESCRIPTION
## What

`ci-okf` root path globs go from `'<root>/**'` to `'<root>/**.md'`, in both the
`pull_request` and `push` blocks.

## Why

`okf-validate` only ever reads markdown. From `scripts/lib/okf.mjs`:

```js
else if (e.isFile() && e.name.endsWith('.md')) out.push(p)
```

So a change to a JSON, CSV, YAML, or image file under `memory/`,
`output/articles/`, `skills/`, or `docs/` cannot possibly change the validator's
verdict. The old `'<root>/**'` globs fired a full job for every one of them.

That is mostly harmless on this repo, which is public and therefore free. It is
not harmless on the private forks that run a live agent, which is where this was
measured. A running instance rewrites `memory/cron-state.json`, `memory/*.json`
and `memory/token-usage.csv` on nearly every skill run.

Sampled 60 push-triggered `ci-okf` runs on the `aeon-vuln` instance:

| trigger touched | count | share |
|---|---|---|
| a `.md` in OKF scope (check is meaningful) | 22 | 37% |
| no `.md` in scope (check is a no-op) | 38 | **63%** |

On that instance `ci-okf` was 607 runs and 611 billed minutes over 30 days,
which was 65% of all its CI minutes. Actions rounds every job up to a whole
billable minute, and those runs average ~11 seconds, so the rounding is the
entire cost.

## Coverage

None lost. `.md` is the only markdown extension anywhere in the OKF roots (117
`.md` files; the other extensions present are `jpg`, `png`, `json`, `yaml`,
`txt`, `sh`, `gitkeep`). `okf-index.mjs --check` operates on `index.md`, which
still matches.

The check keeps its teeth where it matters. It is not a dead check: on
`aeon-vuln` it has caught 72 real failures and on `aaeron` 44, exactly the
"some run WILL eventually drop the `type:` line" case this workflow's own header
comment predicts. This change only stops it running when there is nothing it
could possibly validate.

## Verification

- `actionlint` clean
- `node scripts/okf-validate.mjs` still passes on this branch (103 concepts)
