### PR TITLE
feat(scheduler): auto-recovering circuit breaker for failing skills

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -77,3 +77,5 @@ jobs:
         run: node scripts/validate-config.js
       - name: cron-due scheduler decision tests
         run: bash scripts/tests/test_cron_due.sh
+      - name: circuit-breaker scheduler decision tests
+        run: bash scripts/tests/test_breaker.sh

--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -55,6 +55,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_GLOBAL || secrets.GITHUB_TOKEN }}
           STATE_BACKEND: ${{ vars.STATE_BACKEND }}
+          BREAKER_THRESHOLD_OVERRIDE: ${{ vars.BREAKER_THRESHOLD }}
+          BREAKER_COOLDOWN_OVERRIDE: ${{ vars.BREAKER_COOLDOWN_MIN }}
         run: |
           NOW_ISO=$(date -u +%FT%TZ)
           NOW_EPOCH=$(date -u +%s)
@@ -68,6 +70,21 @@ jobs:
           # 12h covers a bad half-day tick outage while staying same-day (a daily
           # skill's slots are 24h apart, so this can never double-fire). Tune here.
           CATCHUP_HOURS=12
+
+          # Circuit breaker: once a skill has failed BREAKER_THRESHOLD times in a
+          # row (consecutive_failures, folded by scripts/state_reduce.py), stop
+          # dispatching it every tick so a real outage (a dead upstream API, a
+          # revoked key) doesn't burn a run every */5 for hours. The breaker is
+          # auto-recovering, not a kill switch: while open it still lets ONE probe
+          # run through every BREAKER_COOLDOWN_MIN minutes (half-open). A probe
+          # that succeeds resets consecutive_failures to 0 and the skill resumes
+          # its normal schedule on the next tick; a probe that fails re-arms the
+          # cooldown. This supersedes the flat 30-min failed-skill retry below for
+          # skills that have crossed the threshold. skill-health already reports
+          # CRITICAL at consecutive_failures >= 3, so a tripped breaker is visible.
+          # Set BREAKER_THRESHOLD=0 to disable. Tune via repo vars if desired.
+          BREAKER_THRESHOLD="${BREAKER_THRESHOLD_OVERRIDE:-3}"
+          BREAKER_COOLDOWN_MIN="${BREAKER_COOLDOWN_OVERRIDE:-360}"
 
           # (Cron matching + the due/skip decision live in scripts/cron-due.sh,
           # called by both the per-skill and per-chain loops below.)
@@ -171,6 +188,27 @@ jobs:
             LAST_DISPATCH=$(echo "$STATE" | jq -r --arg s "$SKILL" '.[$s].last_dispatch // "1970-01-01T00:00:00Z"')
             LAST_DISPATCH_EPOCH=$(date -u -d "$LAST_DISPATCH" +%s 2>/dev/null || echo 0)
             MINUTES_SINCE=$(( (NOW_EPOCH - LAST_DISPATCH_EPOCH) / 60 ))
+
+            # --- Circuit breaker (auto-recovering) ---
+            # A skill that has failed BREAKER_THRESHOLD+ times in a row is likely
+            # hitting an outage, not a one-off. scripts/breaker.sh decides whether
+            # to skip it this tick (open) or let one probe through (half-open) so a
+            # real outage can't burn a run every */5 for hours. A successful probe
+            # resets consecutive_failures (state_reduce.py), closing the breaker so
+            # the normal schedule resumes next tick. This gate sits before both the
+            # 30-min retry and cron matching, so once tripped it governs the skill
+            # until it recovers. BREAKER_THRESHOLD=0 disables it (breaker.sh returns
+            # "closed"). The decision logic is the script's, not inlined here.
+            CONSEC=$(echo "$STATE" | jq -r --arg s "$SKILL" '.[$s].consecutive_failures // 0')
+            case "$(bash scripts/breaker.sh "$CONSEC" "$MINUTES_SINCE" "$BREAKER_THRESHOLD" "$BREAKER_COOLDOWN_MIN")" in
+              probe)
+                echo "Circuit breaker HALF-OPEN: $SKILL ($CONSEC consecutive failures) — probing after ${MINUTES_SINCE}m"
+                MATCHED+=("$SKILL")
+                continue ;;
+              open)
+                echo "Circuit breaker OPEN: $SKILL ($CONSEC consecutive failures) — skip, next probe in $(( BREAKER_COOLDOWN_MIN - MINUTES_SINCE ))m"
+                continue ;;
+            esac
 
             # --- Retry failed skills (after 30 min cooldown) ---
             if [ "$LAST_STATUS" = "failed" ] && [ "$MINUTES_SINCE" -ge 30 ]; then

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -48,6 +48,19 @@ schedule:
 
 Claude only installs and runs when a skill actually matches - non-matching ticks cost ~10s.
 
+## Circuit breaker (outage protection)
+
+The scheduler trips a per-skill circuit breaker once a skill logs **3 consecutive failures** (`consecutive_failures` in `memory/cron-state.json`). While tripped it stops dispatching that skill every tick - so a dead upstream API or a revoked key can't burn a run every `*/5` for hours - and instead lets **one probe run through every 6 hours** (half-open). A probe that succeeds resets the counter and the skill resumes its normal schedule automatically; a probe that fails re-arms the 6h cooldown. It is auto-recovering, not a kill switch, so an outage self-heals with no operator action. `skill-health` already reports CRITICAL at the same threshold, so a tripped breaker is visible.
+
+Tune with repo variables (both optional):
+
+```
+BREAKER_THRESHOLD      failures in a row before tripping (default 3; 0 disables)
+BREAKER_COOLDOWN_MIN   minutes between half-open probes while tripped (default 360)
+```
+
+The decision logic lives in `scripts/breaker.sh` (unit-tested in `scripts/tests/test_breaker.sh`); the scheduler calls it, no inline copy. To hard-disable a skill instead, set `enabled: false` in `aeon.yml`.
+
 ## Capability tiers (read-only skills)
 
 A skill declares its write blast-radius in SKILL.md frontmatter:

--- a/scripts/breaker.sh
+++ b/scripts/breaker.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# breaker.sh — auto-recovering circuit breaker for the scheduler.
+#
+# A skill that has failed THRESHOLD times in a row (consecutive_failures, folded
+# by scripts/state_reduce.py) is almost certainly hitting an outage — a dead
+# upstream API, a revoked key — not a one-off. Left alone, the scheduler's flat
+# 30-min failed-skill retry re-runs it every few ticks for hours, burning a run
+# each time to fail the same way. This breaker stops that.
+#
+# It is auto-recovering, NOT a kill switch:
+#   CLOSED    consecutive_failures < THRESHOLD → normal dispatch path.
+#   OPEN      >= THRESHOLD and last dispatch < COOLDOWN_MIN ago → skip this tick.
+#   HALF-OPEN >= THRESHOLD and last dispatch >= COOLDOWN_MIN ago → allow ONE probe.
+# A probe that succeeds resets consecutive_failures to 0 (state_reduce.py), so the
+# breaker is CLOSED again next tick and the skill resumes its normal schedule. A
+# probe that fails re-arms the cooldown. Net cost while an outage persists: one
+# run per COOLDOWN_MIN instead of one per retry window.
+#
+# This is the single source of the breaker decision; scheduler.yml calls it (no
+# inline copy), the same contract cron-due.sh follows.
+#
+# Usage:
+#   breaker.sh <consecutive_failures> <minutes_since_last_dispatch> [threshold] [cooldown_min]
+#
+# Prints exactly one decision token to stdout: closed | probe | open
+#   closed → caller falls through to its normal retry/cron matching
+#   probe  → caller dispatches a single half-open trial run
+#   open   → caller skips the skill this tick
+# THRESHOLD=0 disables the breaker (always prints "closed").
+set -euo pipefail
+
+CONSEC="${1:?consecutive_failures required}"
+MINUTES_SINCE="${2:?minutes_since_last_dispatch required}"
+THRESHOLD="${3:-3}"
+COOLDOWN_MIN="${4:-360}"
+
+# Disabled, or not yet tripped → normal path.
+if [ "$THRESHOLD" -le 0 ] || [ "$CONSEC" -lt "$THRESHOLD" ]; then
+  echo closed
+  exit 0
+fi
+
+# Tripped: one probe per cooldown, otherwise stay open.
+if [ "$MINUTES_SINCE" -ge "$COOLDOWN_MIN" ]; then
+  echo probe
+else
+  echo open
+fi

--- a/scripts/tests/test_breaker.sh
+++ b/scripts/tests/test_breaker.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Tests for scripts/breaker.sh — the auto-recovering circuit-breaker decision.
+# Run:  bash scripts/tests/test_breaker.sh
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/breaker.sh"
+
+pass=0; fail=0
+# check <desc> <consecutive_failures> <minutes_since> <threshold> <cooldown_min> <expect: closed|probe|open>
+check() {
+  local desc="$1" consec="$2" mins="$3" thr="$4" cool="$5" expect="$6" out
+  out=$(bash "$SCRIPT" "$consec" "$mins" "$thr" "$cool" 2>/dev/null || echo "ERR")
+  if [ "$out" = "$expect" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1)); printf 'FAIL: %-38s got=%-6s want=%-6s\n' "$desc" "$out" "$expect"
+  fi
+}
+
+# --- closed: below threshold, normal path ---
+check "zero failures"                  0  10   3 360 closed
+check "one below threshold"            2  10   3 360 closed
+check "one below threshold, old"       2  9999 3 360 closed
+
+# --- tripped: at/above threshold ---
+check "at threshold, fresh dispatch"   3  10   3 360 open
+check "above threshold, fresh"         7  30   3 360 open
+check "at threshold, cooldown not up"  3  359  3 360 open
+check "at threshold, cooldown exactly" 3  360  3 360 probe
+check "at threshold, cooldown passed"  3  700  3 360 probe
+check "way above, cooldown passed"     9  1000 3 360 probe
+
+# --- threshold tuning ---
+check "custom threshold 5, below"      4  10   5 360 closed
+check "custom threshold 5, at"         5  10   5 360 open
+check "custom threshold 5, probe"      5  400  5 360 probe
+
+# --- cooldown tuning ---
+check "short cooldown, still open"     3  59   3 60  open
+check "short cooldown, probe"          3  60   3 60  probe
+
+# --- disabled (threshold 0) always closed ---
+check "disabled, high failures"        50 0    0 360 closed
+check "disabled, negative guard"       50 0   -1 360 closed
+
+echo "---"
+echo "PASS: $pass   FAIL: $fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What

Adds an auto-recovering **circuit breaker** to the scheduler. A skill that fails 3 times in a row (`consecutive_failures`) stops being dispatched every `*/5`, so an outage - a dead upstream API, a revoked key - can't burn a run every tick for hours.

## Why

Today the scheduler's flat 30-min failed-skill retry (`scheduler.yml`) re-fires a failing skill every few ticks indefinitely. During a real outage that is pure wasted compute: it fails the same way each time.

## How

`scripts/breaker.sh` returns one of `closed | probe | open`:

- **closed** (`consecutive_failures < threshold`) - normal path, no change.
- **open** (`>= threshold`, within cooldown) - skip this tick.
- **probe** (`>= threshold`, cooldown elapsed) - half-open: allow ONE trial run.

A probe that succeeds resets `consecutive_failures` (via `state_reduce.py` / `apply_state_update`), closing the breaker so the normal schedule resumes on the next tick. A probe that fails re-arms the cooldown. Net cost while an outage persists: one run per cooldown (default 6h) instead of one per retry window.

The gate sits in the `Match skills` loop **before** the 30-min retry and cron matching, so once tripped it governs the skill until recovery. It reuses the existing `consecutive_failures` field - no writer change - and mirrors the `cron-due.sh` contract (decision logic in the script, no inline copy in the workflow).

Auto-recovering by design, not a kill switch. For a hard disable, `enabled: false` in `aeon.yml` still applies. `skill-health` already reports CRITICAL at the same threshold, so a tripped breaker is visible with no new notification path.

## Config (repo vars, both optional)

```
BREAKER_THRESHOLD      failures in a row before tripping (default 3; 0 disables)
BREAKER_COOLDOWN_MIN   minutes between half-open probes while tripped (default 360)
```

## Tests

- `scripts/tests/test_breaker.sh` - 16 cases (closed/open/probe boundaries, threshold + cooldown tuning, disabled), all pass. Registered in `ci-tests.yml`.
- `actionlint` on `scheduler.yml`: no new issues.

## Files

- `scripts/breaker.sh` (new)
- `scripts/tests/test_breaker.sh` (new)
- `.github/workflows/scheduler.yml`
- `.github/workflows/ci-tests.yml`
- `docs/CONFIGURATION.md`
