### PR TITLE
docs: sync PRs #804-#805 to aeon docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Added
 
+- **New skill: `deploy-uni-hook`** - turns a one-line brief into a live Uniswap
+  v4 hook + test pool on any v4 chain. Generates from a pre-audited template
+  (`dynamic`/`noop`/`skim`) or a from-scratch freeform hook, auto-derives the
+  hook-address flag bits (CREATE2-mined), and gates every deploy behind a static
+  audit, a dangerous-pattern scan, a behavioral `forge` test, and a fork
+  simulation. Dry-run by default; an explicit `arm:` broadcasts. Testnet-only
+  unless `arm:` + an explicit `chain:` + a `HOOK_MAINNET_OK=1` lock all line up
+  (a mainnet triple-lock). Foundry + a built v4 project are staged in a workflow
+  step; the deploy receipt and best-effort explorer verification round it out.
+  `crypto` pack, Opus-pinned, disabled by default; brings the catalog to
+  **66 skills** (65 -> 66). (#805)
 - **New skills: `seo-audit` + `posthog-errors`** - a daily on-page and technical
   SEO audit of every page on a site (sitemap-first discovery, per-page scoring,
   cross-page checks for duplicate titles/canonicals/sitemap gaps, day-over-day

--- a/docs/aeon-setup.md
+++ b/docs/aeon-setup.md
@@ -10,7 +10,7 @@ Aeon ships an **[Agent Skill](https://code.claude.com/docs/en/skills)** (`SKILL.
 
 It's a portable skill, not tied to one product: [Claude Code](https://claude.com/claude-code) is the primary host (it auto-loads skills from `.claude/skills/`, so it's zero-install there), but the skill is just a `SKILL.md` in the open Agent Skills format — it works with **Claude Code, Codex, Hermes, or OpenClaw**, and any other agent tool that supports skills.
 
-> **This is not an Aeon skill.** The 65 skills under [`skills/`](../skills) run unattended on GitHub Actions. **This** one runs inside *your* agent session on *your* machine — it's the operator's assistant for configuring the instance, not something that runs on a schedule. It doesn't appear in `aeon.yml`, the packs, or the catalog.
+> **This is not an Aeon skill.** The 66 skills under [`skills/`](../skills) run unattended on GitHub Actions. **This** one runs inside *your* agent session on *your* machine — it's the operator's assistant for configuring the instance, not something that runs on a schedule. It doesn't appear in `aeon.yml`, the packs, or the catalog.
 
 ## What it does
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,6 +1,6 @@
 # Aeon integration examples
 
-Aeon ships an [MCP server](../apps/mcp-server/) so any Claude client can call its 65 skills. The scripts here are the shortest possible "first call works" demos — build the server, run `python <file>`, get a real Aeon output back.
+Aeon ships an [MCP server](../apps/mcp-server/) so any Claude client can call its 66 skills. The scripts here are the shortest possible "first call works" demos — build the server, run `python <file>`, get a real Aeon output back.
 
 | File | Stack | Skill called | What it shows |
 |------|-------|--------------|---------------|

--- a/docs/skill-packs.md
+++ b/docs/skill-packs.md
@@ -4,7 +4,7 @@ type: Reference
 
 # Skill packs
 
-Aeon ships **65 skills**, but most forks only ever run a handful. Packs make
+Aeon ships **66 skills**, but most forks only ever run a handful. Packs make
 that manageable: by default the dashboard shows **Core** (what makes Aeon
 different) and **Basics** (simple skills you can run right now) — everything else
 is grouped into **packs** that stay hidden until you enable them.
@@ -78,8 +78,8 @@ Pack key = category. Six packs, no empties; three are shown by default.
 | **Core** (`core`) | Fleet coordination, self-configuration, liveness, memory + reporting. Shown by default; not removable. | 11 |
 | **Evolution** (`evolution`) | The self-improvement loop — authors, evolves, installs, and heals its own skills. Shown by default. | 8 |
 | **Basics** (`basics`) | Simple, immediately-runnable skills — one approachable entry per area. Shown by default. | 15 |
-| **Dev & Code** (`dev`) | PR/issue triage, review, merges, changelogs, repo monitoring, security scanning, app deploys. | 8 |
-| **Crypto & Markets** (`crypto`) | Token/DeFi/prediction-market monitoring, narrative tracking, on-chain forensics + automation. | 13 |
+| **Dev & Code** (`dev`) | PR/issue triage, review, merges, changelogs, repo monitoring, security scanning, app deploys. | 10 |
+| **Crypto & Markets** (`crypto`) | Token/DeFi/prediction-market monitoring, narrative tracking, on-chain forensics + automation, Uniswap v4 hook deploys. | 14 |
 | **Productivity** (`productivity`) | Personal + social ops: routines, ideas, retrospectives, mentions, replies, ads, email, OKF housekeeping. | 8 |
 
 ### Core + Evolution + Basics — what a fresh fork shows


### PR DESCRIPTION
Propagates merged `aeonfun/aeon` PRs **#804–#805** to the aeon repo docs. Watermark was #803.

## Synced (1 signal)
- **#805 `feat: deploy-uni-hook`** — new crypto-pack skill (generate/audit/simulate/deploy a Uniswap v4 hook + test pool from a brief). Catalog **65 → 66 skills**.

## Skipped
- **#804** — the previous batch's own aeon-side docs sync (#793–#803). No new capability; not narrated.

## Surfaces changed
- [ ] `CHANGELOG.md` — new `[Unreleased] → Added` entry for `deploy-uni-hook` (catalog 65 → 66).
- [ ] `docs/skill-packs.md` — total **65 → 66**, Crypto pack **13 → 14**, and Dev pack **8 → 10** (a stale count carried over from #802 that left the table summing to 63 while its header said 65 — corrected so the per-pack counts sum to the total).
- [ ] `docs/aeon-setup.md` — "65 skills" → "66 skills".
- [ ] `docs/examples/README.md` — "65 skills" → "66 skills".

Website docs sync is a separate PR on `aaronjmars/aeon-website`.
