### PR TITLE
docs: sync PRs #826-#857 to aeon docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,31 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Added
 
+- **New skill: `video-script`** - turns a repo, product page, or topic into a
+  recording-ready video script. Receipts-first: every number, address, and date is
+  verified against the live source in-run, and anything unverifiable is cut or
+  deferred to a dated "verify before recording" checklist. Standard conventions
+  throughout (`${var}` selector, `--minutes N` runtime, `soul/` voice, output to
+  `output/video-scripts/`). `basics` pack, disabled by default; brings the catalog
+  to **68 skills** (67 -> 68). (#835)
+- **New skill: `aeon-update`** - the downstream counterpart to `fork-fleet`. Runs
+  inside an instance and pulls the parent's shipped framework changes *down* (new
+  skills, script/harness fixes, workflow and doc updates), landing them as one
+  reviewable PR - replacing the hand-run rsync-overlay rebase every managed
+  instance did to stay current with canon. `core` pack, `write` mode, weekly and
+  disabled by default; catalog **67** (66 -> 67). (#832)
+- **New skill: `pack-submit`** - the inverse of `install-skill`. Takes one of the
+  agent's own local skills and publishes it as a community pack: packages it into a
+  standalone pack repo, creates and pushes a public GitHub repo to host it, and
+  opens the registry PR (a README **Community Packs** row plus a matching
+  `catalog/skill-packs.json` entry in one diff, gated on
+  `validate-skill-packs.mjs`). `evolution` pack, disabled by default; catalog
+  **66** (65 -> 66). (#831)
+- **Community skill pack registered: Skim Clean Reads** (`skim-read`) - reads any
+  URL as clean markdown via Skim's x402 endpoint, roughly 4x smaller than the raw
+  HTML so downstream model steps burn far fewer tokens ($0.002 USDC on Base per
+  read, no API key). Listed in the Community Packs table and
+  `bin/install-skill-pack --list`. (#829)
 - **New notification channel: Buzz.** `./notify` can now post to a
   [Buzz](https://buzz.xyz) channel (Block's self-hostable Nostr-relay workspace)
   alongside Telegram / Discord / Slack / email. Unlike the bearer-URL webhooks,
@@ -98,6 +123,16 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Changed
 
+- **README brand refresh.** The `.github/README.md` was rebuilt around an animated
+  hero and section-banner art with a pill navigation, trimmed to MiroShark prose
+  density, and the longer-form detail was relocated into `docs/` (Configuration,
+  Skill packs, Showcase). Adds a "compare vs Claude Code, Hermes, and OpenClaw"
+  pointer and a Community section. Presentation only - no capability change. (#833,
+  #834, #836-#838, #840-#842, #844-#857)
+- **`memory-flush` hardened.** The memory GC pass now stamps the consolidation date
+  on every flush (so a live, repeatedly-flushed store no longer reads as an
+  untouched template), scans an adaptive window instead of a fixed three days,
+  de-duplicates before writing, and rotates its logs. Body-only skill edit. (#828)
 - **Adopted the Agent Skills open standard; removed OKF globally.** All 65 skills
   now use spec-form frontmatter (only `name` + `description` top-level, everything
   else nested under `metadata:`, block-style lists) and pass the official
@@ -129,6 +164,9 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Fixed
 
+- **Stale "Proof of work" numbers corrected** on the README to match
+  aeon.fun/security and `ECOSYSTEM.md`: ~2M stars secured, 69 repos, 68 ecosystem
+  products (community packs stay 12). (#843)
 - **Read-only persistence contract corrected.** Docs told read-only skills they
   could persist to `memory/` during a run, but the OS sandbox write-locks the whole
   workspace on all six harnesses, so those writes silently fail. `CLAUDE.md` and
@@ -394,6 +432,9 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Maintenance
 
+- Webhook Dependabot batch (undici, `@opentelemetry/core`) plus two CI changes:
+  dropped the daily cron from Setup Telegram Commands, and stated the egress-parser
+  scope with a lockfile-coverage gate. (#826, #827, #839)
 - 2 dependency bumps (wrangler in the webhook; the dashboard group) plus a new CI
   eyebrow capability-integrity gate for skills. (#809, #810, #815)
 - CI green-up after the Telegram owner-gate, plus a dashboard PacksPanel

--- a/docs/aeon-setup.md
+++ b/docs/aeon-setup.md
@@ -9,7 +9,7 @@ Aeon ships an **[Agent Skill](https://code.claude.com/docs/en/skills)** (`SKILL.
 
 It's a portable skill, not tied to one product: [Claude Code](https://claude.com/claude-code) is the primary host (it auto-loads skills from `.claude/skills/`, so it's zero-install there), but the skill is just a `SKILL.md` in the open Agent Skills format — it works with **Claude Code, Codex, Hermes, or OpenClaw**, and any other agent tool that supports skills.
 
-> **This is not an Aeon skill.** The 65 skills under [`skills/`](../skills) run unattended on GitHub Actions. **This** one runs inside *your* agent session on *your* machine — it's the operator's assistant for configuring the instance, not something that runs on a schedule. It doesn't appear in `aeon.yml`, the packs, or the catalog.
+> **This is not an Aeon skill.** The 68 skills under [`skills/`](../skills) run unattended on GitHub Actions. **This** one runs inside *your* agent session on *your* machine — it's the operator's assistant for configuring the instance, not something that runs on a schedule. It doesn't appear in `aeon.yml`, the packs, or the catalog.
 
 ## What it does
 

--- a/docs/assets/hero-animated.svg
+++ b/docs/assets/hero-animated.svg
@@ -71,7 +71,7 @@
   <g font-family="'Arial Black','Helvetica Neue',Helvetica,Arial,sans-serif" font-weight="800" font-style="italic" font-size="20" fill="#0d0c0a">
     <g transform="translate(560,346)">
       <rect x="0" y="0" width="150" height="42" rx="21" fill="#F4EFE1" stroke="#0d0c0a" stroke-width="2"/>
-      <text x="75" y="28" text-anchor="middle">67 skills</text>
+      <text x="75" y="28" text-anchor="middle">68 skills</text>
     </g>
     <g transform="translate(725,346)">
       <rect x="0" y="0" width="176" height="42" rx="21" fill="#F4EFE1" stroke="#0d0c0a" stroke-width="2"/>

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,6 +1,6 @@
 # Aeon integration examples
 
-Aeon ships an [MCP server](../apps/mcp-server/) so any Claude client can call its 65 skills. The scripts here are the shortest possible "first call works" demos — build the server, run `python <file>`, get a real Aeon output back.
+Aeon ships an [MCP server](../apps/mcp-server/) so any Claude client can call its 68 skills. The scripts here are the shortest possible "first call works" demos — build the server, run `python <file>`, get a real Aeon output back.
 
 | File | Stack | Skill called | What it shows |
 |------|-------|--------------|---------------|

--- a/docs/skill-packs.md
+++ b/docs/skill-packs.md
@@ -1,6 +1,6 @@
 # Skill packs
 
-Aeon ships **65 skills**, but most forks only ever run a handful. Packs make
+Aeon ships **68 skills**, but most forks only ever run a handful. Packs make
 that manageable: by default the dashboard shows **Core** (what makes Aeon
 different) and **Basics** (simple skills you can run right now) — everything else
 is grouped into **packs** that stay hidden until you enable them.
@@ -71,8 +71,8 @@ Pack key = category. Six packs, no empties; three are shown by default.
 
 | Pack (`category`) | What's in it | count |
 |---|---|---|
-| **Core** (`core`) | Fleet coordination, self-configuration, liveness, memory + reporting. Shown by default; not removable. | 11 |
-| **Evolution** (`evolution`) | The self-improvement loop — authors, evolves, installs, and heals its own skills. Shown by default. | 8 |
+| **Core** (`core`) | Fleet coordination, self-configuration, liveness, memory + reporting. Shown by default; not removable. | 12 |
+| **Evolution** (`evolution`) | The self-improvement loop — authors, evolves, installs, and heals its own skills. Shown by default. | 9 |
 | **Basics** (`basics`) | Simple, immediately-runnable skills — one approachable entry per area. Shown by default. | 17 |
 | **Dev & Code** (`dev`) | PR/issue triage, review, merges, changelogs, repo monitoring, security scanning, app deploys. | 10 |
 | **Crypto & Markets** (`crypto`) | Token/DeFi/prediction-market monitoring, narrative tracking, on-chain forensics + automation, Uniswap v4 hook deploys. | 14 |


### PR DESCRIPTION
Syncs merged PRs **#826–#857** on `aeonfun/aeon` to the aeon repo docs. Watermark was #824. (#825 was this run's own predecessor aeon-side sync — skipped per convention.)

### Surfaces touched
- **`CHANGELOG.md`** (`[Unreleased]`): added `video-script`, `aeon-update`, `pack-submit`, and the Skim Clean Reads community pack (Added); README brand refresh + `memory-flush` hardening (Changed); stale Proof-of-work numbers (Fixed); the CI/Dependabot bundle (Maintenance).
- **`docs/skill-packs.md`**: `65 → 68` skills; summary pack table corrected `Core 11 → 12`, `Evolution 8 → 9` (the full-catalog table below was already at 68). The README's `#full-catalog-all-68-skills-by-pack` anchor now matches the heading.
- **`docs/aeon-setup.md`**, **`docs/examples/README.md`**: `65 → 68`.
- **`docs/assets/hero-animated.svg`**: the hero art text read **`67 skills`** (stale) → `68 skills`.

### Catalog
`65 → 68` (+`aeon-update` #832 → Core, +`pack-submit` #831 → Evolution, +`video-script` #835 → Basics). Live packs: Core 12 / Evolution 9 / Basics 17 / Dev 10 / Crypto 14 / Productivity 6 = 68.

### Bundled as maintenance (noise)
#826 (webhook Dependabot), #827 (ci: drop Telegram cron), #839 (ci: egress-parser scope + lockfile gate).

### Not propagated (intentional)
The ~20 pure-cosmetic README PRs (#833–#857 art/nav/reorder/trim) are README-internal; detail relocation (#838) was intra-repo and already landed. README itself already ships at 68.
