### PR TITLE
docs: correct read-only persistence contract (sandbox write-locks memory/ + output/)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ Two exemptions: **reserved `index.md`/`log.md`** stay untyped (OKF §6/§7), and
 
 Your available tools depend on your skill's frontmatter `mode:` (default `write`):
 - **`write`** — full toolset, including `Write`/`Edit`/`Bash(git:*)`/`Bash(gh:*)`/`python`.
-- **`read-only`** — repo-mutation tools (`Write`, `Edit`, `Bash(git:*)`, `Bash(gh:*)`, python) are **stripped from `--allowedTools`** — you physically cannot mutate the repo or call `gh` (even `gh api` GETs). Produce output via `./notify` and `memory/` only, and fetch GitHub data with WebFetch/curl against `api.github.com`. Any stray writes are reverted after the run, so don't rely on them.
+- **`read-only`** — repo-mutation tools (`Write`, `Edit`, `Bash(git:*)`, `Bash(gh:*)`, python) are **stripped from `--allowedTools`**, and the OS sandbox write-locks the whole workspace — so you physically cannot mutate the repo, call `gh` (even `gh api` GETs), or write anywhere under the checkout (**`memory/` and `output/` included**). Produce output via your **final message** (the run's captured output) and `./notify`; the workflow persists that captured output to `output/.chains/` and appends a `memory/logs/` entry on your behalf after the run. Fetch GitHub data with WebFetch/curl against `api.github.com`. Any stray writes are reverted after the run, so don't rely on them.
 
 ## Skill Chaining
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -70,7 +70,7 @@ mode: read-only   # may read the repo, fetch the web, and ./notify — but canno
 mode: write       # full access (the default): adds Write / Edit / git / gh / python3
 ```
 
-`read-only` strips the repo-mutation tools from Claude Code's `--allowedTools` (`Write`, `Edit`, `Bash(git:*)`, `Bash(gh:*)`), so a research-and-notify skill **physically can't** commit, push, or open a PR — a post-run guard still saves its `memory/` + `output/` and reverts any stray write. Use it for pure read-and-notify skills; `write` (the default, a strict superset) for anything that writes code. It's the runtime half of the install-time [`capabilities:`](../docs/CAPABILITIES.md) hint.
+`read-only` strips the repo-mutation tools from Claude Code's `--allowedTools` (`Write`, `Edit`, `Bash(git:*)`, `Bash(gh:*)`) **and** the OS sandbox write-locks the whole workspace for the run (see [Capabilities → enforcement layers](CAPABILITIES.md)), so a research-and-notify skill **physically can't** commit, push, open a PR, or write anywhere in the checkout — `memory/` and `output/` included. Don't write those directly; route persistence through your **final message** (the run's captured output) and `./notify`. After the run, outside the sandbox, the workflow persists your captured output to `output/.chains/`, appends a `memory/logs/` run entry on your behalf, and reverts any stray write that slipped through. Use it for pure read-and-notify skills; `write` (the default, a strict superset) for anything that writes code. It's the runtime half of the install-time [`capabilities:`](../docs/CAPABILITIES.md) hint.
 
 ## MCP servers in skill runs
 


### PR DESCRIPTION
Follow-up to #816 - the doc/behaviour mismatch a pre-public review pass surfaced.

## Problem
Two docs told read-only skills they can persist to `memory/` during a run:
- `CLAUDE.md` capability tier: "Produce output via `./notify` and `memory/` only"
- `docs/CONFIGURATION.md`: "a post-run guard still saves its `memory/` + `output/`"

They can't. `harness-adapter/lib/sandbox.sh` write-locks the **whole workspace** for a read-only run - `--ro-bind "$ws" "$ws"` (Linux), `(deny file-write* (subpath "$ws"))` (macOS) - with no carve-out, on all six harnesses (`aeon.yml:737`). `memory/` and `output/` sit inside `$ws`, so a read-only skill's own writes there are silently refused. The run still looks healthy because `./notify` works (its queue lives outside the workspace in `$AEON_PENDING_DIR`) and the post-run guard writes a generic `memory/logs/` stub on the skill's behalf - masking the dropped writes.

## Fix (docs only, chosen over widening the sandbox)
Widening the sandbox to re-open `memory/`/`output/` reintroduces a write channel a read-only skill could abuse (poisoned topic file, tampered logs other skills trust). So instead, state the real contract:

- **Don't write `memory/` or `output/` directly under read-only** - the OS sandbox write-locks the whole checkout.
- Persistence routes through your **final captured output** (health scorer grades it, chains consume it) and **`./notify`**.
- After the run, outside the sandbox, the workflow persists the captured output to `output/.chains/` and appends a `memory/logs/` run entry on the skill's behalf, then reverts any stray write.

`docs/CAPABILITIES.md` already describes the sandbox layer correctly (§ enforcement layers); this only fixes the two lines that contradicted it.

## Note (not in this PR)
The three read-only MCP skills (`finance-district-mcp`, `glim-mcp`, `robinhood-mcp`) still have a Step-5 line telling the agent to "log to `memory/logs/${today}.md`". Harmless - the guard writes the stub regardless and reads still work - but if you want them fully consistent with the corrected contract, those lines could drop the direct-write instruction. Left out to keep this doc-only.
