### PR TITLE
docs: sync PRs #808-#824 to aeon docs

### DIFF
--- a/.claude/skills/aeon/SKILL.md
+++ b/.claude/skills/aeon/SKILL.md
@@ -310,7 +310,7 @@ Three at a time, not twelve. Every enabled skill is a recurring notification, an
 
 `ls` footers with `65 skills · 1 enabled` — read it to them before proposing anything. First run installs the CLI runtime (tsx + yaml, ~12MB); the npm noise is one-time and expected. Grep-only equivalents: `references/layout.md`.
 
-Packs are a visibility filter, not a runtime switch — revealing one runs nothing. Core (11), Evolution (8) and Basics (15) show by default; Dev (10), Crypto (13) and Productivity (8) are on demand.
+Packs are a visibility filter, not a runtime switch — revealing one runs nothing. Core (11), Evolution (8) and Basics (16) show by default; Dev (10), Crypto (14) and Productivity (6) are on demand.
 
 Reasonable starting sets:
 

--- a/.claude/skills/aeon/SKILL.md
+++ b/.claude/skills/aeon/SKILL.md
@@ -235,14 +235,17 @@ They just did something in Claude Code and want it to happen on a schedule.
 
 ```yaml
 ---
-type: Skill
-name: My Skill
-category: basics
+name: my-skill
 description: One line — what it does and what it sends.
-var: ""
-tags: [content]
-mode: read-only
-requires: [SOME_API_KEY?]
+metadata:
+  title: My Skill
+  mode: read-only
+  category: basics
+  var: ""
+  tags:
+    - content
+  requires:
+    - SOME_API_KEY?
 ---
 
 Today is ${today}. <the prompt — plain instructions, including judgment calls>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,32 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Added
 
+- **New notification channel: Buzz.** `./notify` can now post to a
+  [Buzz](https://buzz.xyz) channel (Block's self-hostable Nostr-relay workspace)
+  alongside Telegram / Discord / Slack / email. Unlike the bearer-URL webhooks,
+  delivery goes through the `buzz` CLI, which signs each message (NIP-98) with the
+  agent's own keypair and publishes it as a room member rather than a webhook
+  poster. Gated on `BUZZ_PRIVATE_KEY` + `BUZZ_CHANNEL_ID` and the presence of the
+  CLI; outbound only for now (Phase 1). (#822)
+- **OpenTelemetry on the Node entry points and non-claude harnesses.** The opt-in
+  Langfuse tracing that previously covered only the `claude -p` path now extends to
+  the dashboard, MCP server, and webhook (request/routing spans) and emits one
+  coarse `gen_ai` span per run for the grok/codex/pi/vibe/kimi harnesses (numeric
+  usage only, never prompt or result text). No-op unless
+  `OTEL_EXPORTER_OTLP_ENDPOINT` (or the Langfuse keys) is set, and it never fails
+  the caller. (#821, #823)
+- **`aeon` skill Mode 8 - mine Claude Code history for skills to automate.** A new
+  mode that reads the operator's own past Claude Code transcripts, ranks recurring
+  work by distinct sessions x distinct days, and surfaces the strongest candidates
+  to turn into scheduled skills (then hands the chosen one to Mode 4). Local-only;
+  it never runs inside an Aeon run. (#820)
+- **Per-skill icons across the dashboard, docs, and catalog.** Every skill now has
+  its own monochrome glyph from one canonical source (`catalog/skill-icons.json`),
+  driving the dashboard roster/detail/packs surfaces and the README + docs tables
+  through a new `bin/generate-skill-icons` generator (`--check` fails on drift).
+  (#808)
+- **Community skill pack registered: AI2Human Create Task** (`ai2human-handoff`),
+  now listed in `bin/install-skill-pack --list`. (#812)
 - **New skill: `deploy-uni-hook`** - turns a one-line brief into a live Uniswap
   v4 hook + test pool on any v4 chain. Generates from a pre-audited template
   (`dynamic`/`noop`/`skim`) or a from-scratch freeform hook, auto-derives the
@@ -72,6 +98,18 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Changed
 
+- **Adopted the Agent Skills open standard; removed OKF globally.** All 65 skills
+  now use spec-form frontmatter (only `name` + `description` top-level, everything
+  else nested under `metadata:`, block-style lists) and pass the official
+  `skills-ref` validator. OKF is gone entirely - the validator/index/backfill
+  scripts, the `ci-okf` workflow, the MCP `okf://` resources, `docs/OKF.md`, and the
+  `okf-export` / `okf-ingest` skills - and the `type:` frontmatter it mandated is
+  stripped from every bundle file. The readers that parse skill metadata
+  (`skill_requires`, `generate-skills-json`, the dashboard frontmatter parser, the
+  scheduler `depends_on` parser) were rewritten for block-style lists, and the
+  eyebrow lockfile was re-baselined. (#824)
+- **Ecosystem logos refreshed; NoelClaw and SyntheticsAI removed** from
+  `docs/ECOSYSTEM.md`. (#814)
 - **Dashboard catalogs the `PAGESPEED_API_KEY` secret** - seo-audit's optional
   Core Web Vitals key now appears in the Skill Keys group with its brand icon and
   where-to-get-it copy, instead of a bare initials-badge catch-all row. (#803)
@@ -91,6 +129,20 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Fixed
 
+- **Read-only persistence contract corrected.** Docs told read-only skills they
+  could persist to `memory/` during a run, but the OS sandbox write-locks the whole
+  workspace on all six harnesses, so those writes silently fail. `CLAUDE.md` and
+  `docs/CONFIGURATION.md` now state the real contract: persistence routes through
+  the final captured output and `./notify`, and the post-run guard commits it to
+  `output/.chains/` plus a `memory/logs/` entry outside the sandbox. (#817)
+- **Read-only MCP skills route persistence through their output**, not direct
+  `memory/` writes. `finance-district-mcp`, `glim-mcp`, and `robinhood-mcp` no
+  longer instruct the agent to append to `memory/logs/` under read-only (those
+  writes are refused by the sandbox), and the bare `./notify -f` is corrected to
+  `./notify -f <file>` in each. (#818)
+- **`finance-district-mcp` declares `onchain_writes`** (it signs and broadcasts
+  transfers, swaps, and x402 payments) and its `./notify -f` usage is corrected to
+  require a file path. (#816)
 - **`finance-district-mcp` registered in `aeon.yml`.** The skill shipped in #791
   but had no schedule entry, so it never ran; it is now present (disabled by
   default). (#800)
@@ -322,6 +374,16 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Security
 
+- **Skill-scan recalibrated to fire on operations, not syntax.** The HIGH tier now
+  matches dangerous sinks (code execution, secret exfiltration, destruction) and
+  prompt injection rather than ordinary shell syntax, adds a `curl | sh` RCE
+  pattern, and locks the boundary with a fixture test in CI - fixing a state where
+  the gate failed 65 of 67 first-party skills and pushed operators toward `--force`
+  (which skips the deep scan). (#811)
+- **Skill-scan hardening follow-up:** closed an injection-suppression evasion
+  (attacker-appended rejection keywords could silence a HIGH finding), extended the
+  RCE process-substitution detection to `source <(curl ...)`, and caught quoted
+  destructive-`rm` targets. (#813)
 - **Telegram inbound gated on the owner's user ID.** In a group or public chat
   any member could command the bot by tapping a button; inbound is now restricted
   to `TELEGRAM_ALLOWED_USER_ID` (defaults to the chat ID for a 1:1 DM), failing
@@ -332,6 +394,8 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Maintenance
 
+- 2 dependency bumps (wrangler in the webhook; the dashboard group) plus a new CI
+  eyebrow capability-integrity gate for skills. (#809, #810, #815)
 - CI green-up after the Telegram owner-gate, plus a dashboard PacksPanel
   unique-key fix. (#798, #799)
 - Repo-wide cleanup pass across 8 dimensions (dead code, weak types,

--- a/docs/aeon-setup.md
+++ b/docs/aeon-setup.md
@@ -9,7 +9,7 @@ Aeon ships an **[Agent Skill](https://code.claude.com/docs/en/skills)** (`SKILL.
 
 It's a portable skill, not tied to one product: [Claude Code](https://claude.com/claude-code) is the primary host (it auto-loads skills from `.claude/skills/`, so it's zero-install there), but the skill is just a `SKILL.md` in the open Agent Skills format — it works with **Claude Code, Codex, Hermes, or OpenClaw**, and any other agent tool that supports skills.
 
-> **This is not an Aeon skill.** The 66 skills under [`skills/`](../skills) run unattended on GitHub Actions. **This** one runs inside *your* agent session on *your* machine — it's the operator's assistant for configuring the instance, not something that runs on a schedule. It doesn't appear in `aeon.yml`, the packs, or the catalog.
+> **This is not an Aeon skill.** The 65 skills under [`skills/`](../skills) run unattended on GitHub Actions. **This** one runs inside *your* agent session on *your* machine — it's the operator's assistant for configuring the instance, not something that runs on a schedule. It doesn't appear in `aeon.yml`, the packs, or the catalog.
 
 ## What it does
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,6 +1,6 @@
 # Aeon integration examples
 
-Aeon ships an [MCP server](../apps/mcp-server/) so any Claude client can call its 66 skills. The scripts here are the shortest possible "first call works" demos — build the server, run `python <file>`, get a real Aeon output back.
+Aeon ships an [MCP server](../apps/mcp-server/) so any Claude client can call its 65 skills. The scripts here are the shortest possible "first call works" demos — build the server, run `python <file>`, get a real Aeon output back.
 
 | File | Stack | Skill called | What it shows |
 |------|-------|--------------|---------------|

--- a/docs/skill-packs.md
+++ b/docs/skill-packs.md
@@ -1,6 +1,6 @@
 # Skill packs
 
-Aeon ships **66 skills**, but most forks only ever run a handful. Packs make
+Aeon ships **65 skills**, but most forks only ever run a handful. Packs make
 that manageable: by default the dashboard shows **Core** (what makes Aeon
 different) and **Basics** (simple skills you can run right now) — everything else
 is grouped into **packs** that stay hidden until you enable them.
@@ -73,7 +73,7 @@ Pack key = category. Six packs, no empties; three are shown by default.
 |---|---|---|
 | **Core** (`core`) | Fleet coordination, self-configuration, liveness, memory + reporting. Shown by default; not removable. | 11 |
 | **Evolution** (`evolution`) | The self-improvement loop — authors, evolves, installs, and heals its own skills. Shown by default. | 8 |
-| **Basics** (`basics`) | Simple, immediately-runnable skills — one approachable entry per area. Shown by default. | 15 |
+| **Basics** (`basics`) | Simple, immediately-runnable skills — one approachable entry per area. Shown by default. | 16 |
 | **Dev & Code** (`dev`) | PR/issue triage, review, merges, changelogs, repo monitoring, security scanning, app deploys. | 10 |
 | **Crypto & Markets** (`crypto`) | Token/DeFi/prediction-market monitoring, narrative tracking, on-chain forensics + automation, Uniswap v4 hook deploys. | 14 |
 | **Productivity** (`productivity`) | Personal + social ops: routines, ideas, retrospectives, mentions, replies, ads, email. | 6 |


### PR DESCRIPTION
Sync of merged PRs #808-#824 into the aeon repo docs. Source of truth = merged PRs on `aeonfun/aeon`; watermark was #805.

## Surfaces touched
- **CHANGELOG.md** - `[Unreleased]` batch entries across Added / Changed / Fixed / Security / Maintenance, each bullet ending in its PR number (prepend-only).
- **.claude/skills/aeon/SKILL.md** - pack breakdown corrected to the live catalog: Basics 15 -> 16, Crypto 13 -> 14, Productivity 8 -> 6 (cross-checked against `catalog/packs.json`).
- **docs/skill-packs.md** - "66 skills" -> "65"; Basics pack 15 -> 16.
- **docs/aeon-setup.md**, **docs/examples/README.md** - "66 skills" -> "65".

## Signal PRs documented
- #824 Adopt Agent Skills spec form; remove OKF globally
- #822 Buzz outbound notification channel
- #821 / #823 OpenTelemetry on Node entry points + non-claude harnesses (+ otel-cli timestamp fix)
- #820 aeon skill Mode 8 - mine Claude Code history for skills
- #808 per-skill icons across dashboard / docs / catalog
- #817 / #818 / #816 read-only persistence contract + finance-district-mcp capabilities
- #811 / #813 skill-scan calibration + hardening (Security)
- #814 ecosystem logos refresh, drop NoelClaw + SyntheticsAI
- #812 AI2Human Create Task community pack registered

## Bundled as Maintenance (noise)
- #809 wrangler bump, #810 dashboard dep group, #815 CI eyebrow capability-integrity gate

Skipped: #807 (the prior batch's own docs-sync PR).

## Flag (not fixed here)
The operator setup skill's "Skill file shape" example still shows `type: Skill` (`.claude/skills/aeon/SKILL.md`), which #824's spec-form change should have stripped. Upstream residual - left faithful, flagged for a separate fix.
