### PR TITLE
fix(packs): make community skill packs installable end to end

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -9,12 +9,14 @@ on:
   pull_request:
     paths:
       - 'scripts/**'
+      - 'bin/**'
       - 'aeon.yml'
       - '.github/workflows/ci-tests.yml'
   push:
     branches: [main]
     paths:
       - 'scripts/**'
+      - 'bin/**'
       - 'aeon.yml'
   workflow_dispatch:
 
@@ -44,6 +46,8 @@ jobs:
         run: bash scripts/tests/test_validate_pack.sh
       - name: community pack registry validation tests
         run: bash scripts/tests/test_validate_skill_packs.sh
+      - name: community skill install catalog tests
+        run: bash scripts/tests/test_community_skill_install.sh
       - name: grok harness runner tests
         run: bash scripts/tests/test_run_grok.sh
       - name: state reducer tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,32 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Fixed
 
+- **Community skill packs install cleanly.** Five defects, each of which broke
+  `bin/install-skill-pack` for real packs in `catalog/skill-packs.json`; a sweep
+  of all 10 registry packs now installs 52/52 skills with no skips or warnings
+  (was 8/52).
+  - `bin/generate-packs-json` assigned `skills.lock` skills to the synthetic
+    `installed` pack *after* the catch-all check that aborts on an unassigned
+    skill. A community `SKILL.md` is written to its author's conventions and
+    usually has no `category:`, so the catalog build died on exactly the skills
+    the `installed` pack exists to hold - taking out **6 of 10** registry packs
+    (44 skills). The lock pass now runs before the check.
+  - `bin/install-skill-pack` treated a manifest `path` ending in `SKILL.md` as a
+    directory and looked for `SKILL.md/SKILL.md`, skipping every skill in the
+    pack with a "missing" line that reads like the file isn't there. The file
+    form is now accepted as its parent directory.
+  - `record_provenance` called `gh api` with `-f`, which switches the request to
+    POST; `POST /repos/{o}/{r}/commits` 404s and gh prints the error body on
+    stdout, so `skills.lock` recorded `{"message":"Not Found",...}unknown` as the
+    `commit_sha` of every installed skill. Now `-X GET`, pinned to the fetched
+    branch, path-prefixed for `--path` packs, and validated as a 40-char hex.
+  - `skill_fetch_repo` hardcoded `main` with no fallback, making any pack on
+    `master` uninstallable by the documented one-command form (it failed as if
+    the repo didn't exist). It now resolves the repo's real default branch and
+    reports the ref it used, which callers record in `skills.lock`.
+  - `bin/generate-skills-json` read only the first line of a frontmatter field,
+    so a YAML block-scalar `description: >-` was catalogued as the literal `>-`
+    and shown that way in the dashboard. Block scalars are now folded.
 - **Grok OAuth (`GROK_CREDENTIALS`) now survives past 6h.** The captured
   X-account session holds a 6h access token plus a refresh token that xAI
   **rotates and revokes on every refresh**, so a static secret used to break

--- a/bin/generate-packs-json
+++ b/bin/generate-packs-json
@@ -66,25 +66,16 @@ for slug, s in skills.items():
     if key:
         assigned[slug] = key
 
-# 3) catch-all — any skill whose category has no pack (freshly authored or
-# imported skills land here as category 'other') goes to the catch-all pack
-# (the one claiming category 'other'), so adding a skill never breaks the
-# catalog. Without a catch-all declared, an unassigned skill is a hard error.
-catch_all = cat_to_pack.get("other")
-unassigned = sorted(set(skills) - set(assigned))
-if unassigned:
-    if not catch_all:
-        sys.exit(f"ERROR: {len(unassigned)} skill(s) not assigned to any pack and "
-                 f"no catch-all pack (category 'other') is declared: {unassigned}")
-    for slug in unassigned:
-        assigned[slug] = catch_all
-
-# 5) community installs override everything above. Anything recorded in
+# 3) community installs override everything above. Anything recorded in
 # skills.lock was deliberately installed from another repo — it must NOT be
 # folded into a first-party category pack (where the Core-only visibility lens
 # would hide it). Pull it into a synthetic, always-visible "installed" pack so
-# the dashboard surfaces it as yours. Runs LAST so it overrides whatever
-# first-party pack claimed the slug by category. No skills.lock (the upstream
+# the dashboard surfaces it as yours. Runs after the category pass so it
+# overrides whatever first-party pack claimed the slug by category, and BEFORE
+# the catch-all check below — a community SKILL.md is written to its author's
+# conventions and frequently carries no `category:` at all, so a lock-installed
+# skill must be assigned here or step 4 kills the run for a skill that was
+# never going to belong to a first-party pack. No skills.lock (the upstream
 # case) → no override → packs.json is byte-identical to before.
 installed_src = {}  # slug -> source_repo
 lock_path = os.path.join(root, "skills.lock")
@@ -99,6 +90,23 @@ if os.path.exists(lock_path):
         if slug in skills:
             installed_src[slug] = rec.get("source_repo", "")
             assigned[slug] = "installed"
+
+# 4) catch-all — any skill whose category has no pack (freshly authored or
+# imported skills land here as category 'other') goes to the catch-all pack
+# (the one claiming category 'other'), so adding a skill never breaks the
+# catalog. Without a catch-all declared, an unassigned skill is a hard error.
+# Reaching here means a first-party skill in this repo has a missing or unknown
+# `category:` — the ci-skill-category gate is the fix, not a pack edit.
+catch_all = cat_to_pack.get("other")
+unassigned = sorted(set(skills) - set(assigned))
+if unassigned:
+    if not catch_all:
+        sys.exit(f"ERROR: {len(unassigned)} skill(s) not assigned to any pack and "
+                 f"no catch-all pack (category 'other') is declared: {unassigned}\n"
+                 f"Set a valid `category:` in each SKILL.md "
+                 f"(core|evolution|basics|dev|crypto|productivity) — see docs/skill-packs.md.")
+    for slug in unassigned:
+        assigned[slug] = catch_all
 
 def skill_entry(slug):
     s = skills[slug]

--- a/bin/generate-skills-json
+++ b/bin/generate-skills-json
@@ -49,7 +49,28 @@ get_skill_updated() {
 fm() {
   awk -v f="$2" -v q="${3:-}" '
     /^---$/{n++; next}
-    n==1 && $0 ~ "^"f":" { sub("^"f": *", ""); if (q=="strip") gsub(/"/, ""); print; exit }
+    n==1 && $0 ~ "^"f":" {
+      line=$0
+      sub("^"f": *", "", line)
+      # YAML block scalar (">", ">-", "|", "|-", ...): the value is the indented
+      # block that follows, not the marker. Community SKILL.md files lean on this
+      # for long descriptions; reading only this line records the literal ">-" as
+      # the description and the catalog/dashboard shows that. Fold the block into
+      # one space-joined line.
+      if (q=="fold" && line ~ /^[|>][-+0-9]*$/) {
+        val=""
+        while ((getline nxt) > 0) {
+          if (nxt ~ /^---$/ || nxt !~ /^[ \t]/) break
+          gsub(/^[ \t]+/, "", nxt); gsub(/[ \t]+$/, "", nxt)
+          if (nxt == "") continue
+          val = (val == "" ? nxt : val " " nxt)
+        }
+        line=val
+      }
+      if (q=="strip") gsub(/"/, "", line)
+      print line
+      exit
+    }
   ' "$1"
 }
 
@@ -69,7 +90,7 @@ for skill_dir in "$SKILLS_DIR"/*/; do
 
   # Parse frontmatter (fm reads one scalar; `strip` drops double-quotes)
   name=$(fm "$skill_file" name)
-  description=$(fm "$skill_file" description)
+  description=$(fm "$skill_file" description fold)
   var=$(fm "$skill_file" var strip)
 
   # Category is declared in each SKILL.md frontmatter — the single source of

--- a/bin/install-skill-pack
+++ b/bin/install-skill-pack
@@ -291,6 +291,11 @@ PACK_LABEL="$REPO_NAME"
 echo "Fetching $REPO ($BRANCH)..."
 
 REPO_ROOT=$(skill_fetch_repo "$REPO" "$BRANCH" "$TMP_DIR") || exit 1
+# skill_fetch_repo may have resolved a different ref (default-branch fallback);
+# record what was actually fetched so skills.lock provenance stays honest.
+if [[ -f "$TMP_DIR/.skill-fetch-branch" ]]; then
+  BRANCH=$(cat "$TMP_DIR/.skill-fetch-branch")
+fi
 
 PACK_DIR="$REPO_ROOT"
 if [[ -n "$SUBPATH" ]]; then
@@ -367,6 +372,22 @@ if [[ -f "$MANIFEST_PATH" ]]; then
     rel_path=$(jq -r ".skills[$i].path // empty" "$MANIFEST_PATH")
     [[ -z "$rel_path" ]] && rel_path="skills/$slug"
     rel_path="${rel_path#/}"
+    rel_path="${rel_path%/}"
+    # `path` is the skill DIRECTORY. Pack authors routinely point it at the file
+    # instead ("skills/foo/SKILL.md") — we'd then look for SKILL.md/SKILL.md and
+    # skip every skill in the pack with a "missing ..." line that reads like the
+    # file is absent when it's right there. Accept the file form and use its
+    # parent; the whole directory is copied either way, so this is the same
+    # install, not a laxer one.
+    if [[ "$rel_path" == */SKILL.md ]]; then
+      rel_path=$(dirname "$rel_path")
+    elif [[ "$rel_path" == "SKILL.md" ]]; then
+      # A bare root SKILL.md has no directory to copy — taking the parent here
+      # would vacuum the whole repo (LICENSE, README, everything) into skills/.
+      echo "Manifest skill '$slug' sets path to a root-level SKILL.md." >&2
+      echo "Give each skill its own directory (skills/$slug/SKILL.md) and set path to that directory." >&2
+      exit 1
+    fi
     # Reject path traversal.
     if [[ "$rel_path" == *".."* ]]; then
       echo "Manifest path may not contain '..': $rel_path" >&2
@@ -629,7 +650,21 @@ record_provenance() {
   local slug="$1"
   local source_path="$2"
   local commit_sha
-  commit_sha=$(gh api "repos/$REPO/commits" -f path="$source_path/SKILL.md" --jq '.[0].sha' 2>/dev/null || echo "unknown")
+  # -X GET is required: `gh api` switches to POST as soon as a -f field is
+  # present, and POST /repos/{o}/{r}/commits is not an endpoint — it 404s, and
+  # gh prints the error body on STDOUT, so the old form captured
+  # '{"message":"Not Found",...}unknown' and wrote that into skills.lock as the
+  # commit_sha of every installed skill. -f sha= pins the log to the branch we
+  # actually fetched instead of the repo default.
+  # $source_path is relative to the PACK dir; the API wants it relative to the
+  # repo root, so a --path pack has to carry that prefix or every lookup misses
+  # and the whole pack records commit_sha "unknown".
+  local api_path="${SUBPATH:+$SUBPATH/}$source_path/SKILL.md"
+  commit_sha=$(gh api -X GET "repos/$REPO/commits" \
+    -f path="$api_path" -f sha="$BRANCH" -f per_page=1 \
+    --jq '.[0].sha' 2>/dev/null || true)
+  # Anything that isn't a 40-char hex object name is a failure, not a sha.
+  [[ "$commit_sha" =~ ^[0-9a-f]{40}$ ]] || commit_sha="unknown"
   local entry
   entry=$(jq -n \
     --arg name "$slug" \

--- a/docs/community-skill-packs.md
+++ b/docs/community-skill-packs.md
@@ -85,7 +85,7 @@ The manifest lives at the pack root (or under `--path <subdir>` if the pack is n
 | `homepage` | string | optional | Project page, docs, or Twitter handle. |
 | `skills[]` | array | **required** | At least one entry. |
 | `skills[].slug` | string | **required** | Aeon skill slug. Must match `[A-Za-z0-9_-]+`. Used as the directory name under `skills/`. |
-| `skills[].path` | string | optional | Path inside the pack repo (relative). Defaults to `skills/<slug>`. May not contain `..`. |
+| `skills[].path` | string | optional | Path to the skill's **directory** inside the pack repo (relative). Defaults to `skills/<slug>`. May not contain `..`. A path ending in `/SKILL.md` is accepted and its parent directory used, but write the directory. |
 | `skills[].description` | string | optional | Falls back to the SKILL.md frontmatter `description:`. |
 | `skills[].category` | string | optional | One of `research`, `dev`, `crypto`, `social`, `productivity`. Defaults to `research` in `skills.json`. |
 | `skills[].schedule` | string | optional | Cron string written into `aeon.yml`. Default `0 12 * * *`. |
@@ -174,6 +174,12 @@ The operator is always the trust boundary. The install script does not auto-trus
 1. Repo is public with a clear license file.
 2. Each skill has a `SKILL.md` in `skills/<slug>/SKILL.md`.
 3. Skills follow Aeon's `SKILL.md` conventions (frontmatter `name:`, `description:`, etc.).
+   Include a **`category:`** from Aeon's vocabulary - `core`, `evolution`,
+   `basics`, `dev`, `crypto`, `productivity`. Installed skills are grouped under
+   the dashboard's **Installed** pack regardless, but the category is what the
+   catalog records and what the operator sees; a missing or invented one shows
+   up as `other`. The pack's own `skills[].category` is metadata for the
+   installer - the `SKILL.md` frontmatter is what `skills.json` reads.
 4. `skills-pack.json` declares every skill the pack intends to install. Skills present in `skills/` but missing from the manifest are not installed.
 5. Optional but encouraged: a `README.md` that names each skill, explains scheduling assumptions, and lists any required environment variables.
 6. Run `./scripts/validate-pack.sh /path/to/your-pack-dir` (from an Aeon checkout) to pre-flight the pack locally — it runs the same structural invariants `install-skill-pack` enforces (valid `skills-pack.json`, clean slugs, no `..` in paths, present per-skill `SKILL.md`, locked-taxonomy capabilities) and exits non-zero on any blocking error. Add `--path <subdir>` if `skills-pack.json` is nested.

--- a/scripts/lib/skill-install.sh
+++ b/scripts/lib/skill-install.sh
@@ -43,19 +43,40 @@ skill_is_trusted() {
 
 # skill_fetch_repo <repo> <branch> <dest_dir>
 #   Download owner/repo@branch as a tarball into <dest_dir>, extract it, and echo
-#   the extracted top-level directory. Tries refs/heads/<branch> then
-#   refs/tags/<branch>. Returns non-zero (message on stderr) on failure — callers
-#   should use:  root=$(skill_fetch_repo "$REPO" "$BRANCH" "$TMP") || exit 1
+#   the extracted top-level directory. Tries refs/heads/<branch>, then
+#   refs/tags/<branch>, then the repo's actual default branch (callers default
+#   <branch> to "main", which silently fails on every repo still on "master").
+#   Returns non-zero (message on stderr) on failure — callers should use:
+#     root=$(skill_fetch_repo "$REPO" "$BRANCH" "$TMP") || exit 1
 skill_fetch_repo() {
-  local repo="$1" branch="$2" dest="$3" url root
+  local repo="$1" branch="$2" dest="$3" url root default_branch
   url="https://github.com/$repo/archive/refs/heads/$branch.tar.gz"
   if ! curl -sfL "$url" -o "$dest/repo.tar.gz" 2>/dev/null; then
     url="https://github.com/$repo/archive/refs/tags/$branch.tar.gz"
     if ! curl -sfL "$url" -o "$dest/repo.tar.gz" 2>/dev/null; then
-      echo "Failed to fetch $repo (branch/tag: $branch)" >&2
-      return 1
+      # Neither a branch nor a tag by that name. Ask GitHub what the repo's
+      # default branch actually is and retry once — a pack on "master" is
+      # otherwise uninstallable by the documented one-command form, with a
+      # failure that reads like the repo doesn't exist.
+      default_branch=$(curl -sfL --max-time 10 "https://api.github.com/repos/$repo" 2>/dev/null \
+        | sed -n 's/.*"default_branch": *"\([^"]*\)".*/\1/p' | head -1)
+      if [[ -z "$default_branch" ]] || [[ "$default_branch" == "$branch" ]]; then
+        echo "Failed to fetch $repo (branch/tag: $branch)" >&2
+        return 1
+      fi
+      url="https://github.com/$repo/archive/refs/heads/$default_branch.tar.gz"
+      if ! curl -sfL "$url" -o "$dest/repo.tar.gz" 2>/dev/null; then
+        echo "Failed to fetch $repo (branch/tag: $branch, default: $default_branch)" >&2
+        return 1
+      fi
+      branch="$default_branch"
+      echo "  note: '$branch' not found — using default branch '$default_branch'" >&2
     fi
   fi
+  # Callers run this in a command substitution, so an exported variable would not
+  # survive the subshell. Drop the ref that was actually fetched next to the
+  # tarball instead; callers read it back to keep skills.lock provenance honest.
+  printf '%s' "$branch" > "$dest/.skill-fetch-branch"
   tar -xzf "$dest/repo.tar.gz" -C "$dest" 2>/dev/null
   root=$(find "$dest" -mindepth 1 -maxdepth 1 -type d | head -1)
   if [[ -z "$root" ]]; then

--- a/scripts/tests/test_community_skill_install.sh
+++ b/scripts/tests/test_community_skill_install.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Unit test for the catalog side of a community skill install:
+#   bin/generate-packs-json   — a skills.lock skill must reach the "installed"
+#                               pack even when its SKILL.md carries no category
+#   bin/generate-skills-json  — a YAML block-scalar description must be folded,
+#                               not recorded as the literal ">-" marker
+# No network, no GitHub auth required. Builds throwaway repo roots under /tmp.
+set -uo pipefail
+cd "$(dirname "$0")/../.." || exit 1
+ROOT="$PWD"
+
+fail=0
+pass(){ echo "ok   - $1"; }
+bad(){ echo "FAIL - $1"; fail=1; }
+
+# ── Helper: a minimal Aeon repo root that the two generators can run against ──
+# Copies in the real scripts so the test exercises shipped code, not a copy.
+make_root() {
+  local d
+  d=$(mktemp -d)
+  mkdir -p "$d/bin" "$d/catalog" "$d/skills"
+  cp "$ROOT/bin/generate-skills-json" "$ROOT/bin/generate-packs-json" "$d/bin/"
+  cat > "$d/catalog/packs.config.json" <<'EOF'
+{"version":"1.0","packs":[
+  {"key":"crypto","name":"Crypto","description":"c","color":"#000","category":"crypto"}
+]}
+EOF
+  printf '%s\n' "$d"
+}
+
+# Usage: write_skill <root> <slug> <frontmatter-body>
+write_skill() {
+  local root="$1" slug="$2" body="$3"
+  mkdir -p "$root/skills/$slug"
+  { echo "---"; printf '%s\n' "$body"; echo "---"; echo; echo "# $slug"; } \
+    > "$root/skills/$slug/SKILL.md"
+}
+
+# ── 1. Block-scalar description is folded, not left as the marker ────────────
+d=$(make_root)
+write_skill "$d" "folded" 'type: Skill
+name: Folded
+category: crypto
+description: >-
+  First line of the description
+  and its continuation.'
+write_skill "$d" "plain" 'type: Skill
+name: Plain
+category: crypto
+description: A single-line description.'
+(cd "$d" && bin/generate-skills-json >/dev/null 2>&1)
+desc=$(jq -r '.skills[] | select(.slug=="folded") | .description' "$d/catalog/skills.json")
+if [[ "$desc" == "First line of the description and its continuation." ]]; then
+  pass "block-scalar description folded into one line"
+else
+  bad "block-scalar description folded into one line (got: '$desc')"
+fi
+desc=$(jq -r '.skills[] | select(.slug=="plain") | .description' "$d/catalog/skills.json")
+if [[ "$desc" == "A single-line description." ]]; then
+  pass "single-line description unchanged"
+else
+  bad "single-line description unchanged (got: '$desc')"
+fi
+rm -rf "$d"
+
+# ── 2. A lock-installed skill with no category lands in "installed" ──────────
+# Community SKILL.md files are written to their author's conventions and often
+# carry no `category:`. Before the fix the catch-all check ran first and aborted
+# the whole catalog for a skill that was never going to join a first-party pack.
+d=$(make_root)
+write_skill "$d" "native" 'type: Skill
+name: Native
+category: crypto
+description: A first-party skill.'
+write_skill "$d" "from-pack" 'name: From Pack
+description: A community skill with no category.'
+cat > "$d/skills.lock" <<'EOF'
+[{"skill_name":"from-pack","source_repo":"someone/their-pack","source_path":"skills/from-pack/SKILL.md","branch":"main","commit_sha":"unknown","imported_at":"2026-01-01T00:00:00Z","pack":"their-pack"}]
+EOF
+(cd "$d" && bin/generate-skills-json >/dev/null 2>&1)
+out=$(cd "$d" && bin/generate-packs-json 2>&1)
+rc=$?
+if [[ $rc -eq 0 ]]; then
+  pass "generate-packs-json succeeds with an uncategorised installed skill"
+else
+  bad "generate-packs-json succeeds with an uncategorised installed skill (exit $rc: $out)"
+fi
+if [[ -f "$d/catalog/packs.json" ]]; then
+  key=$(jq -r '.packs[] | select(.skills[]?.slug=="from-pack") | .key' "$d/catalog/packs.json")
+  [[ "$key" == "installed" ]] && pass "uncategorised installed skill lands in the 'installed' pack" \
+    || bad "uncategorised installed skill lands in the 'installed' pack (got: '$key')"
+  key=$(jq -r '.packs[] | select(.skills[]?.slug=="native") | .key' "$d/catalog/packs.json")
+  [[ "$key" == "crypto" ]] && pass "first-party skill still claimed by its category pack" \
+    || bad "first-party skill still claimed by its category pack (got: '$key')"
+fi
+rm -rf "$d"
+
+# ── 3. An uncategorised skill that is NOT installed is still a hard error ─────
+# The category gate must keep biting for skills authored in this repo.
+d=$(make_root)
+write_skill "$d" "sloppy" 'name: Sloppy
+description: A local skill missing its category.'
+(cd "$d" && bin/generate-skills-json >/dev/null 2>&1)
+out=$(cd "$d" && bin/generate-packs-json 2>&1)
+if [[ $? -ne 0 ]] && [[ "$out" == *"not assigned to any pack"* ]]; then
+  pass "uncategorised local skill still fails the catalog build"
+else
+  bad "uncategorised local skill still fails the catalog build (got: $out)"
+fi
+rm -rf "$d"
+
+echo ""
+[[ $fail -eq 0 ]] && echo "All community-install catalog tests passed." || echo "Some tests FAILED."
+exit $fail


### PR DESCRIPTION
## What

`bin/install-skill-pack` is the documented one-command way to install a community pack. I ran it against all 10 packs in `catalog/skill-packs.json`. It installed **8 of 52 skills**.

Five separate defects, none of them in the pack authors' control. After this PR: **52/52, no skips, no warnings.**

| Pack | Skills | Before | After |
|---|---|---|---|
| AntFleet/aeon-skills | 2 | ok | ok |
| liquidpadbot/aeon-skill-pack-liquidpad | 4 | catalog build fails | ok |
| ryjin111/aeon-skill-pack-mythosforge | 5 | fetch fails (repo is on `master`) | ok |
| codexvritra/signa | 21 | catalog build fails | ok |
| Atrium-Hermes/aeon-atrium-skills | 4 | catalog build fails | ok |
| mnemedb/aeon-skill-pack-mneme | 8 | catalog build fails | ok |
| clawhunter/clawhunter-skills | 2 | every skill skipped, then catalog build fails | ok |
| SpartanLabsXyz/aeon-skill-pack-polymarket | 3 | ok | ok |
| CharonAI-code/charon | 2 | ok | ok |
| techdigger/aeon-skill-pack-agentlink | 1 | ok | ok |

## The five bugs

**1. `bin/generate-packs-json` — ordering. Broke 6 of 10 packs (44 skills).**

The `skills.lock` pass that assigns installed skills to the synthetic `installed` pack ran *after* the catch-all check that hard-exits on an unassigned skill:

```python
if unassigned:
    if not catch_all:
        sys.exit("ERROR: ... not assigned to any pack ...")   # dies here
...
            assigned[slug] = "installed"                      # 14 lines later
```

A community `SKILL.md` is written to its author's conventions and usually carries no `category:`, so the catalog build died on exactly the skills the `installed` pack exists to hold. The error also points operators at a catch-all `lab` pack claiming `category: other` that isn't in `packs.config.json`. Moved the lock pass ahead of the check. An uncategorised skill authored *in this repo* still fails, so `ci-skill-category` keeps biting; the error message now names the six valid categories.

**2. `bin/install-skill-pack` — `path` pointing at the file.**

`skills[].path` is the skill directory, but authors routinely point it at `skills/<slug>/SKILL.md`. We then looked for `SKILL.md/SKILL.md` and skipped every skill in the pack:

```
skip: 'clawhunter-bounties' (missing skills/clawhunter-bounties/SKILL.md/SKILL.md in pack)
Done: 0 installed, 2 skipped/failed
```

which reads like the file is absent when it's right there. Accept the file form and use its parent. A bare root-level `SKILL.md` is rejected explicitly rather than vacuuming the whole repo into `skills/`.

**3. `record_provenance` — every `commit_sha` in `skills.lock` was a 404 blob.**

`gh api` switches to POST as soon as a `-f` field is present. `POST /repos/{o}/{r}/commits` isn't an endpoint, gh prints the error body on **stdout**, and `|| echo "unknown"` appended to it:

```json
"commit_sha": "{\r\n  \"message\": \"Not Found\",\r\n  \"status\": \"404\"\r\n}unknown"
```

That's every skill installed through this path, and it's what the install prints as its sha (`sha: {\n  "m`). Now `-X GET`, pinned to the fetched branch, path-prefixed for `--path` packs (the path is pack-relative, the API wants repo-relative), and validated as 40-char hex. All 52 lock entries now carry a real sha; before, 52/52 were malformed.

**4. `skill_fetch_repo` — `main` hardcoded, no fallback.**

`ryjin111/aeon-skill-pack-mythosforge` is on `master`, so the command in our own README fails with `Failed to fetch ...`, which reads like the repo doesn't exist. Resolve the repo's real default branch and retry once, report the ref used, and record it in `skills.lock` (via a file next to the tarball, since callers run this in a command substitution and an exported var wouldn't survive the subshell).

**5. `bin/generate-skills-json` — block scalars.**

`fm()` read one line, so `description: >-` followed by an indented block was catalogued as the literal `">-"` and rendered that way in the dashboard. Now folds block scalars. Scoped to `description:` deliberately: `var:` also uses `|` in `schedule-ads`, and folding it there would churn the catalog for a field that isn't prose.

## Verification

- All 10 registry packs installed into a clean clone: 52/52 skills, 0 skips, 0 warnings, 0 malformed shas, `mythosforge` correctly recorded on `master`.
- `catalog/skills.json` and `catalog/packs.json` regenerate **byte-identical** for first-party skills (checked ignoring the `generated` timestamp), so nothing here changes upstream output. No catalog churn is committed.
- `scripts/tests/test_community_skill_install.sh` (new) covers the two catalog generators offline, no network or GitHub auth. It fails against the pre-fix code on both bugs it targets and passes after.
- Existing suites still pass: `test_validate_pack.sh`, `test_validate_skill_packs.sh`, `test_skill_mode.sh`, `test_skill_requires.sh`, plus `validate-skill-packs.mjs`, `check-skill-categories.sh`, `okf-validate.mjs`.
- `ci-tests.yml` now also triggers on `bin/**`, since the suite covers those generators.

## Not in this PR

Pack-side issues that remain the authors' to fix (docs updated to make the conventions explicit): `clawhunter/clawhunter-skills` uses `scheduling`/`secrets` instead of `schedule`/`secrets_required` and declares `category: content`; `codexvritra/signa` declares 21 skills in its manifest but lists 20 in the registry; most packs ship no `category:` in frontmatter, so their skills catalogue as `other`.
