### PR TITLE
fix(ci): restore green after telegram owner-gate (#797)

### DIFF
--- a/apps/dashboard/lib/service-icons.ts
+++ b/apps/dashboard/lib/service-icons.ts
@@ -36,6 +36,7 @@ const DOMAINS: Record<string, string> = {
   // Channels
   TELEGRAM_BOT_TOKEN: 'telegram.org',
   TELEGRAM_CHAT_ID: 'telegram.org',
+  TELEGRAM_ALLOWED_USER_ID: 'telegram.org',
   DISCORD_BOT_TOKEN: 'discord.com',
   DISCORD_CHANNEL_ID: 'discord.com',
   DISCORD_WEBHOOK_URL: 'discord.com',

--- a/scripts/tests/test_notify.sh
+++ b/scripts/tests/test_notify.sh
@@ -89,7 +89,7 @@ ABS_NOTIFY="$ROOT/scripts/notify.sh"
 
 # 7. --buttons attaches an inline_keyboard to the Telegram payload
 reset
-TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 NOTIFY_DRY_RUN=1 \
+TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 AEON_MESSAGES_WF_STATE=active NOTIFY_DRY_RUN=1 \
   bash "$NOTIFY" "Alert body long enough to clear the probe filter here" \
   --buttons '[[{"text":"Snooze","callback_data":"snooze:x:y:60"}]]' >/dev/null 2>&1
 if [ -f "$WORK/tg-payload.jsonl" ] && \
@@ -101,7 +101,7 @@ fi
 
 # 8. --force-reply + --context set force_reply and prefix the [skill::intent] marker
 reset
-TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 NOTIFY_DRY_RUN=1 \
+TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 AEON_MESSAGES_WF_STATE=active NOTIFY_DRY_RUN=1 \
   bash "$NOTIFY" "Which repository should I track for you" \
   --force-reply --placeholder "owner/repo" --context "github-monitor::add-repo" >/dev/null 2>&1
 if [ -f "$WORK/tg-payload.jsonl" ] && \
@@ -142,7 +142,7 @@ rm -rf "$MK"
 
 # 12. a normal skill notification gets the global Run again + Schedule weekly row
 reset
-TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 NOTIFY_DRY_RUN=1 SKILL_NAME=token-movers \
+TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 AEON_MESSAGES_WF_STATE=active NOTIFY_DRY_RUN=1 SKILL_NAME=token-movers \
   bash "$NOTIFY" "A normal skill digest long enough to clear the probe filter here" >/dev/null 2>&1
 if [ -f "$WORK/tg-payload.jsonl" ] && \
    jq -e '.reply_markup.inline_keyboard[-1][0].callback_data=="run:token-movers"' "$WORK/tg-payload.jsonl" >/dev/null 2>&1 && \
@@ -154,7 +154,7 @@ fi
 
 # 13. skill --buttons rows are kept, with the global quick-action row appended beneath
 reset
-TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 NOTIFY_DRY_RUN=1 SKILL_NAME=pr-review \
+TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 AEON_MESSAGES_WF_STATE=active NOTIFY_DRY_RUN=1 SKILL_NAME=pr-review \
   bash "$NOTIFY" "Digest body long enough to clear the probe filter comfortably" \
   --buttons '[[{"text":"Open","url":"https://example.com"}]]' >/dev/null 2>&1
 if [ -f "$WORK/tg-payload.jsonl" ] && \
@@ -167,7 +167,7 @@ fi
 
 # 14. a force_reply prompt never carries inline buttons (mutual exclusivity), even with SKILL_NAME set
 reset
-TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 NOTIFY_DRY_RUN=1 SKILL_NAME=github-monitor \
+TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 AEON_MESSAGES_WF_STATE=active NOTIFY_DRY_RUN=1 SKILL_NAME=github-monitor \
   bash "$NOTIFY" "Which repository should I track for you now" \
   --force-reply --placeholder "owner/repo" --context "github-monitor::add-repo" >/dev/null 2>&1
 if [ -f "$WORK/tg-payload.jsonl" ] && \


### PR DESCRIPTION
## What

Main went red on the `fix(telegram): gate inbound on owner user` commit (#797). Two paired-spot misses, both fixed here.

### 1. ci-apps / dashboard - `service-icon.test.ts`
`TELEGRAM_ALLOWED_USER_ID` was added to the secret catalog with no row in the icon map, so it rendered as a grey initials badge and tripped the "every catalogued secret has a logo or glyph" invariant.

```
secrets missing an icon: TELEGRAM_ALLOWED_USER_ID
```

Fix: one line in `service-icons.ts` mapping it to `telegram.org`, next to `TELEGRAM_BOT_TOKEN` / `TELEGRAM_CHAT_ID`.

### 2. ci-tests / notify - `test_notify.sh`
The commit gated interactive buttons **and** force_reply on the inbound Messages workflow being active (`AEON_MESSAGES_WF_STATE`). Five pre-gating shape cases (#7, #8, #12, #13, #14) never set that env, so the live GitHub lookup suppressed the reply markup and the shape assertions failed:

```
FAIL - --buttons attaches inline_keyboard
FAIL - --force-reply + --context set marker and force_reply
FAIL - global Run again + Schedule weekly buttons attached
FAIL - custom --buttons kept + global row appended
FAIL - force_reply prompt carries no inline buttons
```

Fix: set `AEON_MESSAGES_WF_STATE=active` on those five, mirroring the sibling active case (15d). Gating logic is untouched - its own cases (15b-15e) still cover disabled / active / force-override.

## Verify
- `bash scripts/tests/test_notify.sh` -> ALL PASS
- `node --import tsx --test apps/dashboard/lib/service-icon.test.ts` -> green (`resolveServiceMark` ✔)
