### PR TITLE
fix(deps): bump postcss override past GHSA-r28c-9q8g-f849

### DIFF
--- a/apps/dashboard/package-lock.json
+++ b/apps/dashboard/package-lock.json
@@ -2056,9 +2056,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -2133,9 +2133,9 @@
       "license": "ISC"
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -2152,7 +2152,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -27,7 +27,7 @@
     "typescript": "^6.0.3"
   },
   "overrides": {
-    "postcss": "^8.5.10",
+    "postcss": "^8.5.18",
     "sharp": "^0.35.3"
   },
   "allowScripts": {


### PR DESCRIPTION
Closes the one open Dependabot alert on the repo (postcss, high).

## The finding

[GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849) - postcss `<= 8.5.17` auto-loads a previous source map from the `sourceMappingURL` comment without constraining the path, so a crafted stylesheet can disclose an arbitrary `.map` file off disk. Patched in `8.5.18`.

`apps/dashboard/package-lock.json` had `8.5.15`.

## The fix

`next@16.2.11` pins postcss to exactly `8.4.31`, so `npm update` can't reach the fix - it has to come through the `overrides` entry that already exists in `apps/dashboard/package.json` (same pattern as the `sharp` entry beside it). That entry was just too loose at `^8.5.10`. Tightening it to `^8.5.18` moves the lock to `8.5.23`.

Diff is 2 packages: `postcss` 8.5.15 -> 8.5.23 and its transitive `nanoid` 3.3.12 -> 3.3.16. `lockfileVersion` stays 3.

Note `npm audit` reported this as **2 high** findings - it counts `postcss` and its dependent `next` separately. It is one advisory, and both entries clear with the single bump.

## Verification

- `npm ci` clean from the regenerated lock
- `npm audit` -> `found 0 vulnerabilities` (was `2 high`)
- `npm run typecheck` clean
- `npm run build` succeeds - this is the meaningful one, since postcss runs at build time via Tailwind
- `npm test` -> 165/165 pass

`apps/cli` was already at 0 vulnerabilities and is untouched.
