### PR TITLE
ci: drop daily cron from Setup Telegram Commands

### DIFF
--- a/.github/workflows/setup-commands.yml
+++ b/.github/workflows/setup-commands.yml
@@ -9,16 +9,12 @@ name: Setup Telegram Commands
 #     setup needs no manual step;
 #   • the dashboard's "Re-register commands" button (POST /api/telegram/commands);
 #   • whenever aeon.yml changes on main, so the menu never drifts from the enabled set;
-#   • daily at 06:00 UTC — a belt-and-suspenders re-register in case a push was missed
-#     or Telegram dropped the command list; idempotent, so a no-op when already current;
 #   • on demand from the Actions tab → Run workflow.
 # All paths read TELEGRAM_BOT_TOKEN server-side (no token pasting). No-ops silently on
 # forks without TELEGRAM_BOT_TOKEN configured.
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 6 * * *'   # daily safety re-register (push trigger already keeps it live)
   push:
     branches: [main]
     paths: ['aeon.yml']


### PR DESCRIPTION
Removes the schedule: 0 6 * * * trigger from setup-commands.yml. On canon (no live bot) the daily re-register is a no-op green run - Actions noise. Push-on-aeon.yml, the dashboard secret-save dispatch, the Re-register button, and workflow_dispatch already cover every case the command menu can change. Forks with a live bot are unaffected; no-op on forks without TELEGRAM_BOT_TOKEN regardless.