### PR TITLE
catalog: register AI2Human Create Task skill pack

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -165,7 +165,7 @@ Aeon's skills ship to production. These numbers are live at **[aeon.fun](https:/
 |-------|---------------|
 | **`vuln-scanner`** | **~1.6M GitHub stars secured** - real vulnerabilities found, patched, and responsibly disclosed across 54 open-source projects (31 rated High/Critical). [Every disclosure →](https://www.aeon.fun/security) |
 | **ecosystem** | **72 products & agents** built on Aeon. [`ECOSYSTEM.md`](../docs/ECOSYSTEM.md) |
-| **community** | **10 community skill packs** published to the registry. [`community-skill-packs.md`](../docs/community-skill-packs.md) |
+| **community** | **11 community skill packs** published to the registry. [`community-skill-packs.md`](../docs/community-skill-packs.md) |
 
 **One skill, end to end.** `vuln-scanner` clones a repo from your watchlist, runs Semgrep, OSV, and TruffleHog, then triages the hits hard - a finding ships only if it's exploitable, not theoretical, and you'd defend it to the maintainer's face. Most are discarded. What survives becomes a maintainer-ready report, sent through the repo's private advisory channel with a proposed patch pushed to your fork for the maintainer to cherry-pick. That loop, run across the open-source wild, is what the numbers above are made of.
 
@@ -322,6 +322,7 @@ Either way the installer reads the pack's `skills-pack.json` manifest, runs the 
 | [Polymarket Trader by Simmer](https://github.com/SpartanLabsXyz/aeon-skill-pack-polymarket/tree/main/aeon-skill-pack) (`--path aeon-skill-pack`) | 3 | Signal, discovery, and real order-placing on Polymarket (simulate-by-default, live opt-in). |
 | [Charon for AEON](https://github.com/CharonAI-code/charon/tree/main/skills/aeon) (`--path skills/aeon`) | 2 | Repo-local policy enforcement for AEON runs, with natural-language policy management. |
 | [aeon-skill-pack-agentlink](https://github.com/techdigger/aeon-skill-pack-agentlink) | 1 | Verified, human-backed on-chain identity on Base via AgentLink. Read-only, on-demand. |
+| [AI2Human Create Task](https://github.com/richard7463/ai2human-aeon-skill-pack) | 1 | Route a blocked human step to AI2Human: dispatch human execution, then follow the proof, verify, settle loop before USDC payout. |
 
 **To list a pack here**, open a PR that adds a table row **and** a matching [`catalog/skill-packs.json`](../catalog/skill-packs.json) entry. The full checklist - public repo + license, a per-skill `SKILL.md`, a `skills-pack.json` manifest, the registry schema, and the trust model - is in [`docs/community-skill-packs.md`](../docs/community-skill-packs.md#pack-maintainers-publishing-checklist).
 

--- a/catalog/skill-packs.json
+++ b/catalog/skill-packs.json
@@ -200,8 +200,8 @@
     },
     {
       "repo": "richard7463/ai2human-aeon-skill-pack",
-      "name": "AI2Human Human Fallback",
-      "description": "Human fallback for Aeon - dispatch blocked human steps to AI2Human and follow proof -> verify -> settle.",
+      "name": "AI2Human Handoff",
+      "description": "Human execution for Aeon - dispatch blocked human steps to AI2Human and follow proof -> verify -> settle.",
       "author": "richard7463",
       "license": "MIT",
       "homepage": "https://ai2human.io",

--- a/catalog/skill-packs.json
+++ b/catalog/skill-packs.json
@@ -200,7 +200,7 @@
     },
     {
       "repo": "richard7463/ai2human-aeon-skill-pack",
-      "name": "AI2Human Handoff",
+      "name": "AI2Human Create Task",
       "description": "Human execution for Aeon - dispatch blocked human steps to AI2Human and follow proof -> verify -> settle.",
       "author": "richard7463",
       "license": "MIT",

--- a/catalog/skill-packs.json
+++ b/catalog/skill-packs.json
@@ -209,6 +209,13 @@
       "trust_level": "community",
       "skills": [
         "ai2human-handoff"
+      ],
+      "secrets_required": [
+        "AI2HUMAN_AGENT_KEY"
+      ],
+      "capabilities": [
+        "external_api",
+        "sends_notifications"
       ]
     }
   ]

--- a/catalog/skill-packs.json
+++ b/catalog/skill-packs.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "updated": "2026-07-03",
+  "updated": "2026-08-03",
   "description": "Machine-readable registry of community skill packs installable via bin/install-skill-pack. Mirrors the human-readable table in README.md.",
   "packs": [
     {
@@ -196,6 +196,19 @@
         "read_only",
         "external_api",
         "sends_notifications"
+      ]
+    },
+    {
+      "repo": "richard7463/ai2human-aeon-skill-pack",
+      "name": "AI2Human Human Fallback",
+      "description": "Human fallback for Aeon - dispatch blocked human steps to AI2Human and follow proof -> verify -> settle.",
+      "author": "richard7463",
+      "license": "MIT",
+      "homepage": "https://ai2human.io",
+      "category": "crypto",
+      "trust_level": "community",
+      "skills": [
+        "ai2human-handoff"
       ]
     }
   ]


### PR DESCRIPTION
Register the AI2Human Create Task skill pack in the community registry so it appears in bin/install-skill-pack --list.

Pack: richard7463/ai2human-aeon-skill-pack - 1 skill (ai2human-handoff): create a human-execution task on AI2Human when an Aeon workflow hits a human gate (real social account action, local verification, signature, pickup, screenshot-backed proof), then follow task -> human execution -> proof -> verify -> settle.

Verified: security scan passes; install tested with bin/install-skill-pack richard7463/ai2human-aeon-skill-pack on a fresh upstream clone.