### PR TITLE
fix(otel): otel-cli epoch seconds.fraction, not raw nanoseconds

### DIFF
--- a/harness-adapter/lib/otel-span.sh
+++ b/harness-adapter/lib/otel-span.sh
@@ -18,14 +18,17 @@
 # CONTENT: only numeric usage + model + harness are recorded as gen_ai.*
 # attributes. The prompt and the result text are NEVER put on the span.
 
-# Epoch nanoseconds, portably. GNU date supports %N; BSD/macOS date prints a
-# literal "N", so fall back to second granularity there.
-_rh_now_ns() {
-  local n
-  n=$(date +%s%N 2>/dev/null)
-  case "$n" in
-    *[!0-9]* | "") echo "$(( $(date +%s) * 1000000000 ))" ;;
-    *) echo "$n" ;;
+# A timestamp otel-cli accepts for --start/--end: Unix epoch "seconds.fraction"
+# (its docs' canonical form is `date +%s.%N`). NOT bare nanoseconds — otel-cli
+# misparses a plain 19-digit integer into a far-future time. GNU date supports
+# %N; BSD/macOS date leaves a literal "N", so fall back to whole seconds there
+# (otel-cli accepts a plain epoch-seconds integer too).
+_rh_now() {
+  local t
+  t=$(date +%s.%N 2>/dev/null)
+  case "$t" in
+    *[!0-9.]* | "") date +%s ;;
+    *) echo "$t" ;;
   esac
 }
 

--- a/harness-adapter/run-harness
+++ b/harness-adapter/run-harness
@@ -154,10 +154,10 @@ if [ "$MODE" = "read-only" ] && [ "$SANDBOX" = "auto" ]; then
 fi
 
 OUT="$RH_TMPDIR/envelope.json"
-RH_SPAN_START=$(_rh_now_ns)
+RH_SPAN_START=$(_rh_now)
 "${CMD[@]}" > "$OUT"
 rc=$?
-RH_SPAN_END=$(_rh_now_ns)
+RH_SPAN_END=$(_rh_now)
 if [ $rc -eq 124 ]; then
   echo "error: harness run exceeded --timeout ${TIMEOUT}s" >&2
   exit 124


### PR DESCRIPTION
Follow-up to #821. The Tier-2 harness span reached Langfuse but with a year-2163 timestamp: run-harness passed `otel-cli` a bare 19-digit nanosecond integer, which it misparses. otel-cli's `--start/--end` want Unix epoch `seconds.fraction` (`date +%s.%N`) or RFC3339. Fix emits `%s.%N` with a `%s` fallback on BSD/macOS. Verified: `--start 1000000000` lands at exactly 2001-09-09T01:46:40Z (epoch 1e9 s), confirming otel-cli reads the value as seconds; so `1785870789`s resolves to 2026. Tests + actionlint green.