### PR TITLE
fix(harness): MCP was silently dead on codex, grok and kimi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,39 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Fixed
 
+- **MCP now actually works on codex, grok and kimi.** A live sweep of all six
+  harnesses against a remote MCP server (glim.sh over streamable HTTP, run on
+  GitHub Actions) found three broken. Each failed *silently*: the agent reported
+  the server "not connected", fell back to plain HTTP, and the run still went
+  green with a plausible-looking answer - so the run log was not evidence the
+  tools had been used. Only `vibe` worked untouched; `pi` rejects MCP by design.
+  - **codex could not load its config at all** when a server carried `headers`
+    or `env`. `lib/mcp-translate.sh` emitted those as JSON objects, but codex
+    parses `-c` values as TOML, where an object must be an inline table
+    (`{ "K" = "V" }`, not `{"K":"V"}`). Every remote MCP server carries an auth
+    header, so codex exited 1 before the model started: `Error loading
+    config.toml: invalid type: string "{\"Authorization\":...}", expected a map`.
+    Now emitted as inline tables with quoted keys, so header names that are not
+    TOML bare keys (`X-Api-Key`) stay valid.
+  - **grok never started the server.** It gates repo-local (project-scoped) MCP
+    servers behind its folder-trust store (`~/.grok/trusted_folders.toml`), and
+    a CI runner checks the repo out into a never-trusted path on every run - so
+    no `mcp__<srv>__*` tool existed, on every run, forever. The adapter now
+    passes `--trust`, and only when an MCP config is in play.
+  - **kimi sent unexpanded `${VAR}` placeholders.** It auto-discovers
+    `<cwd>/.mcp.json`, and that wins over the expanded copy staged in
+    `$KIMI_CODE_HOME`, so a `Bearer ${MCP_GLIM_TOKEN}` header went to the server
+    verbatim and 401'd. `lib/sandbox.sh` now overlays the expanded config onto
+    the workspace file inside the bwrap sandbox - process-private, so no secret
+    is written into the working tree. Linux only; macOS `sandbox-exec` has no
+    bind-mounts.
+- **Dashboard: the MCP panel warned about the wrong harness.** It disabled its
+  controls on `codex`, citing `openai/codex#24135` (tool approvals auto-denied
+  under `codex exec`). Re-measured on codex-cli 0.144.6: codex calls MCP tools
+  fine, and the real fault was the config-load crash above. `pi` is the harness
+  that genuinely cannot use MCP - its adapter warns and skips every server by
+  design - so the banner, disabled controls and tooltips now point at `pi`, and
+  codex is no longer blocked from a feature that works.
 - **Community skill packs install cleanly.** Five defects, each of which broke
   `bin/install-skill-pack` for real packs in `catalog/skill-packs.json`; a sweep
   of all 10 registry packs now installs 52/52 skills with no skips or warnings

--- a/apps/dashboard/components/McpPanel.tsx
+++ b/apps/dashboard/components/McpPanel.tsx
@@ -9,12 +9,18 @@ import type { Secret, McpServer, McpServers, Harness } from '../lib/types'
 // One-click starters - public HTTP MCP servers that install with no token.
 const FEATURED = MCP_CATALOG
 
-// Codex can't call MCP tools in headless runs: under `codex exec` each tool call
-// raises an approval prompt that reads EOF on the closed stdin and resolves as
-// cancel, so the tool never runs (upstream openai/codex#24135). Wiring a server
-// on codex would silently no-op at run time, so the MCP controls are disabled and
-// the operator is told to switch harness. Keep in sync with harness-adapter.
-const MCP_DISABLED_MSG = "Codex can't run MCP tools in headless runs (openai/codex#24135). Switch the harness to claude, grok, kimi or vibe to use MCP."
+// Pi rejects MCP as a design decision — its adapter warns and skips every server
+// (`pi does not support MCP by design`), so a server wired here would silently
+// no-op at run time. The controls are disabled and the operator is told to switch
+// harness. Keep in sync with harness-adapter/adapters/pi.sh.
+//
+// This gate used to target CODEX, on the belief that `codex exec` auto-denied
+// every tool call (openai/codex#24135). Re-measured live 2026-07-27 on codex-cli
+// 0.144.6: codex calls MCP tools fine, and the real fault was ours — the adapter
+// emitted `headers`/`env` as JSON objects where codex wants TOML inline tables,
+// which crashed config load before the model started. Fixed in
+// harness-adapter/lib/mcp-translate.sh; codex is a supported MCP harness now.
+const MCP_DISABLED_MSG = "Pi does not support MCP - it rejects MCP servers by design, so any server configured here is skipped at run time. Switch the harness to claude, grok, codex, kimi or vibe to use MCP."
 
 interface McpPanelProps {
   harness: Harness
@@ -53,9 +59,9 @@ function transportOf(server: McpServer): string {
 }
 
 export function McpPanel({ harness, servers, loading, saving, secrets, busy, onSave, onSetSecret, onDeleteSecret, onGoToSecret }: McpPanelProps) {
-  // Codex can't use MCP headlessly (see MCP_DISABLED_MSG): grey out every MCP
-  // action so a run isn't configured to use tools it will silently skip.
-  const mcpDisabled = harness === 'codex'
+  // Pi skips MCP entirely (see MCP_DISABLED_MSG): grey out every MCP action so a
+  // run isn't configured to use tools it will silently skip.
+  const mcpDisabled = harness === 'pi'
 
   const [draft, setDraft] = useState<McpServers>(servers)
   useEffect(() => { setDraft(servers) }, [servers])
@@ -197,7 +203,7 @@ export function McpPanel({ harness, servers, loading, saving, secrets, busy, onS
 
       {mcpDisabled && (
         <div className="border border-aeon-red/40 bg-aeon-panel px-[var(--space-md)] py-[var(--space-sm)]">
-          <p className="text-[10px] font-mono uppercase tracking-[0.14em] text-aeon-red mb-1.5">⚠ MCP is unavailable on the Codex harness</p>
+          <p className="text-[10px] font-mono uppercase tracking-[0.14em] text-aeon-red mb-1.5">⚠ MCP is unavailable on the Pi harness</p>
           <p className="text-[11px] text-primary-40 leading-relaxed">
             {MCP_DISABLED_MSG} You can still view your servers below, but the actions are disabled until you switch harness in the top bar.
           </p>

--- a/harness-adapter/README.md
+++ b/harness-adapter/README.md
@@ -46,7 +46,7 @@ output **fails the run** — partial or empty results are never emitted as succe
 | Token usage | ✅ + cost | ✅ + cost¹ | ✅ | ✅ + cost | 0² | 0² |
 | Read-only enforcement | ✅ sandbox | ✅ sandbox³ | ✅ native | ✅ sandbox | ✅ sandbox⁴ | ✅ sandbox⁴ |
 | Structured output | native | native | native | shim⁵ | shim⁵ | shim⁵ |
-| MCP tool call (live) | ✅ | ✅ | ⚠️ wired, headless-denied⁶ | n/a — warn+skip | ✅ | ✅ |
+| MCP tool call (live) | ✅ | ✅ needs `--trust`⁷ | ✅⁶ | n/a — warn+skip | ✅ | ✅ needs overlay⁸ |
 | Native provider auth | Claude Pro/Max OAuth | X account · `XAI_API_KEY` | ChatGPT OAuth · `OPENAI_API_KEY` | provider env key | Mistral key | Moonshot OAuth · key |
 
 All six round-trip the contract on real CLIs (claude ≥2.1, grok 0.2.101,
@@ -68,12 +68,21 @@ Linux) mounting the workspace read-only.
 ⁵ prompt-shim (`lib/schema-retry.sh`): the schema is appended to the prompt, the
 result validated, and one corrective retry runs. No native `--json-schema` flag
 exists on these.
-⁶ codex registers the MCP server and the model *does* invoke the tool, but
-`approval_policy="never"` resolves each call's approval as `Cancel` under
-`codex exec` (stdin closed → EOF → decline), so the tool never runs headlessly
-([openai/codex#24135](https://github.com/openai/codex/issues/24135)). The only
-override also drops codex's native sandbox, so MCP stays effectively unavailable on
-codex headlessly until upstream lands.
+⁶ codex calls MCP tools fine headlessly. This previously read "wired but
+approval-denied"; re-measured 2026-07-27 on codex-cli 0.144.6, the real blocker was
+a translation bug in `lib/mcp-translate.sh` — `env`/`headers` were emitted as JSON
+objects, which codex (parsing `-c` values as TOML) rejects outright, killing the
+run before the model started. With inline tables emitted instead, a live aeon run
+invoked `glim_twitter_get` and returned data only the MCP server could supply.
+⁷ grok gates repo-local (project-scoped) MCP servers behind its folder-trust store
+(`~/.grok/trusted_folders.toml`); a CI checkout is never trusted, so the adapter
+passes `--trust` whenever an MCP config is in play. Without it the server is
+silently never started and no `mcp__<srv>__*` tool exists.
+⁸ kimi auto-discovers `<cwd>/.mcp.json` and that WINS over the config staged in
+`$KIMI_CODE_HOME`, so it sends `${VAR}` placeholders verbatim instead of the
+expanded secret. `lib/sandbox.sh` overlays the expanded copy onto the workspace
+file inside the bwrap sandbox. Linux-only: on macOS (`sandbox-exec`, no
+bind-mounts) kimi still reads the literal `${VAR}`s.
 
 ## Flags
 
@@ -98,7 +107,7 @@ codex headlessly until upstream lands.
 | Result | envelope passthrough | `type=="text"` chunks (never `thought`) | last `agent_message` | last assistant `message_end` | last assistant `content` (never `reasoning_content`) | last assistant `content` |
 | Usage | native + cost | streaming `end` event → cost | sum of `turn.completed.usage` | per-message usage + cost | none → 0 | none → 0 |
 | Read-only | `--allowedTools` + wrapper sandbox | `bypassPermissions` + wrapper sandbox | `--sandbox read-only` (native) | `--tools` subset + wrapper sandbox | wrapper sandbox only | wrapper sandbox only |
-| MCP | `--mcp-config` | native `.mcp.json` + `MCPTool(...)` allows | `-c mcp_servers.*` (auto-denied headless⁶) | unsupported by design → warn+skip | `config.toml [[mcp_servers]]` in temp `VIBE_HOME` | `{mcpServers}` in temp `KIMI_CODE_HOME` |
+| MCP | `--mcp-config` | native `.mcp.json` + `MCPTool(...)` allows + `--trust`⁷ | `-c mcp_servers.*` (TOML inline tables⁶) | unsupported by design → warn+skip | `config.toml [[mcp_servers]]` in temp `VIBE_HOME` | `{mcpServers}` in temp `KIMI_CODE_HOME` + sandbox overlay⁸ |
 | CLAUDE.md | native + `@imports` | native (no imports) | via `project_doc_fallback_filenames` | native | native | native |
 
 ### Design notes
@@ -131,9 +140,14 @@ carrying just the delta in `AGENTS.md`, which every other harness reads.
 - **Read-only really holds**: codex answered *"this workspace is read-only"*; pi
   lost write/edit/bash to `--tools` subsetting; vibe/kimi are held by the wrapper
   sandbox — no stray files, on any harness.
-- **Codex MCP tools are wired but auto-denied headlessly** (footnote ⁶) — an open
-  upstream limitation; claude/grok call live MCP tools cleanly, vibe/kimi via their
-  temp-home configs, pi warns-and-skips by design.
+- **Every harness but pi calls live MCP tools** (2026-07-27 sweep, glim.sh over
+  streamable HTTP). Three of them needed a dispatcher fix first, and each failed
+  *silently* — the agent just reported the server "not connected" and quietly fell
+  back to raw HTTP, which reads as a working run: codex crashed on config load
+  (footnote ⁶), grok never started the server in an untrusted checkout (⁷), and
+  kimi sent unexpanded `${VAR}` placeholders (⁸). vibe worked untouched; pi
+  warns-and-skips by design. **Verify MCP by what the tool returned, not by whether
+  the run went green.**
 - **Pi's minimalism is measurable**: the same one-line prompt consumed ~2.4k input
   tokens on pi vs ~12k on codex — its sub-1k system prompt holds up.
 

--- a/harness-adapter/adapters/grok.sh
+++ b/harness-adapter/adapters/grok.sh
@@ -117,8 +117,27 @@ fi
 [ -n "$RULES" ] && ARGS+=(--rules "$RULES")
 
 # MCP: grok discovers the project .mcp.json natively (cwd->git-root walk) and
-# expands ${VAR} from the env itself — we only grant permission to call the tools.
+# expands ${VAR} from the env itself (verified: a `Bearer ${TOK}` header arrives at
+# the server fully expanded) — we grant permission to call the tools, and --trust
+# the folder.
+#
+# --trust is REQUIRED, not optional hardening. grok gates every repo-local
+# (project-scoped) MCP server behind its folder-trust store
+# (~/.grok/trusted_folders.toml, shared with hooks + LSP): in an untrusted folder
+# the server is silently never started and no mcp__<srv>__* tool exists. A CI
+# runner checks the repo out fresh into a never-trusted path every single run, so
+# without this flag MCP is dead on grok 100% of the time — `grok mcp doctor` names
+# it exactly ("folder untrusted … re-run with --trust"), but the run itself only
+# shows an agent that can't find its tools. Measured on a real runner 2026-07-27:
+# the glim-mcp skill reported GLIM_NOT_CONNECTED while MCP_GLIM_TOKEN was live and
+# the workflow had logged "MCP enabled: glim".
+#
+# Trusting is sound here: the folder is the operator's own checked-out repo, which
+# the harness is already executing as the agent's workspace. The flag is hidden on
+# --help but accepted (grok 0.2.101+); it is passed ONLY when an MCP config is in
+# play, so a non-MCP run keeps the default untrusted posture.
 if [ -n "${RH_MCP_CONFIG:-}" ] && [ -f "${RH_MCP_CONFIG:-}" ]; then
+  ARGS+=(--trust)
   for srv in $(jq -r '.mcpServers // {} | keys[]' "$RH_MCP_CONFIG"); do
     ARGS+=(--allow "MCPTool(${srv}__*)")
   done

--- a/harness-adapter/lib/mcp-translate.sh
+++ b/harness-adapter/lib/mcp-translate.sh
@@ -29,16 +29,28 @@ mcp_to_codex_flags() {
   # NOTE: codex parses -c values as TOML. JSON strings and arrays are valid TOML;
   # the env OBJECT is emitted as JSON and may need `key = value` inline-table
   # syntax on some codex versions — verify against your installed codex.
+  #
+  # Scalars and arrays round-trip as JSON because JSON strings/arrays ARE valid
+  # TOML. OBJECTS do not: `{"Authorization":"Bearer x"}` is a JSON object, and
+  # TOML wants an inline table `{ "Authorization" = "Bearer x" }` (`:` vs `=`).
+  # Passing the JSON form makes codex refuse to load its config at all —
+  #   Error loading config.toml: invalid type: string "{\"Authorization\":...}",
+  #   expected a map in `mcp_servers.probe.http_headers`
+  # — so the whole run dies before the model starts, not just MCP. Measured on
+  # codex-cli 0.144.6 with an http server carrying an auth header (the shape
+  # every real remote MCP server uses). Keys are emitted QUOTED so header names
+  # like `X-Api-Key`, which are not TOML bare keys, stay valid.
   jq -r '
+    def inline_table: "{ " + ([to_entries[] | "\(.key|tojson) = \(.value|tojson)"] | join(", ")) + " }";
     .mcpServers // {} | to_entries[] |
     .key as $k | .value as $s |
     ( if $s.command then
         ["mcp_servers.\($k).command=\($s.command | tojson)"]
         + (if $s.args then ["mcp_servers.\($k).args=\($s.args | tojson)"] else [] end)
-        + (if $s.env then ["mcp_servers.\($k).env=\($s.env | tojson)"] else [] end)
+        + (if $s.env then ["mcp_servers.\($k).env=\($s.env | inline_table)"] else [] end)
       elif $s.url then
         ["mcp_servers.\($k).url=\($s.url | tojson)"]
-        + (if $s.headers then ["mcp_servers.\($k).http_headers=\($s.headers | tojson)"] else [] end)
+        + (if $s.headers then ["mcp_servers.\($k).http_headers=\($s.headers | inline_table)"] else [] end)
       else [] end
     ) | .[] | "-c", .' "$1"
 }

--- a/harness-adapter/lib/sandbox.sh
+++ b/harness-adapter/lib/sandbox.sh
@@ -9,12 +9,27 @@
 # repo" — and makes it mean the same thing on all five harnesses.
 
 sandbox_prefix() {
-  # sandbox_prefix TMPDIR -> prints prefix argv tokens (one per line), or
-  # returns 1 if no OS sandbox is available on this machine.
-  local tmp="$1" ws
+  # sandbox_prefix TMPDIR [EXPANDED_MCP] -> prints prefix argv tokens (one per
+  # line), or returns 1 if no OS sandbox is available on this machine.
+  #
+  # EXPANDED_MCP (optional) is the ${VAR}-expanded .mcp.json run-harness built.
+  # When the workspace also carries a literal `.mcp.json`, that file is overlaid
+  # with the expanded copy for the duration of the run. Reason: several harnesses
+  # AUTO-DISCOVER `<cwd>/.mcp.json` and that discovery WINS over the config the
+  # adapter stages. kimi is the measured case — with a project .mcp.json present
+  # it sent `Authorization: Bearer ${MCP_GLIM_TOKEN}` verbatim (the literal, not
+  # the value) and silently ignored the expanded copy in $KIMI_CODE_HOME; against
+  # a real server that is a 401, so the agent falls back to raw curl and reports
+  # the MCP server as "not connected". Overlaying at the sandbox layer fixes it
+  # for every harness at once without writing a secret into the working tree
+  # (the bind is process-private and vanishes with the sandbox).
+  local tmp="$1" mcp="${2:-}" ws
   ws="$(pwd -P)"
   case "$(uname -s)" in
     Darwin)
+      # No bind-mounts here, so the EXPANDED_MCP overlay is a Linux-only fix.
+      # aeon runs on ubuntu runners; on macOS a harness that auto-discovers
+      # `<cwd>/.mcp.json` still sees the literal ${VAR}s.
       command -v sandbox-exec >/dev/null 2>&1 || return 1
       local profile="$tmp/readonly-workspace.sb"
       cat > "$profile" <<EOF
@@ -27,7 +42,12 @@ EOF
     Linux)
       command -v bwrap >/dev/null 2>&1 || return 1
       # bind everything rw, then overlay the workspace read-only
-      printf '%s\n' bwrap --dev-bind / / --ro-bind "$ws" "$ws" --die-with-parent
+      printf '%s\n' bwrap --dev-bind / / --ro-bind "$ws" "$ws"
+      # ...then layer the expanded config over the literal one. Order matters:
+      # bwrap applies binds left to right, so this must follow the workspace bind.
+      [ -n "$mcp" ] && [ -f "$mcp" ] && [ -f "$ws/.mcp.json" ] && \
+        printf '%s\n' --ro-bind "$mcp" "$ws/.mcp.json"
+      printf '%s\n' --die-with-parent
       ;;
     *) return 1 ;;
   esac

--- a/harness-adapter/run-harness
+++ b/harness-adapter/run-harness
@@ -140,7 +140,7 @@ if [ "$MODE" = "read-only" ] && [ "$SANDBOX" = "auto" ]; then
     claude | grok | codex | pi | vibe | kimi)
       . "$HERE/lib/sandbox.sh"
       SB=()
-      if PREFIX=$(sandbox_prefix "$RH_TMPDIR"); then
+      if PREFIX=$(sandbox_prefix "$RH_TMPDIR" "$MCP"); then
         while IFS= read -r tok; do SB+=("$tok"); done <<<"$PREFIX"
         CMD=("${SB[@]}" "${CMD[@]}")
         echo "read-only: workspace write-locked via ${SB[0]}" >&2


### PR DESCRIPTION
## What

A live sweep of all six harnesses against a **real remote MCP server** (glim.sh over streamable HTTP, dispatched on GitHub Actions) found MCP broken on three of them.

Every failure was **silent**. The agent reported the server "not connected", fell back to plain HTTP, and the run finished green with a plausible-looking answer. A passing run was never evidence the MCP tools ran — one of the broken runs even returned fabricated Hacker News item IDs while reporting success.

| harness | before | after |
|---|---|---|
| `claude` | ✅ | ✅ |
| `grok` | ❌ server never started | ✅ `--trust` |
| `codex` | ❌ run exited 1 on config load | ✅ TOML inline tables |
| `pi` | n/a — rejects MCP by design | n/a |
| `vibe` | ✅ | ✅ |
| `kimi` | ❌ sent `${VAR}` verbatim → 401 | ✅ sandbox overlay |

## The three bugs

**codex — config-load crash, not an upstream limitation.** `mcp_to_codex_flags` emitted `env`/`headers` as JSON objects, but codex parses `-c` values as TOML, where an object must be an inline table (`{ "K" = "V" }`, not `{"K":"V"}`). Every remote MCP server carries an auth header, so codex refused to load its config and the whole run died before the model started:

```
Error loading config.toml: invalid type: string "{\"Authorization\":\"***\"}",
expected a map in `mcp_servers.glim.http_headers`
```

Keys are now emitted quoted, so header names that are not TOML bare keys (`X-Api-Key`) stay valid.

**grok — folder trust.** grok gates repo-local (project-scoped) MCP servers behind `~/.grok/trusted_folders.toml`. A CI runner checks the repo out into a never-trusted path on **every** run, so the server was never started and no `mcp__<srv>__*` tool ever existed. `grok mcp doctor` names it exactly (`folder untrusted … re-run with --trust`); the run itself just shows an agent that can't find its tools. `--trust` is passed only when an MCP config is in play, so non-MCP runs keep the default untrusted posture.

**kimi — unexpanded `${VAR}`.** kimi auto-discovers `<cwd>/.mcp.json` and that **wins** over the expanded copy staged in `$KIMI_CODE_HOME`, so `Authorization: Bearer ${MCP_GLIM_TOKEN}` went to the server literally and 401'd. Fixed at the sandbox layer by overlaying the expanded config onto the workspace file inside bwrap — process-private, so no secret is written into the working tree. Linux only; macOS `sandbox-exec` has no bind-mounts (noted in the README).

## Also corrected

Two places documented the codex crash as an upstream limitation:

- `harness-adapter/README.md` — the support matrix said codex was "wired, headless-denied" per `openai/codex#24135`. Re-measured on codex-cli 0.144.6: codex calls MCP tools fine.
- `apps/dashboard/components/McpPanel.tsx` — the MCP panel **disabled its controls on codex**, citing the same issue, blocking a feature that works. `pi` is the harness that genuinely cannot use MCP (its adapter warns and skips every server by design), so the banner, disabled controls and tooltips now point at `pi`.

## Verification

Each fix was confirmed twice — locally against a purpose-built MCP server whose single tool returns an unguessable secret (so a correct answer *proves* the tool was called), then live on Actions against glim.sh:

- **grok** — 4 glim calls, live HN data.
- **codex** — invoked `glim_twitter_get`, returned tweet IDs + engagement metrics that are unreachable without the server.
- **kimi** — went from "not connected / 1 call / fabricated item IDs" to 4 calls and real HN item IDs matching grok's independent run.
- **vibe** — regression-checked after the sandbox change; returned the same two tweet IDs as codex.
- Dashboard: typecheck, 165 tests, `next build` all pass; banner verified rendering with `harness: pi`, controls confirmed genuinely `disabled` via the accessibility tree.

Also verified as part of this: grok **does** expand `${VAR}` in `.mcp.json` headers itself (a `Bearer ${TOK}` header arrived at a local echo server fully expanded), which is why grok needs no translation — only trust.
