### PR TITLE
refactor(harness): route messages.yml + mcp-server through run-harness

### DIFF
--- a/.github/workflows/messages.yml
+++ b/.github/workflows/messages.yml
@@ -452,12 +452,36 @@ jobs:
           # aeon.yml). A grok-only repo (no Claude creds) must respond via grok.
           CONFIG_HARNESS=$(grep -E '^harness:' aeon.yml | sed 's/^harness: *//' | tr -d ' ')
           HARNESS="${CONFIG_HARNESS:-claude}"
-          if [ "$HARNESS" != "grok" ]; then HARNESS="claude"; fi   # unknown → safe default
+          # Only claude and grok have their CLI staged on this workflow ("Install
+          # Claude Code" above, plus the grok setup below). The other four
+          # run-harness harnesses would need their CLI + provider auth installed
+          # here the way aeon.yml's "Install harness CLI" step does. Until that
+          # lands, a repo configured for one of them answers messages on claude —
+          # say so out loud instead of swapping the harness silently.
+          case "$HARNESS" in
+            claude|grok) ;;
+            codex|pi|vibe|kimi)
+              echo "::warning::harness '$HARNESS' has no CLI staged on the messages workflow — replying on claude instead (skill runs still use $HARNESS)."
+              HARNESS="claude" ;;
+            *)
+              echo "::warning::unknown harness '$HARNESS' — falling back to claude"
+              HARNESS="claude" ;;
+          esac
           # On grok a claude-* model id is meaningless — fall back to grok's default.
           if [ "$HARNESS" = "grok" ]; then
             case "$MODEL" in claude-*|"") MODEL="grok-4.5" ;; esac
           fi
           echo "Using harness: $HARNESS  |  model: $MODEL"
+
+          # Stage grok's CLI + auth. run-grok.sh's `setup` subcommand is the single
+          # source of truth for the version pin, the GROK_CREDENTIALS restore and
+          # the OAuth refresh/persist (§2b). This used to happen implicitly, because
+          # the run itself went through run-grok.sh and step 1 installs the CLI on
+          # demand; now that the run goes through run-harness (whose grok adapter
+          # only checks `command -v grok`), staging has to be explicit.
+          if [ "$HARNESS" = "grok" ]; then
+            bash "${GITHUB_WORKSPACE}/scripts/run-grok.sh" setup
+          fi
 
           # AI Gateway routing — same path as aeon.yml's Run steps. The grok harness
           # has its own auth and does NOT use the gateway, so skip it there (avoids
@@ -571,25 +595,36 @@ jobs:
           - For anything else, do your best and explain what you did.
 
           Always send your response back via ./notify so the user sees it."
-          # Harness split — both paths emit the SAME {result, usage} envelope, so
-          # the token/notify handling below is unchanged. run-grok.sh discovers
-          # .mcp.json natively (the preflight above already exported its secrets)
-          # and maps SKILL_MODE=write to grok's permission flags; a conversational
-          # reply can run skills, update memory, and notify, i.e. write mode.
-          if [ "$HARNESS" = "grok" ]; then
-            if ! CLAUDE_OUTPUT=$(
-              export MODEL SKILL_MODE=write
-              echo "$PROMPT" | bash "${GITHUB_WORKSPACE}/scripts/run-grok.sh"
-            ); then
-              echo "::error::grok harness failed. Output: $(printf '%s' "$CLAUDE_OUTPUT" | tail -c 300 | tr '\n' ' ')"
-              exit 1
-            fi
-          elif ! CLAUDE_OUTPUT=$(echo "$PROMPT" | claude -p - \
-            --model "$MODEL" --allowedTools "$ALLOWED" \
-            "${MCP_FLAGS[@]}" --output-format json 2>&1); then
-            echo "::error::Claude CLI failed. Output: $CLAUDE_OUTPUT"
+          # Unified execution: EVERY harness runs through harness-adapter's
+          # run-harness, the same way aeon.yml runs a skill — one
+          # {result, usage{...}} envelope, so the token/notify handling below is
+          # unchanged. This is the point of the change: fixes that live in the
+          # adapter now apply here too. Previously this path called
+          # scripts/run-grok.sh directly and bypassed the adapter entirely, which
+          # is why grok's MCP folder-trust gate stayed broken on inbound messages
+          # after it was fixed for skill runs (#779 → #781).
+          #
+          # Write mode: a conversational reply can run skills, update memory and
+          # notify. run-harness applies its OS sandbox only to read-only runs, so
+          # there is nothing to opt out of here.
+          RH="${GITHUB_WORKSPACE}/harness-adapter/run-harness"
+          RH_ARGS=(--mode write --allowed-tools "$ALLOWED" --timeout 600)
+          # Pass --mcp-config only when the preflight actually ENABLED MCP (every
+          # referenced ${VAR} resolved) — MCP_FLAGS doubles as that gate.
+          # run-harness re-expands the config and translates it per harness; the
+          # claude adapter adds --strict-mcp-config itself, as this step used to.
+          if [ "${#MCP_FLAGS[@]}" -gt 0 ]; then RH_ARGS+=(--mcp-config .mcp.json); fi
+          HARNESS_ERR=$(mktemp)
+          if ! CLAUDE_OUTPUT=$(echo "$PROMPT" | bash "$RH" "$HARNESS" \
+            --model "$MODEL" "${RH_ARGS[@]}" 2>"$HARNESS_ERR"); then
+            echo "::error::$HARNESS harness failed: $(tail -c 400 "$HARNESS_ERR" | tr '\n' ' ')"
             exit 1
           fi
+          # run-harness diagnostics are the only signal when a harness degrades but
+          # still exits 0 (a skipped MCP server, a token-estimate fallback), so
+          # surface them in the job log rather than swallowing them.
+          if [ -s "$HARNESS_ERR" ]; then sed 's/^/run-harness: /' "$HARNESS_ERR" >&2; fi
+          rm -f "$HARNESS_ERR"
 
           echo "$CLAUDE_OUTPUT" | jq -r '.result // empty'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,21 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Fixed
 
+- **One run path: `messages.yml` and `apps/mcp-server` now dispatch through
+  `run-harness`.** They were the last two surfaces calling `scripts/run-grok.sh`
+  (and, on the claude side, `claude -p -`) directly, bypassing the harness
+  adapter. That is a fix-delivery bug, not a style one: grok's MCP folder-trust
+  gate was fixed for skill runs and stayed broken on these two for two releases,
+  because the fix lived in the adapter they didn't use. With one path, an
+  adapter-level fix reaches every surface by construction. `run-grok.sh` is now
+  genuinely **setup-only** (CLI pin + `GROK_CREDENTIALS` restore/refresh), which
+  `messages.yml` invokes explicitly since the run no longer installs grok on
+  demand. Verified live on a real instance: an inbound message answered on grok
+  called a live MCP tool (`glim__glim_web_fetch`) and reported real token usage.
+  `apps/mcp-server` also now resolves **all six** harnesses — it previously
+  recognised only `claude`/`grok` and silently ran anything else on claude.
+  `messages.yml` stages only `claude`/`grok`, so the other four are answered on
+  claude with a `::warning::` instead of a silent swap.
 - **Removed the dead `GROK_JSON_SCHEMA` knob.** `scripts/run-grok.sh` mapped it
   to grok's `--json-schema`, but **nothing in the repo has ever set it** (checked
   the full history) - it was introduced as part of grok's run-shaping surface and

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -8,9 +8,9 @@
  * Tool naming: aeon-{slug} (e.g. aeon-article, aeon-hn-digest)
  * Each tool accepts a single optional `var` argument (the skill's variable input).
  *
- * Skill execution: spawns the configured harness (`claude -p -`, or the Grok
- * `run-grok.sh` when `harness: grok`) with the skill prompt, exactly as GitHub
- * Actions does, so local runs are identical to scheduled runs.
+ * Skill execution: spawns the configured harness through harness-adapter's
+ * `run-harness` with the skill prompt, exactly as GitHub Actions does, so local
+ * runs are identical to scheduled runs.
  */
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";

--- a/apps/mcp-server/src/skill-executor.ts
+++ b/apps/mcp-server/src/skill-executor.ts
@@ -1,6 +1,6 @@
 /**
  * Aeon skill executor — shared core for loading the skill catalog and running a
- * skill through the configured harness (`claude` CLI or the Grok `run-grok.sh`),
+ * skill through the configured harness via harness-adapter's `run-harness`,
  * identical to how GitHub Actions invokes it.
  *
  * Extracted from the MCP server so the load → prompt → spawn → parse logic lives
@@ -51,18 +51,25 @@ export function buildSkillPrompt(slug: string, varValue: string): string {
   return prompt;
 }
 
+/** Every harness harness-adapter's run-harness can dispatch to. */
+export const HARNESSES = ["claude", "grok", "codex", "pi", "vibe", "kimi"] as const;
+export type Harness = (typeof HARNESSES)[number];
+const isHarness = (v: string): v is Harness =>
+  (HARNESSES as readonly string[]).includes(v);
+
 /**
  * Which agent harness runs the skill. Mirrors aeon.yml's resolution so a local
  * MCP run matches a scheduled one: the AEON_HARNESS env wins, else the repo's
  * global `harness:` in aeon.yml, else `claude`. Any unknown value → `claude`.
  */
-export function resolveHarness(repoRoot: string): "claude" | "grok" {
+export function resolveHarness(repoRoot: string): Harness {
   const envH = (process.env.AEON_HARNESS || "").trim().toLowerCase();
-  if (envH === "grok" || envH === "claude") return envH;
+  if (isHarness(envH)) return envH;
   try {
     const cfg = readFileSync(join(repoRoot, "aeon.yml"), "utf-8");
     const m = cfg.match(/^harness:\s*["']?([A-Za-z]+)/m);
-    if (m && m[1].toLowerCase() === "grok") return "grok";
+    const configured = m?.[1].toLowerCase();
+    if (configured && isHarness(configured)) return configured;
   } catch {
     /* no aeon.yml → default */
   }
@@ -70,11 +77,11 @@ export function resolveHarness(repoRoot: string): "claude" | "grok" {
 }
 
 /**
- * Run a skill synchronously and return its text output. Uses `claude -p -` on the
- * Claude harness and `scripts/run-grok.sh` on the Grok harness — both emit the
- * same `{ result }` JSON envelope, so parsing is shared. Failure modes (missing
- * skill, missing CLI, non-zero exit, empty output) are returned as human-readable
- * strings rather than thrown, so callers can surface them without special-casing.
+ * Run a skill synchronously and return its text output. Dispatches through
+ * harness-adapter's `run-harness`, which emits one `{ result, usage }` envelope
+ * for every harness, so parsing is shared. Failure modes (missing skill, missing
+ * CLI, non-zero exit, empty output) are returned as human-readable strings rather
+ * than thrown, so callers can surface them without special-casing.
  */
 export function runSkill(
   repoRoot: string,
@@ -97,30 +104,32 @@ export function runSkill(
     `${logPrefix} Running skill: ${slug}${varValue ? ` (var=${varValue})` : ""} [harness: ${harness}]\n`
   );
 
-  const [cmd, args, spawnEnv]: [string, string[], NodeJS.ProcessEnv] =
-    harness === "grok"
-      ? // run-grok.sh reads the prompt on stdin, discovers .mcp.json natively, and
-        // maps SKILL_MODE to grok's permission flags. MODEL unset → grok's default.
-        ["bash", [join(repoRoot, "scripts", "run-grok.sh")], { ...process.env, SKILL_MODE: "write" }]
-      : ["claude", ["-p", "-", "--output-format", "json"], process.env];
+  // Every harness goes through harness-adapter's run-harness — the same dispatcher
+  // aeon.yml uses — so a local MCP run behaves like a scheduled one and adapter-level
+  // fixes (grok's MCP folder --trust, codex's TOML config translation, kimi's
+  // config overlay) apply here too. This path used to call `claude -p -` and
+  // scripts/run-grok.sh directly, which is how it missed those fixes.
+  // Write mode: a skill run may edit memory, commit, and notify.
+  const runHarness = join(repoRoot, "harness-adapter", "run-harness");
+  const args = [runHarness, harness, "--mode", "write", "--timeout", "600"];
+  if (existsSync(join(repoRoot, ".mcp.json"))) {
+    args.push("--mcp-config", join(repoRoot, ".mcp.json"));
+  }
 
-  const result = spawnSync(cmd, args, {
+  const result = spawnSync("bash", args, {
     input: prompt,
     cwd: repoRoot,
-    env: spawnEnv,
+    env: process.env,
     timeout: 600_000, // 10 minutes — same as the GitHub Actions timeout
     maxBuffer: 10 * 1024 * 1024, // 10 MB
     encoding: "utf-8",
   });
 
   if (result.error) {
-    const enoent =
-      (result.error as NodeJS.ErrnoException).code === "ENOENT";
+    const enoent = (result.error as NodeJS.ErrnoException).code === "ENOENT";
     const msg = enoent
-      ? harness === "grok"
-        ? `'bash' or scripts/run-grok.sh not found — run from inside an Aeon repo clone with the grok CLI installed (npm i -g @xai-official/grok).`
-        : `'claude' command not found. Install it with: npm install -g @anthropic-ai/claude-code`
-      : `Failed to spawn ${cmd}: ${result.error.message}`;
+      ? `'bash' or harness-adapter/run-harness not found — run from inside an Aeon repo clone.`
+      : `Failed to spawn run-harness: ${result.error.message}`;
     return `Error: ${msg}`;
   }
 
@@ -134,8 +143,8 @@ export function runSkill(
     return `Skill '${slug}' produced no output.`;
   }
 
-  // Both harnesses wrap the result as { result: "..." } (run-grok.sh normalizes
-  // grok's envelope to match claude's --output-format json).
+  // run-harness normalizes every harness to { result: "..." }, so this parse is
+  // harness-agnostic.
   try {
     const parsed = JSON.parse(stdout) as { result?: string };
     return parsed.result ?? stdout;

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -193,9 +193,8 @@ default untrusted posture. The flag is hidden on `grok --help` but accepted.
 (`GROK_FOLDER_TRUST=0` disables the gate wholesale, but it ungates project hooks
 along with MCP — prefer the scoped flag.)
 
-Both grok run paths do this: `harness-adapter/adapters/grok.sh` for skill runs,
-and `scripts/run-grok.sh` for inbound messages and the local MCP server (see
-[the two run paths](#newer-grok-knobs-opt-in-per-skill) below).
+This is applied by `harness-adapter/adapters/grok.sh`, which every surface now
+goes through — see [one run path](#newer-grok-knobs-opt-in-per-skill) below.
 
 Trusting is sound here: the folder is the operator's own checked-out repo, which
 the harness is already executing as the agent's workspace.
@@ -230,39 +229,47 @@ api.x.ai strings the CLI rejects as "unknown model id"). `best_of_n`/`verify` bu
 on grok's subagents (so the harness drops `--no-subagents` for those runs);
 `verify` can't combine with structured output.
 
-These knobs are read by `harness-adapter/adapters/grok.sh` (ported from
-`run-grok.sh` §3c), which is what runs a skill on the `aeon.yml` path. There are
-**two grok run paths**, and knowing which one you're on matters:
+These knobs are read by `harness-adapter/adapters/grok.sh`, ported from
+`run-grok.sh` §3c.
 
-| Path | Runs grok via | Used by |
-|------|---------------|---------|
-| adapter | `run-harness grok` → `adapters/grok.sh` | scheduled/manual skill runs + the scorer (`aeon.yml`) |
-| script | `scripts/run-grok.sh` (stdin prompt) | inbound messages (`messages.yml`), local MCP server (`apps/mcp-server`) |
+**There is exactly one run path.** Every surface that runs a skill or a reply —
+scheduled and manual runs, the scorer, inbound messages, the local MCP server —
+goes through `run-harness`. `scripts/run-grok.sh` is now **setup-only**: it
+installs the pinned grok CLI and stages/refreshes `GROK_CREDENTIALS` (§2b), and
+callers invoke it as `run-grok.sh setup`.
 
-`aeon.yml` additionally calls `run-grok.sh setup` — install the pinned CLI, stage
-and refresh auth — on both paths. Both paths honour folder trust and the MCPTool
-allows; the run-shaping knobs above are adapter-side, so a `messages.yml` reply
-uses `run-grok.sh`'s own defaults.
+That consolidation is deliberate. `messages.yml` and `apps/mcp-server` used to
+call `run-grok.sh` directly and so bypassed the adapter, which is how grok's MCP
+folder-trust gate stayed broken on those two surfaces after it was fixed for
+skill runs — a fix landed in one path and silently didn't reach the other. With
+one path, an adapter-level fix reaches every surface by construction.
 
 **Structured output** is `run-harness --json-schema`, on every harness (native on
-claude/grok/codex, prompt-shim on pi/vibe/kimi). It is therefore adapter-path
-only — a `messages.yml` reply or an `apps/mcp-server` call returns plain text.
-(A grok-only `GROK_JSON_SCHEMA` env var existed on the script path until it was
-removed: nothing in the repo ever set it, and the scorer it was reserved for goes
-schema-less on purpose so a single parse path covers all six harnesses.)
+claude/grok/codex, prompt-shim on pi/vibe/kimi). Callers that don't pass it get
+plain text. (A grok-only `GROK_JSON_SCHEMA` env var existed on the old script
+path until it was removed: nothing in the repo ever set it, and the scorer it was
+reserved for goes schema-less on purpose so a single parse path covers all six
+harnesses.)
+
+**Harness coverage differs by surface**, because each has to stage the CLI it
+dispatches to. Skill runs (`aeon.yml`) install any of the six. The local MCP
+server resolves all six but expects the CLI to already be installed on your
+machine. `messages.yml` stages only `claude` and `grok`; a repo configured for
+one of the other four gets a `::warning::` and is answered on claude, rather than
+being switched silently.
 
 ## Every entry point runs on either harness
 
 The harness split isn't just the scheduled skill run — it's wired through every
 surface that launches the agent, so a grok-only fork (no Claude credentials)
-behaves identically everywhere:
+behaves identically everywhere. All of them dispatch through `run-harness`:
 
 | Surface | How grok is selected | Notes |
 |---------|---------------------|-------|
 | Scheduled / manual skill run (`aeon.yml`) | dispatch **Harness** input → per-skill `harness:` → global `harness:` → `claude` | full flags + MCP + scorer |
 | Skill chains (`chain-runner.yml`) | inherits — each step dispatches `aeon.yml`, which resolves per-skill/global | |
-| Inbound messages (`messages.yml`, Telegram/Discord/Slack) | global `harness:` in `aeon.yml` | conversational reply in write mode |
-| Local MCP server (`apps/mcp-server`) | `AEON_HARNESS` env → global `harness:` | `resolveHarness()` in `skill-executor.ts` |
+| Inbound messages (`messages.yml`, Telegram/Discord/Slack) | global `harness:` in `aeon.yml` | conversational reply in write mode; only `claude`/`grok` have a CLI staged here — the other four warn and answer on claude |
+| Local MCP server (`apps/mcp-server`) | `AEON_HARNESS` env → global `harness:` | `resolveHarness()` in `skill-executor.ts`; resolves all six, expects the CLI installed locally |
 | Webhook (`apps/webhook`) | relay only → dispatches `messages.yml` | harness-agnostic |
 | Post-run quality scorer (`aeon.yml`) | scores through the same harness the skill ran on | |
 


### PR DESCRIPTION
Closes the two-path problem behind #781.

## Why

`messages.yml` and `apps/mcp-server` were the last two surfaces that ran a skill **without** the harness adapter — piping their prompt straight into `scripts/run-grok.sh` (or `claude -p -`).

That's a fix-delivery bug, not a style preference. grok's MCP folder-trust gate was fixed in `adapters/grok.sh` (#779); these two surfaces kept the broken behavior for two releases, because the fix lived in a path they didn't use. MCP stayed silently dead on inbound messages until #781 patched `run-grok.sh` separately. **Two paths means every adapter fix has to be applied twice, and one of them gets forgotten.** With one path that can't happen.

## What changes

- **`messages.yml`** — one `run-harness "$HARNESS"` call replaces the `if grok … elif claude …` split. `--mode write` (a reply may run skills, edit memory, notify); `--allowed-tools` and `--mcp-config` carry over unchanged; run-harness stderr is now surfaced in the job log, since that's the only signal when a harness degrades but still exits 0.
- **`run-grok.sh` is now genuinely setup-only.** `messages.yml` calls `run-grok.sh setup` explicitly — the run used to install grok as a side effect of the script's step 1, and `adapters/grok.sh` only does `command -v grok`.
- **`apps/mcp-server`** — spawns `run-harness` and resolves **all six** harnesses. It previously recognised only `claude`/`grok` and silently ran `codex`/`pi`/`vibe`/`kimi` on claude.
- **`messages.yml` stages only `claude`/`grok` CLIs**, so the other four are answered on claude with a loud `::warning::` instead of a silent swap. Staging all six there needs `aeon.yml`'s *Install harness CLI* step extracted into a shared script — deliberate follow-up, not done here.
- Docs updated: `docs/harnesses.md`'s "two grok run paths" table (which I added in #781) is replaced by **one run path**, plus a note on per-surface harness coverage.

## Verified live, not by inspection

**Inbound message on grok, through the new path** (real instance, real Actions run):

```
Using harness: grok  |  model: grok-4.5
MCP enabled: glim
run-harness: notice: CLAUDE.md uses @imports (not expanded by grok) …
```

The reply called a live MCP tool and named it — **`glim__glim_web_fetch`**, twice, against the HN Firebase API — and reported real token usage (`input 33968, output 1289, cache_read 119808`), confirming the envelope still parses for the token/notify handling downstream. That's the surface that was broken; it now works through the adapter.

**`apps/mcp-server`** — `runSkill()` end to end against a probe skill whose output can't be guessed:

- `AEON_HARNESS=grok` → `resolveHarness -> grok`, returned `PROBE_OK`
- `AEON_HARNESS=vibe` → `resolveHarness -> vibe`, returned `PROBE_OK` (this is the widened resolution — before this PR vibe would have silently run on claude)

`actionlint` clean on `messages.yml`, `tsc --noEmit` clean on `apps/mcp-server`, `okf-validate` OK.

## Follow-up worth doing

`run-grok.sh` still carries its full run path (~200 lines) that nothing calls now. It can be reduced to `setup`, but that touches its 30-case test suite, so it deserves its own pass rather than riding along here.
