### PR TITLE
fix(grok): pass --trust on the run-grok.sh path too, not just the adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,14 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Fixed
 
+- **grok's MCP `--trust` fix extended to the other two run paths.** #779 fixed
+  only `harness-adapter/adapters/grok.sh`, which covers scheduled and manual
+  skill runs. grok is *also* run directly through `scripts/run-grok.sh` by
+  **inbound messages** (`messages.yml`) and the **local MCP server**
+  (`apps/mcp-server`) - both of which do a full MCP preflight and then hit the
+  same untrusted-checkout gate, so MCP stayed silently dead there. `run-grok.sh`
+  now passes `--trust` alongside its `MCPTool` allows, scoped to runs with a
+  `.mcp.json`. Covered by two new cases in `scripts/tests/test_run_grok.sh`.
 - **MCP now actually works on codex, grok and kimi.** A live sweep of all six
   harnesses against a remote MCP server (glim.sh over streamable HTTP, run on
   GitHub Actions) found three broken. Each failed *silently*: the agent reported

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -188,10 +188,14 @@ glim (http: https://glim.sh/mcp)
   → re-run with --trust to allow repo-local servers
 ```
 
-The adapter passes `--trust` only when an MCP config is in play, so a non-MCP run
-keeps the default untrusted posture. The flag is hidden on `grok --help` but
-accepted. (`GROK_FOLDER_TRUST=0` disables the gate wholesale, but it ungates
-project hooks along with MCP — prefer the scoped flag.)
+`--trust` is passed only when an MCP config is in play, so a non-MCP run keeps the
+default untrusted posture. The flag is hidden on `grok --help` but accepted.
+(`GROK_FOLDER_TRUST=0` disables the gate wholesale, but it ungates project hooks
+along with MCP — prefer the scoped flag.)
+
+Both grok run paths do this: `harness-adapter/adapters/grok.sh` for skill runs,
+and `scripts/run-grok.sh` for inbound messages and the local MCP server (see
+[the two run paths](#newer-grok-knobs-opt-in-per-skill) below).
 
 Trusting is sound here: the folder is the operator's own checked-out repo, which
 the harness is already executing as the agent's workspace.
@@ -227,12 +231,23 @@ on grok's subagents (so the harness drops `--no-subagents` for those runs);
 `verify` can't combine with structured output.
 
 These knobs are read by `harness-adapter/adapters/grok.sh` (ported from
-`run-grok.sh` §3c), which is what actually runs a skill now — `run-grok.sh` is
-invoked only as `run-grok.sh setup`, to install the pinned CLI and stage/refresh
-grok's auth. One consequence: **`GROK_JSON_SCHEMA` no longer reaches a run.** It
-is still implemented in `run-grok.sh`'s (now unused) run path, but nothing in
-`aeon.yml` → `run-harness grok` reads it; the adapter takes structured output
-from `run-harness --json-schema` instead.
+`run-grok.sh` §3c), which is what runs a skill on the `aeon.yml` path. There are
+**two grok run paths**, and knowing which one you're on matters:
+
+| Path | Runs grok via | Used by |
+|------|---------------|---------|
+| adapter | `run-harness grok` → `adapters/grok.sh` | scheduled/manual skill runs + the scorer (`aeon.yml`) |
+| script | `scripts/run-grok.sh` (stdin prompt) | inbound messages (`messages.yml`), local MCP server (`apps/mcp-server`) |
+
+`aeon.yml` additionally calls `run-grok.sh setup` — install the pinned CLI, stage
+and refresh auth — on both paths. Both paths honour folder trust and the MCPTool
+allows; the run-shaping knobs above are adapter-side, so a `messages.yml` reply
+uses `run-grok.sh`'s own defaults.
+
+`GROK_JSON_SCHEMA` is script-side only: `run-grok.sh` maps it to `--json-schema`,
+but nothing in the repo sets it (the scorer it was reserved for now goes
+schema-less, so one parse path covers all six harnesses). On the adapter path,
+structured output comes from `run-harness --json-schema` instead.
 
 ## Every entry point runs on either harness
 

--- a/scripts/run-grok.sh
+++ b/scripts/run-grok.sh
@@ -237,9 +237,24 @@ fi
 # headless run they're blocked unless an explicit allow rule names them. Add one
 # `--allow MCPTool(<server>__*)` per server declared in .mcp.json (grok namespaces
 # every MCP tool as `<server>__<tool>`).
+#
+# Permission is necessary but NOT sufficient: grok also gates every repo-local
+# (project-scoped) MCP server behind its folder-trust store
+# (~/.grok/trusted_folders.toml, shared with hooks + LSP). A CI runner checks the
+# repo out into a path that has never been trusted, on every run, so without
+# --trust the server is silently never STARTED and no mcp__<srv>__* tool exists —
+# the allow rules above then grant permission to call tools that don't exist. The
+# run doesn't fail; the agent reports the server "not connected" and falls back to
+# plain HTTP, which reads as a normal green run. `grok mcp doctor` names it
+# ("folder untrusted … re-run with --trust"). Same fix as
+# harness-adapter/adapters/grok.sh; applied here for the surfaces that still run
+# through this script (messages.yml, apps/mcp-server). Scoped to MCP runs, so a
+# repo with no .mcp.json keeps the default untrusted posture. The flag is hidden
+# on `grok --help` but accepted.
 MCP_ALLOW=()
 if [ -f .mcp.json ] && jq -e '.mcpServers' .mcp.json >/dev/null 2>&1; then
   MCP_SERVERS=$(jq -r '.mcpServers | keys[]' .mcp.json)
+  MCP_ALLOW+=(--trust)
   for srv in $MCP_SERVERS; do
     MCP_ALLOW+=(--allow "MCPTool(${srv}__*)")
   done

--- a/scripts/tests/test_run_grok.sh
+++ b/scripts/tests/test_run_grok.sh
@@ -177,7 +177,19 @@ JSON
 ( cd "$MCPDIR" && echo "p" | GROK_FAKE_OUT='{"text":"x"}' MODEL="" SKILL_MODE=write XAI_API_KEY=xai-test bash "$RABS" >/dev/null 2>&1 )
 { grep -Fqx "MCPTool(github__*)" "$ARGS_FILE" && grep -Fqx "MCPTool(seqthink__*)" "$ARGS_FILE"; } \
   && pass "MCP: one MCPTool allow per .mcp.json server" || bad "MCP allow rules (args: $(tr '\n' ' ' < "$ARGS_FILE"))"
+# 9b. …and --trust, without which grok never STARTS a repo-local server on an
+# untrusted checkout (every CI run) — the allows would then permit tools that
+# don't exist, and the run goes green having silently skipped MCP.
+grep -Fqx -- "--trust" "$ARGS_FILE" \
+  && pass "MCP: --trust passed for a repo-local .mcp.json" || bad "MCP --trust missing (args: $(tr '\n' ' ' < "$ARGS_FILE"))"
 rm -rf "$MCPDIR"
+
+# 9c. No .mcp.json → no --trust (default untrusted posture preserved).
+NOMCPDIR="$(mktemp -d)"
+( cd "$NOMCPDIR" && echo "p" | GROK_FAKE_OUT='{"text":"x"}' MODEL="" SKILL_MODE=write XAI_API_KEY=xai-test bash "$RABS" >/dev/null 2>&1 )
+grep -Fqx -- "--trust" "$ARGS_FILE" \
+  && bad "MCP: --trust leaked into a run with no .mcp.json" || pass "MCP: no --trust without a .mcp.json"
+rm -rf "$NOMCPDIR"
 
 # 9b. No .mcp.json in cwd → no MCPTool rules leak in
 TMPD="$(mktemp -d)"


### PR DESCRIPTION
Follow-up to #779, which fixed grok's folder-trust gate in **one** of two places. Found while answering a question about `GROK_JSON_SCHEMA`, which forced a proper audit of who still calls `run-grok.sh`.

## The gap

#779 patched `harness-adapter/adapters/grok.sh` — that covers scheduled and manual skill runs (`aeon.yml`). But grok has a **second live run path**: `scripts/run-grok.sh` is still invoked directly by

- **`messages.yml`** — inbound Telegram/Discord/Slack replies on the grok harness (`echo "$PROMPT" | bash scripts/run-grok.sh`)
- **`apps/mcp-server`** — `skill-executor.ts` spawns it for `harness: grok`

Both do a **full MCP preflight** — OAuth refresh, `${VAR}` resolution, `MCP enabled: …` in the log — and then run grok on a checkout grok has never trusted. So the server is never started, no `mcp__<srv>__*` tool exists, and `run-grok.sh`'s `MCPTool` allow rules were granting permission to call tools that were never registered.

Same silent failure as #779: the run doesn't fail, the agent reports "not connected" and falls back to plain HTTP.

## The fix

`run-grok.sh` now passes `--trust` alongside its `MCPTool` allows, scoped to runs with a `.mcp.json` so a repo without one keeps the default untrusted posture — matching the adapter's behavior exactly.

Two new cases in `scripts/tests/test_run_grok.sh`:
- `--trust` **is** passed for a repo-local `.mcp.json`
- `--trust` does **not** leak into a run with no `.mcp.json`

Full suite passes (33 cases).

## Doc correction

`docs/harnesses.md` claimed `run-grok.sh` "is invoked only as `run-grok.sh setup`". **I wrote that in #780 and it was wrong** — it's true of `aeon.yml`, not of the repo. The doc now carries a small table naming both run paths and which surfaces use each, and scopes `GROK_JSON_SCHEMA` correctly.

## On `GROK_JSON_SCHEMA` (context, no change)

It maps to grok's `--json-schema` (structured output). Introduced in #587; `skill_mode.sh` reserves it for "the scorer". Searching all 1031 commits, **nothing has ever set it** — no producer in any workflow, not even at introduction — and today's scorer deliberately goes schema-less so one parse path covers all six harnesses.

So it's a reachable-but-unused escape hatch on the script path, not a regression. Verified locally: `run-harness grok --json-schema '<schema>'` returns clean constrained JSON, while exporting `GROK_JSON_SCHEMA` without the flag is ignored by the adapter (grok replies in free-form markdown). Left as-is; whether to wire it adapter-side or drop it is a separate call.
