### PR TITLE
docs(skills): read-only MCP skills route persistence through output, not memory/ writes

### DIFF
--- a/skills/finance-district-mcp/SKILL.md
+++ b/skills/finance-district-mcp/SKILL.md
@@ -26,7 +26,7 @@ Wired by the dashboard MCP panel's one-click **Connect** (OAuth with `offline_ac
 2. **Prices / yield (when relevant)** — `getTokenPrice` for held tokens; note 24h moves over ±5%. `discoverYieldStrategies` for idle stablecoins (EVM only) — surface the top option (protocol, APY, TVL) as a suggestion. Never deposit unless the task explicitly asks.
 3. **Act only on explicit instruction** — transfers, swaps, yield deposits, and x402 payments move real value. Do exactly what `${var}` asks, nothing more; sequence any irreversible action last, fail-closed. Amounts above the auto-approve threshold are rejected by the wallet — report that, never try to work around it.
 4. **x402 paid calls** — follow the 402 flow (authorize within caps; gasless for the payer via EIP-3009).
-5. **Notify** once via `./notify -f <file>`, and **log** to `memory/logs/${today}.md`. Every value-moving action (transfer, swap, deposit, x402 payment) goes in **both** — the notification is the operator's only guaranteed record, so a payment that isn't in it effectively went unreported:
+5. **Notify** once via `./notify -f <file>`, and put the same record in your **final output**. This skill is `read-only`, so you can't write `memory/logs/` yourself (the sandbox write-locks the workspace); the workflow commits your captured output to `memory/logs/` + `output/.chains/` after the run. Every value-moving action (transfer, swap, deposit, x402 payment) goes in **both the notify and the output** — the notification is the operator's only guaranteed record, so a payment that isn't in it effectively went unreported:
 
    ```
    ### finance-district-mcp

--- a/skills/glim-mcp/SKILL.md
+++ b/skills/glim-mcp/SKILL.md
@@ -39,13 +39,13 @@ Write the digest: a 2–3 sentence answer up top, then the supporting evidence g
 
 ### 4. Notify
 
-Deliver via `./notify -f` (ordinary Markdown): the answer, the evidence, a `Sources` list of clickable URLs, and a final line `calls: N/<budget>`. This skill is on-demand — a completed run always notifies (unlike monitors, silence isn't signal here).
+Deliver via `./notify -f <file>` (ordinary Markdown): the answer, the evidence, a `Sources` list of clickable URLs, and a final line `calls: N/<budget>`. This skill is on-demand — a completed run always notifies (unlike monitors, silence isn't signal here).
 
 **Exactly one `./notify` call per run.** Each call overwrites `apps/dashboard/outputs/.pending-<skill>.md` (last-writer-wins), which becomes the chain artifact `output/.chains/glim-mcp.md` that `consume:` steps and the feed read — a follow-up "headline" ping would replace the digest with a stub. Everything goes in the single `-f` file.
 
-### 5. Log
+### 5. Result record
 
-Append to `memory/logs/${today}.md`:
+This skill is `read-only`, so it can't write the repo during the run (the sandbox write-locks the workspace). Don't append to `memory/logs/` yourself — put this record in your **final output**; the workflow persists it to `memory/logs/` and `output/.chains/glim-mcp.md` on your behalf after the run:
 
 ```
 ### glim-mcp
@@ -54,7 +54,7 @@ Append to `memory/logs/${today}.md`:
 - Calls: N (budget 10|25) | sources cited: M
 ```
 
-If the answer is durable knowledge about a tracked topic (a token, a protocol, a watched repo), also fold the finding into the matching `memory/topics/` note per the OKF rules — bump its `timestamp:`.
+If the answer is durable knowledge about a tracked topic (a token, a protocol, a watched repo), it can't be folded into `memory/topics/` from a read-only run — surface it clearly in the output so the operator (or a write-mode skill) can persist it per the OKF rules.
 
 ## Constraints
 

--- a/skills/robinhood-mcp/SKILL.md
+++ b/skills/robinhood-mcp/SKILL.md
@@ -37,14 +37,14 @@ Operator-initiated only — never trade on a scheduled/default run, and never in
 
 ### 3. Notify
 
-This skill is on-demand — deliver the result via `./notify -f` (ordinary Markdown), **exactly one `./notify` call per run** (each call overwrites the `.pending-<skill>.md` file the chain artifact is captured from — a second ping would clobber the report):
+This skill is on-demand — deliver the result via `./notify -f <file>` (ordinary Markdown), **exactly one `./notify` call per run** (each call overwrites the `.pending-<skill>.md` file the chain artifact is captured from — a second ping would clobber the report):
 
 - **Report branches:** portfolio value + day change, buying power, a positions table, open orders, and one line of what stands out (concentration, a position moving hard). Keep it tight — signal, not a data dump.
 - **Trade branch:** the exact order placed (side, symbol, size, order id, status) — or, on refusal, exactly what was ambiguous and how to restate it. Severity `success` for a placed order, `warn` for a refusal.
 
-### 4. Log
+### 4. Result record
 
-Append to `memory/logs/${today}.md`:
+This skill is `read-only`, so it can't write the repo during the run (the sandbox write-locks the workspace). Don't append to `memory/logs/` yourself — put this record in your **final output**; the workflow persists it to `memory/logs/` and `output/.chains/robinhood-mcp.md` on your behalf after the run:
 
 ```
 ### robinhood-mcp


### PR DESCRIPTION
Completes the read-only persistence cleanup from #816 / #817 - the three `mode: read-only` MCP skills still instructed the agent to write `memory/` directly.

## What changed
Each skill's Step-5 / Log block said "Append to `memory/logs/${today}.md`" (glim also "fold into `memory/topics/`"). Under read-only the OS sandbox write-locks the whole workspace (`harness-adapter/lib/sandbox.sh`), so those writes silently fail - the post-run guard commits the captured output to `memory/logs/` + `output/.chains/` on the skill's behalf instead.

- **finance-district-mcp** - Step 5: record goes in the final output + notify, not a direct `memory/logs/` write.
- **glim-mcp** - "Log" → "Result record"; same reframing; the `memory/topics/` fold-in note now says a read-only run can't persist it, surface it in the output.
- **robinhood-mcp** - "Log" → "Result record"; same reframing.

Also fixed the same bare `./notify -f` → `./notify -f <file>` from #816 that still lived in glim (line 42) and robinhood (line 40).

No catalog regen: descriptions/categories/`requires` unchanged, only `sha`/`updated` churn (normalized out of `ci-skills-json`). Frontmatter untouched, so `ci-okf` is unaffected.

## Not changed (flagging, not fixing)
`finance-district-mcp` Step 1 diffs current balances against "the last entry in `memory/logs/`". Reads still work, but under read-only the last entry is the guard's generic stub, not real balance data - the substantive prior record now lives in `output/.chains/finance-district-mcp.md` (the committed captured output). Repointing that diff source is a functional change, left out of this doc-consistency PR.
