### PR TITLE
feat(aeon skill): mine Claude Code history for skills to automate

### DIFF
--- a/.claude/skills/aeon/SKILL.md
+++ b/.claude/skills/aeon/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aeon
-description: Set up and run an Aeon agent instance — get started from scratch, pick which skills to turn on or install more from packs, reschedule or change what runs, edit what an existing skill does, fix a skill that isn't firing, set the STRATEGY.md north star and soul/ voice, and turn a Claude Code chat into a scheduled Aeon skill. Use when the user mentions Aeon, aeon.yml, an Aeon skill / instance / routine / pack, or asks to schedule, enable, edit, or debug an agent that runs on a cron.
+description: Set up and run an Aeon agent instance — get started from scratch, pick which skills to turn on or install more from packs, reschedule or change what runs, edit what an existing skill does, fix a skill that isn't firing, set the STRATEGY.md north star and soul/ voice, turn a Claude Code chat into a scheduled Aeon skill, and mine past Claude Code conversations for recurring work worth automating as a skill. Use when the user mentions Aeon, aeon.yml, an Aeon skill / instance / routine / pack, asks to schedule, enable, edit, or debug an agent that runs on a cron, or asks what of their repeated/manual work Aeon could take over.
 ---
 
 # Aeon
@@ -18,6 +18,7 @@ Pick the mode they're asking for:
 | **5 · Edit a skill** | Change what an existing skill does |
 | **6 · What to turn on** | Pick skills, browse packs, install more |
 | **7 · Strategy & voice** | `STRATEGY.md` and `soul/` — the north star and the tone |
+| **8 · Mine history → skill** | "What of my repeated work could Aeon do for me?" — surface it from past Claude Code chats |
 
 ## Preflight (every mode)
 
@@ -367,6 +368,37 @@ By default Aeon has no personality. `soul/SOUL.md` (identity, worldview, opinion
 **The quality bar: specific enough to be wrong.** *"I think most AI safety discourse is galaxy-brained cope"* is useful. *"I have nuanced views on AI safety"* is not. Push for the first kind — a soul that can't offend anyone won't sound like anyone.
 
 Neither file takes `type:` frontmatter — both are outside the OKF scope.
+
+---
+
+## Mode 8 — Mine history for skills to automate
+
+"What am I doing by hand over and over that Aeon could just do?" Mode 4 turns *this* chat into a skill; Mode 8 mines *past* chats to find which chat is worth turning into one. It reads the operator's local Claude Code transcripts (`~/.claude/projects/*/*.jsonl`), so it only works on their own machine — never inside an Aeon run.
+
+1. **Scan.** Run the miner from the instance repo root:
+
+   ```bash
+   node .claude/skills/aeon/scripts/mine-history.mjs --days 45 --top 15
+   ```
+
+   It parses every top-level session in the window (skips subagent sidechains), normalises shell commands to `binary subcommand`, groups session titles, and prints a digest ranked by **distinct sessions × distinct days** — recurrence and cadence, not raw volume. Flags: `--days N` (window, default 120), `--project SUBSTR` (only sessions whose cwd matches — scope to one repo/topic), `--top N`, `--min-sessions N`, `--json`. It has no dependencies and reverts to a clean error if there's no history. Deeper reading of the tables and the candidate rubric: `references/history-mining.md`.
+
+2. **Read it as a human would.** The digest is raw signal, not a verdict — the judgment is yours:
+   - **Recurring command workflows** — a `binary subcommand` across many sessions *and* many days is a habit. Universal plumbing (`git status`, `gh auth`, bare `node`/`python3`) is already filtered out, but `gh pr`/`gh api`/`npm run` are substrate too — high everywhere, weak as a skill idea. Look for the *distinctive* recurring call: a named script, a specific CLI (`x-cli`, `langfuse`, `raindrop`), a tight `gh api` pattern.
+   - **Recurring task themes** — grouped session titles are the strongest signal. A title you've hit across many days at a rough cadence ("check X", "review Y", "digest Z") is almost always the real automation candidate.
+   - **Tooling / projects** — which MCP servers and repos the work lives in; tells you what a skill would need wired and where to scope `--project`.
+
+3. **Filter to genuine candidates.** A row is worth proposing only if it's all of:
+   - **Recurring** — spans several sessions across several days, not one busy afternoon.
+   - **Fetch/compute/report-shaped** — pulls or checks something and reports. Interactive, decision-heavy, or one-off migration work does *not* automate.
+   - **Unattended-safe** — no dependence on local files, logged-in desktop apps, or a human answering mid-task (Mode 4 step 2/3 covers hardening).
+   - **Not already a skill.** Dedup against the instance: `./aeon skills ls`. Much recurring `gh pr` work is already `pr-review`/`pr-check`; a research cadence is already `digest`/`mention-radar`. If an existing skill covers it, the move is Mode 2 (reschedule) or Mode 5 (edit its `var`), **not** a new skill.
+
+4. **Propose three, with evidence.** Don't dump the digest. Name **three** candidates, each with its recurrence count as proof ("you did X across N sessions over D days"), a one-line skill sketch (what it fetches, what it sends), a suggested `mode:` (`read-only` if it only fetches and reports) and a suggested `schedule:` inferred from the observed cadence (seen ~daily → daily; ~weekly → weekly). Ask which to build.
+
+5. **Hand off to Mode 4** to author the chosen one — the same skill-file shape, unattended-hardening, quoted-`schedule:` entry, and dual-catalog CI. Mode 8 finds the work; Mode 4 ships it.
+
+**Privacy:** the transcripts are read locally and only the aggregate digest is surfaced. Don't paste raw prompt bodies or anything sensitive from a session into a channel or a committed file; the counts and titles are enough to decide.
 
 ---
 

--- a/.claude/skills/aeon/references/history-mining.md
+++ b/.claude/skills/aeon/references/history-mining.md
@@ -1,0 +1,168 @@
+# History mining — deep reference (Mode 8)
+
+`scripts/mine-history.mjs` reads the operator's local Claude Code transcripts and
+surfaces recurring work that could become a scheduled Aeon skill. This file is the
+detail behind Mode 8: what the tool reads, how it ranks, and how to turn a digest
+row into a real skill without proposing junk.
+
+## What it reads
+
+Claude Code writes one JSONL transcript per session under
+`~/.claude/projects/<encoded-cwd>/<session-uuid>.jsonl`. Each line is a record;
+the ones the miner uses:
+
+| record `type` | field | used for |
+|---|---|---|
+| `ai-title` | `aiTitle` | the session's generated title — the semantic label for theme grouping (last one in a file wins = freshest) |
+| `user` | `message.content` (string) | real human prompts — only plain strings without a `<system-reminder>`/`<command-name>` wrapper; tool-result echoes are lists and are skipped |
+| `assistant` | `message.content[].tool_use` | `Bash` commands → normalised workflows; `mcp__*` names → MCP tool usage |
+| any | `cwd`, `timestamp`, `sessionId` | project scoping, cadence (distinct days), dedup |
+
+It only scans **top-level sessions** — files under a `subagents/` path are
+sidechains (agent fan-out) and would double-count the parent's work, so they're
+skipped. The scan window is bounded by file mtime (`--days`, default 120) so it
+stays a few seconds even over thousands of transcripts.
+
+## How it ranks
+
+Everything is ranked by `distinct sessions × 1000 + distinct days × 10 + runs` —
+so **breadth of recurrence dominates raw volume**. A command run 500 times in one
+marathon session ranks below one run once each across 20 days: the second is a
+habit with a cadence, the first is a one-off you happened to repeat. Days are the
+cadence signal that tells you *daily* vs *weekly* when you get to `schedule:`.
+
+`--min-sessions N` (default 2) drops anything seen in a single session — a true
+one-off is never an automation candidate.
+
+### Command normalisation
+
+Each `Bash` command is split on `&&`, `|`, `;`, and loop keywords into segments;
+each segment's first token becomes `binary subcommand` (for `node`/`python3` the
+script basename is the "subcommand", since that's the recurring workflow). Two
+denylists keep the signal clean:
+
+- **`NOISE_BIN`** — file-poking and shell/JS keywords (`ls`, `cat`, `grep`,
+  `printf`, `done`, `const`, …). Never a workflow.
+- **`PLUMBING`** — universal git/gh navigation (`git status`, `git log`,
+  `git diff`, `gh auth`, …). Present in nearly every coding session, so it tells
+  you nothing about *what* to automate. Filtered from the command table.
+
+What survives is the distinctive stuff: named scripts, specific CLIs, tight API
+patterns. Note that `gh pr`, `gh api`, `npm run` survive the filter but are still
+near-substrate — high in *every* repo. Treat them as weak on their own; they
+matter only when a **title theme** explains *what* the PR/API work was for.
+
+### Title grouping
+
+Session titles are lowercased, stripped to their content words (stopwords
+removed), truncated to the first six, and grouped. Near-identical titles collapse
+("Synthesize activity logs into timeline cards" ≈ "Synthesizing user activity
+logs…"), and the group is ranked by sessions then days. This is usually the
+**most useful table** — the titles are already semantic, so a high-count group is
+a plain-language description of a thing the operator keeps doing.
+
+## From a digest row to a skill
+
+A row is a candidate only if it clears all four gates:
+
+1. **Recurring** — several sessions across several days. One busy day = not yet.
+2. **Fetch / compute / report-shaped** — it pulls or checks something and reports
+   a result. Read-heavy monitoring, digests, and status checks automate cleanly.
+   Interactive debugging, decision-heavy review, and one-off migrations do not —
+   they need a human in the loop that a cron run doesn't have.
+3. **Unattended-safe** — no reliance on local files, a logged-in desktop app, or
+   the operator answering a question mid-task. If the observed work used a local
+   MCP server or read `~`, that part has to be re-wired as a repo secret /
+   `.mcp.json` or dropped (Mode 4 steps 2–3).
+4. **Not already covered.** Dedup against `./aeon skills ls` *before* proposing.
+   Common overlaps to watch for:
+
+   | Digest signal | Already a skill → do this instead |
+   |---|---|
+   | Heavy `gh pr` / PR review | `pr-review`, `pr-check` → Mode 2 reschedule |
+   | Recurring topic research / "digest X" | `digest`, `article`, `mention-radar` → Mode 5 `--var` |
+   | Repo / commit monitoring | `github-monitor`, `changelog` |
+   | Shipping recap | `shiplog`, `heartbeat` |
+
+   If an existing skill fits, the win is a **reschedule (Mode 2)** or a **`var`
+   change (Mode 5)**, not a new skill. Only genuinely uncovered recurring work
+   earns a new `SKILL.md`.
+
+## Inferring the schedule
+
+Read cadence from the `days` column of the winning row against the window:
+
+- days ≈ window length (hit almost every active day) → **daily** (`0 13 * * *`).
+- days ≈ window / 7 (a weekly rhythm) → **weekly** (`0 13 * * 1`).
+- bursty / irregular → propose `workflow_dispatch` (on-demand) first; let the
+  operator promote it to cron once it proves useful.
+
+Always convert to UTC and confirm the next 3 fire times in their timezone
+(Mode 2 rules), and remember the quoted-`schedule:` gotcha when the entry lands
+(Mode 4 step 4).
+
+## Privacy
+
+Transcripts are the operator's own and can contain anything they've ever pasted
+into Claude Code. The miner only emits **aggregates** — command patterns, grouped
+titles, counts. Keep it that way: never surface a raw prompt body, and never write
+transcript contents into a committed file or a notification. The counts and titles
+carry all the signal needed to decide what to automate.
+
+## Running it
+
+From the instance repo root, on the operator's own machine:
+
+```bash
+# default: last 120 days, markdown digest
+node .claude/skills/aeon/scripts/mine-history.mjs
+
+# a tighter recent window, more rows
+node .claude/skills/aeon/scripts/mine-history.mjs --days 45 --top 20
+
+# scope to one repo/topic (matches the session's cwd)
+node .claude/skills/aeon/scripts/mine-history.mjs --project my-repo
+
+# machine-readable, to post-process
+node .claude/skills/aeon/scripts/mine-history.mjs --json | jq '.titles'
+```
+
+Needs only Node (>=16) and a local `~/.claude/projects` — it exits with a clear
+message anywhere that directory is absent (e.g. a CI checkout), and never writes
+anything. If a busy background app dominates the tables (a tool that itself drives
+Claude Code will pile up near-identical sessions), scope past it with `--project`.
+
+### Flags
+
+| flag | default | effect |
+|---|---|---|
+| `--days N` | 120 | only sessions whose transcript was modified in the last N days |
+| `--top N` | 20 | rows per table |
+| `--project SUBSTR` | — | only sessions whose cwd contains SUBSTR |
+| `--min-sessions N` | 2 | drop candidates seen in fewer than N distinct sessions |
+| `--json` | off | raw JSON instead of the markdown digest |
+
+### Sample output (synthetic)
+
+```
+# Automation candidates — mined from Claude Code history
+
+Scanned 240 sessions (240 files, last 45 days) across 38 active days.
+
+## Recurring command workflows
+| # | pattern      | runs | sessions | days | projects |
+| 1 | `gh pr`      | 610  | 92       | 34   | 40       |
+| 2 | `gh api`     | 240  | 55       | 30   | 28       |
+| 3 | `npm run`    | 180  | 41       | 22   | 12       |
+
+## Recurring task themes
+| # | recurring session title  | sessions | days |
+| 1 | Review open pull requests| 14       | 12   |
+| 2 | Weekly analytics digest  | 6        | 6    |
+| 3 | Audit repos for cleanup  | 4        | 4    |
+```
+
+Read that as: PR review is a near-daily habit (route to `pr-review`, don't
+re-invent it); a weekly analytics digest recurs on a clean 7-day cadence and has
+no covering skill (a real new-skill candidate → daily/weekly `mode: read-only`);
+the repo audit is real but low-cadence (offer `workflow_dispatch` first).

--- a/.claude/skills/aeon/scripts/mine-history.mjs
+++ b/.claude/skills/aeon/scripts/mine-history.mjs
@@ -1,0 +1,317 @@
+#!/usr/bin/env node
+// mine-history.mjs — scan local Claude Code conversation history and surface
+// recurring work worth turning into a scheduled Aeon skill.
+//
+// OPERATOR-SIDE ONLY. Reads ~/.claude/projects/*/*.jsonl (local Claude Code
+// transcripts). Does nothing on GitHub Actions (no history there) — the aeon
+// `aeon` skill invokes it during skill authoring (Mode 8), never at run time.
+//
+// It does the mechanical part — parse transcripts, normalise commands, count
+// recurrence and cadence — and prints a compact digest. The semantic judgment
+// (which cluster is actually a good skill) is left to the model reading it.
+//
+// Usage:
+//   node mine-history.mjs [--days N] [--top N] [--project SUBSTR]
+//                         [--min-sessions N] [--json]
+//
+//   --days N         only sessions whose file was modified in the last N days (default 120)
+//   --top N          rows per table (default 20)
+//   --project SUBSTR only sessions whose cwd contains SUBSTR
+//   --min-sessions N drop candidates seen in fewer than N distinct sessions (default 2)
+//   --json           emit raw JSON instead of the markdown digest
+//
+// No dependencies — plain Node (>=16), reads line-by-line.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import readline from 'node:readline';
+
+// ---- args ----------------------------------------------------------------
+const argv = process.argv.slice(2);
+const opt = (name, def) => {
+  const i = argv.indexOf(name);
+  return i >= 0 && argv[i + 1] ? argv[i + 1] : def;
+};
+const flag = (name) => argv.includes(name);
+const DAYS = parseInt(opt('--days', '120'), 10);
+const TOP = parseInt(opt('--top', '20'), 10);
+const PROJECT = opt('--project', '');
+const MIN_SESSIONS = parseInt(opt('--min-sessions', '2'), 10);
+const JSON_OUT = flag('--json');
+
+const ROOT = path.join(os.homedir(), '.claude', 'projects');
+if (!fs.existsSync(ROOT)) {
+  console.error(`No Claude history at ${ROOT} — nothing to mine (this is normal off a local machine).`);
+  process.exit(2);
+}
+const CUTOFF_MS = Date.now() - DAYS * 86400_000;
+
+// ---- helpers -------------------------------------------------------------
+// The interesting binaries — the ones a workflow is built from. Bare file
+// pokers (ls/cat/cd/echo/grep/…) are noise and get dropped.
+const VERBS = new Set([
+  'gh', 'git', 'npm', 'npx', 'node', 'python', 'python3', 'pip', 'pip3',
+  'cargo', 'forge', 'cast', 'docker', 'vercel', 'gcloud', 'aws', 'railway',
+  'potpie', 'raindrop', 'langfuse', 'openrouter', 'x-cli', 'yt-dlp',
+  './aeon', './notify', './secretcurl', './scripts/skill-runs', 'bin/install-skill-pack',
+]);
+const NOISE_BIN = new Set(['ls', 'cd', 'cat', 'echo', 'head', 'tail', 'grep',
+  'rg', 'find', 'wc', 'sed', 'awk', 'sort', 'uniq', 'cut', 'tr', 'chmod',
+  'mkdir', 'rm', 'cp', 'mv', 'touch', 'pwd', 'which', 'true', 'export', 'set',
+  'jq', 'tee', 'xargs', 'sleep', 'read', 'test', 'source', '.',
+  // shell loop / conditional keywords that leak through segment splitting
+  'do', 'done', 'then', 'fi', 'else', 'elif', 'esac', 'while', 'for', 'if',
+  'case', 'in', 'time', 'env', 'command', 'sudo', 'exec', 'eval', 'wait',
+  'printf', 'break', 'continue', 'local', 'declare', 'unset', 'trap', 'shift',
+  'exit', 'return', 'printenv', 'basename', 'dirname', 'seq', 'date', 'sleep',
+  // JS keywords leaking from `node -e "... ; ..."` split on ';'
+  'const', 'let', 'var', 'function', 'import', 'class', 'await', 'async',
+  'console', 'require', 'module', 'yield', 'throw', 'typeof', 'new',
+  'error', 'warn', 'warning', 'note', 'fail', 'failed', 'success', 'ok']);
+
+// Universal coding substrate — present in nearly every session, tells you
+// nothing about what to automate. Dropped from the command leaderboard.
+const PLUMBING = new Set([
+  'git log', 'git status', 'git diff', 'git branch', 'git checkout', 'git switch',
+  'git remote', 'git pull', 'git fetch', 'git add', 'git stash', 'git rev-parse',
+  'git config', 'git show', 'git reset', 'git rebase', 'git init', 'git clone',
+  'git restore', 'git ls-files', 'git worktree', 'gh auth',
+]);
+const isPlumbing = (label) => PLUMBING.has(label);
+
+const STOP = new Set(('the a an and or but of to in on for with at by from is are be it this that ' +
+  'i you we can could should would do does did my your our me us it its as if then else so ' +
+  'what how why when where which who not no yes okay ok just get got make made need want ' +
+  'please thanks lets let also more most some any all one two now new use using used via ' +
+  'check fix add update change into out up off over about like know see look try help ' +
+  'run running runs file files repo pr prs claude code session task ' +
+  // pronouns / connectives / filler that dominated the raw keyword cluster
+  'they them these those their there here have has had been will was were would could ' +
+  'only each good line page across still such very much many more into onto than that ' +
+  'this with your our were are you can not but and the for who why how when what does ' +
+  'want need make made done work working works thing things stuff really actually maybe ' +
+  'right left same other another every both either neither also again back down then than ' +
+  'give given take taken keep kept show shown tell told find found look looked well good ' +
+  'better best worse first last next previous current whole full part some most least ' +
+  'okay yeah yep nope sure fine great nice cool right wrong true false null please thanks').split(/\s+/));
+
+function normCmd(cmd) {
+  if (!cmd || typeof cmd !== 'string') return [];
+  const out = [];
+  // split a compound line into segments run as separate binaries
+  for (let seg of cmd.split(/&&|\|\||[|;]|\bthen\b|\bdo\b/)) {
+    seg = seg.trim().replace(/^["'(]+/, '');
+    if (!seg) continue;
+    const toks = seg.split(/\s+/).filter(Boolean);
+    if (!toks.length) continue;
+    let bin = toks[0];
+    if (bin.startsWith('$') || bin.includes('=')) continue; // var / env-assign
+    const base = bin.split('/').pop();
+    if (NOISE_BIN.has(base) || NOISE_BIN.has(bin)) continue;
+    const known = VERBS.has(bin) || VERBS.has(base);
+    // second, non-flag token = the subcommand or the script name
+    let sub = toks.slice(1).find((t) => t && !t.startsWith('-'));
+    if (sub && (base === 'node' || base === 'python' || base === 'python3')) {
+      sub = sub.split('/').pop(); // script basename
+    } else if (sub) {
+      sub = sub.split('/').pop();
+    }
+    // keep known verbs always; unknown binaries only if they look like a tool call
+    if (!known && !/^[a-z][a-z0-9._-]{1,}$/.test(base)) continue;
+    if (!known && (base.length < 3 || base.includes('.'))) continue;
+    const label = sub && /^[a-z0-9][\w.-]*$/i.test(sub) ? `${base} ${sub}` : base;
+    out.push(label);
+  }
+  return out;
+}
+
+function dayKey(ts) {
+  return (ts || '').slice(0, 10);
+}
+
+// ---- scan ----------------------------------------------------------------
+// per-candidate accumulator: {runs, sessions:Set, days:Set, projects:Set}
+const cmds = new Map();
+const mcp = new Map();
+const slash = new Map();
+const themeWords = new Map(); // keyword -> {sessions:Set, days:Set, titles:[]}
+const titleGroups = new Map(); // normalised title -> {sessions:Set, days:Set, sample}
+const projects = new Map();   // cwd -> {sessions:Set, last}
+let sessionsScanned = 0;
+const allDays = new Set();
+
+function bump(map, key, sid, day, proj) {
+  let e = map.get(key);
+  if (!e) { e = { runs: 0, sessions: new Set(), days: new Set(), projects: new Set() }; map.set(key, e); }
+  e.runs++; e.sessions.add(sid); if (day) e.days.add(day); if (proj) e.projects.add(proj);
+}
+
+async function scanFile(fp) {
+  const rl = readline.createInterface({ input: fs.createReadStream(fp), crlfDelay: Infinity });
+  let sid = path.basename(fp, '.jsonl');
+  let cwd = '', title = '', minTs = '', maxTs = '';
+  const prompts = [];
+  const localCmds = [], localMcp = [], localSlash = [];
+  for await (const line of rl) {
+    if (!line) continue;
+    let d;
+    try { d = JSON.parse(line); } catch { continue; }
+    const t = d.type;
+    if (d.sessionId) sid = d.sessionId;
+    if (d.cwd) cwd = d.cwd;
+    if (d.timestamp) { if (!minTs || d.timestamp < minTs) minTs = d.timestamp; if (d.timestamp > maxTs) maxTs = d.timestamp; }
+    if (t === 'ai-title' && d.aiTitle) title = d.aiTitle; // last one wins = freshest
+    if (t === 'user') {
+      const c = d.message?.content;
+      if (typeof c === 'string') {
+        if (c.startsWith('/') || c.startsWith('<command-name>')) {
+          const name = (c.match(/<command-name>([^<]+)/) || c.match(/^\/([\w:-]+)/) || [])[1];
+          if (name) localSlash.push(name.replace(/^\//, '').trim());
+        } else if (!c.includes('<system-reminder>') && c.trim().length > 3) {
+          prompts.push(c);
+        }
+      }
+    } else if (t === 'assistant') {
+      const c = d.message?.content;
+      if (Array.isArray(c)) {
+        for (const b of c) {
+          if (b?.type !== 'tool_use') continue;
+          if (b.name === 'Bash') localCmds.push(...normCmd(b.input?.command));
+          else if (typeof b.name === 'string' && b.name.startsWith('mcp__')) localMcp.push(b.name);
+        }
+      }
+    }
+  }
+  if (PROJECT && !cwd.includes(PROJECT)) return false;
+  sessionsScanned++;
+  const proj = cwd || 'unknown';
+  const day = dayKey(maxTs || minTs);
+  if (day) allDays.add(day);
+  // commands / mcp / slash — count each distinct pattern once per session too via Sets
+  for (const k of localCmds) bump(cmds, k, sid, day, proj);
+  for (const k of localMcp) bump(mcp, k, sid, day, proj);
+  for (const k of localSlash) bump(slash, k, sid, day, proj);
+  // project activity
+  let p = projects.get(proj);
+  if (!p) { p = { sessions: new Set(), last: '' }; projects.set(proj, p); }
+  p.sessions.add(sid); if (maxTs > p.last) p.last = maxTs;
+  // recurring session titles — the strongest human-readable "what I keep doing"
+  // signal. Normalise so near-identical titles collapse into one group.
+  if (title) {
+    const norm = title.toLowerCase().replace(/[^a-z0-9 ]+/g, ' ').replace(/\s+/g, ' ').trim()
+      .split(' ').filter((w) => !STOP.has(w)).slice(0, 6).join(' ');
+    if (norm) {
+      let g = titleGroups.get(norm);
+      if (!g) { g = { sessions: new Set(), days: new Set(), sample: title }; titleGroups.set(norm, g); }
+      g.sessions.add(sid); if (day) g.days.add(day);
+    }
+  }
+  // theme keywords from title + prompts
+  const text = (title + ' ' + prompts.join(' ')).toLowerCase();
+  const words = new Set();
+  for (const w of text.split(/[^a-z0-9.+-]+/)) {
+    if (w.length < 4 || w.length > 24 || STOP.has(w)) continue;
+    if (/^\d+$/.test(w) || /^https?/.test(w)) continue;
+    words.add(w);
+  }
+  for (const w of words) {
+    let e = themeWords.get(w);
+    if (!e) { e = { sessions: new Set(), days: new Set(), titles: [] }; themeWords.set(w, e); }
+    e.sessions.add(sid); if (day) e.days.add(day); if (title && e.titles.length < 5 && !e.titles.includes(title)) e.titles.push(title);
+  }
+  return true;
+}
+
+// gather candidate files (top-level sessions only; skip subagent sidechains),
+// windowed by mtime for speed.
+function listFiles() {
+  const files = [];
+  for (const dir of fs.readdirSync(ROOT)) {
+    const dp = path.join(ROOT, dir);
+    let st; try { st = fs.statSync(dp); } catch { continue; }
+    if (!st.isDirectory()) continue;
+    for (const f of fs.readdirSync(dp)) {
+      if (!f.endsWith('.jsonl')) continue;
+      const fp = path.join(dp, f);
+      let fst; try { fst = fs.statSync(fp); } catch { continue; }
+      if (fst.mtimeMs < CUTOFF_MS) continue;
+      files.push(fp);
+    }
+  }
+  return files;
+}
+
+// ---- render --------------------------------------------------------------
+const spanDays = (e) => e.days ? e.days.size : 0;
+// rank by breadth of recurrence: distinct sessions first, then distinct days
+const score = (e) => e.sessions.size * 1000 + spanDays(e) * 10 + (e.runs || 0);
+function rank(map, minSessions = MIN_SESSIONS) {
+  return [...map.entries()]
+    .filter(([, e]) => e.sessions.size >= minSessions)
+    .sort((a, b) => score(b[1]) - score(a[1]));
+}
+
+function mdTable(rows, headers) {
+  const line = (r) => `| ${r.join(' | ')} |`;
+  return [line(headers), line(headers.map(() => '---')), ...rows.map(line)].join('\n');
+}
+
+const files = listFiles();
+for (const fp of files) { try { await scanFile(fp); } catch { /* skip unreadable */ } }
+
+const cmdRows = rank(cmds).filter(([k]) => !isPlumbing(k)).slice(0, TOP).map((e, i) => {
+  const [k, v] = e;
+  return [i + 1, '`' + k + '`', v.runs, v.sessions.size, v.days.size, v.projects.size];
+});
+const titleRows = rank(titleGroups).slice(0, TOP).map((e, i) => {
+  const [, v] = e;
+  return [i + 1, v.sample.slice(0, 64), v.sessions.size, v.days.size];
+});
+const keywordList = rank(themeWords).slice(0, 18).map((e) => `${e[0]} (${e[1].sessions.size})`);
+const mcpRows = rank(mcp, 1).slice(0, 12).map((e) => `${e[0].replace(/^mcp__/, '')} (${e[1].sessions.size})`);
+const slashRows = rank(slash, 1).slice(0, 12).map((e) => `/${e[0]} (${e[1].sessions.size})`);
+const projRows = [...projects.entries()]
+  .sort((a, b) => b[1].sessions.size - a[1].sessions.size).slice(0, 12)
+  .map((e) => [e[0].replace(os.homedir(), '~'), e[1].sessions.size, (e[1].last || '').slice(0, 10)]);
+
+if (JSON_OUT) {
+  const dump = (map, min = MIN_SESSIONS) => rank(map, min).map(([k, v]) => ({
+    key: k, runs: v.runs, sessions: v.sessions.size, days: v.days?.size || 0, projects: v.projects?.size || 0,
+  }));
+  console.log(JSON.stringify({
+    scanned: { sessions: sessionsScanned, files: files.length, days: allDays.size, windowDays: DAYS },
+    commands: dump(cmds).filter((r) => !isPlumbing(r.key)),
+    titles: rank(titleGroups).map(([, v]) => ({ title: v.sample, sessions: v.sessions.size, days: v.days.size })),
+    keywords: rank(themeWords).map(([k, v]) => ({ key: k, sessions: v.sessions.size, days: v.days.size })),
+    mcp: dump(mcp, 1), slash: dump(slash, 1),
+  }, null, 2));
+} else {
+  const out = [];
+  out.push(`# Automation candidates — mined from Claude Code history`);
+  out.push('');
+  out.push(`Scanned **${sessionsScanned}** sessions (${files.length} files, last ${DAYS} days) across **${allDays.size}** active days${PROJECT ? `, project filter \`${PROJECT}\`` : ''}.`);
+  out.push('');
+  out.push(`## Recurring command workflows`);
+  out.push(`Normalised \`binary subcommand\`, ranked by distinct sessions then distinct days. High sessions+days = a habit, not a one-off.`);
+  out.push('');
+  out.push(cmdRows.length ? mdTable(cmdRows, ['#', 'pattern', 'runs', 'sessions', 'days', 'projects']) : '_none above threshold_');
+  out.push('');
+  out.push(`## Recurring task themes`);
+  out.push(`Session titles grouped by their normalised form, ranked by distinct sessions then days. A title you've hit across many days at a rough cadence is a scheduled-skill candidate.`);
+  out.push('');
+  out.push(titleRows.length ? mdTable(titleRows, ['#', 'recurring session title', 'sessions', 'days']) : '_none above threshold_');
+  out.push('');
+  out.push(`**Topic keywords** (title+prompt, noise-filtered): ${keywordList.join(', ') || '—'}`);
+  out.push('');
+  out.push(`## Tooling`);
+  out.push(`- **MCP tools:** ${mcpRows.join(', ') || '—'}`);
+  out.push(`- **Slash / skills:** ${slashRows.join(', ') || '—'}`);
+  out.push('');
+  out.push(`## Where the work happens`);
+  out.push(projRows.length ? mdTable(projRows, ['project', 'sessions', 'last seen']) : '_none_');
+  out.push('');
+  out.push(`---`);
+  out.push(`Next: pick the 2-3 rows that are **recurring + fetch/report-shaped + not already an Aeon skill**, then author each via Mode 4. A workflow spanning many days at a rough cadence → a \`schedule:\`; a read-only fetch-and-report → \`mode: read-only\`.`);
+  console.log(out.join('\n'));
+}


### PR DESCRIPTION
## What

Adds **Mode 8 — Mine history for skills to automate** to the operator-facing `aeon` skill. It answers "what am I doing by hand over and over that Aeon could just do?" by mining the operator's own past Claude Code conversations and surfacing recurring work worth turning into a scheduled skill.

Mode 4 turns *this* chat into a skill; Mode 8 mines *past* chats to find which chat is worth turning into one.

## How it works

`node .claude/skills/aeon/scripts/mine-history.mjs` reads local Claude Code transcripts (`~/.claude/projects/*/*.jsonl`), then:

- normalises shell commands to `binary subcommand` (drops universal git/gh plumbing and shell/JS keyword leaks),
- groups session titles (`ai-title` records) into themes,
- ranks candidates by **distinct sessions x distinct days** — recurrence and cadence, not raw volume,
- prints a compact digest (or `--json`).

The model then reads the digest, filters to genuine candidates through four gates (recurring / fetch-report-shaped / unattended-safe / not-already-a-skill), proposes three with evidence, and hands the chosen one to Mode 4 to author.

## Files

- `.claude/skills/aeon/scripts/mine-history.mjs` — zero-dep Node (>=16) miner. Operator-side only: exits with a clear message where no history exists (e.g. a CI checkout) and never writes anything. Flags: `--days --project --top --min-sessions --json`.
- `.claude/skills/aeon/SKILL.md` — new Mode 8 section + router row + frontmatter trigger.
- `.claude/skills/aeon/references/history-mining.md` — record schema, ranking math, the digest-row-to-skill rubric, cadence inference, run instructions, and a synthetic sample digest.

## Run it

```bash
node .claude/skills/aeon/scripts/mine-history.mjs --days 45 --top 20
node .claude/skills/aeon/scripts/mine-history.mjs --project my-repo
node .claude/skills/aeon/scripts/mine-history.mjs --json | jq '.titles'
```

## Notes

- Emits only aggregates (command patterns, grouped titles, counts) — never raw prompt bodies. Reads locally; nothing leaves the machine.
- No runtime `skills/` catalog change, so the skills.json / packs.json CI gates do not apply. `.claude/skills/` is outside the OKF scope, so no `type:` frontmatter is required (matches the existing `references/*.md`).
