### PR TITLE
ci: state egress-parser scope; gate lockfile coverage

### DIFF
--- a/.github/workflows/ci-skill-integrity.yml
+++ b/.github/workflows/ci-skill-integrity.yml
@@ -19,6 +19,12 @@ name: ci-skill-integrity
 # exactly like an over-broad scanner. It complements skill-scan.sh; it does not
 # replace it.
 #
+# Scope, stated honestly: the egress parser is line-based and host-granular. A
+# URL split across lines, assembled from shell vars, or a new PATH on an
+# already-listed host is not caught here — that is skill-scan.sh's territory and
+# reviewer territory. This gate is defense-in-depth for the common shape (a new
+# endpoint appearing on a call line), not a parser of everything bash can do.
+#
 # Refresh the lockfile when a skill legitimately changes its reach:
 #   eyebrow scan --path . --lockfile eyebrowlock.json
 # and commit eyebrowlock.json in the same PR. The diff on that file is the audit
@@ -52,6 +58,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      # A skill added without regenerating the lockfile would otherwise be
+      # silently ungated (drift is advisory by policy, and a brand-new skill has
+      # no baseline to expand against). This makes coverage itself a hard gate.
+      - name: lockfile covers every skill
+        run: |
+          missing=0
+          for f in skills/*/SKILL.md; do
+            slug=$(basename "$(dirname "$f")")
+            grep -q "\"discoveredFrom\": \"skills/$slug/SKILL.md\"" eyebrowlock.json || {
+              echo "::error::skills/$slug has no eyebrowlock.json entry — run: eyebrow scan --path . --lockfile eyebrowlock.json and commit the result"
+              missing=1
+            }
+          done
+          exit "$missing"
       - name: eyebrow verify (drift / rug-pull gate)
         uses: alexverify/eyebrow/action@9592921a04a41fc0aae5439406511ed70a15f03a # v0.4.1
         with:

--- a/docs/skill-integrity.md
+++ b/docs/skill-integrity.md
@@ -31,8 +31,7 @@ touches a skill, the [`ci-skill-integrity`](../.github/workflows/ci-skill-integr
 workflow re-derives that fingerprint and, per [`eyebrow.policy.json`](../eyebrow.policy.json),
 fails the build **only** when a skill:
 
-- **gains a new egress host** vs the lockfile (`failOnCapabilityExpansion`) — the
-  real rug-pull signal, or
+- **gains a new egress host** vs the lockfile (`failOnCapabilityExpansion`), or
 - introduces a **new critical finding** (`failOnSeverity: critical`).
 
 It **does not** fail on a skill's wording changing (`allowContentDrift: true`).
@@ -41,6 +40,12 @@ Prose edits, refactors, and secret-plumbing changes that keep the same hosts are
 constantly, and a gate that fired on every byte would be forced off within a week
 — the exact failure mode of an over-broad scanner. eyebrow gates on *reach*, not
 wording, so the signal stays meaningful.
+
+**Scope, honestly:** the egress parser is line-based and host-granular. It
+catches the common rug-pull shape — a new endpoint appearing on a call line. It
+does **not** catch a URL split across lines, one assembled from shell variables,
+or a new *path* on an already-listed host; those remain `skill-scan.sh` and
+reviewer territory. Treat this gate as defense-in-depth, not a bash parser.
 
 This **complements** `skill-scan.sh` — it does not replace it. Scan catches
 dangerous *content*; eyebrow catches a skill *expanding what it can reach*.

--- a/eyebrowlock.json
+++ b/eyebrowlock.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-08-04T20:48:47.359696Z",
+  "generatedAt": "2026-08-05T17:47:16.370189Z",
   "generator": "eyebrow/0.4.1",
   "artifacts": [
     {
@@ -1107,6 +1107,26 @@
       "discoveredFrom": "skills/you-web-search/SKILL.md"
     },
     {
+      "id": "8da144d58a83bb15",
+      "tool": "aeon",
+      "scope": "project:.",
+      "type": "skill",
+      "name": "pack-submit",
+      "source": {
+        "kind": "local",
+        "ref": "skills/pack-submit"
+      },
+      "capabilities": {},
+      "files": [
+        {
+          "path": "SKILL.md",
+          "hash": "5e5e5a92042525a0a6d31b848883a61b0310102d590499cd2fdfcf1426f6820b"
+        }
+      ],
+      "contentHash": "sha256-cf926d867b47cf47c406ff2071d54619e67b2860e3f70fb5bb39eb91bddf18c2",
+      "discoveredFrom": "skills/pack-submit/SKILL.md"
+    },
+    {
       "id": "92d7ed59c1803aec",
       "tool": "aeon",
       "scope": "project:.",
@@ -1120,10 +1140,10 @@
       "files": [
         {
           "path": "SKILL.md",
-          "hash": "06dbaf80b656ef0162bc2b26b068601b9ebcff4e45b816ddba58688b874fc93b"
+          "hash": "fe9e344aff0fb0035ab030d69b19aeb6066faf8108fc12f9c32b7759243fcfd4"
         }
       ],
-      "contentHash": "sha256-50657f858e49dedf753cbcf6499f4970b4530006e769c9a11f1afcc7f67bd004",
+      "contentHash": "sha256-89eeae8f14c965d2dddc3062ec0315c11ede4ea0a4f5587453d18924ac555ed5",
       "discoveredFrom": "skills/memory-flush/SKILL.md"
     },
     {
@@ -1678,7 +1698,7 @@
       "files": [
         {
           "path": "SKILL.md",
-          "hash": "8cedcf07e1d139d98748efb433cd2c73342528b0018f8f320451fc527868850f"
+          "hash": "9068bf394a671f656d598423fc93ebaf4c3959fae7f790303445cc3419c5b380"
         },
         {
           "path": "references/ci.md",
@@ -1709,7 +1729,7 @@
           "hash": "0edc7445542a21cb5518e813a6ae462a1d469636601a799efc1bec86b4058c5a"
         }
       ],
-      "contentHash": "sha256-79e0f552595cb8782ab2f0e67e88124f776c5b181f45bc6fabdd786c24800e39",
+      "contentHash": "sha256-03377e139ed510956c63a4ed03ba2ea6beb7d2eb272d543329345eba37306d8f",
       "discoveredFrom": ".claude/skills/aeon/SKILL.md"
     },
     {
@@ -1926,6 +1946,37 @@
       ],
       "contentHash": "sha256-d98ad4253b8ea27e4e2ce65e23d1a2a3a2dc69883055c0db739e188bf08cae90",
       "discoveredFrom": "skills/robinhood-mcp/SKILL.md"
+    },
+    {
+      "id": "fd5fbb1b82c59598",
+      "tool": "aeon",
+      "scope": "project:.",
+      "type": "skill",
+      "name": "aeon-update",
+      "source": {
+        "kind": "local",
+        "ref": "skills/aeon-update"
+      },
+      "capabilities": {},
+      "files": [
+        {
+          "path": "SKILL.md",
+          "hash": "c7aec12b2246f16c79eb70eb1eccc1f00c8cea78fa6d8dde3ef1159f5d9eb86c"
+        }
+      ],
+      "findings": [
+        {
+          "ruleId": "SENSITIVE-PATH-READ",
+          "severity": "high",
+          "owasp": "ASK-06",
+          "file": "SKILL.md",
+          "line": 93,
+          "snippet": "output/**           .mcp.json           .env*               aeon.db",
+          "explanation": "references sensitive credential or secret paths"
+        }
+      ],
+      "contentHash": "sha256-915ef57cf4dc5214a125f55df7bfe821503fd3252a8b80095f29d8343f47b5ae",
+      "discoveredFrom": "skills/aeon-update/SKILL.md"
     }
   ]
 }


### PR DESCRIPTION
## What

Follow-up to #815, delivering the two review points that were deliberately kept out of the merge diff: 

(1) the workflow and doc now **state the egress parser's scope honestly**: what the gate catches and what stays with `skill-scan.sh` and reviewers;
(2) a new **lockfile-coverage step** fails a PR when a skill exists under `skills/` with no `eyebrowlock.json` entry, so a skill can't be added while skipping the fingerprint. Also refreshes `eyebrowlock.json` to cover `aeon-update` (#832) and `pack-submit` (#831), which landed after #815 without lockfile entries.

## Why

**Scope honesty (review point 2):** the egress parser is line-based and host-granular. A URL split across lines, one assembled from shell variables, or a new *path* on an already-listed host is not caught by this gate, that remains `skill-scan.sh` and reviewer territory. Saying so in the workflow header and `docs/skill-integrity.md` keeps anyone from treating the gate as more than the defense-in-depth layer it is.

**Coverage gate (review point 3):** content drift is advisory by policy, and a brand-new skill has no baseline to expand against, so a skill added without regenerating the lockfile was silently ungated. Not hypothetical: `aeon-update` and `pack-submit` merged after #815 with no lockfile entries, and the gate had nothing to say about either. The new step makes coverage itself a hard gate: it fails with a `::error` naming the uncovered skill and the exact `eyebrow scan` command that fixes it.

Longer-term this check belongs inside eyebrow as a policy flag (e.g. `failOnUnlockedArtifact`) so every consumer gets it without bash, on the eyebrow roadmap; the CI step is the stopgap.

## Type of change

- [x] Core fix (dashboard / scripts / workflows / docs)

---

### Core fix (dashboard / scripts / workflows / docs)

- [x] Change is focused — one concern (close out the #815 review points), no unrelated refactor
- [x] Touched code follows the existing pattern in the file — coverage step is a plain `run:` step in the existing job, same shape as the other `ci-*.yml` steps; doc edits extend the existing sections
- [x] Relevant CI gates pass locally — workflow YAML parses; coverage check passes 68/68 and correctly fails (exit 1, `::error`) on a fake uncovered skill; `eyebrow verify --ci` exits 0 on the refreshed lockfile
- [x] Touched `apps/**`? No — one workflow, one doc, the lockfile
---

### What's in the PR

```
.github/workflows/ci-skill-integrity.yml  scope paragraph in header comment; new "lockfile covers every skill" step
docs/skill-integrity.md                   same scope paragraph; dropped an overclaiming phrase
eyebrowlock.json                          regenerated — covers aeon-update + pack-submit; refreshed drifted hashes
```

The lockfile diff is the audit trail: two new entries (`aeon-update` records a high `SENSITIVE-PATH-READ` finding, below the critical threshold, so advisory) and refreshed content hashes for `memory-flush` and the `aeon` helper skill, which changed after #815 (prose drift — advisory by design, no egress changes anywhere).

### How to verify

```sh
# coverage: clean tree — passes
for f in skills/*/SKILL.md; do slug=$(basename "$(dirname "$f")")
  grep -q "\"discoveredFrom\": \"skills/$slug/SKILL.md\"" eyebrowlock.json || echo "MISSING: $slug"
done                                                              # no output

# coverage: a skill without a lockfile entry — fails
mkdir -p skills/zzz-fake && echo '# fake' > skills/zzz-fake/SKILL.md
# re-run the loop above → MISSING: zzz-fake  (CI step exits 1)
rm -rf skills/zzz-fake

# integrity gate unchanged — still green on the refreshed lockfile
eyebrow verify --ci --path . --lockfile eyebrowlock.json          # exit 0
```

