### PR TITLE
fix(finance-district-mcp): declare onchain_writes + correct notify -f usage

### DIFF
--- a/skills/finance-district-mcp/SKILL.md
+++ b/skills/finance-district-mcp/SKILL.md
@@ -7,7 +7,7 @@ description: Multichain non-custodial agent wallet via Finance District - check 
 var: ""
 tags: [crypto, wallet, mcp]
 mcp: [finance-district]
-capabilities: [external_api, writes_external_host, sends_notifications]
+capabilities: [external_api, writes_external_host, onchain_writes, sends_notifications]
 ---
 > **${var}** — what to do with the wallet. Empty → a daily wallet brief (balances + notable price moves + top stablecoin yield). Or a specific instruction, e.g. `best USDC yield on Base`, `swap 5 USDC to ETH on Base`, `pay <x402-url> for <data>`.
 
@@ -26,7 +26,7 @@ Wired by the dashboard MCP panel's one-click **Connect** (OAuth with `offline_ac
 2. **Prices / yield (when relevant)** — `getTokenPrice` for held tokens; note 24h moves over ±5%. `discoverYieldStrategies` for idle stablecoins (EVM only) — surface the top option (protocol, APY, TVL) as a suggestion. Never deposit unless the task explicitly asks.
 3. **Act only on explicit instruction** — transfers, swaps, yield deposits, and x402 payments move real value. Do exactly what `${var}` asks, nothing more; sequence any irreversible action last, fail-closed. Amounts above the auto-approve threshold are rejected by the wallet — report that, never try to work around it.
 4. **x402 paid calls** — follow the 402 flow (authorize within caps; gasless for the payer via EIP-3009).
-5. **Notify** once via `./notify -f`, and **log** to `memory/logs/${today}.md`. Every value-moving action (transfer, swap, deposit, x402 payment) goes in **both** — the notification is the operator's only guaranteed record, so a payment that isn't in it effectively went unreported:
+5. **Notify** once via `./notify -f <file>`, and **log** to `memory/logs/${today}.md`. Every value-moving action (transfer, swap, deposit, x402 payment) goes in **both** — the notification is the operator's only guaranteed record, so a payment that isn't in it effectively went unreported:
 
    ```
    ### finance-district-mcp


### PR DESCRIPTION
Two-line fix in `skills/finance-district-mcp/SKILL.md`, from a pre-public review pass on the Finance District MCP repo. Both verified against this repo.

### 1. Declare `onchain_writes`
```diff
-capabilities: [external_api, writes_external_host, sends_notifications]
+capabilities: [external_api, writes_external_host, onchain_writes, sends_notifications]
```
The skill signs and broadcasts transfers, swaps, and x402 payments. `docs/CAPABILITIES.md` defines `onchain_writes` as exactly that ("Signs and broadcasts blockchain transactions... can move funds"), and `skills/distribute-tokens/SKILL.md` already declares the same set. Operators should see the honest risk class from day one.

### 2. Correct `notify -f` usage
```diff
-5. **Notify** once via `./notify -f`, and **log** to ...
+5. **Notify** once via `./notify -f <file>`, and **log** to ...
```
`scripts/notify.sh` `-f`/`--file`/`--body` requires an existing file path and errors otherwise (`notify: -f requires an existing file path`). The bare `./notify -f` would fail.

No catalog regen needed: `catalog/skills.json` / `packs.json` carry no `capabilities` field, and `ci-skills-json` normalizes out the per-skill `sha`/`updated` churn.

---

**Separate follow-up (not in this PR, flagged for after the announcement):** `docs/CONFIGURATION.md` says read-only's post-run guard preserves `memory/` + `output/`, but `harness-adapter/lib/sandbox.sh` ro-binds the whole workspace (`--ro-bind "$ws" "$ws"` on Linux, `deny file-write* (subpath "$ws")` on macOS) with no carve-out. `memory/` and `output/` are inside the workspace, so under the OS sandbox (now all six harnesses) a read-only skill (glim, robinhood, finance-district) physically can't write its own `memory/logs` or topic notes during the run - the daily log stub the guard writes on its behalf lands, but the skill's own writes are silently refused. Worth a look; leaving it out of this fix since it needs a design decision, not a one-liner.
