### PR TITLE
fix(dashboard): stop harness Connect opening two browser tabs, restore Settings icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,24 @@ from or pin to; the template keeps serving the latest `main` to new forks.
   so a file a read-only skill *created* outside those 6 (e.g. under
   `apps/dashboard/lib/`, or a new top-level directory) survived and was committed
   by `git add -A`. Both lists are now the same set.
+- **Connecting a harness account no longer opens two browser tabs.** The
+  dashboard's "Connect X account" (grok) and "Connect ChatGPT"/"Connect Kimi"
+  (codex/kimi) routes each parsed the verification URL out of the CLI's live
+  output and opened it, on the premise that the CLI printed the URL and waited.
+  All three CLIs open it themselves, so every Connect landed the operator on two
+  identical auth tabs (verified on grok 0.2.106, codex, and kimi). The routes now
+  wait on the tab the CLI opened. They still parse the URL, but only to quote
+  back in the timeout error so an operator whose browser never opened can finish
+  by hand. `openBrowser` remains in use for MCP OAuth, where the dashboard builds
+  the authorize URL itself and no CLI is involved.
+- **Every credential in Settings shows its brand mark again.** `CODEX_AUTH`,
+  `KIMI_AUTH`, `OPENAI_API_KEY`, `MOONSHOT_API_KEY`, `MISTRAL_API_KEY`,
+  `GH_READ_PAT` and `GH_SECRETS_PAT` were added to the secrets catalog without a
+  matching row in the service-icon map, so all seven rendered as grey two-letter
+  initials badges. The icon map and `lib/secrets-catalog.ts` are separate lists,
+  so a new `resolveServiceMark` export plus `lib/service-icon.test.ts` now fail
+  the build when a catalogued secret has no logo or glyph, naming the offender.
+
 - **`scripts/run-grok.sh` is now setup-only.** With every surface dispatching
   through `run-harness`, the script's ~260-line run path (model/permission flags,
   MCP allows, run-shaping knobs, grok invocation, envelope normalization) had no

--- a/apps/dashboard/app/api/grok-auth/route.ts
+++ b/apps/dashboard/app/api/grok-auth/route.ts
@@ -6,24 +6,24 @@ import { join } from 'path'
 import { ghArgsRepo } from '@/lib/gh'
 import { syncGatewayProvider, syncHarness } from '@/lib/gateway'
 import { errorResponse, requireGh } from '@/lib/http'
-import { openBrowser } from '@/lib/open-browser'
 
 // One-click "Connect X account" for the Grok Build (`grok`) harness — the exact
 // parallel to the Claude subscription flow (app/api/auth: run `claude
 // setup-token`, capture the credential). Because the dashboard runs on the
-// operator's own machine, the route can drive the CLI and open their browser.
+// operator's own machine, the route can drive the CLI directly.
 //
 // Two paths:
 //  1. key present → store it as the XAI_API_KEY secret (API-key auth; also powers
 //     the Grok gateway). No browser flow.
-//  2. no key → run `grok login --device-auth`. Unlike `claude setup-token`, grok's
-//     device flow prints the verification URL and *waits* rather than opening the
-//     browser itself, so we parse the URL from its live output (never hardcoded —
-//     xAI rotates the per-attempt user_code) and open it. On approval grok writes
-//     ~/.grok/auth.json; we tar+base64 that into the GROK_CREDENTIALS secret, which
-//     scripts/run-grok.sh restores into ~/.grok before each Actions run.
+//  2. no key → run `grok login --device-auth`. grok opens the verification URL in
+//     the operator's browser ITSELF, so this route must not open it too - doing
+//     both is what made Connect spawn two identical accounts.x.ai tabs. We still
+//     parse the URL out of grok's live output (never hardcoded - xAI rotates the
+//     per-attempt user_code), but only to hand back if the flow fails. On approval
+//     grok writes ~/.grok/auth.json; we tar+base64 that into the GROK_CREDENTIALS
+//     secret, which scripts/run-grok.sh restores into ~/.grok before each run.
 //
-// The credential file is ~/.grok/auth.json (confirmed on grok 0.2.82, mode 0600).
+// The credential file is ~/.grok/auth.json (confirmed on grok 0.2.106, mode 0600).
 
 const GROK_DIR = '.grok'
 const AUTH_FILE = `${GROK_DIR}/auth.json`
@@ -31,8 +31,9 @@ const AUTH_FILE = `${GROK_DIR}/auth.json`
 const DEVICE_URL_RE = /https:\/\/accounts\.x\.ai\/oauth2\/device\S*/
 const LOGIN_TIMEOUT_MS = 240_000 // ample time to approve in the browser (< Node's 5-min request cap)
 
-// Run `grok login --device-auth`, opening the browser at the verification URL as
-// soon as grok prints it. Resolves on approval (exit 0), rejects otherwise.
+// Run `grok login --device-auth` and wait for the operator to approve in the tab
+// grok opened. Resolves on approval (exit 0), rejects otherwise, quoting the
+// verification URL so an operator whose browser never opened can finish by hand.
 function grokLogin(): Promise<void> {
   return new Promise((resolve, reject) => {
     let child
@@ -41,21 +42,18 @@ function grokLogin(): Promise<void> {
     } catch (e) {
       return reject(e)
     }
-    let opened = false
     let buf = ''
-    const onData = (chunk: Buffer) => {
-      buf += chunk.toString()
-      if (!opened) {
-        const m = buf.match(DEVICE_URL_RE)
-        if (m) { opened = true; openBrowser(m[0]) }
-      }
-    }
+    const onData = (chunk: Buffer) => { buf += chunk.toString() }
     child.stdout?.on('data', onData)
     child.stderr?.on('data', onData)
+    // Read off the whole buffer at failure time rather than latching the first
+    // chunk: a chunk boundary mid-URL would otherwise pin a truncated link.
+    const verifyUrl = () => buf.match(DEVICE_URL_RE)?.[0] ?? ''
 
     const timer = setTimeout(() => {
       child.kill()
-      reject(new Error('Timed out waiting for approval. Approve in the browser and click Connect again.'))
+      const url = verifyUrl()
+      reject(new Error(`Timed out waiting for approval. Approve in the browser and click Connect again.${url ? ` If no tab opened, visit ${url}` : ''}`))
     }, LOGIN_TIMEOUT_MS)
 
     child.on('error', (e: NodeJS.ErrnoException) => {

--- a/apps/dashboard/app/api/harness-auth/route.ts
+++ b/apps/dashboard/app/api/harness-auth/route.ts
@@ -1,18 +1,17 @@
 import { NextResponse } from 'next/server'
 import { syncHarness } from '@/lib/gateway'
 import { errorResponse, requireGh } from '@/lib/http'
-import { openBrowser } from '@/lib/open-browser'
 import { HARNESS_AUTH } from '@/lib/harness-auth'
 import { driveDeviceLogin, captureHarnessCreds, setHarnessApiKey } from '@/lib/harness-auth-server'
 import type { Harness } from '@/lib/types'
 
 // Native per-harness auth for codex/pi/vibe/kimi — the generic parallel to
 // app/api/grok-auth. Because the dashboard runs on the operator's own machine it
-// can drive the CLI and open their browser. POST { harness, key? }:
+// can drive the CLI directly. POST { harness, key? }:
 //   - key present (or the harness is key-only) → store it under the harness's
 //     provider secret (pi auto-detects the secret from the key prefix). No browser.
-//   - no key + the harness has an OAuth flow → run its device login, open the
-//     browser at the verification URL, capture the credential file into its secret.
+//   - no key + the harness has an OAuth flow → run its device login (the CLI opens
+//     the browser itself), capture the credential file into its secret.
 // The OAuth captures (CODEX_AUTH/KIMI_AUTH) are that-harness-only, so — exactly
 // like connecting the X account for grok — they also switch the repo to that
 // harness. The api-key paths don't (a provider key isn't an unambiguous signal).
@@ -36,8 +35,8 @@ export async function POST(request: Request) {
       return NextResponse.json({ ok: true, harness, method: 'api-key', secret })
     }
 
-    // Path 2 — native OAuth: drive the device login, open the browser, capture.
-    await driveDeviceLogin(harness, openBrowser)
+    // Path 2: native OAuth. Drive the device login (the CLI opens the browser), capture.
+    await driveDeviceLogin(harness)
     const { secret } = captureHarnessCreds(harness)
     const sync = await syncHarness(harness as Harness)
     return NextResponse.json({ ok: true, harness, method: 'oauth', secret, synced: sync.synced })

--- a/apps/dashboard/components/ui/ServiceIcon.tsx
+++ b/apps/dashboard/components/ui/ServiceIcon.tsx
@@ -1,90 +1,15 @@
 'use client'
 
 import { useState } from 'react'
-import { GATEWAY_REGISTRY } from '@/lib/gateway-registry'
+import { resolveServiceMark, type ServiceGlyph, type ServiceMarkQuery } from '@/lib/service-icons'
 
-// LLM-gateway domains derive from the single registry so a new provider doesn't
-// need a hand-added row here.
-const GATEWAY_DOMAINS: Record<string, string> = Object.fromEntries(
-  Object.values(GATEWAY_REGISTRY).map((p) => [p.secretName, p.domain] as [string, string]),
-)
-
-// Maps each credential / group to the brand domain whose logo we show. Logos
-// come from DuckDuckGo's privacy-respecting favicon service (no domain list
-// leaked to Google) and are rendered grayscale-by-default, lifting to full
-// colour on row hover so they stay calm against the monochrome shell. When a
-// service has no favicon (or the request fails) we fall back to a glyph or a
-// monochrome initials badge so every row still carries a mark.
-const DOMAINS: Record<string, string> = {
-  // Core - Claude-native auth (LLM-gateway domains spread in from the registry)
-  CLAUDE_CODE_OAUTH_TOKEN: 'claude.ai',
-  ANTHROPIC_API_KEY: 'anthropic.com',
-  // Grok Build (grok CLI) X-account OAuth session — same brand as XAI_API_KEY.
-  GROK_CREDENTIALS: 'x.ai',
-  // Native harness auth. A captured OAuth session carries the same brand as the
-  // provider key it substitutes for, so CODEX_AUTH sits under OpenAI (Codex signs
-  // in with ChatGPT) and KIMI_AUTH under Kimi, its own product domain.
-  CODEX_AUTH: 'openai.com',
-  OPENAI_API_KEY: 'openai.com',
-  KIMI_AUTH: 'kimi.com',
-  MOONSHOT_API_KEY: 'moonshot.ai',
-  MISTRAL_API_KEY: 'mistral.ai',
-  ...GATEWAY_DOMAINS,
-  // Channels
-  TELEGRAM_BOT_TOKEN: 'telegram.org',
-  TELEGRAM_CHAT_ID: 'telegram.org',
-  DISCORD_BOT_TOKEN: 'discord.com',
-  DISCORD_CHANNEL_ID: 'discord.com',
-  DISCORD_WEBHOOK_URL: 'discord.com',
-  SLACK_BOT_TOKEN: 'slack.com',
-  SLACK_CHANNEL_ID: 'slack.com',
-  SLACK_WEBHOOK_URL: 'slack.com',
-  // Skill keys
-  XAI_API_KEY: 'x.ai',
-  COINGECKO_API_KEY: 'coingecko.com',
-  ALCHEMY_API_KEY: 'alchemy.com',
-  ETHERSCAN_API_KEY: 'etherscan.io',
-  BASESCAN_API_KEY: 'basescan.org',
-  BANKR_API_KEY: 'bankr.bot',
-  VERCEL_TOKEN: 'vercel.com',
-  REPLICATE_API_TOKEN: 'replicate.com',
-  RESEND_API_KEY: 'resend.com',
-  ADMANAGE_API_KEY: 'admanage.ai',
-  // All three GitHub PATs (write / read-only / secrets-write) carry the same mark.
-  GH_GLOBAL: 'github.com',
-  GH_READ_PAT: 'github.com',
-  GH_SECRETS_PAT: 'github.com',
-  BASE_RPC_URL: 'base.org',
-  // Observability
-  LANGFUSE_PUBLIC_KEY: 'langfuse.com',
-  LANGFUSE_SECRET_KEY: 'langfuse.com',
-}
-
-// Non-brand entries - no logo exists, so show a meaningful glyph instead.
-const GLYPHS: Record<string, 'mail' | 'key'> = {
-  NOTIFY_EMAIL_TO: 'mail',
-}
-
-// Explicit logo overrides for services whose favicon is wrong/outdated. Vendored
-// into public/icons so they don't depend on a third-party host staying up.
-const ICON_URLS: Record<string, string> = {
-}
-
-// Same idea, keyed by DOMAIN — applies to group headers (which pass `domain`
-// directly) as well as any credential resolving to that domain. Langfuse's
-// favicon-service icon renders as a generic mark, so we vendor the real logo.
-const DOMAIN_ICON_URLS: Record<string, string> = {
-  'langfuse.com': '/icons/langfuse.svg',
-}
+// Renders the mark lib/service-icons.ts resolves: brand logo, glyph, or an
+// initials badge. Which mark a credential gets lives there, not here.
 
 // Heroicons (outline) paths - match the stroke icons used elsewhere in the UI.
-const GLYPH_PATHS: Record<'mail' | 'key', string> = {
+const GLYPH_PATHS: Record<ServiceGlyph, string> = {
   mail: 'M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25m19.5 0v.243a2.25 2.25 0 0 1-1.07 1.916l-7.5 4.615a2.25 2.25 0 0 1-2.36 0L3.32 8.91a2.25 2.25 0 0 1-1.07-1.916V6.75',
   key: 'M15.75 5.25a3 3 0 0 1 3 3m3 0a6 6 0 0 1-7.029 5.912c-.563-.097-1.159.026-1.563.43L10.5 17.25H8.25v2.25H6v2.25H2.25v-2.818c0-.597.237-1.17.659-1.591l6.499-6.499c.404-.404.527-1 .43-1.563A6 6 0 1 1 21.75 8.25z',
-}
-
-function faviconUrl(domain: string): string {
-  return `https://icons.duckduckgo.com/ip3/${domain}.ico`
 }
 
 function initials(name: string): string {
@@ -92,31 +17,8 @@ function initials(name: string): string {
   return (clean.slice(0, 2) || '?').toUpperCase()
 }
 
-interface ServiceIconProps {
-  // A credential / group name resolved against the maps above…
-  name?: string
-  // …or pass a domain / glyph directly (used for group headers).
-  domain?: string
-  glyph?: 'mail' | 'key'
+interface ServiceIconProps extends ServiceMarkQuery {
   className?: string
-}
-
-// Resolve a credential / group to the mark it renders: a logo `src`, a `glyph`,
-// or neither (the initials badge). Exported so a test can assert every catalogued
-// secret earns a real mark. The maps above and lib/secrets-catalog.ts are separate
-// lists, and a credential added to only one of them silently degrades to a grey
-// two-letter badge - which is how CODEX_AUTH, KIMI_AUTH, OPENAI_API_KEY,
-// MOONSHOT_API_KEY, MISTRAL_API_KEY, GH_READ_PAT and GH_SECRETS_PAT lost theirs.
-export function resolveServiceMark({ name, domain, glyph }: Omit<ServiceIconProps, 'className'>): {
-  src?: string
-  glyph?: 'mail' | 'key'
-} {
-  const resolvedDomain = domain ?? (name ? DOMAINS[name] : undefined)
-  // Explicit override wins over the domain favicon; a vendored domain logo wins
-  // over the favicon service.
-  const explicitSrc = name ? ICON_URLS[name] : undefined
-  const domainSrc = resolvedDomain ? (DOMAIN_ICON_URLS[resolvedDomain] ?? faviconUrl(resolvedDomain)) : undefined
-  return { src: explicitSrc ?? domainSrc, glyph: glyph ?? (name ? GLYPHS[name] : undefined) }
 }
 
 export function ServiceIcon({ name, domain, glyph, className = '' }: ServiceIconProps) {

--- a/apps/dashboard/components/ui/ServiceIcon.tsx
+++ b/apps/dashboard/components/ui/ServiceIcon.tsx
@@ -21,6 +21,14 @@ const DOMAINS: Record<string, string> = {
   ANTHROPIC_API_KEY: 'anthropic.com',
   // Grok Build (grok CLI) X-account OAuth session — same brand as XAI_API_KEY.
   GROK_CREDENTIALS: 'x.ai',
+  // Native harness auth. A captured OAuth session carries the same brand as the
+  // provider key it substitutes for, so CODEX_AUTH sits under OpenAI (Codex signs
+  // in with ChatGPT) and KIMI_AUTH under Kimi, its own product domain.
+  CODEX_AUTH: 'openai.com',
+  OPENAI_API_KEY: 'openai.com',
+  KIMI_AUTH: 'kimi.com',
+  MOONSHOT_API_KEY: 'moonshot.ai',
+  MISTRAL_API_KEY: 'mistral.ai',
   ...GATEWAY_DOMAINS,
   // Channels
   TELEGRAM_BOT_TOKEN: 'telegram.org',
@@ -42,7 +50,10 @@ const DOMAINS: Record<string, string> = {
   REPLICATE_API_TOKEN: 'replicate.com',
   RESEND_API_KEY: 'resend.com',
   ADMANAGE_API_KEY: 'admanage.ai',
+  // All three GitHub PATs (write / read-only / secrets-write) carry the same mark.
   GH_GLOBAL: 'github.com',
+  GH_READ_PAT: 'github.com',
+  GH_SECRETS_PAT: 'github.com',
   BASE_RPC_URL: 'base.org',
   // Observability
   LANGFUSE_PUBLIC_KEY: 'langfuse.com',
@@ -90,15 +101,27 @@ interface ServiceIconProps {
   className?: string
 }
 
-export function ServiceIcon({ name, domain, glyph, className = '' }: ServiceIconProps) {
-  const [failed, setFailed] = useState(false)
+// Resolve a credential / group to the mark it renders: a logo `src`, a `glyph`,
+// or neither (the initials badge). Exported so a test can assert every catalogued
+// secret earns a real mark. The maps above and lib/secrets-catalog.ts are separate
+// lists, and a credential added to only one of them silently degrades to a grey
+// two-letter badge - which is how CODEX_AUTH, KIMI_AUTH, OPENAI_API_KEY,
+// MOONSHOT_API_KEY, MISTRAL_API_KEY, GH_READ_PAT and GH_SECRETS_PAT lost theirs.
+export function resolveServiceMark({ name, domain, glyph }: Omit<ServiceIconProps, 'className'>): {
+  src?: string
+  glyph?: 'mail' | 'key'
+} {
   const resolvedDomain = domain ?? (name ? DOMAINS[name] : undefined)
-  const resolvedGlyph = glyph ?? (name ? GLYPHS[name] : undefined)
   // Explicit override wins over the domain favicon; a vendored domain logo wins
   // over the favicon service.
   const explicitSrc = name ? ICON_URLS[name] : undefined
   const domainSrc = resolvedDomain ? (DOMAIN_ICON_URLS[resolvedDomain] ?? faviconUrl(resolvedDomain)) : undefined
-  const src = explicitSrc ?? domainSrc
+  return { src: explicitSrc ?? domainSrc, glyph: glyph ?? (name ? GLYPHS[name] : undefined) }
+}
+
+export function ServiceIcon({ name, domain, glyph, className = '' }: ServiceIconProps) {
+  const [failed, setFailed] = useState(false)
+  const { src, glyph: resolvedGlyph } = resolveServiceMark({ name, domain, glyph })
 
   // Light chip backing so dark/filled marks (GitHub, Base, x.AI…) stay legible
   // against the near-black UI. Logos sit grayscale-and-calm, lifting to full

--- a/apps/dashboard/lib/harness-auth-server.ts
+++ b/apps/dashboard/lib/harness-auth-server.ts
@@ -50,14 +50,12 @@ export function driveTtyLogin(harness: string): void {
   execFileSync(spec.oauth.cli, spec.oauth.deviceArgs.length && !process.stdout.isTTY ? spec.oauth.deviceArgs : spec.oauth.ttyArgs, { stdio: 'inherit' })
 }
 
-// Drive the DEVICE login (headless: parse the verification URL from live output
-// and open the browser at it), for the dashboard route. Resolves on approval.
-// Faithful to grokLogin() in app/api/grok-auth/route.ts.
-export function driveDeviceLogin(
-  harness: string,
-  openBrowser: (url: string) => void,
-  timeoutMs = 240_000,
-): Promise<void> {
+// Drive the DEVICE login for the dashboard route, waiting on the tab the CLI
+// opens for itself. Resolves on approval. Faithful to grokLogin() in
+// app/api/grok-auth/route.ts, including NOT opening the browser here: codex and
+// kimi both launch it themselves ("If your browser did not open...", "Opening
+// browser for Kimi device login"), so a second open just duplicates the tab.
+export function driveDeviceLogin(harness: string, timeoutMs = 240_000): Promise<void> {
   const spec = HARNESS_AUTH[harness]
   if (!spec?.oauth) return Promise.reject(new Error(`${harness} has no OAuth login`))
   const { cli, deviceArgs } = spec.oauth
@@ -68,24 +66,20 @@ export function driveDeviceLogin(
     } catch (e) {
       return reject(e)
     }
-    let opened = false
     let buf = ''
-    const onData = (chunk: Buffer) => {
-      buf += chunk.toString()
-      if (!opened) {
-        // Open the first EXTERNAL verification URL. codex prints its localhost
-        // callback server first (http://localhost:1455) — opening that instead of
-        // the auth page would do nothing, so skip loopback hosts.
-        const urls = buf.match(new RegExp(DEVICE_URL_RE.source, 'g')) || []
-        const ext = urls.find((u) => !/localhost|127\.0\.0\.1|\[::1\]/.test(u))
-        if (ext) { opened = true; openBrowser(ext) }
-      }
-    }
+    const onData = (chunk: Buffer) => { buf += chunk.toString() }
     child.stdout?.on('data', onData)
     child.stderr?.on('data', onData)
+    // The first EXTERNAL URL in the output, quoted back only when the flow fails
+    // so an operator whose browser never opened can finish by hand. codex prints
+    // its localhost callback server first (http://localhost:1455), which is not
+    // the auth page, so skip loopback hosts.
+    const verifyUrl = () => (buf.match(new RegExp(DEVICE_URL_RE.source, 'g')) || [])
+      .find((u) => !/localhost|127\.0\.0\.1|\[::1\]/.test(u)) ?? ''
     const timer = setTimeout(() => {
       child.kill()
-      reject(new Error('Timed out waiting for approval. Approve in the browser and connect again.'))
+      const url = verifyUrl()
+      reject(new Error(`Timed out waiting for approval. Approve in the browser and connect again.${url ? ` If no tab opened, visit ${url}` : ''}`))
     }, timeoutMs)
     child.on('error', (e: NodeJS.ErrnoException) => {
       clearTimeout(timer)

--- a/apps/dashboard/lib/harness-auth.ts
+++ b/apps/dashboard/lib/harness-auth.ts
@@ -20,7 +20,7 @@ export interface HarnessOAuth {
   // server + browser) and kimi (`kimi login` → device URL + browser) open their
   // own browser and complete on approval, so the same args work for the aeon CLI
   // (TTY, inherit stdio) and the dashboard route (spawn, wait for exit 0). The
-  // route also opens the verification URL it parses, as a fallback.
+  // route must NOT open the URL as well, or the operator lands on two tabs.
   cli: string
   ttyArgs: string[]
   deviceArgs: string[]

--- a/apps/dashboard/lib/open-browser.ts
+++ b/apps/dashboard/lib/open-browser.ts
@@ -1,6 +1,8 @@
 // Server-only: open the operator's browser at `url`. The dashboard runs on the
-// operator's own machine, so the auth routes (Grok device-auth, MCP OAuth) can
-// drive it directly.
+// operator's own machine, so MCP OAuth can drive it directly - there the
+// dashboard builds the authorize URL itself and no CLI is involved. The harness
+// logins (grok/codex/kimi) deliberately do NOT call this: their CLIs open the
+// browser themselves, and opening it again duplicates the tab.
 import { execFile } from 'child_process'
 
 // Fire-and-forget; a failure to auto-open isn't fatal — every caller also

--- a/apps/dashboard/lib/service-icon.test.ts
+++ b/apps/dashboard/lib/service-icon.test.ts
@@ -1,15 +1,15 @@
 /**
- * Tests for components/ui/ServiceIcon - the brand marks beside every credential
- * in Settings > Access Keys (regression: five native-harness secrets and two
- * GitHub PATs were added to lib/secrets-catalog.ts without a matching row in the
- * icon map, so they rendered as grey two-letter badges instead of a logo).
+ * Tests for lib/service-icons.ts - the brand marks beside every credential in
+ * Settings > Access Keys (regression: five native-harness secrets and two GitHub
+ * PATs were added to lib/secrets-catalog.ts without a matching row in the icon
+ * map, so they rendered as grey two-letter badges instead of a logo).
  *
  * Run with:  node --import tsx --test apps/dashboard/lib/service-icon.test.ts
  */
 import { describe, it } from "node:test";
 import { strict as assert } from "node:assert";
 
-import { resolveServiceMark } from "../components/ui/ServiceIcon";
+import { resolveServiceMark } from "./service-icons";
 import { BUILTIN_SECRETS } from "./secrets-catalog";
 
 describe("resolveServiceMark", () => {

--- a/apps/dashboard/lib/service-icon.test.ts
+++ b/apps/dashboard/lib/service-icon.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Tests for components/ui/ServiceIcon - the brand marks beside every credential
+ * in Settings > Access Keys (regression: five native-harness secrets and two
+ * GitHub PATs were added to lib/secrets-catalog.ts without a matching row in the
+ * icon map, so they rendered as grey two-letter badges instead of a logo).
+ *
+ * Run with:  node --import tsx --test apps/dashboard/lib/service-icon.test.ts
+ */
+import { describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+
+import { resolveServiceMark } from "../components/ui/ServiceIcon";
+import { BUILTIN_SECRETS } from "./secrets-catalog";
+
+describe("resolveServiceMark", () => {
+  it("gives every catalogued secret a logo or a glyph, never the initials badge", () => {
+    const unmarked = BUILTIN_SECRETS
+      .map(s => s.name)
+      .filter(name => {
+        const { src, glyph } = resolveServiceMark({ name });
+        return !src && !glyph;
+      });
+    assert.deepEqual(unmarked, [], `secrets missing an icon: ${unmarked.join(", ")}`);
+  });
+
+  it("routes a credential to its brand favicon", () => {
+    assert.match(resolveServiceMark({ name: "CODEX_AUTH" }).src ?? "", /openai\.com/);
+    assert.match(resolveServiceMark({ name: "GH_SECRETS_PAT" }).src ?? "", /github\.com/);
+  });
+
+  it("prefers a vendored logo over the favicon service", () => {
+    assert.equal(resolveServiceMark({ domain: "langfuse.com" }).src, "/icons/langfuse.svg");
+  });
+
+  it("falls back to the initials badge for an unknown custom secret", () => {
+    const { src, glyph } = resolveServiceMark({ name: "SOME_CUSTOM_KEY" });
+    assert.equal(src, undefined);
+    assert.equal(glyph, undefined);
+  });
+});

--- a/apps/dashboard/lib/service-icons.ts
+++ b/apps/dashboard/lib/service-icons.ts
@@ -1,0 +1,112 @@
+import { GATEWAY_REGISTRY } from './gateway-registry'
+
+// Which brand mark each credential / group carries, and the rules for picking it.
+// Kept apart from components/ui/ServiceIcon.tsx (the rendering) so it stays plain
+// TS: apps/cli typechecks ../dashboard/lib/**/*.ts without `jsx`, so anything a
+// lib test imports has to be reachable without touching a .tsx.
+
+// LLM-gateway domains derive from the single registry so a new provider doesn't
+// need a hand-added row here.
+const GATEWAY_DOMAINS: Record<string, string> = Object.fromEntries(
+  Object.values(GATEWAY_REGISTRY).map((p) => [p.secretName, p.domain] as [string, string]),
+)
+
+// Maps each credential / group to the brand domain whose logo we show. Logos
+// come from DuckDuckGo's privacy-respecting favicon service (no domain list
+// leaked to Google) and are rendered grayscale-by-default, lifting to full
+// colour on row hover so they stay calm against the monochrome shell. When a
+// service has no favicon (or the request fails) we fall back to a glyph or a
+// monochrome initials badge so every row still carries a mark.
+const DOMAINS: Record<string, string> = {
+  // Core - Claude-native auth (LLM-gateway domains spread in from the registry)
+  CLAUDE_CODE_OAUTH_TOKEN: 'claude.ai',
+  ANTHROPIC_API_KEY: 'anthropic.com',
+  // Grok Build (grok CLI) X-account OAuth session — same brand as XAI_API_KEY.
+  GROK_CREDENTIALS: 'x.ai',
+  // Native harness auth. A captured OAuth session carries the same brand as the
+  // provider key it substitutes for, so CODEX_AUTH sits under OpenAI (Codex signs
+  // in with ChatGPT) and KIMI_AUTH under Kimi, its own product domain.
+  CODEX_AUTH: 'openai.com',
+  OPENAI_API_KEY: 'openai.com',
+  KIMI_AUTH: 'kimi.com',
+  MOONSHOT_API_KEY: 'moonshot.ai',
+  MISTRAL_API_KEY: 'mistral.ai',
+  ...GATEWAY_DOMAINS,
+  // Channels
+  TELEGRAM_BOT_TOKEN: 'telegram.org',
+  TELEGRAM_CHAT_ID: 'telegram.org',
+  DISCORD_BOT_TOKEN: 'discord.com',
+  DISCORD_CHANNEL_ID: 'discord.com',
+  DISCORD_WEBHOOK_URL: 'discord.com',
+  SLACK_BOT_TOKEN: 'slack.com',
+  SLACK_CHANNEL_ID: 'slack.com',
+  SLACK_WEBHOOK_URL: 'slack.com',
+  // Skill keys
+  XAI_API_KEY: 'x.ai',
+  COINGECKO_API_KEY: 'coingecko.com',
+  ALCHEMY_API_KEY: 'alchemy.com',
+  ETHERSCAN_API_KEY: 'etherscan.io',
+  BASESCAN_API_KEY: 'basescan.org',
+  BANKR_API_KEY: 'bankr.bot',
+  VERCEL_TOKEN: 'vercel.com',
+  REPLICATE_API_TOKEN: 'replicate.com',
+  RESEND_API_KEY: 'resend.com',
+  ADMANAGE_API_KEY: 'admanage.ai',
+  // All three GitHub PATs (write / read-only / secrets-write) carry the same mark.
+  GH_GLOBAL: 'github.com',
+  GH_READ_PAT: 'github.com',
+  GH_SECRETS_PAT: 'github.com',
+  BASE_RPC_URL: 'base.org',
+  // Observability
+  LANGFUSE_PUBLIC_KEY: 'langfuse.com',
+  LANGFUSE_SECRET_KEY: 'langfuse.com',
+}
+
+// Non-brand entries - no logo exists, so show a meaningful glyph instead.
+const GLYPHS: Record<string, ServiceGlyph> = {
+  NOTIFY_EMAIL_TO: 'mail',
+}
+
+// Explicit logo overrides for services whose favicon is wrong/outdated. Vendored
+// into public/icons so they don't depend on a third-party host staying up.
+const ICON_URLS: Record<string, string> = {
+}
+
+// Same idea, keyed by DOMAIN — applies to group headers (which pass `domain`
+// directly) as well as any credential resolving to that domain. Langfuse's
+// favicon-service icon renders as a generic mark, so we vendor the real logo.
+const DOMAIN_ICON_URLS: Record<string, string> = {
+  'langfuse.com': '/icons/langfuse.svg',
+}
+
+export type ServiceGlyph = 'mail' | 'key'
+
+export interface ServiceMarkQuery {
+  // A credential / group name resolved against the maps above…
+  name?: string
+  // …or pass a domain / glyph directly (used for group headers).
+  domain?: string
+  glyph?: ServiceGlyph
+}
+
+export function faviconUrl(domain: string): string {
+  return `https://icons.duckduckgo.com/ip3/${domain}.ico`
+}
+
+// Resolve a credential / group to the mark it renders: a logo `src`, a `glyph`,
+// or neither (the initials badge). Exported so a test can assert every catalogued
+// secret earns a real mark. The maps above and lib/secrets-catalog.ts are separate
+// lists, and a credential added to only one of them silently degrades to a grey
+// two-letter badge - which is how CODEX_AUTH, KIMI_AUTH, OPENAI_API_KEY,
+// MOONSHOT_API_KEY, MISTRAL_API_KEY, GH_READ_PAT and GH_SECRETS_PAT lost theirs.
+export function resolveServiceMark({ name, domain, glyph }: ServiceMarkQuery): {
+  src?: string
+  glyph?: ServiceGlyph
+} {
+  const resolvedDomain = domain ?? (name ? DOMAINS[name] : undefined)
+  // Explicit override wins over the domain favicon; a vendored domain logo wins
+  // over the favicon service.
+  const explicitSrc = name ? ICON_URLS[name] : undefined
+  const domainSrc = resolvedDomain ? (DOMAIN_ICON_URLS[resolvedDomain] ?? faviconUrl(resolvedDomain)) : undefined
+  return { src: explicitSrc ?? domainSrc, glyph: glyph ?? (name ? GLYPHS[name] : undefined) }
+}


### PR DESCRIPTION
Two dashboard fixes found while running the app locally.

## Connect opened the auth page twice

The grok, codex and kimi connect routes each parsed the verification URL out of the CLI's live output and opened it themselves. The grok route's comment recorded that as necessary because grok "prints the verification URL and *waits* rather than opening the browser itself" (noted as confirmed on grok 0.2.82), and the codex/kimi helper documented its own open as a deliberate fallback.

Neither holds. All three CLIs open the URL themselves, so every Connect landed the operator on two identical auth tabs. From the default browser's tab list:

```
device?user_code=YJMX-Y6RY   <- bare `grok login --device-auth`: 1 tab (grok self-opens)
device?user_code=TX2F-8ZAE   <- the same flow via the dashboard route
device?user_code=TX2F-8ZAE   <- same code, second tab
```

Same for the siblings: `codex login` took the browser from 7 to 8 tabs on its own, and `kimi login` prints `Opening browser for Kimi device login`. Verified on grok 0.2.106.

The routes now wait on the tab the CLI opened. They still parse the URL, but only to quote back in the timeout error so an operator whose browser never opened can finish by hand. That parse is also no longer latched to the first matching chunk, which could pin a truncated link when a chunk boundary fell mid-URL.

`openBrowser` stays in use for MCP OAuth, where the dashboard builds the authorize URL itself and no CLI is involved.

**Tradeoff worth naming:** if a CLI ever fails to open a browser, the URL now surfaces only when the 240s timeout fires rather than immediately. That is the cost of removing the guaranteed duplicate; showing it sooner would mean streaming the URL back mid-request, a larger change. The dashboard is explicitly a local-machine tool, so the CLI's own open is the right primary.

## Seven credentials had no icon in Settings

`CODEX_AUTH`, `KIMI_AUTH`, `OPENAI_API_KEY`, `MOONSHOT_API_KEY`, `MISTRAL_API_KEY`, `GH_READ_PAT` and `GH_SECRETS_PAT` were added to `lib/secrets-catalog.ts` without a matching row in the service-icon map, so each fell through to the grey two-letter initials badge.

Each favicon was checksummed against a 404 control and visually inspected before being wired, so none of them is the service's generic fallback mark.

Those are two separate lists that nothing diffed, which is exactly how they drifted. Icon resolution is now an exported `resolveServiceMark`, and a new `lib/service-icon.test.ts` asserts every catalogued secret earns a logo or glyph, failing with the offending name:

```
AssertionError: secrets missing an icon: GH_READ_PAT
```

Confirmed the guard bites by deleting an entry and watching it fail. Custom (non-catalog) secrets still fall back to initials by design, which the test pins too.

## Verification

Checked in the running dashboard, not just in tests: Connect now opens exactly one tab, and a DOM sweep of Settings returns zero initials badges with every new `<img>` loading (`naturalWidth > 0`).

`npm run typecheck`, `npm test` (169 pass) and `npm run build` are clean in this tree; knip reports no new unused exports.
