### PR TITLE
docs(mcp-oauth): add finance-district row to Current catalog table

### DIFF
--- a/docs/mcp-oauth.md
+++ b/docs/mcp-oauth.md
@@ -49,6 +49,7 @@ discovery notes) and their companion skills:
 | Robinhood Trading (`robinhood-trading`) | `agent.robinhood.com/mcp/trading` | *(default — no `offline_access`; it only advertises `internal`)* | unverified — assume yes | `robinhood-mcp` |
 | glim.sh (`glim`) | `glim.sh/mcp` | `openid offline_access` | yes — **verified live 2026-07-16** | `glim-mcp` |
 | Executor (`executor`) | `executor.sh/mcp` | `openid offline_access` | yes — **verified live 2026-07-16** | `executor-mcp` |
+| Finance District Agent Wallet (`finance-district`) | `wallet-mcp.fd.xyz` | `openid offline_access api://fd-agent-wallet-mcp/mcp:tools` (resource scope gates tool access) | yes | `finance-district-mcp` |
 
 The glim and Executor loops were verified end-to-end on a live instance
 (Connect → per-run refresh → PAT-persisted rotation → refresh off the persisted


### PR DESCRIPTION
## What

Adds the missing **Finance District Agent Wallet** row to the "Current catalog" table in `docs/mcp-oauth.md`.

The table listed Base, Robinhood, glim, and Executor, but not Finance District, even though it ships as a featured OAuth server and is already present in the README full catalog and `docs/CONFIGURATION.md`.

## Row values

Sourced from the single source of truth, `apps/dashboard/lib/mcp-catalog.ts`:

| Field | Value |
|---|---|
| Server (slug) | Finance District Agent Wallet (`finance-district`) |
| MCP URL | `wallet-mcp.fd.xyz` |
| Scopes | `openid offline_access api://fd-agent-wallet-mcp/mcp:tools` (resource scope gates tool access) |
| Rotates refresh token? | yes |
| Skill | `finance-district-mcp` |

The catalog comment notes `oauth.fd.xyz` rotates refresh tokens, so `GH_SECRETS_PAT` is required, which is consistent with the "every catalog provider rotates" note below the table. The resource scope is called out because, unlike glim/executor, this server gates tool access on it.

## Verification

- `node scripts/okf-validate.mjs` passes (OK, 104 concepts).
- No test asserts the contents of this table (`test_mcp_oauth_refresh.sh` covers the refresh script only).
