### PR TITLE
chore(grok): reduce run-grok.sh to setup-only, move its tests to the adapter

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -788,7 +788,7 @@ jobs:
           HARNESS="$RESOLVED_HARNESS"
           # On the grok harness a claude-* model id is meaningless — fall back to
           # grok's current default (grok-4.5) unless an explicit grok model was
-          # chosen. run-grok.sh omits --model for a non-grok value as a safety net.
+          # chosen. The grok adapter omits --model for a non-grok value as a safety net.
           if [ "$HARNESS" = "grok" ]; then
             case "$MODEL" in claude-*|"") MODEL="grok-4.5" ;; esac
           fi
@@ -877,7 +877,7 @@ jobs:
           # than let Claude's config parse-failure break the whole skill run.
           # The MCP_FLAGS/ALLOWED additions below are the CLAUDE path; the exported
           # ${VAR}s are harness-agnostic and also feed grok, which reads .mcp.json
-          # natively and expands them (run-grok.sh only adds the MCPTool allows).
+          # natively and expands them (the adapter adds --trust + MCPTool allows).
           MCP_FLAGS=()
           if [ -f .mcp.json ] && jq -e '.mcpServers' .mcp.json >/dev/null 2>&1; then
             # MCP OAuth (durable): mint a fresh access token from any captured refresh

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -48,8 +48,10 @@ jobs:
         run: bash scripts/tests/test_validate_skill_packs.sh
       - name: community skill install catalog tests
         run: bash scripts/tests/test_community_skill_install.sh
-      - name: grok harness runner tests
+      - name: grok setup/auth tests
         run: bash scripts/tests/test_run_grok.sh
+      - name: harness-adapter grok tests
+        run: bash scripts/tests/test_harness_adapter_grok.sh
       - name: state reducer tests
         run: python3 scripts/tests/test_state_reduce.py
       - name: health triage tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,19 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Fixed
 
+- **`scripts/run-grok.sh` is now setup-only.** With every surface dispatching
+  through `run-harness`, the script's ~260-line run path (model/permission flags,
+  MCP allows, run-shaping knobs, grok invocation, envelope normalization) had no
+  callers — a second, drifting copy of `adapters/grok.sh`. Removed. What remains
+  is the CLI version pin and the `GROK_CREDENTIALS` restore + rotating-refresh
+  persistence (§2b). A stale caller using the old contract (prompt on stdin) now
+  **exits 2 with a pointer to `run-harness`** rather than staging grok and
+  returning empty stdout, which would read as "the model returned nothing".
+  Its flag/envelope/MCP test coverage was **moved, not deleted**, into a new
+  `scripts/tests/test_harness_adapter_grok.sh` — the first test suite for
+  `harness-adapter` — which guards the `--trust` regression, the thought
+  firewall, the per-server `MCPTool` allows, model-id forwarding, and
+  abnormal-stop handling against the code that now implements them.
 - **One run path: `messages.yml` and `apps/mcp-server` now dispatch through
   `run-harness`.** They were the last two surfaces calling `scripts/run-grok.sh`
   (and, on the claude side, `claude -p -`) directly, bypassing the harness

--- a/apps/dashboard/lib/constants.ts
+++ b/apps/dashboard/lib/constants.ts
@@ -13,7 +13,7 @@ export const MODELS = [
 // Models offered when the Grok (`grok`) harness is selected — only grok-4.5, the
 // one model the X-account (GROK_CREDENTIALS) login exposes to the grok CLI's
 // --model flag. grok-4.5 is grok's current default: the flagship reasoning model
-// that powers Grok Build, multi-agent-capable (run-grok.sh passes --no-subagents
+// that powers Grok Build, multi-agent-capable (the grok adapter passes --no-subagents
 // in CI).
 // Everything else xAI documents — grok-composer-2.5-fast, grok-build, grok-build-0.1,
 // grok-4.3 — is an api.x.ai model *string*, NOT a valid CLI --model value on the
@@ -136,7 +136,7 @@ export function authSecretsForHarness(harness: string): string[] {
 // web-search quality, NOT the premium xAI x_search feed. So on the grok harness
 // XAI_API_KEY is not required to get output; we drop the dashboard's "needs key" gate
 // there (only there — claude skills still declare it). The runtime half lives in
-// scripts/run-grok.sh, whose compat `--rules` tell the model to fetch X via WebSearch
+// harness-adapter/lib/compat-rules.md, whose `--rules` tell the model to fetch X via WebSearch
 // when the key is absent instead of hard-exiting. The key stays fully settable either
 // way — it powers the premium xAI x_search on BOTH harnesses and the grok gateway.
 export const HARNESS_NATIVE_KEYS: Record<string, string[]> = {

--- a/scripts/llm-gateway.sh
+++ b/scripts/llm-gateway.sh
@@ -20,7 +20,7 @@
 #
 # NOTE: `grok` here is the GATEWAY path — Claude Code (`claude -p`) pointed at
 # xAI's Anthropic-compatible API. It is distinct from the grok CLI *harness*
-# (harness: grok in aeon.yml → scripts/run-grok.sh), which runs the grok binary
+# (harness: grok in aeon.yml → harness-adapter/adapters/grok.sh), which runs the grok binary
 # itself and never sources this file.
 #
 # NOTE: do not add `set -e/-u` here — this file is sourced and must not change

--- a/scripts/run-grok.sh
+++ b/scripts/run-grok.sh
@@ -1,63 +1,54 @@
 #!/usr/bin/env bash
-# run-grok.sh — run one Aeon skill through the Grok Build (`grok`) harness.
+# run-grok.sh — STAGE the Grok Build (`grok`) harness: install the pinned CLI and
+# restore/refresh its auth. It does NOT run skills.
 #
-# This is the Grok counterpart to the inline `claude -p -` call in
-# .github/workflows/aeon.yml. It is invoked ONLY when the resolved harness for a
-# run is `grok` (harness: grok in aeon.yml, per-skill, or the workflow_dispatch
-# input). The default harness is still `claude`, whose path is untouched.
+#   usage: run-grok.sh setup
 #
-# Contract (so the rest of the pipeline is harness-agnostic):
-#   stdin   — the fully-built prompt (same prompt the claude path pipes in)
-#   stdout  — a NORMALIZED JSON envelope, byte-identical in shape to Claude
-#             Code's `--output-format json`, so aeon.yml's downstream jq
-#             (.result, .usage.input_tokens, …) works unchanged:
-#               { "result": "<text>",
-#                 "usage": { "input_tokens": N, "output_tokens": N,
-#                            "cache_read_input_tokens": N,
-#                            "cache_creation_input_tokens": N } }
-#   stderr  — all diagnostics / notices (never mixed into stdout)
-#   exit    — 0 on success, non-zero on any grok failure (caller falls to error)
+# Running a skill on grok goes through harness-adapter/run-harness, like every
+# other harness:
+#
+#   echo "$PROMPT" | harness-adapter/run-harness grok --mode write
+#
+# This script used to do both — stage grok AND run the skill, emitting a
+# Claude-shaped {result, usage} envelope on stdout. That second job is gone. It
+# was a duplicate of adapters/grok.sh, and a duplicate that drifts is worse than
+# no duplicate: grok's MCP folder-trust gate was fixed in the adapter, and the
+# surfaces still calling this script (inbound messages, the local MCP server)
+# silently kept the broken behaviour until they were migrated. Everything that
+# ran a skill now shares one path, so an adapter fix reaches every surface.
+#
+# What stays here, because it has no better home: the CLI version pin and the
+# GROK_CREDENTIALS restore + rotating-refresh-token persistence (§2b), which the
+# workflows call as `run-grok.sh setup` before dispatching to run-harness.
+#
+#   stdout  — nothing (diagnostics go to stderr)
+#   exit    — 0 when grok is staged, non-zero if the CLI or auth cannot be set up
 #
 # Inputs from the environment:
-#   MODEL                 resolved model id; empty ⇒ grok's own default (now grok-4.5)
-#   SKILL_MODE            read-only | write (maps to grok --allow/--deny/--sandbox
-#                         via scripts/skill_mode.sh grok-args)
 #   XAI_API_KEY           xAI API key auth (CI-friendly; the simple path)
 #   GROK_CREDENTIALS      base64 of the X-account OAuth session captured by the
 #                         dashboard (a tar rooted at $HOME, or a single cred file)
 #   GROK_CREDENTIALS_PATH single-file restore target (default ~/.grok/credentials.json)
-#   GH_SECRETS_PAT       secrets-write PAT (or GH_GLOBAL as the repo-wide fallback)
+#   GH_SECRETS_PAT        secrets-write PAT (or GH_GLOBAL as the repo-wide fallback)
 #                         used to PERSIST a rotated refresh token back to the
 #                         GROK_CREDENTIALS secret so OAuth auth survives past 6h (§2b);
 #                         without it a rotating provider breaks one run after expiry.
 #   GROK_OAUTH_SKEW       seconds-before-expiry to trigger a refresh (default 1800)
 #   GROK_CLI_VERSION      npm pin override (default below)
-#   Run-shaping knobs (all optional; aeon.yml maps a skill's frontmatter to them):
-#   GROK_MAX_TURNS        agentic-turn cap (default 60; 0/off = uncapped)
-#   GROK_EFFORT           low|medium|high|xhigh|max  → --effort  (reasoning models only)
-#   GROK_REASONING_EFFORT low|medium|high|xhigh|max  → --reasoning-effort (reasoning models only)
-#   GROK_BEST_OF_N        N>=2: run N ways in parallel, keep the best → --best-of-n
-#   GROK_CHECK            1/true/yes/on: append a self-verification loop → --check
-#   GROK_COMPAT_RULES     override the Claude→grok compatibility preamble appended
-#                         to grok's system prompt via --rules (default below, §3d)
 #
-# Structured output is NOT available on this path. There was a GROK_JSON_SCHEMA
-# knob here, but nothing in the repo ever set it (checked the full history) and
-# the scorer it was reserved for went schema-less on purpose, so one parse path
-# covers all six harnesses. Structured output now lives where it is uniform:
-# `run-harness --json-schema` (native on claude/grok/codex, prompt-shim on
-# pi/vibe/kimi). Re-adding a grok-only env var here would recreate exactly the
-# per-harness divergence the harness-adapter exists to remove.
-#
-# MCP: grok discovers the project .mcp.json natively (no flag needed); this script
-# only adds `--allow MCPTool(<server>__*)` so the model may call those tools.
+# The run-shaping knobs (GROK_MAX_TURNS / GROK_EFFORT / GROK_BEST_OF_N /
+# GROK_CHECK / GROK_COMPAT_RULES) moved with the run path: aeon.yml maps a
+# skill's frontmatter to them and harness-adapter/adapters/grok.sh reads them.
+# Structured output is `run-harness --json-schema`, uniform across all six
+# harnesses; a grok-only env var here would recreate the divergence the adapter
+# exists to remove.
 #
 # Sandbox note: grok's own network calls (to api.x.ai / auth.x.ai) go out from
 # this step, which the Actions sandbox permits for the CLI itself. Auth material
 # is either an env var (XAI_API_KEY) or restored from a repo secret — never
 # fetched at run time.
 
-set -uo pipefail   # NOT -e: we capture grok's exit code and output explicitly.
+set -uo pipefail   # NOT -e: every step below handles its own failure explicitly.
 
 # --- pin (single source of truth for the grok CLI version) ------------------
 # Keep this current the same way aeon.yml/messages.yml pin the claude CLI.
@@ -65,14 +56,17 @@ GROK_CLI_VERSION="${GROK_CLI_VERSION:-0.2.101}"
 
 log() { echo "$@" >&2; }
 
-# Optional `setup` subcommand: run ONLY steps 1–2 (install the pinned CLI +
-# restore auth) and exit, without reading a prompt or invoking the model. The
-# workflow's "Install harness CLI" step calls `run-grok.sh setup` so grok is
-# staged for the unified run-harness path, keeping THIS script the single source
-# of truth for the CLI pin and the GROK_CREDENTIALS restore logic. Any other
-# invocation is a normal run (prompt on stdin), unchanged.
-SETUP_ONLY=0
-[ "${1:-}" = "setup" ] && SETUP_ONLY=1
+# `setup` is the only subcommand. Reject anything else LOUDLY rather than
+# staging grok and exiting 0: a stale caller piping a prompt in (the old run
+# contract) would otherwise get an empty stdout and read it as "the model
+# returned nothing" — the silent-no-op class this whole consolidation removed.
+case "${1:-setup}" in
+  setup) ;;
+  *)
+    log "::error::run-grok.sh only stages the grok CLI now — it does not run skills."
+    log "::error::Run a skill with: harness-adapter/run-harness grok --mode <write|read-only>"
+    exit 2 ;;
+esac
 
 # --- 1. ensure the CLI ------------------------------------------------------
 if ! command -v grok >/dev/null 2>&1; then
@@ -208,267 +202,5 @@ grok_oauth_refresh() {
 # a local `grok login` session (no GROK_CREDENTIALS) is deliberately left untouched.
 [ -n "${GROK_CREDENTIALS:-}" ] && grok_oauth_refresh
 
-if [ "$SETUP_ONLY" = 1 ]; then
-  log "::debug::grok setup complete (CLI + auth staged); the run itself goes through run-harness grok"
-  exit 0
-fi
-
-# --- 3. model + permission flags --------------------------------------------
-# Only pass --model for a real grok model id; for an empty value or a leftover
-# claude-* id (harness switched but model not), OMIT it so grok uses its own
-# current default (now grok-4.5) rather than a hardcoded id.
-MODEL="${MODEL:-}"
-SKILL_MODE="${SKILL_MODE:-write}"
-MODEL_FLAG=()
-case "$MODEL" in
-  ""|default|claude-*) ;;                 # let grok pick its default model
-  *)                   MODEL_FLAG=(--model "$MODEL") ;;
-esac
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# One argv token per line → array. Plain while-read (not `mapfile`) so this runs
-# on bash 3.2 (macOS) as well as CI's bash 5.
-GROK_ARGS=()
-if [ -f "$SCRIPT_DIR/skill_mode.sh" ]; then
-  while IFS= read -r _tok; do GROK_ARGS+=("$_tok"); done < <(bash "$SCRIPT_DIR/skill_mode.sh" grok-args "$SKILL_MODE")
-fi
-
-# --- 3b. MCP ----------------------------------------------------------------
-# grok has first-class MCP and DISCOVERS the project .mcp.json natively: it walks
-# cwd→git-root loading `.mcp.json` (MCP-standard format) and expands ${VAR} in it
-# from the environment — the same secrets aeon.yml's MCP preflight exports before
-# this script runs (confirmed with `grok inspect --json`). So there is nothing to
-# "wire": we do NOT pass a --mcp-config flag (grok has none) and we do NOT
-# translate config schemas. We only have to grant PERMISSION to call the tools:
-# MCP tools are not on grok's read-class fast path, so under a deny-by-default
-# headless run they're blocked unless an explicit allow rule names them. Add one
-# `--allow MCPTool(<server>__*)` per server declared in .mcp.json (grok namespaces
-# every MCP tool as `<server>__<tool>`).
-#
-# Permission is necessary but NOT sufficient: grok also gates every repo-local
-# (project-scoped) MCP server behind its folder-trust store
-# (~/.grok/trusted_folders.toml, shared with hooks + LSP). A CI runner checks the
-# repo out into a path that has never been trusted, on every run, so without
-# --trust the server is silently never STARTED and no mcp__<srv>__* tool exists —
-# the allow rules above then grant permission to call tools that don't exist. The
-# run doesn't fail; the agent reports the server "not connected" and falls back to
-# plain HTTP, which reads as a normal green run. `grok mcp doctor` names it
-# ("folder untrusted … re-run with --trust"). Same fix as
-# harness-adapter/adapters/grok.sh; applied here for the surfaces that still run
-# through this script (messages.yml, apps/mcp-server). Scoped to MCP runs, so a
-# repo with no .mcp.json keeps the default untrusted posture. The flag is hidden
-# on `grok --help` but accepted.
-MCP_ALLOW=()
-if [ -f .mcp.json ] && jq -e '.mcpServers' .mcp.json >/dev/null 2>&1; then
-  MCP_SERVERS=$(jq -r '.mcpServers | keys[]' .mcp.json)
-  MCP_ALLOW+=(--trust)
-  for srv in $MCP_SERVERS; do
-    MCP_ALLOW+=(--allow "MCPTool(${srv}__*)")
-  done
-  log "::debug::MCP: grok loads .mcp.json natively; allowing tools from: $(printf '%s ' $MCP_SERVERS)"
-  # A referenced ${VAR} that isn't in the env expands empty → that one server
-  # can't authenticate and grok logs a connect error, but the run and the other
-  # servers are unaffected. Warn (don't fail) so it's visible without breaking.
-  MCP_MISSING=""
-  for v in $(grep -oE '\$\{[A-Z_][A-Z0-9_]*\}' .mcp.json | sed -E 's/[${}]//g' | sort -u); do
-    [ -z "${!v:-}" ] && MCP_MISSING="$MCP_MISSING $v"
-  done
-  [ -n "$MCP_MISSING" ] && log "::warning::MCP: .mcp.json references unset var(s):${MCP_MISSING} — those servers are unavailable this run (set them in the dashboard)"
-fi
-
-# --- 3c. run-shaping flags (structured output / effort / turns / verify) -----
-# Newer grok headless features, all opt-in via env (aeon.yml maps a skill's
-# frontmatter to these). Two hard-won constraints are enforced here, verified
-# against grok 0.2.101:
-#   * --effort / --reasoning-effort map to the API's `reasoningEffort`, which
-#     composer REJECTS with a 400 ("does not support parameter reasoningEffort").
-#     They only work on a reasoning model (grok-4.5 / grok-build), so we gate them
-#     on MODEL and skip-with-warning on composer rather than hard-fail the run.
-#   * grok's own arg parser rejects some combinations; those are reconciled below
-#     and again where --no-subagents is chosen (see the run step).
-# Invalid values are warned-and-skipped, never passed through to fail the run.
-RUN_FLAGS=()
-
-# Is the resolved model reasoning-capable? Composer is not; grok-4.5 / grok-build are.
-# Empty MODEL means grok picks its own default (now grok-4.5, a reasoning model), but
-# we can't know that here, so treat empty as non-reasoning to stay 400-safe.
-MODEL_IS_REASONING=0
-case "$MODEL" in
-  ""|default|claude-*|*composer*) ;;      # composer / unknown → NOT reasoning
-  grok-*)                MODEL_IS_REASONING=1 ;;
-esac
-
-# --max-turns: a runaway/cost guard on agentic loops (generous, not a tight
-# bound — hitting it degrades to partial output, it doesn't hard-fail). Defaults
-# to 60; set GROK_MAX_TURNS to a positive integer to override, or 0/off to remove.
-_max_turns="${GROK_MAX_TURNS:-60}"
-case "$_max_turns" in
-  0|off|none|"") ;;                                     # explicitly uncapped
-  *[!0-9]*) log "::warning::ignoring non-integer GROK_MAX_TURNS='$_max_turns'";;
-  *) RUN_FLAGS+=(--max-turns "$_max_turns") ;;
-esac
-# --effort / --reasoning-effort: low|medium|high|xhigh|max — reasoning models only.
-# add_effort <envname> <flag> <value>: validate, gate on model, append or warn.
-add_effort() {
-  local env="$1" flag="$2" val="$3"
-  case "$val" in
-    "") return 0 ;;
-    low|medium|high|xhigh|max) ;;
-    *) log "::warning::ignoring invalid $env (want low|medium|high|xhigh|max): '$val'"; return 0 ;;
-  esac
-  if [ "$MODEL_IS_REASONING" = 1 ]; then
-    RUN_FLAGS+=("$flag" "$val")
-  else
-    log "::debug::ignoring $flag $val — model '${MODEL:-<grok default>}' doesn't support reasoning effort (use a reasoning model like grok-4.5)"
-  fi
-}
-add_effort GROK_EFFORT --effort "${GROK_EFFORT:-}"
-add_effort GROK_REASONING_EFFORT --reasoning-effort "${GROK_REASONING_EFFORT:-}"
-# --best-of-n: run the task N ways in parallel and keep the best (N>=2).
-GROK_WANTS_SUBAGENTS=0
-case "${GROK_BEST_OF_N:-}" in
-  ""|0|1) ;;
-  *[!0-9]*) log "::warning::ignoring non-integer GROK_BEST_OF_N='${GROK_BEST_OF_N}'";;
-  *) RUN_FLAGS+=(--best-of-n "$GROK_BEST_OF_N"); GROK_WANTS_SUBAGENTS=1 ;;
-esac
-# --check: append a self-verification loop before finishing.
-# (This used to be gated against GROK_JSON_SCHEMA, since grok refuses to combine
-# --check with --json-schema. That knob is gone — see the header note — so there
-# is nothing left to conflict with. Structured output on this path would need
-# reintroducing both the flag and that precedence rule.)
-case "${GROK_CHECK:-}" in
-  1|true|yes|on) RUN_FLAGS+=(--check); GROK_WANTS_SUBAGENTS=1 ;;
-esac
-
-# --- 3d. Claude→grok compatibility preamble (--rules) -----------------------
-# Every Aeon skill is authored for the Claude Code harness: its data-fetch steps name
-# Claude's tools (WebFetch), assume Claude's sandbox-bypass patterns, and lean on
-# `gh api`. Rather than reimplement ~100 skills for grok, we append ONE standing
-# ruleset to grok's system prompt (`--rules`) that (a) translates those idioms to
-# grok's tools and (b) — the load-bearing part — tells grok to ROUTE AROUND a
-# missing/failed tool instead of giving up. That give-up-and-Cancel behavior is what
-# turned Claude-authored runs into empty/partial non-answers (see run history). This
-# is skill-agnostic (fix once, applies to every skill) and cheap (~a few hundred
-# tokens/run). It pairs with --permission-mode bypassPermissions from skill_mode.sh:
-# bypass stops the hard turn-abort, these rules stop the soft "I'll try other ways" give-up.
-# Override/extend via GROK_COMPAT_RULES in the environment.
-# EDITING NOTE: this heredoc sits inside "$(cat <<'RULES' … )" — bash's scanner for
-# that construct still counts apostrophes/backticks in the body, so keep them
-# BALANCED (even count) or the whole assignment breaks at EOF. Prefer "do not" over
-# "don't" and pair every backtick. (bash -n scripts/run-grok.sh catches a slip.)
-GROK_COMPAT_RULES="${GROK_COMPAT_RULES:-$(cat <<'RULES'
-This skill was authored for the Claude Code harness. Adapt its instructions to your
-own tools; do not abort when something does not match one-to-one:
-- Tool names are Claude's. Map them: when a skill says "WebFetch", use your web
-  fetch/search tools; when it says to curl a URL the sandbox blocks, fetch the same
-  URL with your web tools instead.
-- When a skill relies on the gh CLI (e.g. `gh api`) and gh is unavailable, call the
-  GitHub REST API directly over the web (https://api.github.com/...) — public for reads.
-- X/Twitter data: fetch it with your built-in WebSearch and WebFetch tools. A skill
-  step that curls the xAI `x_search` API or needs XAI_API_KEY to pull posts is
-  Claude-harness scaffolding — when that key is absent, get the same posts by searching
-  the web for x.com results yourself and carry on. Never skip a section, or emit a
-  NO_KEY / NO_API_KEY status just because XAI_API_KEY is absent; WebSearch covers it.
-- If any tool is missing, denied, or returns unusable content, do NOT stop or end the
-  turn. Try another route and finish the task; only surface a failure after you have
-  exhausted the alternatives the skill names.
-- Never end a run having produced only planning or commentary. Deliver the skill's
-  actual output — the notify/file/log it specifies, or its defined error signal — and
-  never emit interim narration as the result.
-RULES
-)}"
-
-# --- 4. run -----------------------------------------------------------------
-PROMPT="$(cat)"
-out_file="$(mktemp)"; err_file="$(mktemp)"
-# --no-subagents: by default a headless skill run is a single focused agent. The
-# multi-agent models (grok-build) otherwise try to DELEGATE to parallel subagents,
-# whose Task/spawn tool is not in our allowlist — the denial aborts the whole turn
-# (observed: grok-build → stopReason=Cancelled, empty text, ~18s). Disabling
-# subagents keeps the model doing the work itself. Composer is single-agent, so
-# it's a no-op there. EXCEPTION: --best-of-n and --check are built ON subagents,
-# and grok's arg parser refuses --no-subagents alongside either — so when a skill
-# opted into those (GROK_WANTS_SUBAGENTS=1) we must NOT pass --no-subagents.
-SUBAGENT_FLAG=(--no-subagents)
-[ "${GROK_WANTS_SUBAGENTS:-0}" = 1 ] && SUBAGENT_FLAG=()
-# Guard the array expansions for the empty case under bash 3.2 set -u.
-grok -p "$PROMPT" \
-  ${MODEL_FLAG[@]+"${MODEL_FLAG[@]}"} \
-  --output-format json \
-  --no-auto-update \
-  --rules "$GROK_COMPAT_RULES" \
-  ${SUBAGENT_FLAG[@]+"${SUBAGENT_FLAG[@]}"} \
-  ${RUN_FLAGS[@]+"${RUN_FLAGS[@]}"} \
-  ${MCP_ALLOW[@]+"${MCP_ALLOW[@]}"} \
-  ${GROK_ARGS[@]+"${GROK_ARGS[@]}"} >"$out_file" 2>"$err_file"
-rc=$?
-# Surface grok's own diagnostics into the step log regardless of outcome.
-cat "$err_file" >&2
-if [ $rc -ne 0 ]; then
-  log "::error::grok exited $rc"
-  rm -f "$out_file" "$err_file"
-  exit $rc
-fi
-
-# --- 5. normalize output ----------------------------------------------------
-# Map grok's --output-format json onto the envelope the pipeline expects.
-# Confirmed shape (grok 0.2.82): {"text": "...", "stopReason", "sessionId",
-# "requestId", "thought"} — the result is in .text and there is NO usage/token
-# field, so token counts normalize to 0 (grok-harness runs report 0 tokens).
-# With --json-schema a reasoning model (grok-build) ALSO fills .structuredOutput
-# with the parsed object; we prefer it (re-serialized) so a schema consumer gets
-# clean JSON. Composer leaves it null and puts JSON in .text, which still flows
-# through the .text branch — so both models normalize correctly.
-#
-# CRITICAL: `.thought` is grok's internal chain-of-thought. It must NEVER become
-# the skill result — downstream this gets committed to the repo, sent via
-# ./notify, and fed into chains. So .result is built ONLY from recognized text
-# fields (or the schema-validated .structuredOutput), and a valid grok JSON object
-# is NEVER dumped raw (which is how .thought previously leaked when .text was
-# empty). Common aliases are kept for forward-compat; the raw-stdout fallback
-# fires only for genuinely non-JSON output.
-NORMALIZE='
-  (if (.structuredOutput // null) != null then (.structuredOutput|tojson)
-   else (.result // .text // .output // .response // .content // .message // "") end) as $r
-  | (.usage // .usageMetadata // {}) as $u
-  | {
-      result: (if ($r|type)=="string" then $r
-               elif ($r|type)=="array" then ([$r[]? | (.text // (.|tostring))] | join(""))
-               else ($r|tostring) end),
-      usage: {
-        input_tokens: (($u.input_tokens // $u.prompt_tokens // $u.inputTokens // $u.promptTokenCount // 0) | floor),
-        output_tokens: (($u.output_tokens // $u.completion_tokens // $u.outputTokens // $u.candidatesTokenCount // 0) | floor),
-        cache_read_input_tokens: (($u.cache_read_input_tokens // $u.cache_read // $u.cachedContentTokenCount // 0) | floor),
-        cache_creation_input_tokens: (($u.cache_creation_input_tokens // $u.cache_creation // 0) | floor)
-      }
-    }'
-
-if jq -e 'type == "object"' "$out_file" >/dev/null 2>&1; then
-  # A recognized grok JSON envelope. Build the normalized result (text fields
-  # only — never .thought) and inspect how the turn ended.
-  ENVELOPE=$(jq -ce "$NORMALIZE" "$out_file")
-  RESULT_TEXT=$(printf '%s' "$ENVELOPE" | jq -r '.result // ""')
-  STOP=$(jq -r '.stopReason // .stop_reason // ""' "$out_file")
-  # grok exits 0 even when a run is Cancelled / aborted with no output. That is a
-  # FAILED run, not an empty-but-successful one — surface it so the workflow's
-  # grok-error path fires instead of committing/reporting an empty (or partial)
-  # result. A clean EndTurn with empty text is legitimate (the skill did its work
-  # via tool calls and wrote no final message) and passes through as result "".
-  case "$STOP" in
-    Cancelled|cancelled|Aborted|aborted|Interrupted|interrupted|Error|error|Failed|failed|Refusal|refusal)
-      if [ -z "$RESULT_TEXT" ]; then
-        log "::error::grok terminated abnormally (stopReason=$STOP) with no output — failing the run rather than emitting an empty/partial result"
-        rm -f "$out_file" "$err_file"
-        exit 3
-      fi
-      log "::warning::grok stopReason=$STOP — retaining partial output"
-      ;;
-  esac
-  printf '%s\n' "$ENVELOPE"
-else
-  # Not a single JSON object: shape changed, plain-text output, or leading noise.
-  # Wrap raw stdout so a mismatch never silently looks like "no output". (This
-  # path only fires for non-JSON, so it can't leak a JSON object's .thought.)
-  log "::warning::grok output was not a JSON object (expected --output-format json) — wrapping raw stdout; verify the grok CLI version/output format"
-  jq -Rsc '{result: ., usage: {input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0}}' "$out_file"
-fi
-rm -f "$out_file" "$err_file"
+log "::debug::grok setup complete (CLI + auth staged); runs go through run-harness grok"
+exit 0

--- a/scripts/skill_mode.sh
+++ b/scripts/skill_mode.sh
@@ -91,10 +91,18 @@ write_tools() { echo "$BASE_TOOLS,$WRITE_TOOLS"; }
 # the intent reads identically on either harness: read-only documents no Edit and no
 # git/gh/python; write adds them.
 #
-# Output: one argv token per line, so run-grok.sh can read it with
+# Output: one argv token per line, so a caller can read it with
 #   mapfile -t GROK_ARGS < <(skill_mode.sh grok-args "$MODE")
 # and pass "${GROK_ARGS[@]}" straight through (a Bash rule's embedded space is
 # preserved because each whole line becomes one array element).
+#
+# ORPHANED as of the run-path consolidation: `run-grok.sh` was the only consumer,
+# and harness-adapter/adapters/grok.sh maps capability mode differently
+# (--permission-mode bypassPermissions plus the dispatcher's OS sandbox, because
+# a denied tool aborts grok's whole turn). Nothing calls `grok-args` today. It is
+# kept, not deleted, because removing it means settling what grok's read-only
+# enforcement should actually be — see docs/CAPABILITIES.md, which still
+# describes THIS allowlist as the mechanism.
 
 # Bash command globs allowed on every tier (mirror BASE_TOOLS' Bash(...:*) set).
 GROK_BASE_BASH="curl jq ./notify ./notify-jsonrender mkdir ls cat chmod date echo node npm npx head tail wc sort grep"
@@ -123,7 +131,8 @@ grok_args() {
 }
 
 # --- Grok Build run-shaping: frontmatter -> GROK_* env -----------------------
-# Map optional per-skill frontmatter to the env vars run-grok.sh reads, so a
+# Map optional per-skill frontmatter to the env vars harness-adapter's grok
+# adapter reads, so a
 # skill can opt into grok's newer headless features without any workflow change:
 #
 #   effort: high            # low|medium|high|xhigh|max  -> --effort

--- a/scripts/tests/test_harness_adapter_grok.sh
+++ b/scripts/tests/test_harness_adapter_grok.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Tests for harness-adapter's grok path (run-harness → adapters/grok.sh), which is
+# now the ONLY way a skill runs on grok. Uses a fake `grok` on PATH that records
+# its argv and replays a canned streaming-json stream, so no network, real CLI or
+# xAI account is required.
+#
+# These assertions were previously carried by test_run_grok.sh against the
+# script's own run path. That path is gone, so the coverage moved here rather than
+# being deleted with it — the MCP cases in particular guard the exact regression
+# that made MCP silently dead on grok for two releases (a repo-local server is
+# never started in an untrusted checkout, so no mcp__<srv>__* tool exists, and the
+# run still goes green).
+#
+# Run: bash scripts/tests/test_harness_adapter_grok.sh
+set -uo pipefail
+cd "$(dirname "$0")/../.." || exit 1
+RH="$(pwd)/harness-adapter/run-harness"
+fail=0
+pass() { echo "ok   - $1"; }
+bad()  { echo "FAIL - $1"; fail=1; }
+
+command -v jq >/dev/null 2>&1 || { echo "SKIP - jq not installed"; exit 0; }
+[ -x "$RH" ] || { echo "FAIL - $RH not executable"; exit 1; }
+
+BIN="$(mktemp -d)"
+ARGS_FILE="$BIN/grok-args.txt"
+cleanup() { rm -rf "$BIN"; }
+trap cleanup EXIT
+
+# Fake grok: record argv, emit $GROK_FAKE_OUT (a streaming-json stream), exit RC.
+cat > "$BIN/grok" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$GROK_ARGS_FILE"
+printf '%s' "${GROK_FAKE_OUT:-}"
+exit "${GROK_FAKE_RC:-0}"
+EOF
+chmod +x "$BIN/grok"
+export GROK_ARGS_FILE="$ARGS_FILE"
+export PATH="$BIN:$PATH"
+export XAI_API_KEY=xai-test    # adapters/grok.sh refuses to run unauthenticated
+
+# A minimal well-formed stream: one text chunk + the terminal end event.
+STREAM='{"type":"text","data":"hello"}
+{"type":"end","stopReason":"EndTurn","usage":{"input_tokens":7,"output_tokens":2}}'
+
+run_in() {  # run_in <dir> [extra run-harness args...] -> envelope on stdout
+  local dir="$1"; shift
+  ( cd "$dir" && echo "prompt" | GROK_FAKE_OUT="$STREAM" \
+      bash "$RH" grok --mode write --no-sandbox "$@" 2>/dev/null )
+}
+
+# --- 1. envelope ------------------------------------------------------------
+WS="$(mktemp -d)"
+OUT=$(run_in "$WS")
+{ [ "$(jq -r '.result' <<<"$OUT")" = "hello" ] \
+  && [ "$(jq -r '.usage.input_tokens' <<<"$OUT")" = "7" ]; } \
+  && pass "streaming-json normalizes to {result, usage}" || bad "envelope (got: $OUT)"
+
+# The thought firewall: grok's chain-of-thought must NEVER become .result.
+OUT=$(cd "$WS" && echo p | GROK_FAKE_OUT='{"type":"thought","data":"SECRET REASONING"}
+{"type":"text","data":"answer"}
+{"type":"end","stopReason":"EndTurn"}' bash "$RH" grok --mode write --no-sandbox 2>/dev/null)
+{ [ "$(jq -r '.result' <<<"$OUT")" = "answer" ] && ! grep -q "SECRET REASONING" <<<"$OUT"; } \
+  && pass "thought chunks never leak into .result" || bad "thought firewall (got: $OUT)"
+
+# --- 2. MCP: --trust + per-server allow rules -------------------------------
+# grok gates repo-local (project-scoped) MCP servers behind its folder-trust store.
+# A CI runner checks the repo out into a never-trusted path on EVERY run, so without
+# --trust the server is never started and no mcp__<srv>__* tool exists — while the
+# run still exits 0 and the agent quietly falls back to plain HTTP.
+MCPDIR="$(mktemp -d)"
+cat > "$MCPDIR/.mcp.json" <<'JSON'
+{ "mcpServers": {
+  "github":   { "type": "http",  "url": "https://api.example/mcp/" },
+  "seqthink": { "type": "stdio", "command": "npx", "args": ["-y", "pkg"] }
+} }
+JSON
+run_in "$MCPDIR" --mcp-config "$MCPDIR/.mcp.json" >/dev/null
+grep -Fqx -- "--trust" "$ARGS_FILE" \
+  && pass "MCP: --trust passed for a repo-local .mcp.json" \
+  || bad "MCP --trust missing (args: $(tr '\n' ' ' < "$ARGS_FILE"))"
+{ grep -Fqx "MCPTool(github__*)" "$ARGS_FILE" && grep -Fqx "MCPTool(seqthink__*)" "$ARGS_FILE"; } \
+  && pass "MCP: one MCPTool allow per .mcp.json server" \
+  || bad "MCP allow rules (args: $(tr '\n' ' ' < "$ARGS_FILE"))"
+
+# No MCP config → default untrusted posture, no stray allow rules.
+: > "$ARGS_FILE"
+run_in "$WS" >/dev/null
+if grep -Fqx -- "--trust" "$ARGS_FILE"; then bad "--trust leaked into a non-MCP run"; else
+  pass "no --trust without an MCP config"; fi
+if grep -q "MCPTool(" "$ARGS_FILE"; then bad "MCPTool rules leaked into a non-MCP run"; else
+  pass "no MCPTool rules without an MCP config"; fi
+
+# --- 3. model + run-shaping knobs -------------------------------------------
+# Only a real grok id is forwarded; a leftover claude-* id would otherwise pin the
+# run to a model that does not exist and every downstream record would name it.
+: > "$ARGS_FILE"; run_in "$WS" --model claude-sonnet-5 >/dev/null
+if grep -Fqx -- "--model" "$ARGS_FILE"; then bad "--model should be omitted for a claude-* id"; else
+  pass "--model omitted for a leftover claude-* id"; fi
+: > "$ARGS_FILE"; run_in "$WS" --model grok-4.5 >/dev/null
+{ grep -Fqx -- "--model" "$ARGS_FILE" && grep -Fqx "grok-4.5" "$ARGS_FILE"; } \
+  && pass "--model forwarded for a real grok id" || bad "--model grok-4.5 not forwarded"
+
+# GROK_* frontmatter knobs (aeon.yml exports these) reach the adapter.
+: > "$ARGS_FILE"
+( cd "$WS" && echo p | GROK_FAKE_OUT="$STREAM" GROK_MAX_TURNS=7 \
+    bash "$RH" grok --mode write --no-sandbox 2>/dev/null ) >/dev/null
+{ grep -Fqx -- "--max-turns" "$ARGS_FILE" && grep -Fqx "7" "$ARGS_FILE"; } \
+  && pass "GROK_MAX_TURNS reaches the adapter" || bad "GROK_MAX_TURNS (args: $(tr '\n' ' ' < "$ARGS_FILE"))"
+
+# --- 4. failure modes -------------------------------------------------------
+# An abnormal stop with NO output must fail, never emit an empty success envelope.
+if ( cd "$WS" && echo p | GROK_FAKE_OUT='{"type":"end","stopReason":"Cancelled"}' \
+     bash "$RH" grok --mode write --no-sandbox >/dev/null 2>&1 ); then
+  bad "cancelled-with-no-output should fail"
+else
+  pass "abnormal stop with no output fails instead of emitting an empty result"
+fi
+
+rm -rf "$WS" "$MCPDIR"
+echo "---"
+[ "$fail" = "0" ] && echo "ALL PASS" || echo "SOME FAILED"
+exit "$fail"

--- a/scripts/tests/test_run_grok.sh
+++ b/scripts/tests/test_run_grok.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
-# Tests for scripts/run-grok.sh — auth gating, invocation flags, and output
-# normalization. Uses a fake `grok` on PATH so no network/CLI is required.
+# Tests for scripts/run-grok.sh — which now only STAGES grok (CLI pin + auth
+# restore + durable OAuth refresh). Its run path moved to harness-adapter; the
+# flag/envelope/MCP coverage that used to live here is in
+# scripts/tests/test_harness_adapter_grok.sh. Uses a fake `grok`/`curl`/`gh` on
+# PATH so no network or real CLI is required.
 # Run: bash scripts/tests/test_run_grok.sh
 set -uo pipefail
 cd "$(dirname "$0")/../.." || exit 1
@@ -29,176 +32,41 @@ chmod +x "$BIN/grok"
 export GROK_ARGS_FILE="$ARGS_FILE"
 export PATH="$BIN:$PATH"
 
-run() { echo "test prompt" | GROK_FAKE_OUT="$1" GROK_FAKE_RC="${2:-0}" MODEL="${3:-grok-4.5}" SKILL_MODE="${4:-write}" XAI_API_KEY=xai-test bash "$R" 2>/dev/null; }
+# --- 1. subcommand contract -------------------------------------------------
+# `setup` is the only verb. A stale caller using the OLD run contract (prompt on
+# stdin, expecting an envelope on stdout) must FAIL LOUDLY - staging grok and
+# exiting 0 would hand it empty stdout, which reads as "the model returned
+# nothing": exactly the silent no-op this consolidation removed.
+echo "prompt" | XAI_API_KEY=xai-test bash "$R" run >/dev/null 2>"$BIN/e0"; rc=$?
+{ [ "$rc" = 2 ] && grep -q "does not run skills" "$BIN/e0"; } \
+  && pass "rejects a non-setup subcommand with a pointer to run-harness" \
+  || bad "stale run invocation should exit 2 (rc=$rc, err=$(cat "$BIN/e0"))"
 
-# 1. Claude-shaped JSON normalizes to result + usage
-OUT=$(run '{"result":"hi there","usage":{"input_tokens":11,"output_tokens":4}}')
-[ "$(echo "$OUT" | jq -r '.result')" = "hi there" ] && pass "normalizes .result" || bad "normalizes .result (got: $OUT)"
-[ "$(echo "$OUT" | jq -r '.usage.input_tokens')" = "11" ] && pass "normalizes usage.input_tokens" || bad "normalizes usage.input_tokens"
+# `setup` and a bare invocation both stage and exit 0, emitting NOTHING on stdout.
+OUT=$(XAI_API_KEY=xai-test bash "$R" setup 2>/dev/null); rc=$?
+{ [ "$rc" = 0 ] && [ -z "$OUT" ]; } \
+  && pass "setup exits 0 with empty stdout" || bad "setup (rc=$rc out=$OUT)"
+XAI_API_KEY=xai-test bash "$R" >/dev/null 2>&1 \
+  && pass "bare invocation defaults to setup" || bad "bare invocation should default to setup"
 
-# 2. OpenAI-ish aliases (text / prompt_tokens) normalize too
-OUT=$(run '{"text":"grok hi","usage":{"prompt_tokens":50,"completion_tokens":7}}')
-[ "$(echo "$OUT" | jq -r '.result')" = "grok hi" ] && pass "maps .text alias" || bad "maps .text alias (got: $OUT)"
-[ "$(echo "$OUT" | jq -r '.usage.output_tokens')" = "7" ] && pass "maps completion_tokens alias" || bad "maps completion_tokens alias"
+# The run path is GONE - staging must never invoke the grok binary.
+: > "$ARGS_FILE"
+XAI_API_KEY=xai-test bash "$R" setup >/dev/null 2>&1
+[ ! -s "$ARGS_FILE" ] && pass "setup never invokes the grok binary" \
+  || bad "setup invoked grok (args: $(tr '\n' ' ' < "$ARGS_FILE"))"
 
-# 2b. Exact real grok 0.2.82 shape: .text present, NO usage field → tokens = 0
-OUT=$(run '{"text":"ok","stopReason":"EndTurn","sessionId":"s","requestId":"r","thought":"t"}')
-[ "$(echo "$OUT" | jq -r '.result')" = "ok" ] && pass "real grok shape → .result from .text" || bad "real grok shape → .result (got: $OUT)"
-[ "$(echo "$OUT" | jq -r '.usage.input_tokens')" = "0" ] && pass "real grok shape → 0 tokens (no usage field)" || bad "real grok shape → 0 tokens"
-
-# 2c. grok's internal .thought is NEVER surfaced as the result (leak guard)
-OUT=$(run '{"text":"visible answer","stopReason":"EndTurn","thought":"SECRET_CHAIN_OF_THOUGHT"}')
-{ [ "$(echo "$OUT" | jq -r '.result')" = "visible answer" ] && ! echo "$OUT" | grep -q "SECRET_CHAIN_OF_THOUGHT"; } \
-  && pass "does not leak .thought into result" || bad "leaked .thought (got: $OUT)"
-
-# 2d. Cancelled/aborted with EMPTY text → hard fail; must NOT emit an empty result
-# or raw-wrap the JSON (which would leak .thought). Regression for the grok-build
-# 'Cancelled' run that committed chain-of-thought to the repo.
-if OUT=$(run '{"text":"","stopReason":"Cancelled","thought":"SECRET"}' 0 2>/dev/null); then
-  bad "Cancelled+empty should fail (got rc 0, out: $OUT)"
-else
-  echo "$OUT" | grep -q "SECRET" && bad "Cancelled+empty leaked .thought" || pass "Cancelled+empty fails without leaking .thought"
-fi
-
-# 2e. Clean EndTurn with empty text is a legitimate success (skill acted via tools,
-# no final message) → result "" and exit 0, NOT a failure.
-if OUT=$(run '{"text":"","stopReason":"EndTurn"}' 0 2>/dev/null); then
-  [ "$(echo "$OUT" | jq -r '.result')" = "" ] && pass "empty EndTurn → clean empty result" || bad "empty EndTurn result (got: $OUT)"
-else
-  bad "empty EndTurn should succeed"
-fi
-
-# 3. Non-JSON stdout falls back to raw-text envelope (never "no output")
-OUT=$(run 'plain text, not json')
-[ "$(echo "$OUT" | jq -r '.result')" = "plain text, not json" ] && pass "wraps non-JSON stdout" || bad "wraps non-JSON stdout (got: $OUT)"
-
-# 4. Invocation passes --output-format json, --no-auto-update, and the model
-run '{"result":"x"}' >/dev/null
-grep -qx -- "--output-format" "$ARGS_FILE" && grep -qx "json" "$ARGS_FILE" \
-  && pass "passes --output-format json" || bad "passes --output-format json"
-grep -qx -- "--no-auto-update" "$ARGS_FILE" && pass "passes --no-auto-update" || bad "passes --no-auto-update"
-grep -qx -- "--no-subagents" "$ARGS_FILE" && pass "passes --no-subagents" || bad "passes --no-subagents"
-grep -qx -- "--model" "$ARGS_FILE" && grep -qx "grok-4.5" "$ARGS_FILE" \
-  && pass "passes --model for a real grok model" || bad "passes --model"
-grep -qx -- "--permission-mode" "$ARGS_FILE" && grep -qx "bypassPermissions" "$ARGS_FILE" \
-  && pass "passes permission flags from skill_mode" || bad "passes permission flags"
-# compat preamble is appended to grok's system prompt via --rules
-grep -qx -- "--rules" "$ARGS_FILE" && pass "passes --rules compat preamble" || bad "passes --rules compat preamble"
-
-# 4b. --model is OMITTED for a leftover claude-* id or empty (grok uses its default)
-echo "p" | GROK_FAKE_OUT='{"text":"x"}' MODEL=claude-sonnet-5 SKILL_MODE=write XAI_API_KEY=xai-test bash "$R" >/dev/null 2>&1
-if grep -qx -- "--model" "$ARGS_FILE"; then bad "omits --model for claude-* id"; else pass "omits --model for claude-* id"; fi
-echo "p" | GROK_FAKE_OUT='{"text":"x"}' MODEL="" SKILL_MODE=write XAI_API_KEY=xai-test bash "$R" >/dev/null 2>&1
-if grep -qx -- "--model" "$ARGS_FILE"; then bad "omits --model for empty model"; else pass "omits --model for empty model"; fi
-
-# 4c. grok-4.5 (grok's current default) is a real grok id → --model is passed through,
-# and it's a reasoning model so GROK_EFFORT maps to --effort (unlike fast composer).
-echo "p" | GROK_FAKE_OUT='{"text":"x"}' MODEL=grok-4.5 SKILL_MODE=write XAI_API_KEY=xai-test GROK_EFFORT=high bash "$R" >/dev/null 2>&1
-grep -qx -- "--model" "$ARGS_FILE" && grep -qx "grok-4.5" "$ARGS_FILE" \
-  && pass "passes --model grok-4.5" || bad "passes --model grok-4.5"
-grep -qx -- "--effort" "$ARGS_FILE" && grep -qx "high" "$ARGS_FILE" \
-  && pass "grok-4.5 is reasoning → GROK_EFFORT maps to --effort" || bad "grok-4.5 reasoning effort"
-
-# 5. read-only mode adds --sandbox read-only
-echo "p" | GROK_FAKE_OUT='{"result":"x"}' MODEL=grok-build-0.1 SKILL_MODE=read-only XAI_API_KEY=xai-test bash "$R" >/dev/null 2>&1
-grep -qx -- "--sandbox" "$ARGS_FILE" && grep -qx "read-only" "$ARGS_FILE" \
-  && pass "read-only run sandboxes grok" || bad "read-only run sandboxes grok"
-
-# 6. grok non-zero exit → run-grok.sh fails
-if run '{"result":"x"}' 1 >/dev/null 2>&1; then bad "propagates grok failure"; else pass "propagates grok failure"; fi
-
-# 7. No auth at all (no XAI_API_KEY / GROK_CREDENTIALS / ~/.grok session) → hard fail.
-# Use a clean HOME so an ambient ~/.grok/auth.json on the test machine can't satisfy it.
+# --- 2. auth gating ---------------------------------------------------------
+# No XAI_API_KEY / GROK_CREDENTIALS / ~/.grok session → hard fail, so a misconfigured
+# repo surfaces at staging instead of at the model call.
 EMPTY_HOME="$(mktemp -d)"
-if echo "p" | env -u XAI_API_KEY -u GROK_CREDENTIALS HOME="$EMPTY_HOME" GROK_FAKE_OUT='{"text":"x"}' MODEL="" SKILL_MODE=write bash "$R" >/dev/null 2>&1; then
-  bad "fails without auth"
+if env -u XAI_API_KEY -u GROK_CREDENTIALS HOME="$EMPTY_HOME" bash "$R" setup >/dev/null 2>&1; then
+  bad "no auth should fail"
 else
-  pass "fails without auth"
+  pass "no auth (no key, no creds, no session) fails loudly"
 fi
 rm -rf "$EMPTY_HOME"
 
-# 8. Run-shaping flags -------------------------------------------------------
-# 8a. --max-turns defaults to 60 (runaway/cost guard)
-run '{"result":"x"}' >/dev/null
-grep -qx -- "--max-turns" "$ARGS_FILE" && grep -qx "60" "$ARGS_FILE" \
-  && pass "default --max-turns 60" || bad "default --max-turns 60 (args: $(tr '\n' ' ' < "$ARGS_FILE"))"
-
-# 8b. GROK_MAX_TURNS overrides; =0 removes the cap
-echo "p" | GROK_FAKE_OUT='{"text":"x"}' MODEL="" SKILL_MODE=write XAI_API_KEY=xai-test GROK_MAX_TURNS=7 bash "$R" >/dev/null 2>&1
-grep -qx "7" "$ARGS_FILE" && pass "GROK_MAX_TURNS overrides the cap" || bad "GROK_MAX_TURNS override"
-echo "p" | GROK_FAKE_OUT='{"text":"x"}' MODEL="" SKILL_MODE=write XAI_API_KEY=xai-test GROK_MAX_TURNS=0 bash "$R" >/dev/null 2>&1
-if grep -qx -- "--max-turns" "$ARGS_FILE"; then bad "GROK_MAX_TURNS=0 removes the cap"; else pass "GROK_MAX_TURNS=0 removes the cap"; fi
-
-# 8c. GROK_EFFORT is gated on model capability: composer (default/empty) REJECTS
-# reasoningEffort with a 400, so it must be skipped there; a grok-build model gets it.
-echo "p" | GROK_FAKE_OUT='{"text":"x"}' MODEL=grok-build SKILL_MODE=write XAI_API_KEY=xai-test GROK_EFFORT=high bash "$R" >/dev/null 2>&1
-grep -qx -- "--effort" "$ARGS_FILE" && grep -qx "high" "$ARGS_FILE" && pass "GROK_EFFORT=high → --effort on a reasoning model" || bad "GROK_EFFORT on grok-build"
-echo "p" | GROK_FAKE_OUT='{"text":"x"}' MODEL="" SKILL_MODE=write XAI_API_KEY=xai-test GROK_EFFORT=high bash "$R" >/dev/null 2>&1
-if grep -qx -- "--effort" "$ARGS_FILE"; then bad "GROK_EFFORT skipped on composer (would 400)"; else pass "GROK_EFFORT skipped on composer (would 400)"; fi
-echo "p" | GROK_FAKE_OUT='{"text":"x"}' MODEL=grok-build SKILL_MODE=write XAI_API_KEY=xai-test GROK_EFFORT=turbo bash "$R" >/dev/null 2>&1
-if grep -qx -- "--effort" "$ARGS_FILE"; then bad "invalid GROK_EFFORT is dropped"; else pass "invalid GROK_EFFORT is dropped"; fi
-
-# 8d. GROK_BEST_OF_N (>=2) and GROK_CHECK map to flags AND drop --no-subagents
-# (grok's parser rejects --no-subagents with either). N<2 is a no-op.
-echo "p" | GROK_FAKE_OUT='{"text":"x"}' MODEL="" SKILL_MODE=write XAI_API_KEY=xai-test GROK_BEST_OF_N=3 GROK_CHECK=true bash "$R" >/dev/null 2>&1
-grep -qx -- "--best-of-n" "$ARGS_FILE" && grep -qx "3" "$ARGS_FILE" && grep -qx -- "--check" "$ARGS_FILE" \
-  && pass "GROK_BEST_OF_N=3 + GROK_CHECK → --best-of-n 3 --check" || bad "best-of-n/check mapping"
-if grep -qx -- "--no-subagents" "$ARGS_FILE"; then bad "best-of-n/check drops --no-subagents"; else pass "best-of-n/check drops --no-subagents"; fi
-echo "p" | GROK_FAKE_OUT='{"text":"x"}' MODEL="" SKILL_MODE=write XAI_API_KEY=xai-test GROK_BEST_OF_N=1 bash "$R" >/dev/null 2>&1
-if grep -qx -- "--best-of-n" "$ARGS_FILE"; then bad "GROK_BEST_OF_N=1 is a no-op"; else pass "GROK_BEST_OF_N=1 is a no-op"; fi
-grep -qx -- "--no-subagents" "$ARGS_FILE" && pass "default run keeps --no-subagents" || bad "default run keeps --no-subagents"
-
-# 8e. This path emits NO --json-schema: structured output is run-harness's job
-# (uniform across all six harnesses), not a grok-only env var. Guards against
-# reintroducing the divergence, and against a stray GROK_JSON_SCHEMA in the
-# environment silently taking effect again.
-echo "p" | GROK_FAKE_OUT='{"text":"x"}' MODEL="" SKILL_MODE=write XAI_API_KEY=xai-test GROK_JSON_SCHEMA='{"type":"object"}' bash "$R" >/dev/null 2>&1
-if grep -qx -- "--json-schema" "$ARGS_FILE"; then bad "no --json-schema on the run-grok.sh path"; else pass "no --json-schema on the run-grok.sh path"; fi
-# ...and --check is no longer suppressed by it (nothing left to conflict with).
-echo "p" | GROK_FAKE_OUT='{"text":"x"}' MODEL="" SKILL_MODE=write XAI_API_KEY=xai-test GROK_CHECK=true GROK_JSON_SCHEMA='{"type":"object"}' bash "$R" >/dev/null 2>&1
-grep -qx -- "--check" "$ARGS_FILE" && pass "--check no longer gated on a schema knob" || bad "--check gating"
-
-# 8f. .structuredOutput (grok-build under run-harness --json-schema) is normalized
-# into .result — the normalizer still has to handle it, even though this script
-# never sets the flag itself.
-OUT=$(run '{"text":"interim chatter","structuredOutput":{"score":4,"flags":[]},"stopReason":"EndTurn","thought":"secret"}')
-RES=$(echo "$OUT" | jq -r '.result')
-{ echo "$RES" | jq -e '.score==4' >/dev/null 2>&1 && ! echo "$OUT" | grep -q "secret" && ! echo "$RES" | grep -q "interim"; } \
-  && pass ".structuredOutput → .result (over .text, no thought leak)" || bad ".structuredOutput normalization (got: $OUT)"
-
-# 9. MCP: a project .mcp.json → one --allow MCPTool(<srv>__*) per server -------
-# grok discovers .mcp.json natively; run-grok.sh only grants permission to call.
-MCPDIR="$(mktemp -d)"
-cat > "$MCPDIR/.mcp.json" <<'JSON'
-{ "mcpServers": {
-  "github":   { "type": "http",  "url": "https://api.example/mcp/" },
-  "seqthink": { "type": "stdio", "command": "npx", "args": ["-y", "pkg"] }
-} }
-JSON
-( cd "$MCPDIR" && echo "p" | GROK_FAKE_OUT='{"text":"x"}' MODEL="" SKILL_MODE=write XAI_API_KEY=xai-test bash "$RABS" >/dev/null 2>&1 )
-{ grep -Fqx "MCPTool(github__*)" "$ARGS_FILE" && grep -Fqx "MCPTool(seqthink__*)" "$ARGS_FILE"; } \
-  && pass "MCP: one MCPTool allow per .mcp.json server" || bad "MCP allow rules (args: $(tr '\n' ' ' < "$ARGS_FILE"))"
-# 9b. …and --trust, without which grok never STARTS a repo-local server on an
-# untrusted checkout (every CI run) — the allows would then permit tools that
-# don't exist, and the run goes green having silently skipped MCP.
-grep -Fqx -- "--trust" "$ARGS_FILE" \
-  && pass "MCP: --trust passed for a repo-local .mcp.json" || bad "MCP --trust missing (args: $(tr '\n' ' ' < "$ARGS_FILE"))"
-rm -rf "$MCPDIR"
-
-# 9c. No .mcp.json → no --trust (default untrusted posture preserved).
-NOMCPDIR="$(mktemp -d)"
-( cd "$NOMCPDIR" && echo "p" | GROK_FAKE_OUT='{"text":"x"}' MODEL="" SKILL_MODE=write XAI_API_KEY=xai-test bash "$RABS" >/dev/null 2>&1 )
-grep -Fqx -- "--trust" "$ARGS_FILE" \
-  && bad "MCP: --trust leaked into a run with no .mcp.json" || pass "MCP: no --trust without a .mcp.json"
-rm -rf "$NOMCPDIR"
-
-# 9b. No .mcp.json in cwd → no MCPTool rules leak in
-TMPD="$(mktemp -d)"
-( cd "$TMPD" && echo "p" | GROK_FAKE_OUT='{"text":"x"}' MODEL="" SKILL_MODE=write XAI_API_KEY=xai-test bash "$RABS" >/dev/null 2>&1 )
-if grep -q "MCPTool(" "$ARGS_FILE"; then bad "no MCPTool rules without .mcp.json"; else pass "no MCPTool rules without .mcp.json"; fi
-rm -rf "$TMPD"
-
-# --- 10. OAuth durable refresh + persist (§2b) --------------------------------
+# --- 3. OAuth durable refresh + persist (§2b) --------------------------------
 # The captured GROK_CREDENTIALS rotates its refresh token on refresh; run-grok.sh
 # must refresh from it AND persist the rotated auth.json back to the secret, or auth
 # breaks ~6h after capture. Fake curl (token endpoint) + fake gh (secret persist),
@@ -227,7 +95,7 @@ EOF
 }
 authf() { jq -r ".[\"https://auth.x.ai::CID\"].$1" "$OHOME/.grok/auth.json"; }
 
-# 10a. expired token + PAT → refresh happens AND the rotated secret is persisted
+# 3a. expired token + PAT → refresh happens AND the rotated secret is persisted
 CREDS="$(seed_auth "2000-01-01T00:00:00.000000Z")"; GH_LOG="$OHOME/gh.log"; : >"$GH_LOG"
 HOME="$OHOME" PATH="$OBIN:$PATH" GROK_CREDENTIALS="$CREDS" GH_SECRETS_PAT="pat-test" GH_LOG="$GH_LOG" \
   bash "$RABS" setup >/dev/null 2>"$OHOME/e1"
@@ -236,21 +104,21 @@ HOME="$OHOME" PATH="$OBIN:$PATH" GROK_CREDENTIALS="$CREDS" GH_SECRETS_PAT="pat-t
 grep -q "secret set GROK_CREDENTIALS" "$GH_LOG" \
   && pass "oauth: rotated refresh token persisted via gh secret set" || bad "oauth persist not called (gh.log: $(cat "$GH_LOG"))"
 
-# 10b. expired token, NO PAT → still refreshes on disk, must NOT persist, warns loudly
+# 3b. expired token, NO PAT → still refreshes on disk, must NOT persist, warns loudly
 CREDS="$(seed_auth "2000-01-01T00:00:00.000000Z")"; GH_LOG="$OHOME/gh2.log"; : >"$GH_LOG"
 HOME="$OHOME" PATH="$OBIN:$PATH" GROK_CREDENTIALS="$CREDS" GH_LOG="$GH_LOG" \
   bash "$RABS" setup >/dev/null 2>"$OHOME/e2"
 { [ "$(authf key)" = "NEWACCESS" ] && ! grep -q "secret set" "$GH_LOG" && grep -q "no secrets-write PAT" "$OHOME/e2"; } \
   && pass "oauth: no PAT → refreshes but does not persist (warns)" || bad "oauth no-PAT (key=$(authf key); gh=$(cat "$GH_LOG"); err=$(cat "$OHOME/e2"))"
 
-# 10c. token still valid (far-future expiry) → skip refresh, no token-endpoint call
+# 3c. token still valid (far-future expiry) → skip refresh, no token-endpoint call
 CREDS="$(seed_auth "2099-01-01T00:00:00.000000Z")"; CURL_LOG="$OHOME/curl.log"; : >"$CURL_LOG"
 HOME="$OHOME" PATH="$OBIN:$PATH" GROK_CREDENTIALS="$CREDS" GH_SECRETS_PAT="pat-test" CURL_LOG="$CURL_LOG" \
   bash "$RABS" setup >/dev/null 2>"$OHOME/e3"
 { [ "$(authf key)" = "OLDACCESS" ] && [ ! -s "$CURL_LOG" ]; } \
   && pass "oauth: valid token → skips refresh" || bad "oauth skip-when-valid (key=$(authf key); curl=$(cat "$CURL_LOG"))"
 
-# 10d. token endpoint returns invalid_grant → warn, keep on-disk token, exit 0
+# 3d. token endpoint returns invalid_grant → warn, keep on-disk token, exit 0
 CREDS="$(seed_auth "2000-01-01T00:00:00.000000Z")"
 HOME="$OHOME" PATH="$OBIN:$PATH" GROK_CREDENTIALS="$CREDS" GH_SECRETS_PAT="pat-test" \
   CURL_FAKE_OUT='{"error":"invalid_grant","error_description":"Refresh token has been revoked"}' \
@@ -258,9 +126,9 @@ HOME="$OHOME" PATH="$OBIN:$PATH" GROK_CREDENTIALS="$CREDS" GH_SECRETS_PAT="pat-t
 { [ "$rc" = 0 ] && [ "$(authf key)" = "OLDACCESS" ] && grep -q "invalid_grant" "$OHOME/e4"; } \
   && pass "oauth: invalid_grant → warns, keeps token, rc 0" || bad "oauth invalid_grant (rc=$rc key=$(authf key) err=$(cat "$OHOME/e4"))"
 
-# 10e. XAI_API_KEY path (no GROK_CREDENTIALS) → the OAuth refresh never runs
+# 3e. XAI_API_KEY path (no GROK_CREDENTIALS) → the OAuth refresh never runs
 CURL_LOG="$OHOME/curl2.log"; : >"$CURL_LOG"
-echo p | HOME="$OHOME" PATH="$OBIN:$PATH" XAI_API_KEY=xai-test GROK_FAKE_OUT='{"text":"x"}' MODEL="" SKILL_MODE=write CURL_LOG="$CURL_LOG" bash "$RABS" >/dev/null 2>&1
+HOME="$OHOME" PATH="$OBIN:$PATH" XAI_API_KEY=xai-test CURL_LOG="$CURL_LOG" bash "$RABS" setup >/dev/null 2>&1
 [ ! -s "$CURL_LOG" ] && pass "oauth: API-key path does not run the OAuth refresh" || bad "oauth refresh wrongly ran on API-key path"
 rm -rf "$OBIN" "$OHOME"
 


### PR DESCRIPTION
Final piece of the run-path consolidation (#779 → #781 → #782 → #784).

## What goes

With every surface dispatching through `run-harness` (#784), `scripts/run-grok.sh`'s run path had **no callers** — ~260 lines of model/permission flags, MCP allows, run-shaping knobs, grok invocation and envelope normalization. It was a second copy of `adapters/grok.sh`, and a duplicate that drifts is precisely how grok's MCP folder-trust gate stayed broken on two surfaces for two releases.

`474 → 206` lines. What remains is the CLI version pin and the `GROK_CREDENTIALS` restore + rotating-refresh-token persistence (§2b), which the workflows call as `run-grok.sh setup`.

**A stale caller now fails loudly.** Using the old contract (prompt on stdin) exits 2 with a pointer to `run-harness`:

```
::error::run-grok.sh only stages the grok CLI now — it does not run skills.
::error::Run a skill with: harness-adapter/run-harness grok --mode <write|read-only>
```

Staging grok and exiting 0 would have handed it empty stdout, which reads as "the model returned nothing" — the silent no-op class this whole thread was about.

## The tests move, they don't disappear

`harness-adapter` had **no test suite at all**, so deleting `test_run_grok.sh`'s flag/envelope/MCP cases would have dropped the regression guard for the exact bug this thread started with. New **`scripts/tests/test_harness_adapter_grok.sh`** — the first tests for `harness-adapter` — asserts against the code that now implements those behaviours:

- `--trust` **is** passed for a repo-local `.mcp.json`, and does **not** leak into a non-MCP run
- one `--allow MCPTool(<srv>__*)` per declared server
- the **thought firewall** — grok's chain-of-thought never becomes `.result`
- `--model` forwarded for a real grok id, omitted for a leftover `claude-*` id
- `GROK_MAX_TURNS` reaches the adapter
- an abnormal stop with no output **fails** rather than emitting an empty success envelope

I checked the guard actually bites rather than trusting a green run: reverting `ARGS+=(--trust)` in the adapter turns it red.

```
FAIL - MCP --trust missing (args: -p prompt --output-format streaming-json …)
SOME FAILED
```

`test_run_grok.sh` keeps auth gating and all five OAuth refresh/persist cases, and gains three for the new subcommand contract. Both are wired into `ci-tests.yml`.

## Also

Comments in `skill_mode.sh`, `llm-gateway.sh`, `aeon.yml` and `apps/dashboard/lib/constants.ts` still described `run-grok.sh` as the thing that runs grok, passes `--no-subagents`, supplies the compat `--rules`. Corrected to point at the adapter.

## One thing deliberately left

**`skill_mode.sh grok-args` is now orphaned.** `run-grok.sh` was its only consumer, and `adapters/grok.sh` maps capability mode differently — `--permission-mode bypassPermissions` plus the dispatcher's OS sandbox, because a denied tool aborts grok's whole turn.

I labelled it rather than deleting it, because removing it means settling a question I shouldn't answer unilaterally: `docs/CAPABILITIES.md` still documents that allowlist (plus `--sandbox read-only`) as how grok enforces read-only, and that is not what runs today. Worth a look — grok read-only currently rests on the post-run stray-write revert, since `aeon.yml` passes `--no-sandbox` for grok. Deciding whether that is the intended posture is a separate call from this cleanup.
