### PR TITLE
docs: Docs pill nav (replace Reference list)

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -371,19 +371,23 @@ The full walkthrough - App permissions, the tenant-isolation check, dispatch got
 
 ---
 
-## Reference & advanced
+## Docs
 
-Everything above gets you running. The deeper reference lives in [`docs/`](../docs) so this page stays short.
+Everything above gets you running. The deep reference lives in [`docs/`](../docs) - jump in:
 
-- **[Configuration & advanced](../docs/CONFIGURATION.md)** - skill chaining, reactive triggers, scheduler frequency, capability modes, MCP in runs, cross-repo tokens, `STRATEGY.md` / soul, Fleet Watcher, remote dashboard, two-repo setup, Actions cost.
-- **[ADK (Aeon Developer Kit)](../docs/ADK.md)** - build products on top of Aeon: authorize access to your users' instances with a GitHub App, drive skills over the GitHub API, and ship your own skills as a pack.
-- **[LLM gateways](../docs/CONFIGURATION.md#llm-gateways)** - eight ways to power Claude Code, resolved by an automatic fail-over cascade.
-- **[Harnesses](../docs/harnesses.md)** - run skills on any of six agent CLIs (Claude Code, Grok, Codex, Pi, Vibe, Kimi) behind one contract via [`harness-adapter`](../harness-adapter/); auth, token accounting, per-skill knobs, and the live verification matrix.
-- **[Use Aeon's skills from Claude](../apps/mcp-server/README.md)** - every skill as an `aeon-<name>` MCP tool in Claude Desktop and Code.
-- **[Command line](../apps/cli/README.md)** - the whole dashboard as scriptable `./aeon` commands.
-- **[Telegram instant mode](../apps/webhook/README.md)** - ~1s replies via a self-hosted Cloudflare Worker.
-- **[Observability](../docs/langfuse.md)** and **[provenance](../docs/attestation.md)** - optional Langfuse tracing and Sigstore attestation.
-- **[Project layout](CONTRIBUTING.md#project-layout)** - an annotated tour of the repo.
+<p align="center">
+  <a href="../docs/CONFIGURATION.md"><img src="../docs/assets/doc-config.svg" alt="Configuration - chaining, triggers, scheduler, capability modes, gateways, Fleet Watcher" height="30" align="absmiddle"></a>&nbsp;
+  <a href="../docs/harnesses.md"><img src="../docs/assets/doc-harnesses.svg" alt="Harnesses - run skills on any of six agent CLIs behind one contract" height="30" align="absmiddle"></a>&nbsp;
+  <a href="../docs/skill-packs.md"><img src="../docs/assets/doc-packs.svg" alt="Skill Packs - how packs work and how to build your own" height="30" align="absmiddle"></a>&nbsp;
+  <a href="../docs/CORE.md"><img src="../docs/assets/doc-core.svg" alt="Core - the self-healing health and repair loop" height="30" align="absmiddle"></a>
+</p>
+<p align="center">
+  <a href="../apps/cli/README.md"><img src="../docs/assets/doc-cli.svg" alt="CLI - the whole dashboard as scriptable ./aeon commands" height="30" align="absmiddle"></a>&nbsp;
+  <a href="../apps/mcp-server/README.md"><img src="../docs/assets/doc-mcp.svg" alt="MCP server - every skill as an aeon MCP tool in Claude" height="30" align="absmiddle"></a>&nbsp;
+  <a href="../apps/webhook/README.md"><img src="../docs/assets/doc-webhooks.svg" alt="Webhooks - ~1s Telegram instant mode via a self-hosted worker" height="30" align="absmiddle"></a>&nbsp;
+  <a href="../docs/ADK.md"><img src="../docs/assets/doc-adk.svg" alt="ADK - build products on top of Aeon over the GitHub API" height="30" align="absmiddle"></a>&nbsp;
+  <a href="../docs/ECOSYSTEM.md"><img src="../docs/assets/doc-ecosystem.svg" alt="Ecosystem - products and agents built on Aeon" height="30" align="absmiddle"></a>
+</p>
 
 ---
 

--- a/docs/assets/doc-adk.svg
+++ b/docs/assets/doc-adk.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="88" height="40" viewBox="0 0 88 40" role="img" aria-label="ADK">
+  <defs><linearGradient id="g" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#1c1a15"/><stop offset="1" stop-color="#0d0c0a"/></linearGradient></defs>
+  <rect x="0.5" y="0.5" width="87" height="39" rx="19.5" fill="url(#g)" stroke="#F4EFE1" stroke-opacity="0.5"/>
+  <rect x="2" y="1.5" width="84" height="15" rx="12" fill="#F4EFE1" opacity="0.05"/>
+  <g stroke="#F4EFE1" stroke-width="1.6" fill="none" stroke-linejoin="round"><rect x="14.3" y="14.3" width="6" height="6" rx="1.1"/><rect x="23" y="14.3" width="6" height="6" rx="1.1"/><rect x="18.6" y="21" width="6" height="6" rx="1.1"/></g>
+  <text x="37" y="25.5" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="700" fill="#F4EFE1">ADK</text>
+</svg>

--- a/docs/assets/doc-cli.svg
+++ b/docs/assets/doc-cli.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="86" height="40" viewBox="0 0 86 40" role="img" aria-label="CLI">
+  <defs><linearGradient id="g" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#1c1a15"/><stop offset="1" stop-color="#0d0c0a"/></linearGradient></defs>
+  <rect x="0.5" y="0.5" width="85" height="39" rx="19.5" fill="url(#g)" stroke="#F4EFE1" stroke-opacity="0.5"/>
+  <rect x="2" y="1.5" width="82" height="15" rx="12" fill="#F4EFE1" opacity="0.05"/>
+  <g stroke="#F4EFE1" stroke-width="1.6" fill="none" stroke-linecap="round" stroke-linejoin="round"><rect x="14" y="13.5" width="16" height="13" rx="2"/><path d="M17 18l3 2-3 2"/><line x1="22.5" y1="23" x2="26.5" y2="23"/></g>
+  <text x="37" y="25.5" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="700" fill="#F4EFE1">CLI</text>
+</svg>

--- a/docs/assets/doc-config.svg
+++ b/docs/assets/doc-config.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="40" viewBox="0 0 160 40" role="img" aria-label="Configuration">
+  <defs><linearGradient id="g" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#1c1a15"/><stop offset="1" stop-color="#0d0c0a"/></linearGradient></defs>
+  <rect x="0.5" y="0.5" width="159" height="39" rx="19.5" fill="url(#g)" stroke="#F4EFE1" stroke-opacity="0.5"/>
+  <rect x="2" y="1.5" width="156" height="15" rx="12" fill="#F4EFE1" opacity="0.05"/>
+  <g stroke="#F4EFE1" stroke-width="1.6" fill="none" stroke-linecap="round"><line x1="15" y1="15" x2="29" y2="15"/><circle cx="20" cy="15" r="2.2" fill="#0d0c0a"/><line x1="15" y1="20" x2="29" y2="20"/><circle cx="26" cy="20" r="2.2" fill="#0d0c0a"/><line x1="15" y1="25" x2="29" y2="25"/><circle cx="18" cy="25" r="2.2" fill="#0d0c0a"/></g>
+  <text x="37" y="25.5" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="700" fill="#F4EFE1">Configuration</text>
+</svg>

--- a/docs/assets/doc-core.svg
+++ b/docs/assets/doc-core.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="92" height="40" viewBox="0 0 92 40" role="img" aria-label="Core">
+  <defs><linearGradient id="g" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#1c1a15"/><stop offset="1" stop-color="#0d0c0a"/></linearGradient></defs>
+  <rect x="0.5" y="0.5" width="91" height="39" rx="19.5" fill="url(#g)" stroke="#F4EFE1" stroke-opacity="0.5"/>
+  <rect x="2" y="1.5" width="88" height="15" rx="12" fill="#F4EFE1" opacity="0.05"/>
+  <g stroke="#F4EFE1" stroke-width="1.6" fill="none" stroke-linecap="round" stroke-linejoin="round"><circle cx="22" cy="20" r="7.6"/><path d="M16.4 20h2.1l1.4-3 2 6 1.5-3h2.2"/></g>
+  <text x="37" y="25.5" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="700" fill="#F4EFE1">Core</text>
+</svg>

--- a/docs/assets/doc-ecosystem.svg
+++ b/docs/assets/doc-ecosystem.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="138" height="40" viewBox="0 0 138 40" role="img" aria-label="Ecosystem">
+  <defs><linearGradient id="g" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#1c1a15"/><stop offset="1" stop-color="#0d0c0a"/></linearGradient></defs>
+  <rect x="0.5" y="0.5" width="137" height="39" rx="19.5" fill="url(#g)" stroke="#F4EFE1" stroke-opacity="0.5"/>
+  <rect x="2" y="1.5" width="134" height="15" rx="12" fill="#F4EFE1" opacity="0.05"/>
+  <g stroke="#F4EFE1" stroke-width="1.6" fill="none"><circle cx="22" cy="14.6" r="2.3"/><circle cx="15.6" cy="25.2" r="2.3"/><circle cx="28.4" cy="25.2" r="2.3"/><line x1="20.9" y1="16.6" x2="16.7" y2="23.2"/><line x1="23.1" y1="16.6" x2="27.3" y2="23.2"/><line x1="17.9" y1="25.2" x2="26.1" y2="25.2"/></g>
+  <text x="37" y="25.5" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="700" fill="#F4EFE1">Ecosystem</text>
+</svg>

--- a/docs/assets/doc-harnesses.svg
+++ b/docs/assets/doc-harnesses.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="40" viewBox="0 0 128 40" role="img" aria-label="Harnesses">
+  <defs><linearGradient id="g" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#1c1a15"/><stop offset="1" stop-color="#0d0c0a"/></linearGradient></defs>
+  <rect x="0.5" y="0.5" width="127" height="39" rx="19.5" fill="url(#g)" stroke="#F4EFE1" stroke-opacity="0.5"/>
+  <rect x="2" y="1.5" width="124" height="15" rx="12" fill="#F4EFE1" opacity="0.05"/>
+  <g stroke="#F4EFE1" stroke-width="1.6" fill="none" stroke-linejoin="round"><path d="M22 12.7l7.2 3.7-7.2 3.7-7.2-3.7z"/><path d="M14.8 20.3l7.2 3.7 7.2-3.7"/><path d="M14.8 24l7.2 3.7 7.2-3.7"/></g>
+  <text x="37" y="25.5" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="700" fill="#F4EFE1">Harnesses</text>
+</svg>

--- a/docs/assets/doc-mcp.svg
+++ b/docs/assets/doc-mcp.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="90" height="40" viewBox="0 0 90 40" role="img" aria-label="MCP">
+  <defs><linearGradient id="g" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#1c1a15"/><stop offset="1" stop-color="#0d0c0a"/></linearGradient></defs>
+  <rect x="0.5" y="0.5" width="89" height="39" rx="19.5" fill="url(#g)" stroke="#F4EFE1" stroke-opacity="0.5"/>
+  <rect x="2" y="1.5" width="86" height="15" rx="12" fill="#F4EFE1" opacity="0.05"/>
+  <g stroke="#F4EFE1" stroke-width="1.6" fill="none"><circle cx="16" cy="20" r="2.3"/><circle cx="28" cy="15" r="2.3"/><circle cx="28" cy="25" r="2.3"/><line x1="18.1" y1="19.2" x2="25.9" y2="15.8"/><line x1="18.1" y1="20.8" x2="25.9" y2="24.2"/></g>
+  <text x="37" y="25.5" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="700" fill="#F4EFE1">MCP</text>
+</svg>

--- a/docs/assets/doc-packs.svg
+++ b/docs/assets/doc-packs.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="138" height="40" viewBox="0 0 138 40" role="img" aria-label="Skill Packs">
+  <defs><linearGradient id="g" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#1c1a15"/><stop offset="1" stop-color="#0d0c0a"/></linearGradient></defs>
+  <rect x="0.5" y="0.5" width="137" height="39" rx="19.5" fill="url(#g)" stroke="#F4EFE1" stroke-opacity="0.5"/>
+  <rect x="2" y="1.5" width="134" height="15" rx="12" fill="#F4EFE1" opacity="0.05"/>
+  <g stroke="#F4EFE1" stroke-width="1.6" fill="none" stroke-linejoin="round"><path d="M22 12.4l7 3.5v7l-7 3.5-7-3.5v-7z"/><path d="M15 15.9l7 3.5 7-3.5"/><path d="M22 19.4V27"/></g>
+  <text x="37" y="25.5" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="700" fill="#F4EFE1">Skill Packs</text>
+</svg>

--- a/docs/assets/doc-webhooks.svg
+++ b/docs/assets/doc-webhooks.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="40" viewBox="0 0 128 40" role="img" aria-label="Webhooks">
+  <defs><linearGradient id="g" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#1c1a15"/><stop offset="1" stop-color="#0d0c0a"/></linearGradient></defs>
+  <rect x="0.5" y="0.5" width="127" height="39" rx="19.5" fill="url(#g)" stroke="#F4EFE1" stroke-opacity="0.5"/>
+  <rect x="2" y="1.5" width="124" height="15" rx="12" fill="#F4EFE1" opacity="0.05"/>
+  <path d="M23.5 12l-7 9.5h4.2l-1.2 6.5 7-9.5h-4.3z" fill="#F4EFE1"/>
+  <text x="37" y="25.5" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif" font-size="15" font-weight="700" fill="#F4EFE1">Webhooks</text>
+</svg>


### PR DESCRIPTION
Same MiroShark treatment, applied to Aeon's brand: turn the text-heavy "Reference & advanced" bullet list into a visual **Docs** pill nav.

- Nine self-hosted pills (Configuration, Harnesses, Skill Packs, Core / CLI, MCP, Webhooks, ADK, Ecosystem), aeon black+cream, matching the header pills, readable on GitHub light **and** dark. Rendered-verified in headless Chrome on both.
- Each pill links to its real doc page; the long descriptions move into those pages so the front page stays lean.

### Further text reduction - your call
The remaining prose-heavy blocks (Notifications channel setup, Configure) can go two ways, neither done here:
1. **Image-ify** them like the section banners - needs generated art.
2. **Relocate** the detail into their `docs/` pages, leaving short teasers - I can do this on request (touches the doc pages too).

Say which and I'll follow up.
