### PR TITLE
docs: sync PRs #793-#803 to aeon docs

### DIFF
--- a/.claude/skills/aeon/SKILL.md
+++ b/.claude/skills/aeon/SKILL.md
@@ -248,7 +248,7 @@ requires: [SOME_API_KEY?]
 Today is ${today}. <the prompt — plain instructions, including judgment calls>
 
 ## Steps
-1. <the procedure — 41 of 63 skills lead with this>
+1. <the procedure — 43 of 65 skills lead with this>
 
 ## Network note
 <curl / WebFetch / `./secretcurl` / `gh api` — how this skill fetches>
@@ -308,9 +308,9 @@ Three at a time, not twelve. Every enabled skill is a recurring notification, an
 ./aeon packs ls                  # the six first-party packs
 ```
 
-`ls` footers with `63 skills · 1 enabled` — read it to them before proposing anything. First run installs the CLI runtime (tsx + yaml, ~12MB); the npm noise is one-time and expected. Grep-only equivalents: `references/layout.md`.
+`ls` footers with `65 skills · 1 enabled` — read it to them before proposing anything. First run installs the CLI runtime (tsx + yaml, ~12MB); the npm noise is one-time and expected. Grep-only equivalents: `references/layout.md`.
 
-Packs are a visibility filter, not a runtime switch — revealing one runs nothing. Core (11), Evolution (8) and Basics (15) show by default; Dev (8), Crypto (13) and Productivity (8) are on demand.
+Packs are a visibility filter, not a runtime switch — revealing one runs nothing. Core (11), Evolution (8) and Basics (15) show by default; Dev (10), Crypto (13) and Productivity (8) are on demand.
 
 Reasonable starting sets:
 

--- a/.claude/skills/aeon/references/layout.md
+++ b/.claude/skills/aeon/references/layout.md
@@ -12,7 +12,7 @@ Where everything lives in an Aeon repo, and the fastest way to see what's on.
 ./aeon skills ls --enabled --json # for building the Mode 2 timeline
 ```
 
-`ls` prints `SKILL / ON / SCHEDULE / PACK / DESCRIPTION` and a footer — `63 skills · 1 enabled`. First run installs the CLI runtime (tsx + yaml, ~12MB, one-time); the noise is expected.
+`ls` prints `SKILL / ON / SCHEDULE / PACK / DESCRIPTION` and a footer — `65 skills · 1 enabled`. First run installs the CLI runtime (tsx + yaml, ~12MB, one-time); the noise is expected.
 
 **The `SCHEDULE` column is populated for disabled skills too** — it's their `aeon.yml` entry, not proof anything fires. Only the `●` in `ON` means it runs.
 

--- a/.claude/skills/aeon/references/mcp.md
+++ b/.claude/skills/aeon/references/mcp.md
@@ -7,7 +7,7 @@ Two unrelated things share the name. Get this wrong and nothing works.
 | | |
 |---|---|
 | **`.mcp.json`** — *external MCP servers, called BY Aeon skills* | Wired via the dashboard MCP panel or `./aeon mcp add`. This is what you want when a skill needs a tool. |
-| **`bin/add-mcp`** — *Aeon itself AS an MCP server* | Builds `apps/mcp-server` and registers it with Claude Code / Desktop, so all 63 skills appear as `aeon-*` tools **in your local Claude**. Nothing to do with a skill calling out. |
+| **`bin/add-mcp`** — *Aeon itself AS an MCP server* | Builds `apps/mcp-server` and registers it with Claude Code / Desktop, so all 65 skills appear as `aeon-*` tools **in your local Claude**. Nothing to do with a skill calling out. |
 
 The rest of this doc is the first one. For the second: `bin/add-mcp`, `--desktop` for a Claude Desktop snippet, `--uninstall` to remove, `claude mcp list` to verify.
 

--- a/.claude/skills/aeon/references/skill-anatomy.md
+++ b/.claude/skills/aeon/references/skill-anatomy.md
@@ -1,10 +1,10 @@
 # How Aeon skills are actually written
 
-Surveyed across all 63 skills in `aeonfun/aeon`. Frequencies are real counts — match the dominant convention unless there's a reason not to. Bodies run 133–757 lines (~306 median); a skill is a prompt, not a config file, and reads as prose.
+Surveyed across all 65 skills in `aeonfun/aeon`. Frequencies are real counts — match the dominant convention unless there's a reason not to. Bodies run 133–757 lines (~306 median); a skill is a prompt, not a config file, and reads as prose.
 
 ## Frontmatter
 
-Universal — **all 63 skills** carry these five:
+Universal — **all 65 skills** carry these five:
 
 ```yaml
 type: Skill          # required by ci-okf; every .md under skills/ needs a type:
@@ -88,7 +88,7 @@ var=<value>
 
 ## Calling external scripts
 
-**These do not exist in the repo.** The workflow copies them to the repo root before each run (`.github/workflows/aeon.yml:435-444`), which is why `ls` shows no `notify` but 57 skills call `./notify`. Don't "fix" the missing file, and don't expect them locally.
+**These do not exist in the repo.** The workflow copies them to the repo root before each run (`.github/workflows/aeon.yml:435-444`), which is why `ls` shows no `notify` but 61 skills call `./notify`. Don't "fix" the missing file, and don't expect them locally.
 
 | Call | Skills | Notes |
 |---|---|---|
@@ -114,7 +114,7 @@ There is **no network sandbox** — plain `curl` works for unauthenticated GETs.
 
 `memory/` is the durable state that survives between runs. Four conventions, in order of how often skills touch them:
 
-### `memory/logs/${today}.md` — the run log (59 of 63 skills)
+### `memory/logs/${today}.md` — the run log (61 of 65 skills)
 
 Every skill appends what it did, under **one** heading that is exactly its slug:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Added
 
+- **New skills: `seo-audit` + `posthog-errors`** - a daily on-page and technical
+  SEO audit of every page on a site (sitemap-first discovery, per-page scoring,
+  cross-page checks for duplicate titles/canonicals/sitemap gaps, day-over-day
+  diff, and a standing `FIXES.md` work list), and a weekly cross-project PostHog
+  error digest over the PostHog MCP server (ranks issues by impact across every
+  project the OAuth grant covers, flags new vs ongoing, links a full committed
+  report). PostHog joins the featured MCP servers with one-click dashboard
+  Connect (a sixth `MCP_CATALOG` entry). Both `dev` pack, disabled by default;
+  brings the catalog to **65 skills** (63 -> 65). (#802)
+- **Auto-recovering circuit breaker for failing skills** - the scheduler now
+  trips a breaker on a skill that fails repeatedly, pausing it and auto-recovering
+  once it succeeds again, so one broken skill cannot burn every run. (#801)
 - **New skill: `finance-district-mcp`** — a multichain non-custodial agent
   wallet over MCP (contributed by @raul1stdigital). Checks balances and prices,
   discovers the best DeFi yields, swaps, moves funds, and makes x402 paid API
@@ -49,6 +61,12 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Changed
 
+- **Dashboard catalogs the `PAGESPEED_API_KEY` secret** - seo-audit's optional
+  Core Web Vitals key now appears in the Skill Keys group with its brand icon and
+  where-to-get-it copy, instead of a bare initials-badge catch-all row. (#803)
+- **Docs: MCP catalog drift fixed and harness framing flattened** - plus a README
+  catalog drift-guard and a `finance-district` row added to the mcp-oauth catalog
+  table. (#794, #796)
 - **Secret rename** — `BASESCAN_KEY` → `BASESCAN_API_KEY`, to follow the
   `<PROVIDER>_API_KEY` convention every sibling explorer/provider key uses.
   Operators who set the old secret should re-add it under the new name (or rely
@@ -62,6 +80,9 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Fixed
 
+- **`finance-district-mcp` registered in `aeon.yml`.** The skill shipped in #791
+  but had no schedule entry, so it never ran; it is now present (disabled by
+  default). (#800)
 - **Read-only skills ran in write mode on the MCP-server path.**
   `apps/mcp-server`'s `skill-executor.ts` hardcoded `--mode write` and never
   consulted `scripts/skill_mode.sh`, so all twelve `mode: read-only` skills ran
@@ -290,12 +311,18 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Security
 
+- **Telegram inbound gated on the owner's user ID.** In a group or public chat
+  any member could command the bot by tapping a button; inbound is now restricted
+  to `TELEGRAM_ALLOWED_USER_ID` (defaults to the chat ID for a 1:1 DM), failing
+  closed otherwise. (#797)
 - Patched two high-severity CVE classes in the dashboard — `sharp`/`libvips`,
   and Next.js `16.2.10 → 16.2.11`. (#758, #759)
 - Bumped the dashboard `postcss` override past `GHSA-r28c-9q8g-f849`. (#783)
 
 ### Maintenance
 
+- CI green-up after the Telegram owner-gate, plus a dashboard PacksPanel
+  unique-key fix. (#798, #799)
 - Repo-wide cleanup pass across 8 dimensions (dead code, weak types,
   duplication, circular deps). (#757)
 - Second code-quality sweep across the dashboard, CLI, mcp-server, and

--- a/docs/aeon-setup.md
+++ b/docs/aeon-setup.md
@@ -10,7 +10,7 @@ Aeon ships an **[Agent Skill](https://code.claude.com/docs/en/skills)** (`SKILL.
 
 It's a portable skill, not tied to one product: [Claude Code](https://claude.com/claude-code) is the primary host (it auto-loads skills from `.claude/skills/`, so it's zero-install there), but the skill is just a `SKILL.md` in the open Agent Skills format — it works with **Claude Code, Codex, Hermes, or OpenClaw**, and any other agent tool that supports skills.
 
-> **This is not an Aeon skill.** The 63 skills under [`skills/`](../skills) run unattended on GitHub Actions. **This** one runs inside *your* agent session on *your* machine — it's the operator's assistant for configuring the instance, not something that runs on a schedule. It doesn't appear in `aeon.yml`, the packs, or the catalog.
+> **This is not an Aeon skill.** The 65 skills under [`skills/`](../skills) run unattended on GitHub Actions. **This** one runs inside *your* agent session on *your* machine — it's the operator's assistant for configuring the instance, not something that runs on a schedule. It doesn't appear in `aeon.yml`, the packs, or the catalog.
 
 ## What it does
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,6 +1,6 @@
 # Aeon integration examples
 
-Aeon ships an [MCP server](../apps/mcp-server/) so any Claude client can call its 63 skills. The scripts here are the shortest possible "first call works" demos — build the server, run `python <file>`, get a real Aeon output back.
+Aeon ships an [MCP server](../apps/mcp-server/) so any Claude client can call its 65 skills. The scripts here are the shortest possible "first call works" demos — build the server, run `python <file>`, get a real Aeon output back.
 
 | File | Stack | Skill called | What it shows |
 |------|-------|--------------|---------------|

--- a/docs/skill-packs.md
+++ b/docs/skill-packs.md
@@ -4,7 +4,7 @@ type: Reference
 
 # Skill packs
 
-Aeon ships **63 skills**, but most forks only ever run a handful. Packs make
+Aeon ships **65 skills**, but most forks only ever run a handful. Packs make
 that manageable: by default the dashboard shows **Core** (what makes Aeon
 different) and **Basics** (simple skills you can run right now) — everything else
 is grouped into **packs** that stay hidden until you enable them.


### PR DESCRIPTION
Doc sync for the merged batch **#793-#803** (source of truth: merged PRs on `aeonfun/aeon`).

## Changelog
`CHANGELOG.md` `[Unreleased]` gains the batch, grouped Keep-a-Changelog style:
- **Added:** seo-audit + posthog-errors skills + PostHog featured MCP (#802); auto-recovering circuit breaker (#801)
- **Changed:** dashboard catalogs `PAGESPEED_API_KEY` (#803); MCP catalog drift / harness framing / README drift-guard / mcp-oauth finance-district row (#794, #796)
- **Fixed:** `finance-district-mcp` registered in `aeon.yml` (#800)
- **Security:** Telegram inbound gated on owner user ID (#797)
- **Maintenance:** CI green-up + PacksPanel unique keys (#798, #799)

## Skill-count propagation (63 -> 65)
#802 bumped the README to 65 but left "63" in several current-state surfaces. Fixed here:
- `docs/aeon-setup.md`, `docs/skill-packs.md`, `docs/examples/README.md`
- in-repo `/aeon` setup skill: `.claude/skills/aeon/SKILL.md` + `references/{skill-anatomy,layout,mcp}.md` (footer `65 skills · 1 enabled`, per-category `Dev (10)`)
- skill-anatomy survey stats re-derived against the live 65 skills: lead-with-`## Steps` 43, `./notify` 61, run-log 61, all-carry 65

## Not documented
- **#793** was the previous batch's own aeon-side sync (docs for #778-#792, already reflected) - not re-documented.
- The optional-field frequency sub-table in skill-anatomy (`var`/`mode`/`requires`/...) carries pre-existing drift unrelated to this batch; left untouched to keep the sync scoped to the count fact.

New watermark: **#803**.
