### PR TITLE
feat(notify): add Buzz as an outbound notification channel

### DIFF
--- a/.claude/skills/aeon/references/secrets.md
+++ b/.claude/skills/aeon/references/secrets.md
@@ -57,6 +57,7 @@ The first two are the direct-to-Anthropic options; the rest are gateways. Settin
 | `SLACK_WEBHOOK_URL` | api.slack.com/apps → Create App → Incoming Webhooks → Install → Copy URL |
 | `SLACK_BOT_TOKEN` + `SLACK_CHANNEL_ID` | Same app → add `channels:history` + `reactions:write` scopes. Only for inbound |
 | `RESEND_API_KEY` + `NOTIFY_EMAIL_TO` | resend.com/api-keys. Powers **all** outbound email — the notification channel, emailed digests, and security disclosures |
+| `BUZZ_PRIVATE_KEY` + `BUZZ_CHANNEL_ID` (+ `BUZZ_RELAY_URL`) | [Buzz](https://buzz.xyz) (Block's Nostr-relay workspace). `BUZZ_PRIVATE_KEY` is the agent's `nsec` keypair, `BUZZ_CHANNEL_ID` the target channel UUID (`buzz channels list`), `BUZZ_RELAY_URL` your relay (defaults to localhost). Outbound only; needs the `buzz` CLI staged in the run |
 
 Telegram is the fastest to set up and the only one with inline buttons and slash-commands. Start there.
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -266,6 +266,7 @@ Set the secret → channel activates. No code changes needed.
 | Telegram | `TELEGRAM_BOT_TOKEN` + `TELEGRAM_CHAT_ID` | Same |
 | Discord | `DISCORD_WEBHOOK_URL` | `DISCORD_BOT_TOKEN` + `DISCORD_CHANNEL_ID` |
 | Slack | `SLACK_WEBHOOK_URL` | `SLACK_BOT_TOKEN` + `SLACK_CHANNEL_ID` |
+| Buzz | `BUZZ_PRIVATE_KEY` + `BUZZ_CHANNEL_ID` (+ `BUZZ_RELAY_URL`) | - |
 | Email | `RESEND_API_KEY` + `NOTIFY_EMAIL_TO` | - |
 
 **Set up each channel:**
@@ -274,6 +275,7 @@ Set the secret → channel activates. No code changes needed.
 - **Discord** - *outbound:* a channel webhook URL. *Inbound:* a bot token + channel ID, with the `channels:history` scope. ([discord.com/developers](https://discord.com/developers/applications))
 - **Slack** - *outbound:* an Incoming Webhook URL. *Inbound:* a bot token + channel ID, with the `channels:history` + `reactions:write` scopes. ([api.slack.com/apps](https://api.slack.com/apps))
 - **Email** - [resend.com/api-keys](https://resend.com/api-keys) → Create API Key → set it as `RESEND_API_KEY`, and `NOTIFY_EMAIL_TO` to your inbox. Optional: `NOTIFY_EMAIL_FROM` (default `aeon@notifications.aeon.bot` - **must be a sender/domain verified in Resend**) and `NOTIFY_EMAIL_SUBJECT_PREFIX` (default `[Aeon]`). Same key as security disclosures, so one Resend key powers all outbound email.
+- **Buzz** - [Buzz](https://buzz.xyz) is Block's open, self-hostable workspace where humans and agents are first-class members ([github.com/block/buzz](https://github.com/block/buzz)). *Outbound:* set `BUZZ_PRIVATE_KEY` (the agent's `nsec` keypair), `BUZZ_CHANNEL_ID` (target channel UUID from `buzz channels list`), and `BUZZ_RELAY_URL` (your relay; defaults to `http://localhost:3000`). Aeon posts Markdown as itself via the [`buzz` CLI](https://github.com/block/buzz/tree/main/crates/buzz-cli), which signs (NIP-98) and publishes each message over the relay. The CLI must be staged in the run (no prebuilt binary yet - `cargo install --path crates/buzz-cli`); the channel skips silently until it is. Inbound (agent-as-participant) is a later phase.
 
 **Restrict who can command the agent (inbound):** Telegram is scoped to a single `TELEGRAM_CHAT_ID`. That's enough for a **1:1 DM** (there the chat ID *is* your user ID). For a **group/public chat**, also set `TELEGRAM_ALLOWED_USER_ID` to your numeric user ID (from [@userinfobot](https://t.me/userinfobot)) - otherwise any group member can command the bot, including by tapping a **Run again / Schedule weekly** button on a posted notification (Telegram delivers those taps even with group-privacy mode on). Left unset in a group, taps and messages **fail closed**. For Discord and Slack, set the optional repo variables `DISCORD_ALLOWED_AUTHOR_ID` / `SLACK_ALLOWED_USER_ID` (or same-named secrets) to the authorized sender's user ID - inbound messages from anyone else in the channel are then ignored. **Leaving those unset processes commands from any non-bot member of the channel**, so set them whenever the channel isn't private to you.
 

--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -291,6 +291,19 @@ jobs:
           # which is the part that drifted last time, is shared.
           bash scripts/install-harness.sh "$H"
 
+      # Stage the Buzz CLI so ./notify can deliver to the Buzz channel. The script
+      # self-gates: it is an instant no-op unless BUZZ_PRIVATE_KEY is set, so every
+      # non-Buzz operator pays nothing. Set BUZZ_CLI_URL (repo var) to a prebuilt
+      # binary to skip the from-source cargo build.
+      - name: Stage Buzz CLI
+        env:
+          BUZZ_PRIVATE_KEY: ${{ secrets.BUZZ_PRIVATE_KEY }}
+          BUZZ_CLI_URL: ${{ vars.BUZZ_CLI_URL }}
+          BUZZ_CLI_REF: ${{ vars.BUZZ_CLI_REF }}
+        run: |
+          set -euo pipefail
+          bash scripts/install-buzz-cli.sh
+
       - name: Validate skill secrets
         if: steps.work.outputs.mode != ''
         env:
@@ -491,6 +504,12 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          # Buzz channel (Block's Nostr-relay workspace). ./notify signs + publishes
+          # via the buzz CLI staged by "Stage Buzz CLI"; the channel no-ops without
+          # BUZZ_PRIVATE_KEY. BUZZ_RELAY_URL is a var (defaults to localhost in the CLI).
+          BUZZ_PRIVATE_KEY: ${{ secrets.BUZZ_PRIVATE_KEY }}
+          BUZZ_CHANNEL_ID: ${{ secrets.BUZZ_CHANNEL_ID }}
+          BUZZ_RELAY_URL: ${{ vars.BUZZ_RELAY_URL }}
           NOTIFY_EMAIL_TO: ${{ secrets.NOTIFY_EMAIL_TO }}
           NOTIFY_EMAIL_FROM: ${{ vars.NOTIFY_EMAIL_FROM || 'aeon@notifications.aeon.bot' }}
           NOTIFY_EMAIL_SUBJECT_PREFIX: ${{ vars.NOTIFY_EMAIL_SUBJECT_PREFIX || '[Aeon]' }}

--- a/.github/workflows/messages.yml
+++ b/.github/workflows/messages.yml
@@ -471,6 +471,19 @@ jobs:
           set -euo pipefail
           bash scripts/install-harness.sh "$H"
 
+      # Stage the Buzz CLI for the Buzz notify channel — instant no-op unless
+      # BUZZ_PRIVATE_KEY is set. Set BUZZ_CLI_URL (var) to a prebuilt binary to skip
+      # the from-source build.
+      - name: Stage Buzz CLI
+        if: steps.msg.outputs.source != ''
+        env:
+          BUZZ_PRIVATE_KEY: ${{ secrets.BUZZ_PRIVATE_KEY }}
+          BUZZ_CLI_URL: ${{ vars.BUZZ_CLI_URL }}
+          BUZZ_CLI_REF: ${{ vars.BUZZ_CLI_REF }}
+        run: |
+          set -euo pipefail
+          bash scripts/install-buzz-cli.sh
+
       - name: Run
         id: run
         if: steps.msg.outputs.source != ''
@@ -515,6 +528,11 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          # Buzz channel — ./notify signs + publishes via the buzz CLI (staged by
+          # "Stage Buzz CLI"); no-ops without BUZZ_PRIVATE_KEY.
+          BUZZ_PRIVATE_KEY: ${{ secrets.BUZZ_PRIVATE_KEY }}
+          BUZZ_CHANNEL_ID: ${{ secrets.BUZZ_CHANNEL_ID }}
+          BUZZ_RELAY_URL: ${{ vars.BUZZ_RELAY_URL }}
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
           GROK_CREDENTIALS: ${{ secrets.GROK_CREDENTIALS }}   # grok harness: X-account OAuth (restored by run-grok.sh)
           GH_SECRETS_PAT: ${{ secrets.GH_SECRETS_PAT }}   # persist rotated grok refresh token → GROK_CREDENTIALS (run-grok.sh §2b)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,7 +135,7 @@ Two exemptions: **reserved `index.md`/`log.md`** stay untyped (OKF §6/§7), and
 
 ## Tools
 
-- **`./notify "message"`** — Send to all configured channels (Telegram, Discord, Slack, Resend email, json-render). Unconfigured channels are skipped silently.
+- **`./notify "message"`** — Send to all configured channels (Telegram, Discord, Slack, Buzz, Resend email, json-render). Unconfigured channels are skipped silently.
   - **Multi-line content: `./notify -f path/to/file.md`** (`--file`/`--body` also accepted). Do NOT use `./notify "$(cat file.md)"` — long multi-line argv trips the sandbox; the `-f` flag reads the file inside the script so argv stays short.
   - Optional flags: `--title`, `--severity {info|success|warn|critical}`, `--link`. Note: short messages containing `test`/`ping`/`debug`/`trace` are suppressed as diagnostic probes, and `NOTIFY_MIN_SEVERITY` gates low-severity sends — so don't rely on a "test" ping to confirm delivery.
   - **Formatting is global — just write ordinary Markdown.** `notify` renders each channel for you: `##` headings, `**bold**`, `- bullets`, `| tables |`, `` `code` ``, ```` ``` ```` fences, and `[label](url)` links all render correctly on Telegram (normalized to HTML by `scripts/notify_format.py`), Discord, and Slack. Don't hand-format for Telegram, don't cap length for "Telegram limits" (it auto-chunks at ~3900 chars with `[i/N]`), and don't worry about stray `*`/`_`/`<` breaking the message. Keep messages tight for **signal**, not for the transport. (Editorial choices are still yours: use `x.com/handle` not `@handle` to avoid pinging users; `./notify` bodies are the only channel where email renders as plain text — see the send-email/vuln-scanner notes.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ Two exemptions: **reserved `index.md`/`log.md`** stay untyped (OKF §6/§7), and
 
 ## Tools
 
-- **`./notify "message"`** — Send to all configured channels (Telegram, Discord, Slack, Resend email, json-render). Unconfigured channels are skipped silently.
+- **`./notify "message"`** — Send to all configured channels (Telegram, Discord, Slack, Buzz, Resend email, json-render). Unconfigured channels are skipped silently.
   - **Multi-line content: `./notify -f path/to/file.md`** (`--file`/`--body` also accepted). Do NOT use `./notify "$(cat file.md)"` — long multi-line argv trips the sandbox; the `-f` flag reads the file inside the script so argv stays short.
   - Optional flags: `--title`, `--severity {info|success|warn|critical}`, `--link`. Note: short messages containing `test`/`ping`/`debug`/`trace` are suppressed as diagnostic probes, and `NOTIFY_MIN_SEVERITY` gates low-severity sends — so don't rely on a "test" ping to confirm delivery.
   - **Formatting is global — just write ordinary Markdown.** `notify` renders each channel for you: `##` headings, `**bold**`, `- bullets`, `| tables |`, `` `code` ``, ```` ``` ```` fences, and `[label](url)` links all render correctly on Telegram (normalized to HTML by `scripts/notify_format.py`), Discord, and Slack. Don't hand-format for Telegram, don't cap length for "Telegram limits" (it auto-chunks at ~3900 chars with `[i/N]`), and don't worry about stray `*`/`_`/`<` breaking the message. Keep messages tight for **signal**, not for the transport. (Editorial choices are still yours: use `x.com/handle` not `@handle` to avoid pinging users; `./notify` bodies are the only channel where email renders as plain text — see the send-email/vuln-scanner notes.)

--- a/scripts/install-buzz-cli.sh
+++ b/scripts/install-buzz-cli.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# install-buzz-cli — stage the `buzz` CLI for the Buzz notification channel.
+#
+# Buzz (github.com/block/buzz) is the one notify channel that isn't a bearer-URL
+# webhook: ./notify signs + publishes each message through this CLI (it holds the
+# agent's Schnorr keypair). So the binary must be on PATH for the channel to fire.
+# Everything else degrades gracefully without it — notify.sh gates delivery on
+# `command -v buzz` — which is exactly why this installer is safe to call
+# unconditionally: it is a fast no-op unless the operator has configured Buzz.
+#
+# Self-gating, in order:
+#   1. BUZZ_PRIVATE_KEY unset -> operator hasn't configured Buzz; do nothing.
+#   2. `buzz` already on PATH -> nothing to do.
+#   3. BUZZ_CLI_URL set       -> download a prebuilt binary (fast path). Use this
+#                                once Block ships a CLI release, or point it at a
+#                                binary you built / host yourself.
+#   4. otherwise              -> cargo install from source at BUZZ_CLI_REF (slow:
+#                                a full Rust workspace compile; needs cargo on the
+#                                runner). No prebuilt CLI release exists yet — Block
+#                                ships Desktop app releases only — so this is the
+#                                default fallback. Set BUZZ_CLI_URL to skip it.
+set -euo pipefail
+
+# 1. Not configured -> no-op. Keeps the step free for every non-Buzz operator.
+if [ -z "${BUZZ_PRIVATE_KEY:-}" ]; then
+  echo "buzz-cli: BUZZ_PRIVATE_KEY unset — Buzz channel not configured, skipping install"
+  exit 0
+fi
+
+# 2. Already present.
+if command -v buzz >/dev/null 2>&1; then
+  echo "buzz-cli: already on PATH ($(command -v buzz))"
+  exit 0
+fi
+
+# 3. Prebuilt binary (preferred once available — no Rust build).
+if [ -n "${BUZZ_CLI_URL:-}" ]; then
+  DEST="$HOME/.local/bin"
+  mkdir -p "$DEST"
+  echo "buzz-cli: downloading prebuilt binary from \$BUZZ_CLI_URL"
+  curl -fsSL "$BUZZ_CLI_URL" -o "$DEST/buzz"
+  chmod +x "$DEST/buzz"
+  [ -n "${GITHUB_PATH:-}" ] && echo "$DEST" >> "$GITHUB_PATH"
+  echo "buzz-cli: installed prebuilt binary to $DEST/buzz"
+  exit 0
+fi
+
+# 4. Build from source (slow). Pin the ref via BUZZ_CLI_REF for reproducibility.
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "::error::buzz-cli: no prebuilt BUZZ_CLI_URL and no cargo on the runner — cannot stage the Buzz CLI" >&2
+  exit 1
+fi
+BUZZ_CLI_REF="${BUZZ_CLI_REF:-main}"
+echo "buzz-cli: building from source (block/buzz@$BUZZ_CLI_REF) — this is slow; set BUZZ_CLI_URL to a prebuilt binary to skip"
+cargo install --git https://github.com/block/buzz --branch "$BUZZ_CLI_REF" buzz-cli
+[ -n "${GITHUB_PATH:-}" ] && echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+echo "buzz-cli: installed via cargo"

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -13,8 +13,9 @@
 #
 # Per-channel rendering (via scripts/notify_format.py): Telegram = Markdown
 # normalized to HTML (parse_mode=HTML, fence-safe chunks, 3900), Discord embeds
-# (color by severity), Slack Block Kit. Falls back to $AEON_PENDING_DIR/notify-queue for
-# post-run delivery when the sandbox blocks outbound curl.
+# (color by severity), Slack Block Kit, Buzz = raw Markdown via the buzz-cli. Falls
+# back to $AEON_PENDING_DIR/notify-queue for post-run delivery when the sandbox blocks
+# outbound curl.
 set -euo pipefail
 
 # Resolve the formatter whether run as ./notify (repo root) or scripts/notify.sh
@@ -326,6 +327,32 @@ if [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
     curl -sf -X POST "$SLACK_WEBHOOK_URL" -H "Content-Type: application/json" \
       -d "$SLACK_PAYLOAD" > /dev/null 2>&1 && DELIVERED=true || true
   fi
+fi
+
+# Buzz — Block's Nostr-relay workspace (buzz.xyz / github.com/block/buzz). Aeon posts
+# as itself: BUZZ_PRIVATE_KEY is a Schnorr keypair (nsec) and the buzz-cli signs each
+# message + publishes it over the relay at BUZZ_RELAY_URL into channel BUZZ_CHANNEL_ID.
+# Unlike the webhook channels above there is no bearer-URL to POST to, so delivery needs
+# the `buzz` binary staged in the run (see install-harness); we gate on its presence and
+# skip cleanly when it is absent — same graceful degrade as a missing webhook. Content is
+# Markdown, which Buzz renders natively (no HTML/Block-Kit transform). One send per chunk.
+if { command -v buzz >/dev/null 2>&1 || [ "${NOTIFY_DRY_RUN:-}" = "1" ]; } \
+   && [ -n "${BUZZ_PRIVATE_KEY:-}" ] && [ -n "${BUZZ_CHANNEL_ID:-}" ]; then
+  BUZZ_CHUNKS_B64=$(printf '%s' "$MSG" | python3 "$FMT" buzz --title "$TITLE" --severity "$SEVERITY" || true)
+  while IFS= read -r BZ_B64; do
+    [ -z "$BZ_B64" ] && continue
+    BZ_MSG=$(printf '%s' "$BZ_B64" | base64 -d)
+    # Dry-run (tests): record the decoded Markdown instead of sending. No binary, no network.
+    if [ "${NOTIFY_DRY_RUN:-}" = "1" ]; then
+      mkdir -p "$PENDING_DIR/notify-queue"
+      printf '%s\n---\n' "$BZ_MSG" >> "$PENDING_DIR/notify-queue/buzz-payload.txt"
+      DELIVERED=true
+      continue
+    fi
+    printf '%s' "$BZ_MSG" | buzz messages send --channel "$BUZZ_CHANNEL_ID" --content - >/dev/null 2>&1 \
+      && DELIVERED=true || true
+    sleep 0.3
+  done <<< "$BUZZ_CHUNKS_B64"
 fi
 
 # Email via Resend (operator-notify channel — same provider/key as the in-run

--- a/scripts/notify_format.py
+++ b/scripts/notify_format.py
@@ -10,6 +10,7 @@ Channels & limits:
   - telegram : Markdown -> Telegram HTML (parse_mode=HTML), chunks <= 3900; base64 per line
   - discord  : embeds, description <= 4096; one JSON POST body per line
   - slack    : Block Kit, section text <= 3000; one JSON POST body (stdout)
+  - buzz     : raw Markdown (Buzz renders it natively), chunks <= 15000; base64 per line
 
 Two correctness properties this guarantees and the tests pin:
   1. No chunk exceeds its channel limit.
@@ -286,9 +287,26 @@ def slack(text, title, severity, limit=3000):
     return {"blocks": blocks}  # dict
 
 
+def buzz(text, title, severity, limit=15000):
+    # Buzz (Block's Nostr-relay workspace) renders Markdown natively, so unlike the
+    # Telegram/Slack paths there is no HTML or Block-Kit transform — just chunk the
+    # Markdown fence-safely. `limit` sits well under the relay's 65,536-byte per-message
+    # cap and small enough to stay readable in a chat channel. One `buzz messages send`
+    # per chunk; the caller base64-decodes each line and pipes it to the CLI's stdin.
+    meta = SEVERITY.get(severity, SEVERITY[DEFAULT_SEVERITY])
+    body = text
+    if title:
+        body = "%s **%s**\n\n%s" % (meta["emoji"], title, body)
+    chunks = chunk(body, limit)
+    n = len(chunks)
+    if n > 1:
+        chunks = [c + f"\n\n[{i + 1}/{n}]" for i, c in enumerate(chunks)]
+    return chunks  # list[str] of Markdown, one message per chunk
+
+
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("channel", choices=["telegram", "discord", "slack"])
+    ap.add_argument("channel", choices=["telegram", "discord", "slack", "buzz"])
     ap.add_argument("--title", default="")
     ap.add_argument("--severity", default=DEFAULT_SEVERITY)
     ap.add_argument("--limit", type=int, default=0)
@@ -306,6 +324,10 @@ def main():
     elif args.channel == "slack":
         lim = args.limit or 3000
         sys.stdout.write(json.dumps(slack(text, args.title, args.severity, lim)) + "\n")
+    elif args.channel == "buzz":
+        lim = args.limit or 15000
+        for c in buzz(text, args.title, args.severity, lim):
+            sys.stdout.write(base64.b64encode(c.encode()).decode() + "\n")
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_notify.sh
+++ b/scripts/tests/test_notify.sh
@@ -287,6 +287,29 @@ else
   rm -f "${UNWRITABLE}.err"
 fi
 
+# 18. Buzz channel — dry-run records the decoded Markdown (no `buzz` binary, no network).
+#     Gated on BUZZ_PRIVATE_KEY + BUZZ_CHANNEL_ID; NOTIFY_DRY_RUN bypasses `command -v buzz`.
+reset
+BUZZ_PRIVATE_KEY=nsec1x BUZZ_CHANNEL_ID=chan-uuid NOTIFY_DRY_RUN=1 \
+  bash "$NOTIFY" --title "Scan Report" --severity warn "Found 3 movers worth a look today" >/dev/null 2>&1
+BZ="$WORK/buzz-payload.txt"
+if [ -f "$BZ" ] && grep -q "Scan Report" "$BZ" && grep -q "Found 3 movers" "$BZ"; then
+  pass "buzz dry-run records decoded markdown payload"
+else
+  bad "buzz dry-run records decoded markdown payload"
+fi
+
+# 18b. Buzz gate — with the binary absent and NOT in dry-run, the channel is skipped
+#      (falls back to the pending queue like any unconfigured channel).
+reset
+BUZZ_PRIVATE_KEY=nsec1x BUZZ_CHANNEL_ID=chan-uuid \
+  bash "$NOTIFY" --severity critical "A real critical notification long enough to clear the floors" >/dev/null 2>&1
+if [ ! -f "$WORK/buzz-payload.txt" ] && [ -n "$(ls "$WORK"/*.md 2>/dev/null)" ]; then
+  pass "buzz skipped when binary absent -> pending-queue fallback"
+else
+  bad "buzz skipped when binary absent -> pending-queue fallback"
+fi
+
 reset
 echo "---"
 [ "$fail" = "0" ] && echo "ALL PASS" || echo "SOME FAILED"

--- a/scripts/tests/test_notify_format.py
+++ b/scripts/tests/test_notify_format.py
@@ -155,6 +155,21 @@ class TestChannels(unittest.TestCase):
             if b["type"] == "section":
                 self.assertLessEqual(len(b["text"]["text"]), 3000)
 
+    def test_buzz_returns_raw_markdown_with_title(self):
+        chunks = nf.buzz("- a bullet\n- another", title="Daily", severity="warn")
+        self.assertEqual(len(chunks), 1)
+        # Markdown is passed through untouched (Buzz renders it natively); title is bolded.
+        self.assertIn("**Daily**", chunks[0])
+        self.assertIn("- a bullet", chunks[0])
+
+    def test_buzz_chunks_within_limit_and_indexes(self):
+        chunks = nf.buzz("z" * 40000, title="", severity="info", limit=15000)
+        self.assertGreater(len(chunks), 1)
+        n = len(chunks)
+        for i, c in enumerate(chunks):
+            self.assertLessEqual(len(c), 15000)
+            self.assertTrue(c.rstrip().endswith(f"[{i + 1}/{n}]"))
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Buzz as a notification channel (Phase 1: outbound)

Adds [Buzz](https://buzz.xyz) - Block's open, self-hostable Nostr-relay workspace where humans and agents are first-class members ([block/buzz](https://github.com/block/buzz)) - as a `./notify` channel alongside Telegram / Discord / Slack / email.

It's the first channel that isn't a bearer-URL webhook. Delivery goes through the [`buzz` CLI](https://github.com/block/buzz/tree/main/crates/buzz-cli), which signs each message (NIP-98) with the agent's own Schnorr keypair and publishes it over the relay - so Aeon posts to a Buzz channel **as itself**, a member of the room, not a webhook poster. That maps cleanly onto Aeon's identity model (it already attributes as `@aeonframework`).

### Channel (render + delivery)
- **`notify_format.py`** - `buzz()` builder emits raw Markdown (Buzz renders it natively, so unlike the Telegram/Slack paths there's no HTML or Block-Kit transform), fence-safe chunks under the relay's 65,536-byte per-message cap, base64 per line, one message per chunk.
- **`notify.sh`** - gated delivery block keyed on `BUZZ_PRIVATE_KEY` + `BUZZ_CHANNEL_ID` **and** the presence of the `buzz` binary. Skips cleanly when the CLI is absent (same graceful degrade as a missing webhook URL). `NOTIFY_DRY_RUN` records the decoded payload for tests.
- Delivery is `buzz messages send --channel <uuid> --content -` (body on stdin). Command shape confirmed against `crates/buzz-cli` source, not guessed.

### Deploy wiring
- **`scripts/install-buzz-cli.sh`** - self-gating installer: an instant no-op unless `BUZZ_PRIVATE_KEY` is set, so every non-Buzz operator pays nothing. Prefers a prebuilt binary via `BUZZ_CLI_URL`; falls back to `cargo install --git` at `BUZZ_CLI_REF` because Block ships no CLI binary release yet (Desktop app only).
- **`aeon.yml` + `messages.yml`** - inject `BUZZ_PRIVATE_KEY` / `BUZZ_CHANNEL_ID` / `BUZZ_RELAY_URL` into the run-step env, plus a `Stage Buzz CLI` step.
- Docs: `CLAUDE.md`, `.github/README.md`, and the aeon-skill secrets reference.

### Config (all opt-in; unset = channel silently skipped)
| Secret / var | Purpose |
|---|---|
| `BUZZ_PRIVATE_KEY` (secret) | agent's `nsec` keypair |
| `BUZZ_CHANNEL_ID` (secret) | target channel UUID (`buzz channels list`) |
| `BUZZ_RELAY_URL` (var) | relay URL (CLI defaults to `http://localhost:3000`) |
| `BUZZ_CLI_URL` (var, optional) | prebuilt `buzz` binary to skip the from-source build |
| `BUZZ_CLI_REF` (var, optional) | git ref for the cargo fallback (default `main`) |

### Tests
- `scripts/tests/test_notify_format.py`: +2 (markdown passthrough with title, chunk-within-limit + `[i/n]` indexing). 25 pass.
- `scripts/tests/test_notify.sh`: +2 (dry-run records decoded payload; binary-absent falls back to the pending queue). Full suite passes.
- `python3 -c yaml.safe_load` on both workflows, `actionlint` (no new findings), `shellcheck` on the installer (clean).

### Scope / follow-ups
- **Outbound only.** The post-run pending re-delivery step still covers only the webhook channels; Buzz delivers inline during the run (Bash egress is open in-run), so the gap is minor. Wiring Buzz into pending re-delivery is a small follow-up.
- **Inbound (Phase 2)** - agent-as-participant: a `buzz messages get --since <cursor>` poller routed to skill dispatch (mirrors the Telegram poller + `telegram-route.sh`), owner-gated by author pubkey allowlist. Deliberately not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
