### PR TITLE
docs: sync PRs #778–#792 to aeon docs

### DIFF
--- a/.claude/skills/aeon/SKILL.md
+++ b/.claude/skills/aeon/SKILL.md
@@ -248,7 +248,7 @@ requires: [SOME_API_KEY?]
 Today is ${today}. <the prompt — plain instructions, including judgment calls>
 
 ## Steps
-1. <the procedure — 41 of 62 skills lead with this>
+1. <the procedure — 41 of 63 skills lead with this>
 
 ## Network note
 <curl / WebFetch / `./secretcurl` / `gh api` — how this skill fetches>
@@ -308,9 +308,9 @@ Three at a time, not twelve. Every enabled skill is a recurring notification, an
 ./aeon packs ls                  # the six first-party packs
 ```
 
-`ls` footers with `62 skills · 1 enabled` — read it to them before proposing anything. First run installs the CLI runtime (tsx + yaml, ~12MB); the npm noise is one-time and expected. Grep-only equivalents: `references/layout.md`.
+`ls` footers with `63 skills · 1 enabled` — read it to them before proposing anything. First run installs the CLI runtime (tsx + yaml, ~12MB); the npm noise is one-time and expected. Grep-only equivalents: `references/layout.md`.
 
-Packs are a visibility filter, not a runtime switch — revealing one runs nothing. Core (11), Evolution (8) and Basics (15) show by default; Dev (8), Crypto (12) and Productivity (8) are on demand.
+Packs are a visibility filter, not a runtime switch — revealing one runs nothing. Core (11), Evolution (8) and Basics (15) show by default; Dev (8), Crypto (13) and Productivity (8) are on demand.
 
 Reasonable starting sets:
 

--- a/.claude/skills/aeon/references/layout.md
+++ b/.claude/skills/aeon/references/layout.md
@@ -12,7 +12,7 @@ Where everything lives in an Aeon repo, and the fastest way to see what's on.
 ./aeon skills ls --enabled --json # for building the Mode 2 timeline
 ```
 
-`ls` prints `SKILL / ON / SCHEDULE / PACK / DESCRIPTION` and a footer — `62 skills · 1 enabled`. First run installs the CLI runtime (tsx + yaml, ~12MB, one-time); the noise is expected.
+`ls` prints `SKILL / ON / SCHEDULE / PACK / DESCRIPTION` and a footer — `63 skills · 1 enabled`. First run installs the CLI runtime (tsx + yaml, ~12MB, one-time); the noise is expected.
 
 **The `SCHEDULE` column is populated for disabled skills too** — it's their `aeon.yml` entry, not proof anything fires. Only the `●` in `ON` means it runs.
 

--- a/.claude/skills/aeon/references/mcp.md
+++ b/.claude/skills/aeon/references/mcp.md
@@ -7,7 +7,7 @@ Two unrelated things share the name. Get this wrong and nothing works.
 | | |
 |---|---|
 | **`.mcp.json`** — *external MCP servers, called BY Aeon skills* | Wired via the dashboard MCP panel or `./aeon mcp add`. This is what you want when a skill needs a tool. |
-| **`bin/add-mcp`** — *Aeon itself AS an MCP server* | Builds `apps/mcp-server` and registers it with Claude Code / Desktop, so all 62 skills appear as `aeon-*` tools **in your local Claude**. Nothing to do with a skill calling out. |
+| **`bin/add-mcp`** — *Aeon itself AS an MCP server* | Builds `apps/mcp-server` and registers it with Claude Code / Desktop, so all 63 skills appear as `aeon-*` tools **in your local Claude**. Nothing to do with a skill calling out. |
 
 The rest of this doc is the first one. For the second: `bin/add-mcp`, `--desktop` for a Claude Desktop snippet, `--uninstall` to remove, `claude mcp list` to verify.
 

--- a/.claude/skills/aeon/references/skill-anatomy.md
+++ b/.claude/skills/aeon/references/skill-anatomy.md
@@ -1,10 +1,10 @@
 # How Aeon skills are actually written
 
-Surveyed across all 62 skills in `aeonfun/aeon`. Frequencies are real counts — match the dominant convention unless there's a reason not to. Bodies run 133–757 lines (~306 median); a skill is a prompt, not a config file, and reads as prose.
+Surveyed across all 63 skills in `aeonfun/aeon`. Frequencies are real counts — match the dominant convention unless there's a reason not to. Bodies run 133–757 lines (~306 median); a skill is a prompt, not a config file, and reads as prose.
 
 ## Frontmatter
 
-Universal — **all 62 skills** carry these five:
+Universal — **all 63 skills** carry these five:
 
 ```yaml
 type: Skill          # required by ci-okf; every .md under skills/ needs a type:
@@ -114,7 +114,7 @@ There is **no network sandbox** — plain `curl` works for unauthenticated GETs.
 
 `memory/` is the durable state that survives between runs. Four conventions, in order of how often skills touch them:
 
-### `memory/logs/${today}.md` — the run log (58 of 62 skills)
+### `memory/logs/${today}.md` — the run log (59 of 63 skills)
 
 Every skill appends what it did, under **one** heading that is exactly its slug:
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -89,11 +89,11 @@ The prompt *is* the skill, judgment and all. You schedule it, hand it a `var`, c
 | **Evolution** - authors, evolves, installs & heals its own skills; shown by default | `evolution` | 8 | `create-skill`, `autoresearch`, `aeon-doctor` |
 | **Basics** - simple, immediately-runnable skills; shown by default | `basics` | 15 | `digest`, `token-movers`, `pr-review` |
 | **Dev & Code** | `dev` | 8 | `github-monitor`, `feature`, `deploy-prototype` |
-| **Crypto & Markets** | `crypto` | 12 | `token-pick`, `defi-overview`, `robinhood-mcp` |
+| **Crypto & Markets** | `crypto` | 13 | `token-pick`, `defi-overview`, `robinhood-mcp` |
 | **Productivity** | `productivity` | 8 | `mention-radar`, `send-email`, `okf-export` |
 
 <details>
-<summary><strong>Full catalog (all 62 skills by pack)</strong></summary>
+<summary><strong>Full catalog (all 63 skills by pack)</strong></summary>
 
 Three packs are shown by default (**Core**, **Evolution**, **Basics**); the rest are revealed on demand.
 
@@ -103,7 +103,7 @@ Three packs are shown by default (**Core**, **Evolution**, **Basics**); the rest
 | **Evolution** (`evolution`, 8) | `aeon-doctor`,`autoresearch`,`create-skill`,`install-skill`,`search-skill`,`self-improve`,`skill-health`,`skill-repair` |
 | **Basics** (`basics`, 15) | `action-converter`,`article`,`bd-radar`,`digest`,`executor-mcp`,`fetch-tweets`,`github-trending`,`glim-mcp`,`idea-forge`,`last30`,`pr-review`,`price-alert`,`token-movers`,`tx-explain`,`write-tweet` |
 | **Dev & Code** (`dev`, 8) | `changelog`,`deploy-prototype`,`feature`,`github-monitor`,`inbox-triage`,`pr-triage`,`vuln-scanner`,`vuln-tracker` |
-| **Crypto & Markets** (`crypto`, 12) | `base-mcp`,`defi-overview`,`distribute-tokens`,`investigation-report`,`monitor-polymarket`,`narrative-tracker`,`onchain-monitor`,`picks-tracker`,`pm-manipulation`,`robinhood-mcp`,`token-pick`,`unlock-monitor` |
+| **Crypto & Markets** (`crypto`, 13) | `base-mcp`,`defi-overview`,`distribute-tokens`,`finance-district-mcp`,`investigation-report`,`monitor-polymarket`,`narrative-tracker`,`onchain-monitor`,`picks-tracker`,`pm-manipulation`,`robinhood-mcp`,`token-pick`,`unlock-monitor` |
 | **Productivity** (`productivity`, 8) | `idea-pipeline`,`mention-radar`,`okf-export`,`okf-ingest`,`operator-scorecard`,`reply-maker`,`schedule-ads`,`send-email` |
 
 Authoritative source: [`skills.json`](../catalog/skills.json) + [`packs.json`](../catalog/packs.json), the dashboard **Packs** view, or `bin/add-skill aeonfun/aeon --list`. A skill's pack comes from its `category:` frontmatter - see [`docs/skill-packs.md`](../docs/skill-packs.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Added
 
+- **New skill: `finance-district-mcp`** — a multichain non-custodial agent
+  wallet over MCP (contributed by @raul1stdigital). Checks balances and prices,
+  discovers the best DeFi yields, swaps, moves funds, and makes x402 paid API
+  calls across EVM, Solana, Bitcoin, and Sui. Private keys never leave a secure
+  enclave (TEE); per-transfer limits, an auto-approve threshold, and a
+  destination denylist are enforced server-side, not in the prompt. One-click
+  Connect from the dashboard MCP panel (a fifth `MCP_CATALOG` entry). Joins the
+  `crypto` pack via its `category`; brings the catalog to **63 skills** (62 →
+  63). Opt-in per deployment. (#791)
 - **Multi-harness support** — skills now run on any of six agent CLIs (Claude
   Code, Grok, Codex, Pi, Vibe, Kimi) behind one `{result, usage, session_id}`
   contract via the new `harness-adapter`'s `run-harness`. The four
@@ -53,6 +62,22 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Fixed
 
+- **Read-only skills ran in write mode on the MCP-server path.**
+  `apps/mcp-server`'s `skill-executor.ts` hardcoded `--mode write` and never
+  consulted `scripts/skill_mode.sh`, so all twelve `mode: read-only` skills ran
+  unsandboxed with the full write toolset when invoked locally through the MCP
+  server (`--mode` is what gates the OS sandbox). `resolveHarness()` had the same
+  drift, ignoring per-skill `harness:` overrides. Both now agree with
+  `resolve-harness.sh`, proven by a differential test over all 64 skills plus
+  synthetic cases. (#792)
+- **`wrap_raw_output` could fabricate a green run.**
+  `harness-adapter/lib/envelope.sh` wraps output an adapter couldn't parse in a
+  schema-valid SUCCESS envelope, so a failed parse published a blob to
+  `output/.chains/<skill>.md` as the skill's deliverable and logged 0/0/0/0 usage
+  indistinguishable from a real cheap run. The path is now countable via an
+  `rh-wrap-fallback:` marker that `aeon.yml` promotes to a `::warning::` (behaviour
+  deliberately unchanged pending blast-radius data), and `envelope.sh` gets its
+  first test suite (`test_harness_envelope.sh`, 22 assertions). (#792)
 - **Inbound messages now run on all six harnesses.** `messages.yml` staged only
   the claude and grok CLIs, so a repo configured for codex/pi/vibe/kimi had every
   inbound message answered on **claude** — loudly (`::warning::`), but still not
@@ -267,11 +292,17 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 - Patched two high-severity CVE classes in the dashboard — `sharp`/`libvips`,
   and Next.js `16.2.10 → 16.2.11`. (#758, #759)
+- Bumped the dashboard `postcss` override past `GHSA-r28c-9q8g-f849`. (#783)
 
 ### Maintenance
 
 - Repo-wide cleanup pass across 8 dimensions (dead code, weak types,
   duplication, circular deps). (#757)
+- Second code-quality sweep across the dashboard, CLI, mcp-server, and
+  harness-adapter — removed dead `opencode`/`GATEWAY` paths and five duplicate
+  helpers, tightened weak types (`Record` → miss-aware value types), wired two
+  orphaned test suites into CI, and fixed a `bin/install-from-atrium` file mode.
+  Circular deps, dead code, and duplication all measured near-zero. (#792)
 
 ## [0.1.0] - 2026-07-09
 

--- a/docs/aeon-setup.md
+++ b/docs/aeon-setup.md
@@ -10,7 +10,7 @@ Aeon ships an **[Agent Skill](https://code.claude.com/docs/en/skills)** (`SKILL.
 
 It's a portable skill, not tied to one product: [Claude Code](https://claude.com/claude-code) is the primary host (it auto-loads skills from `.claude/skills/`, so it's zero-install there), but the skill is just a `SKILL.md` in the open Agent Skills format — it works with **Claude Code, Codex, Hermes, or OpenClaw**, and any other agent tool that supports skills.
 
-> **This is not an Aeon skill.** The 62 skills under [`skills/`](../skills) run unattended on GitHub Actions. **This** one runs inside *your* agent session on *your* machine — it's the operator's assistant for configuring the instance, not something that runs on a schedule. It doesn't appear in `aeon.yml`, the packs, or the catalog.
+> **This is not an Aeon skill.** The 63 skills under [`skills/`](../skills) run unattended on GitHub Actions. **This** one runs inside *your* agent session on *your* machine — it's the operator's assistant for configuring the instance, not something that runs on a schedule. It doesn't appear in `aeon.yml`, the packs, or the catalog.
 
 ## What it does
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,6 +1,6 @@
 # Aeon integration examples
 
-Aeon ships an [MCP server](../apps/mcp-server/) so any Claude client can call its 62 skills. The scripts here are the shortest possible "first call works" demos — build the server, run `python <file>`, get a real Aeon output back.
+Aeon ships an [MCP server](../apps/mcp-server/) so any Claude client can call its 63 skills. The scripts here are the shortest possible "first call works" demos — build the server, run `python <file>`, get a real Aeon output back.
 
 | File | Stack | Skill called | What it shows |
 |------|-------|--------------|---------------|

--- a/docs/skill-packs.md
+++ b/docs/skill-packs.md
@@ -4,7 +4,7 @@ type: Reference
 
 # Skill packs
 
-Aeon ships **62 skills**, but most forks only ever run a handful. Packs make
+Aeon ships **63 skills**, but most forks only ever run a handful. Packs make
 that manageable: by default the dashboard shows **Core** (what makes Aeon
 different) and **Basics** (simple skills you can run right now) — everything else
 is grouped into **packs** that stay hidden until you enable them.
@@ -79,7 +79,7 @@ Pack key = category. Six packs, no empties; three are shown by default.
 | **Evolution** (`evolution`) | The self-improvement loop — authors, evolves, installs, and heals its own skills. Shown by default. | 8 |
 | **Basics** (`basics`) | Simple, immediately-runnable skills — one approachable entry per area. Shown by default. | 15 |
 | **Dev & Code** (`dev`) | PR/issue triage, review, merges, changelogs, repo monitoring, security scanning, app deploys. | 8 |
-| **Crypto & Markets** (`crypto`) | Token/DeFi/prediction-market monitoring, narrative tracking, on-chain forensics + automation. | 12 |
+| **Crypto & Markets** (`crypto`) | Token/DeFi/prediction-market monitoring, narrative tracking, on-chain forensics + automation. | 13 |
 | **Productivity** (`productivity`) | Personal + social ops: routines, ideas, retrospectives, mentions, replies, ads, email, OKF housekeeping. | 8 |
 
 ### Core + Evolution + Basics — what a fresh fork shows


### PR DESCRIPTION
Syncs the aeon repo docs to merged PRs **#778–#792** (source of truth: merged PRs on `aeonfun/aeon`). Watermark advances **777 → 792**.

Most batch PRs already recorded themselves in `CHANGELOG.md [Unreleased]`; this PR fills the gaps and propagates the catalog-count change the PRs left stale.

### Catalog count: 62 → 63
PR #791 added a new skill (`finance-district-mcp`, crypto pack) and regenerated `catalog/*.json` (total 63), but left every prose count at 62. Corrected across:

- [x] `.github/README.md` — pack summary crypto **12 → 13**, "all **63** skills by pack", `finance-district-mcp` added to the crypto catalog row
- [x] `docs/skill-packs.md` — "Aeon ships **63 skills**", crypto pack **12 → 13**
- [x] `docs/aeon-setup.md` — "The **63** skills under `skills/`"
- [x] `docs/examples/README.md` — "call its **63** skills"
- [x] `.claude/skills/aeon/SKILL.md` — `63 skills · 1 enabled` footer, `Crypto (13)` breakdown, `41 of 63 skills`
- [x] `.claude/skills/aeon/references/layout.md` — `63 skills · 1 enabled`
- [x] `.claude/skills/aeon/references/mcp.md` — "all **63** skills appear as `aeon-*`"
- [x] `.claude/skills/aeon/references/skill-anatomy.md` — survey denominators (all **63**; run log **59 of 63**, the new skill writes a `memory/logs/` entry)

### CHANGELOG.md — entries the batch PRs didn't self-record
- [x] **Added** — `finance-district-mcp` new skill (#791)
- [x] **Fixed** — read-only skills ran in write mode on the MCP-server path; `wrap_raw_output` could fabricate a green run (#792)
- [x] **Security** — postcss override past `GHSA-r28c-9q8g-f849` (#783)
- [x] **Maintenance** — second 8-dimension code-quality sweep (#792)

### Bundled as maintenance (noise)
`#782` (drop dead `GROK_JSON_SCHEMA` knob), `#783` (postcss CVE bump), `#785` (run-grok.sh reduced to setup-only).

Re-running the sync with no new merged PRs produces no changes (idempotent).
