### PR TITLE
docs(ecosystem): add Kairune

### DIFF
--- a/docs/ECOSYSTEM.md
+++ b/docs/ECOSYSTEM.md
@@ -47,6 +47,7 @@ These are the projects we know of that run Aeon, extend it, or integrate with th
 | <img src="https://pbs.twimg.com/profile_images/2050846114472202240/fOvJsybI_400x400.jpg" width="36" height="36" alt="Hivra logo"> | Hivra | [@HivraOS](https://x.com/HivraOS) |
 | <img src="https://pbs.twimg.com/profile_images/2060061798691221509/dGZFzJ5e_400x400.jpg" width="36" height="36" alt="Hound Flow logo"> | Hound Flow | [@HoundFlow_](https://x.com/HoundFlow_) · [houndflow.com](https://houndflow.com) |
 | <img src="https://pbs.twimg.com/profile_images/2057685123068534784/gu-mFTdW_400x400.jpg" width="36" height="36" alt="Hunch logo"> | Hunch | [@playhunchxyz](https://x.com/playhunchxyz) |
+|  | Kairune | [@usekairune](https://x.com/usekairune) · [kairune.online](https://kairune.online) |
 | <img src="https://pbs.twimg.com/profile_images/2065880577148882944/eljgIBzJ_400x400.jpg" width="36" height="36" alt="Lens logo"> | Lens | [@lnsx_io](https://x.com/lnsx_io) |
 | <img src="https://pbs.twimg.com/profile_images/2044050121852366850/v70sEXCF_400x400.jpg" width="36" height="36" alt="LiquidPad logo"> | LiquidPad | [@LiquidPadBot](https://x.com/LiquidPadBot) · [liquidpad.site](https://www.liquidpad.site) |
 | <img src="https://pbs.twimg.com/profile_images/2046582343587037184/TxgtMxAh_400x400.jpg" width="36" height="36" alt="Liq logo"> | Liq | [@liquid_launcher](https://x.com/liquid_launcher) |


### PR DESCRIPTION
Adds **Kairune** to the ecosystem table in `docs/ECOSYSTEM.md`.

- **Project:** Kairune — the trust layer for agents that spend (budget ceilings + velocity limits + a counterparty trust gate that blocks payments to bad payees before the money moves).
- **X:** [@usekairune](https://x.com/usekairune)
- **Site:** [kairune.online](https://kairune.online)
- **Overlap with Aeon:** runs in the same autonomous-agent-spend space and on Robinhood Chain (relevant to Aeon skills like `spend-watch` / `robinhood-mcp`).

Row placed alphabetically between **Hunch** and **Lens**. Logo cell left empty per the guideline option (`|  |`); happy to add a square 400x400 avatar if preferred.

Note for maintainers: Kairune is an independent project in the agent-spend ecosystem rather than a fork of Aeon — filing here per the operator's request; please redirect to SHOWCASE.md or close if it doesn't fit the ECOSYSTEM.md criteria.