### PR TITLE
docs: brand refresh for README header - animated hero + pill nav

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,24 +1,31 @@
 <p align="center">
-  <img src="../docs/assets/aeon.jpg" alt="Aeon" width="120" />
-</p>
-
-<h1 align="center">AEON</h1>
-
-<p align="center">
-  <a href="https://www.aeon.fun/docs"><img src="https://img.shields.io/badge/Docs-aeon.fun-blue?style=flat-square&logo=gitbook&logoColor=white&labelColor=1a1a2e" alt="Documentation"></a>
-  <a href="https://github.com/aeonfun/aeon/stargazers"><img src="https://img.shields.io/github/stars/aeonfun/aeon?style=flat-square&logo=github" alt="GitHub stars"></a>
-  <a href="https://github.com/aeonfun/aeon/network/members"><img src="https://img.shields.io/github/forks/aeonfun/aeon?style=flat-square&logo=github" alt="GitHub forks"></a>
-  <a href="https://x.com/aeonframework"><img src="https://img.shields.io/badge/%40aeonframework-black?style=flat-square&logo=x&labelColor=000000" alt="@aeonframework on X"></a>
-  <a href="https://bankr.bot/discover/0xbf8e8f0e8866a7052f948c16508644347c57aba3"><img src="https://img.shields.io/badge/%24aeon%20on-Bankr-orange?style=flat-square&labelColor=1a1a2e" alt="$aeon on Bankr"></a>
+  <img src="../docs/assets/hero-animated.svg" alt="AEON — the most autonomous agent framework. 67 skills across 6 harnesses (Claude Code, Grok, Codex, Pi, Vibe, Kimi), running unattended on GitHub Actions: it ships features to your repos, privately discloses real vulnerabilities, deploys live apps, runs deep research, and writes new skills for itself. Keywords: autonomous AI agent, agent framework, GitHub Actions automation, self-improving agent, multi-agent orchestration, LLM skills, cron agent." width="100%" />
 </p>
 
 <p align="center">
-  <strong>The most autonomous agent framework.</strong><br>
+  <strong>Star us&nbsp;❤️&nbsp;→</strong>&nbsp;&nbsp;
+  <a href="https://github.com/aeonfun/aeon/stargazers"><img src="../docs/assets/btn-star.svg" alt="Star Aeon on GitHub" height="34" align="absmiddle"></a>&nbsp;&nbsp;
+  <a href="https://www.aeon.fun"><img src="../docs/assets/btn-site.svg" alt="aeon.fun" height="34" align="absmiddle"></a>&nbsp;&nbsp;
+  <a href="https://www.aeon.fun/docs"><img src="../docs/assets/btn-docs.svg" alt="Aeon docs" height="34" align="absmiddle"></a>&nbsp;&nbsp;
+  <a href="https://x.com/aeonframework"><img src="../docs/assets/btn-x.svg" alt="@aeonframework on X" height="34" align="absmiddle"></a>&nbsp;&nbsp;
+  <a href="https://bankr.bot/discover/0xbf8e8f0e8866a7052f948c16508644347c57aba3"><img src="../docs/assets/btn-bankr.svg" alt="$aeon on Bankr" height="34" align="absmiddle"></a>
+</p>
+
+<div align="center">
+
+[![stars](https://img.shields.io/github/stars/aeonfun/aeon?style=flat-square&label=stars&color=F4EFE1&labelColor=0d0c0a&logo=github&logoColor=F4EFE1)](https://github.com/aeonfun/aeon/stargazers)
+[![forks](https://img.shields.io/github/forks/aeonfun/aeon?style=flat-square&label=forks&color=F4EFE1&labelColor=0d0c0a&logo=github&logoColor=F4EFE1)](https://github.com/aeonfun/aeon/network/members)
+[![license](https://img.shields.io/badge/license-MIT-F4EFE1?style=flat-square&labelColor=0d0c0a)](../LICENSE)
+[![node](https://img.shields.io/badge/node-20+-F4EFE1?style=flat-square&labelColor=0d0c0a)](https://nodejs.org/)
+
+</div>
+
+<p align="center">
   Give it a direction and it gets the work done: ships features to your repos, finds and privately discloses real vulnerabilities, deploys live apps, runs deep research - and writes new skills for itself. No approval loops. No babysitting. Configure once, forget forever.
 </p>
 
 <p align="center">
-  <img src="../docs/assets/aeon-demo.gif" alt="Aeon Demo" />
+  <img src="../docs/assets/aeon-demo.gif" alt="Aeon live demo — the dashboard configures skills, schedules them on cron, and Aeon runs unattended: shipping PRs, disclosing vulnerabilities, and reporting back to your channels." />
 </p>
 
 ---

--- a/docs/assets/btn-bankr.svg
+++ b/docs/assets/btn-bankr.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="118" height="40" viewBox="0 0 118 40" role="img" aria-label="$aeon on Bankr">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#1c1a15"/>
+      <stop offset="1" stop-color="#0d0c0a"/>
+    </linearGradient>
+    <style>@keyframes flip{0%,100%{transform:scaleX(1)}50%{transform:scaleX(0.16)}}.coin{transform-box:fill-box;transform-origin:center;animation:flip 2.8s ease-in-out infinite}</style>
+  </defs>
+  <rect x="0.5" y="0.5" width="117" height="39" rx="19.5" fill="url(#g)" stroke="#F4EFE1" stroke-opacity="0.5"/>
+  <rect x="2" y="1.5" width="114" height="15" rx="12" fill="#F4EFE1" opacity="0.05"/>
+  <g class="coin">
+    <circle cx="25" cy="20" r="8" fill="none" stroke="#F4EFE1" stroke-width="1.5"/>
+    <text x="25" y="24.5" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif" font-size="11" font-weight="800" fill="#F4EFE1">$</text>
+  </g>
+  <text x="42" y="25.5" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="700" fill="#F4EFE1">$aeon</text>
+</svg>

--- a/docs/assets/btn-docs.svg
+++ b/docs/assets/btn-docs.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="110" height="40" viewBox="0 0 110 40" role="img" aria-label="Docs">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#1c1a15"/>
+      <stop offset="1" stop-color="#0d0c0a"/>
+    </linearGradient>
+    <style>@keyframes rock{0%,100%{transform:rotate(-6deg)}50%{transform:rotate(6deg)}}.bk{transform-box:fill-box;transform-origin:center;animation:rock 3s ease-in-out infinite}</style>
+  </defs>
+  <rect x="0.5" y="0.5" width="109" height="39" rx="19.5" fill="url(#g)" stroke="#F4EFE1" stroke-opacity="0.5"/>
+  <rect x="2" y="1.5" width="106" height="15" rx="12" fill="#F4EFE1" opacity="0.05"/>
+  <g class="bk" stroke="#F4EFE1" stroke-width="1.5" fill="none" stroke-linejoin="round">
+    <path d="M17 13.5h6.5a2 2 0 0 1 2 2v11.5a1.6 1.6 0 0 0-1.6-1.6H17z"/>
+    <path d="M33 13.5h-6.5a2 2 0 0 0-2 2v11.5a1.6 1.6 0 0 1 1.6-1.6H33z"/>
+  </g>
+  <text x="42" y="25.5" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="700" fill="#F4EFE1">Docs</text>
+</svg>

--- a/docs/assets/btn-site.svg
+++ b/docs/assets/btn-site.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="40" viewBox="0 0 140 40" role="img" aria-label="aeon.fun">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#1c1a15"/>
+      <stop offset="1" stop-color="#0d0c0a"/>
+    </linearGradient>
+  </defs>
+  <rect x="0.5" y="0.5" width="139" height="39" rx="19.5" fill="url(#g)" stroke="#F4EFE1" stroke-opacity="0.5"/>
+  <rect x="2" y="1.5" width="136" height="15" rx="12" fill="#F4EFE1" opacity="0.05"/>
+  <g stroke="#F4EFE1" stroke-width="1.5" fill="none">
+    <circle cx="25" cy="20" r="8"/>
+    <ellipse cx="25" cy="20" rx="3.4" ry="8"><animate attributeName="rx" values="3.4;0.5;3.4" dur="3.4s" repeatCount="indefinite"/></ellipse>
+    <line x1="17" y1="20" x2="33" y2="20"/>
+    <line x1="18.5" y1="15" x2="31.5" y2="15"/>
+    <line x1="18.5" y1="25" x2="31.5" y2="25"/>
+  </g>
+  <text x="42" y="25.5" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="700" fill="#F4EFE1">aeon.fun</text>
+</svg>

--- a/docs/assets/btn-star.svg
+++ b/docs/assets/btn-star.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="40" viewBox="0 0 96 40" role="img" aria-label="Star">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#1c1a15"/>
+      <stop offset="1" stop-color="#0d0c0a"/>
+    </linearGradient>
+    <style>@keyframes tw{0%,100%{transform:scale(1)}50%{transform:scale(1.18)}}.ic{transform-box:fill-box;transform-origin:center;animation:tw 2.4s ease-in-out infinite}</style>
+  </defs>
+  <rect x="0.5" y="0.5" width="95" height="39" rx="19.5" fill="url(#g)" stroke="#F4EFE1" stroke-opacity="0.5"/>
+  <rect x="2" y="1.5" width="92" height="15" rx="12" fill="#F4EFE1" opacity="0.05"/>
+  <path class="ic" d="M25 12.5l2.2 4.9 5.3.5-4 3.6 1.2 5.2-4.7-2.8-4.7 2.8 1.2-5.2-4-3.6 5.3-.5z" fill="#F4EFE1"/>
+  <text x="44" y="25.5" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="700" fill="#F4EFE1">Star</text>
+</svg>

--- a/docs/assets/btn-x.svg
+++ b/docs/assets/btn-x.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="196" height="40" viewBox="0 0 196 40" role="img" aria-label="@aeonframework on X">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#1c1a15"/>
+      <stop offset="1" stop-color="#0d0c0a"/>
+    </linearGradient>
+    <style>@keyframes xp{0%,100%{transform:scale(1)}50%{transform:scale(1.14)}}.xp{transform-box:fill-box;transform-origin:center;animation:xp 2.6s ease-in-out infinite}</style>
+  </defs>
+  <rect x="0.5" y="0.5" width="195" height="39" rx="19.5" fill="url(#g)" stroke="#F4EFE1" stroke-opacity="0.5"/>
+  <rect x="2" y="1.5" width="192" height="15" rx="12" fill="#F4EFE1" opacity="0.05"/>
+  <g class="xp"><g transform="translate(16,12) scale(0.667)" fill="#F4EFE1">
+    <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
+  </g></g>
+  <text x="42" y="25.5" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="700" fill="#F4EFE1">@aeonframework</text>
+</svg>

--- a/docs/assets/hero-animated.svg
+++ b/docs/assets/hero-animated.svg
@@ -1,0 +1,107 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 640" width="1600" height="640" role="img" aria-label="AEON — the most autonomous agent framework">
+  <defs>
+    <pattern id="halftone" width="7" height="7" patternUnits="userSpaceOnUse">
+      <circle cx="1.4" cy="1.4" r="1.1" fill="#F4EFE1"/>
+    </pattern>
+    <radialGradient id="vig" cx="50%" cy="46%" r="62%">
+      <stop offset="0%" stop-color="#17150f"/>
+      <stop offset="60%" stop-color="#0d0c0a"/>
+      <stop offset="100%" stop-color="#060504"/>
+    </radialGradient>
+    <radialGradient id="halo" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#F4EFE1" stop-opacity="0.16"/>
+      <stop offset="100%" stop-color="#F4EFE1" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="2.2"/>
+    </filter>
+    <style>
+      @keyframes pulse{0%,100%{transform:scale(1)}50%{transform:scale(1.09)}}
+      @keyframes spin{from{transform:rotate(0deg)}to{transform:rotate(360deg)}}
+      .star{transform-box:fill-box;transform-origin:center;animation:pulse 3.2s ease-in-out infinite}
+      .rays{transform-box:fill-box;transform-origin:center;animation:spin 70s linear infinite}
+    </style>
+  </defs>
+
+  <!-- background -->
+  <rect width="1600" height="640" fill="url(#vig)"/>
+  <rect width="1600" height="640" fill="url(#halftone)" opacity="0.10"/>
+
+  <!-- sunburst rays behind wordmark -->
+  <g class="rays" transform="translate(800,296)">
+    <g stroke="#F4EFE1" stroke-opacity="0.055" stroke-width="3">
+      <line x1="0" y1="0" x2="760" y2="0"/>
+      <line x1="0" y1="0" x2="658" y2="380"/>
+      <line x1="0" y1="0" x2="380" y2="658"/>
+      <line x1="0" y1="0" x2="0" y2="760"/>
+      <line x1="0" y1="0" x2="-380" y2="658"/>
+      <line x1="0" y1="0" x2="-658" y2="380"/>
+      <line x1="0" y1="0" x2="-760" y2="0"/>
+      <line x1="0" y1="0" x2="-658" y2="-380"/>
+      <line x1="0" y1="0" x2="-380" y2="-658"/>
+      <line x1="0" y1="0" x2="0" y2="-760"/>
+      <line x1="0" y1="0" x2="380" y2="-658"/>
+      <line x1="0" y1="0" x2="658" y2="-380"/>
+    </g>
+  </g>
+
+  <!-- twinkling starfield -->
+  <g fill="#F4EFE1">
+    <circle cx="150" cy="90" r="1.8"><animate attributeName="opacity" values="0.2;1;0.2" dur="3.1s" repeatCount="indefinite"/></circle>
+    <circle cx="300" cy="180" r="1.3"><animate attributeName="opacity" values="0.15;0.8;0.15" dur="4.3s" repeatCount="indefinite"/></circle>
+    <circle cx="240" cy="470" r="1.6"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.7s" repeatCount="indefinite"/></circle>
+    <circle cx="470" cy="120" r="1.4"><animate attributeName="opacity" values="0.15;0.85;0.15" dur="5.0s" repeatCount="indefinite"/></circle>
+    <circle cx="120" cy="330" r="1.2"><animate attributeName="opacity" values="0.2;0.7;0.2" dur="4.6s" repeatCount="indefinite"/></circle>
+    <circle cx="1120" cy="120" r="1.5"><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.4s" repeatCount="indefinite"/></circle>
+    <circle cx="1300" cy="200" r="1.3"><animate attributeName="opacity" values="0.15;0.8;0.15" dur="4.1s" repeatCount="indefinite"/></circle>
+    <circle cx="1380" cy="420" r="1.7"><animate attributeName="opacity" values="0.2;1;0.2" dur="3.9s" repeatCount="indefinite"/></circle>
+    <circle cx="1460" cy="110" r="1.2"><animate attributeName="opacity" values="0.15;0.7;0.15" dur="5.2s" repeatCount="indefinite"/></circle>
+    <circle cx="1200" cy="470" r="1.4"><animate attributeName="opacity" values="0.2;0.85;0.2" dur="4.4s" repeatCount="indefinite"/></circle>
+    <circle cx="620" cy="90" r="1.2"><animate attributeName="opacity" values="0.15;0.75;0.15" dur="4.8s" repeatCount="indefinite"/></circle>
+    <circle cx="980" cy="80" r="1.3"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.6s" repeatCount="indefinite"/></circle>
+  </g>
+
+  <!-- star mark -->
+  <circle cx="800" cy="150" r="90" fill="url(#halo)"/>
+  <g transform="translate(800,150)">
+    <path class="star" d="M0 -56 L13.7 -18.9 L53.2 -17.3 L22.3 7.2 L32.9 45.3 L0 23.4 L-32.9 45.3 L-22.3 7.2 L-53.2 -17.3 L-13.7 -18.9 Z"
+      fill="#F4EFE1" stroke="#0d0c0a" stroke-width="1.2"/>
+  </g>
+
+  <!-- wordmark -->
+  <g transform="translate(800,318)">
+    <text x="0" y="0" text-anchor="middle" transform="skewX(-8)"
+      font-family="'Arial Black','Helvetica Neue',Helvetica,Arial,sans-serif" font-weight="900" font-style="italic"
+      font-size="164" letter-spacing="10" fill="#F4EFE1">AEON</text>
+  </g>
+
+  <!-- tagline -->
+  <text x="800" y="398" text-anchor="middle"
+    font-family="'Arial Black','Helvetica Neue',Helvetica,Arial,sans-serif" font-weight="800" font-style="italic"
+    font-size="30" letter-spacing="1.5" fill="#F4EFE1" fill-opacity="0.92">The most autonomous agent framework.</text>
+
+  <!-- stat bubbles -->
+  <g font-family="'Arial Black','Helvetica Neue',Helvetica,Arial,sans-serif" font-weight="800" font-style="italic" font-size="20" fill="#0d0c0a">
+    <g transform="translate(560,452)">
+      <rect x="0" y="0" width="150" height="42" rx="21" fill="#F4EFE1" stroke="#0d0c0a" stroke-width="2"/>
+      <text x="75" y="28" text-anchor="middle">67 skills</text>
+    </g>
+    <g transform="translate(725,452)">
+      <rect x="0" y="0" width="176" height="42" rx="21" fill="#F4EFE1" stroke="#0d0c0a" stroke-width="2"/>
+      <text x="88" y="28" text-anchor="middle">6 harnesses</text>
+    </g>
+    <g transform="translate(916,452)">
+      <rect x="0" y="0" width="184" height="42" rx="21" fill="#F4EFE1" stroke="#0d0c0a" stroke-width="2"/>
+      <text x="92" y="28" text-anchor="middle">no babysitting</text>
+    </g>
+  </g>
+
+  <!-- heartbeat pulse line -->
+  <path id="beat" d="M70 588 H438 l14 -22 l16 40 l20 -104 l18 132 l16 -46 H1530"
+    fill="none" stroke="#F4EFE1" stroke-opacity="0.55" stroke-width="2.4" stroke-linejoin="round" stroke-linecap="round"/>
+  <circle r="5.5" fill="#F4EFE1" filter="url(#soft)">
+    <animateMotion dur="3.4s" repeatCount="indefinite" rotate="auto">
+      <mpath href="#beat"/>
+    </animateMotion>
+  </circle>
+</svg>


### PR DESCRIPTION
Adapts the new MiroShark-style README treatment to Aeon's own brand (black + cream halftone, five-point star, pop-art newsprint - **not** MiroShark's violet chrome).

### What changed (header only)
- **Animated hero SVG** (`docs/assets/hero-animated.svg`) - black/cream halftone field, twinkling starfield, slow sunburst, a pulsing five-point star mark, the `AEON` wordmark + tagline, three stat bubbles (`67 skills` / `6 harnesses` / `no babysitting`), and a live heartbeat pulse line (nods to `heartbeat` + "never sleeps"). SEO-loaded alt text.
- **Self-hosted animated pill nav** replacing the 5 shields badges: Star, aeon.fun, Docs, @aeonframework, $aeon. Near-black fill + cream border/icon/text so they read on GitHub light **and** dark.
- **Slim live-stat line** (stars, forks, license, node) kept for live counts.
- Everything below the header (Quick start, skill catalog, config, community packs, etc.) is untouched.

### Not done here
No section art - the deeper image-per-section pass (like MiroShark's use-case cards / feature wall) would need generated illustrations. This PR is the buildable-now brand layer.

Rendered-verified in headless Chrome on both light and dark backgrounds. Worth eyeballing the live GitHub render for the SVG animation + pill alignment before merge.
