### PR TITLE
chore(grok): drop the dead GROK_JSON_SCHEMA knob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,18 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Fixed
 
+- **Removed the dead `GROK_JSON_SCHEMA` knob.** `scripts/run-grok.sh` mapped it
+  to grok's `--json-schema`, but **nothing in the repo has ever set it** (checked
+  the full history) - it was introduced as part of grok's run-shaping surface and
+  reserved for the scorer, which never used it and now goes schema-less on
+  purpose so one parse path covers all six harnesses. Structured output lives
+  where it is uniform: `run-harness --json-schema` (native on claude/grok/codex,
+  prompt-shim on pi/vibe/kimi); keeping a grok-only env var alongside it would
+  recreate the per-harness divergence `harness-adapter` exists to remove. The
+  `--check` precedence rule it required goes with it. Structured output is
+  therefore adapter-path only - `messages.yml` and `apps/mcp-server` return plain
+  text, as they already did in practice. Two tests now guard against the knob
+  coming back.
 - **grok's MCP `--trust` fix extended to the other two run paths.** #779 fixed
   only `harness-adapter/adapters/grok.sh`, which covers scheduled and manual
   skill runs. grok is *also* run directly through `scripts/run-grok.sh` by

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -244,10 +244,12 @@ and refresh auth — on both paths. Both paths honour folder trust and the MCPTo
 allows; the run-shaping knobs above are adapter-side, so a `messages.yml` reply
 uses `run-grok.sh`'s own defaults.
 
-`GROK_JSON_SCHEMA` is script-side only: `run-grok.sh` maps it to `--json-schema`,
-but nothing in the repo sets it (the scorer it was reserved for now goes
-schema-less, so one parse path covers all six harnesses). On the adapter path,
-structured output comes from `run-harness --json-schema` instead.
+**Structured output** is `run-harness --json-schema`, on every harness (native on
+claude/grok/codex, prompt-shim on pi/vibe/kimi). It is therefore adapter-path
+only — a `messages.yml` reply or an `apps/mcp-server` call returns plain text.
+(A grok-only `GROK_JSON_SCHEMA` env var existed on the script path until it was
+removed: nothing in the repo ever set it, and the scorer it was reserved for goes
+schema-less on purpose so a single parse path covers all six harnesses.)
 
 ## Every entry point runs on either harness
 

--- a/scripts/run-grok.sh
+++ b/scripts/run-grok.sh
@@ -38,10 +38,16 @@
 #   GROK_REASONING_EFFORT low|medium|high|xhigh|max  → --reasoning-effort (reasoning models only)
 #   GROK_BEST_OF_N        N>=2: run N ways in parallel, keep the best → --best-of-n
 #   GROK_CHECK            1/true/yes/on: append a self-verification loop → --check
-#   GROK_JSON_SCHEMA      JSON Schema string → --json-schema (structured output;
-#                         reliably honoured only by grok-build, not composer)
 #   GROK_COMPAT_RULES     override the Claude→grok compatibility preamble appended
 #                         to grok's system prompt via --rules (default below, §3d)
+#
+# Structured output is NOT available on this path. There was a GROK_JSON_SCHEMA
+# knob here, but nothing in the repo ever set it (checked the full history) and
+# the scorer it was reserved for went schema-less on purpose, so one parse path
+# covers all six harnesses. Structured output now lives where it is uniform:
+# `run-harness --json-schema` (native on claude/grok/codex, prompt-shim on
+# pi/vibe/kimi). Re-adding a grok-only env var here would recreate exactly the
+# per-harness divergence the harness-adapter exists to remove.
 #
 # MCP: grok discovers the project .mcp.json natively (no flag needed); this script
 # only adds `--allow MCPTool(<server>__*)` so the model may call those tools.
@@ -324,21 +330,14 @@ case "${GROK_BEST_OF_N:-}" in
   *[!0-9]*) log "::warning::ignoring non-integer GROK_BEST_OF_N='${GROK_BEST_OF_N}'";;
   *) RUN_FLAGS+=(--best-of-n "$GROK_BEST_OF_N"); GROK_WANTS_SUBAGENTS=1 ;;
 esac
-# --check: append a self-verification loop before finishing. grok refuses to
-# combine it with --json-schema (verification would corrupt the structured
-# response), so json-schema wins if both are requested.
+# --check: append a self-verification loop before finishing.
+# (This used to be gated against GROK_JSON_SCHEMA, since grok refuses to combine
+# --check with --json-schema. That knob is gone — see the header note — so there
+# is nothing left to conflict with. Structured output on this path would need
+# reintroducing both the flag and that precedence rule.)
 case "${GROK_CHECK:-}" in
-  1|true|yes|on)
-    if [ -n "${GROK_JSON_SCHEMA:-}" ]; then
-      log "::warning::ignoring --check: grok can't combine it with --json-schema (structured output takes precedence)"
-    else
-      RUN_FLAGS+=(--check); GROK_WANTS_SUBAGENTS=1
-    fi ;;
+  1|true|yes|on) RUN_FLAGS+=(--check); GROK_WANTS_SUBAGENTS=1 ;;
 esac
-# --json-schema: constrain output to a schema (structured output). Populates
-# .structuredOutput on reasoning models; composer leaves it null and just emits
-# JSON text — both are handled by the normalizer below.
-if [ -n "${GROK_JSON_SCHEMA:-}" ]; then RUN_FLAGS+=(--json-schema "$GROK_JSON_SCHEMA"); fi
 
 # --- 3d. Claude→grok compatibility preamble (--rules) -----------------------
 # Every Aeon skill is authored for the Claude Code harness: its data-fetch steps name

--- a/scripts/skill_mode.sh
+++ b/scripts/skill_mode.sh
@@ -132,9 +132,10 @@ grok_args() {
 #   best_of_n: 3            # run N ways, keep the best   -> --best-of-n
 #   verify: true            # append a self-check loop    -> --check
 #
-# Output is `export GROK_X=...` lines for exactly the fields present (so unset
-# fields fall through to run-grok.sh's defaults, and the scorer's own
-# GROK_JSON_SCHEMA is never clobbered). aeon.yml's grok branch evals this.
+# Output is `export GROK_X=...` lines for exactly the fields present, so unset
+# fields fall through to the adapter's defaults. aeon.yml's grok branch evals this.
+# (This note used to reserve GROK_JSON_SCHEMA for the scorer. The scorer never
+# set it and now goes schema-less deliberately, so the knob is gone.)
 # read one frontmatter scalar (first '---' block), stripping inline # comment,
 # quotes and surrounding whitespace. Prints nothing if absent.
 _fm() {

--- a/scripts/tests/test_run_grok.sh
+++ b/scripts/tests/test_run_grok.sh
@@ -148,18 +148,19 @@ echo "p" | GROK_FAKE_OUT='{"text":"x"}' MODEL="" SKILL_MODE=write XAI_API_KEY=xa
 if grep -qx -- "--best-of-n" "$ARGS_FILE"; then bad "GROK_BEST_OF_N=1 is a no-op"; else pass "GROK_BEST_OF_N=1 is a no-op"; fi
 grep -qx -- "--no-subagents" "$ARGS_FILE" && pass "default run keeps --no-subagents" || bad "default run keeps --no-subagents"
 
-# 8d2. --check is dropped when --json-schema is set (grok refuses to combine them)
+# 8e. This path emits NO --json-schema: structured output is run-harness's job
+# (uniform across all six harnesses), not a grok-only env var. Guards against
+# reintroducing the divergence, and against a stray GROK_JSON_SCHEMA in the
+# environment silently taking effect again.
+echo "p" | GROK_FAKE_OUT='{"text":"x"}' MODEL="" SKILL_MODE=write XAI_API_KEY=xai-test GROK_JSON_SCHEMA='{"type":"object"}' bash "$R" >/dev/null 2>&1
+if grep -qx -- "--json-schema" "$ARGS_FILE"; then bad "no --json-schema on the run-grok.sh path"; else pass "no --json-schema on the run-grok.sh path"; fi
+# ...and --check is no longer suppressed by it (nothing left to conflict with).
 echo "p" | GROK_FAKE_OUT='{"text":"x"}' MODEL="" SKILL_MODE=write XAI_API_KEY=xai-test GROK_CHECK=true GROK_JSON_SCHEMA='{"type":"object"}' bash "$R" >/dev/null 2>&1
-if grep -qx -- "--check" "$ARGS_FILE"; then bad "--check dropped when --json-schema present"; else pass "--check dropped when --json-schema present"; fi
-grep -qx -- "--json-schema" "$ARGS_FILE" && pass "--json-schema kept over --check" || bad "--json-schema kept over --check"
+grep -qx -- "--check" "$ARGS_FILE" && pass "--check no longer gated on a schema knob" || bad "--check gating"
 
-# 8e. GROK_JSON_SCHEMA maps to --json-schema (structured output)
-SCHEMA='{"type":"object"}'
-echo "p" | GROK_FAKE_OUT='{"text":"x"}' MODEL="" SKILL_MODE=write XAI_API_KEY=xai-test GROK_JSON_SCHEMA="$SCHEMA" bash "$R" >/dev/null 2>&1
-grep -qx -- "--json-schema" "$ARGS_FILE" && grep -Fqx "$SCHEMA" "$ARGS_FILE" \
-  && pass "GROK_JSON_SCHEMA → --json-schema" || bad "GROK_JSON_SCHEMA mapping"
-
-# 8f. .structuredOutput (grok-build under --json-schema) is normalized into .result
+# 8f. .structuredOutput (grok-build under run-harness --json-schema) is normalized
+# into .result — the normalizer still has to handle it, even though this script
+# never sets the flag itself.
 OUT=$(run '{"text":"interim chatter","structuredOutput":{"score":4,"flags":[]},"stopReason":"EndTurn","thought":"secret"}')
 RES=$(echo "$OUT" | jq -r '.result')
 { echo "$RES" | jq -e '.score==4' >/dev/null 2>&1 && ! echo "$OUT" | grep -q "secret" && ! echo "$RES" | grep -q "interim"; } \


### PR DESCRIPTION
Closes the last loose end from the MCP sweep (#779 / #780 / #781).

## What it was

`scripts/run-grok.sh` mapped `GROK_JSON_SCHEMA` to grok's `--json-schema` (structured output). It arrived in #587 as part of grok's run-shaping surface, and `skill_mode.sh` carried a note reserving it for "the scorer".

**Nothing in the repo has ever set it.** Searching the full history: no producer in any workflow, not even at introduction. The scorer it was reserved for never used it, and today deliberately goes schema-less so a single parse path covers all six harnesses (pi/vibe/kimi have no native schema flag).

## Why remove rather than wire it into the adapter

The capability already exists in the right place: **`run-harness --json-schema`**, uniform across all six harnesses — native on claude/grok/codex, prompt-shim on pi/vibe/kimi. Verified working on grok locally: it returns clean schema-constrained JSON.

Porting `GROK_JSON_SCHEMA` adapter-side would add a *second*, grok-only way to do the same thing — the exact per-harness divergence `harness-adapter` exists to remove. Anything built on it would break the moment that skill ran on kimi or vibe.

Keeping it wasn't free either: it was carried in `run-grok.sh`'s header, its `--check` precedence rule, `skill_mode.sh`'s reservation note, four test assertions, and a paragraph of docs explaining a knob that does nothing.

## What changes

- `run-grok.sh`: knob and its `--json-schema` mapping removed; header explains where structured output lives now.
- The `--check` gate goes with it — it only existed because grok refuses to combine `--check` with `--json-schema`. `--check` is now unconditional.
- `skill_mode.sh`: the stale "reserved for the scorer" note replaced.
- `docs/harnesses.md`: states plainly that structured output is `run-harness --json-schema` and therefore **adapter-path only** — `messages.yml` and `apps/mcp-server` return plain text. That is not a behavior change; it's what already happened, since nothing set the var.

## Tests

The two mapping assertions are replaced by two guards against regression:

- `no --json-schema on the run-grok.sh path` — holds even with `GROK_JSON_SCHEMA` set in the environment, so a stray value can't silently take effect again
- `--check no longer gated on a schema knob`

Full suite passes (33 cases). The `.structuredOutput` normalizer is **untouched** — grok still returns that field when `run-harness` passes the flag, so it still has to be handled.

## Not in this PR

The two-run-path problem underneath (#781 existed because `adapters/grok.sh` and `run-grok.sh` both run skills) is worth closing separately by migrating `messages.yml` and `apps/mcp-server` onto `run-harness`. That would make `run-grok.sh` genuinely setup-only and retire the "fixed one path, forgot the other" class. Bigger than a cleanup — not attempted here.
