### PR TITLE
docs: express headline skill count as a stable 60+ floor

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="../docs/assets/hero-animated.svg" alt="AEON — the most autonomous agent framework. 68 skills across 6 harnesses (Claude Code, Grok, Codex, Pi, Vibe, Kimi), running unattended on GitHub Actions: it ships features to your repos, privately discloses real vulnerabilities, deploys live apps, runs deep research, and writes new skills for itself. Keywords: autonomous AI agent, agent framework, GitHub Actions automation, self-improving agent, multi-agent orchestration, LLM skills, cron agent." width="100%" />
+  <img src="../docs/assets/hero-animated.svg" alt="AEON — the most autonomous agent framework. 60+ skills across 6 harnesses (Claude Code, Grok, Codex, Pi, Vibe, Kimi), running unattended on GitHub Actions: it ships features to your repos, privately discloses real vulnerabilities, deploys live apps, runs deep research, and writes new skills for itself. Keywords: autonomous AI agent, agent framework, GitHub Actions automation, self-improving agent, multi-agent orchestration, LLM skills, cron agent." width="100%" />
 </p>
 
 <p align="center">
@@ -78,7 +78,7 @@ mode: write
 The prompt *is* the skill. You schedule it, hand it a `var`, chain it into others, and Haiku rates every run. How packs work: [`docs/skill-packs.md`](../docs/skill-packs.md).
 
 <p align="center">
-  <img src="../docs/assets/packs-aeon.jpg" alt="Six skill packs, 68 skills total: Core (fleet coordination, self-config, liveness), Evolution (authors and heals its own skills), Basics (simple runnable skills), Dev & Code, Crypto & Markets, and Productivity." width="100%" />
+  <img src="../docs/assets/packs-aeon.jpg" alt="Six skill packs, 60+ skills total: Core (fleet coordination, self-config, liveness), Evolution (authors and heals its own skills), Basics (simple runnable skills), Dev & Code, Crypto & Markets, and Productivity." width="100%" />
 </p>
 
 <p align="center"><a href="../docs/skill-packs.md#full-catalog-all-68-skills-by-pack"><b>Full catalog - all 68 skills by pack →</b></a></p>

--- a/docs/aeon-setup.md
+++ b/docs/aeon-setup.md
@@ -9,7 +9,7 @@ Aeon ships an **[Agent Skill](https://code.claude.com/docs/en/skills)** (`SKILL.
 
 It's a portable skill, not tied to one product: [Claude Code](https://claude.com/claude-code) is the primary host (it auto-loads skills from `.claude/skills/`, so it's zero-install there), but the skill is just a `SKILL.md` in the open Agent Skills format — it works with **Claude Code, Codex, Hermes, or OpenClaw**, and any other agent tool that supports skills.
 
-> **This is not an Aeon skill.** The 68 skills under [`skills/`](../skills) run unattended on GitHub Actions. **This** one runs inside *your* agent session on *your* machine — it's the operator's assistant for configuring the instance, not something that runs on a schedule. It doesn't appear in `aeon.yml`, the packs, or the catalog.
+> **This is not an Aeon skill.** The 60+ skills under [`skills/`](../skills) run unattended on GitHub Actions. **This** one runs inside *your* agent session on *your* machine — it's the operator's assistant for configuring the instance, not something that runs on a schedule. It doesn't appear in `aeon.yml`, the packs, or the catalog.
 
 ## What it does
 

--- a/docs/assets/hero-animated.svg
+++ b/docs/assets/hero-animated.svg
@@ -71,7 +71,7 @@
   <g font-family="'Arial Black','Helvetica Neue',Helvetica,Arial,sans-serif" font-weight="800" font-style="italic" font-size="20" fill="#0d0c0a">
     <g transform="translate(560,346)">
       <rect x="0" y="0" width="150" height="42" rx="21" fill="#F4EFE1" stroke="#0d0c0a" stroke-width="2"/>
-      <text x="75" y="28" text-anchor="middle">68 skills</text>
+      <text x="75" y="28" text-anchor="middle">60+ skills</text>
     </g>
     <g transform="translate(725,346)">
       <rect x="0" y="0" width="176" height="42" rx="21" fill="#F4EFE1" stroke="#0d0c0a" stroke-width="2"/>

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,6 +1,6 @@
 # Aeon integration examples
 
-Aeon ships an [MCP server](../apps/mcp-server/) so any Claude client can call its 68 skills. The scripts here are the shortest possible "first call works" demos — build the server, run `python <file>`, get a real Aeon output back.
+Aeon ships an [MCP server](../apps/mcp-server/) so any Claude client can call its 60+ skills. The scripts here are the shortest possible "first call works" demos — build the server, run `python <file>`, get a real Aeon output back.
 
 | File | Stack | Skill called | What it shows |
 |------|-------|--------------|---------------|

--- a/docs/skill-packs.md
+++ b/docs/skill-packs.md
@@ -1,6 +1,6 @@
 # Skill packs
 
-Aeon ships **68 skills**, but most forks only ever run a handful. Packs make
+Aeon ships **60+ skills**, but most forks only ever run a handful. Packs make
 that manageable: by default the dashboard shows **Core** (what makes Aeon
 different) and **Basics** (simple skills you can run right now) — everything else
 is grouped into **packs** that stay hidden until you enable them.


### PR DESCRIPTION
Makes the headline skill total a stable **`60+` floor** on the surfaces CI does not guard, so a new skill no longer silently leaves them stale (and docs-sync stops chasing the exact digit across six files every batch).

### Changed to `60+` (CI-unguarded — these are the ones that silently rot)
- `.github/README.md`: hero alt-text + packs-banner alt-text.
- `docs/assets/hero-animated.svg`: the hero art `68 skills` text.
- `docs/skill-packs.md` intro, `docs/aeon-setup.md`, `docs/examples/README.md` prose.

### Left EXACT on purpose (CI-guarded → can't rot)
`scripts/validate-readme-catalog.mjs` already diffs these against `catalog/packs.json` on every PR:
- README full-catalog **caption** `all N skills by pack` + its anchor ↔ `docs/skill-packs.md` heading.
- The summary + full-catalog **per-pack tables** and all **per-category counts** (Core 12, Evolution 9, ...).

Website React counts are untouched (they self-update via `getSkillCount()`/ISR). No behavior change; docs only.
