### PR TITLE
vuln-scanner: stage cargo-fuzz toolchain + widen sandbox grant

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -418,7 +418,11 @@ jobs:
         # workaround (there is no network sandbox). Installs semgrep/trufflehog/
         # osv-scanner/slither and appends /tmp/bin to the PATH file so the scanner
         # bare-names resolve in the later claude -p step and its per-call fresh shells
-        # (an in-run `export PATH` doesn't survive between Claude's Bash calls).
+        # (an in-run `export PATH` doesn't survive between Claude's Bash calls). Also
+        # installs a nightly Rust toolchain + cargo-fuzz for step A3.5 (dynamic
+        # testing) — unconditionally, like slither, since the scan target isn't known
+        # until Arm A runs; the skill's own command -v guard makes it a no-op when
+        # the picked repo doesn't ship its own fuzz/fuzz_targets.
         # Execution is separately gated by the write-tier grant in scripts/skill_mode.sh.
         # Best-effort: the script self-guards to vuln-scanner and never fails the run.
         if: steps.work.outputs.mode != '' && steps.skill.outputs.name == 'vuln-scanner'

--- a/scripts/skill_mode.sh
+++ b/scripts/skill_mode.sh
@@ -49,6 +49,16 @@ WRITE_TOOLS="Write,Edit,Bash(gh:*),Bash(git:*),Bash(python3:*),Bash(python:*)"
 # a live-test showed the run logging that denial as "Blocked by sandbox". These are
 # read-only static-analysis tools (no repo/network mutation of their own).
 WRITE_TOOLS="$WRITE_TOOLS,Bash(semgrep:*),Bash(osv-scanner:*),Bash(trufflehog:*),Bash(slither:*)"
+# cargo (vuln-scanner Arm A, step A3.5 — dynamic testing). Staged by
+# scripts/stage-vuln-scanner.sh (nightly toolchain + cargo-fuzz, workflow step,
+# same reason as Foundry below — the sandbox denies toolchain installs in-run).
+# Unlike the scanners above, this is not narrow: `cargo fuzz run` compiles and
+# executes the cloned repo's own code, and `cargo` itself is a much wider surface
+# than a single-purpose analyzer. Accepted deliberately — see A3.5 in
+# skills/vuln-scanner/SKILL.md for the trust-boundary reasoning. The skill only
+# reaches for it when the clone already ships fuzz/fuzz_targets; the guard lives
+# in the skill, not here.
+WRITE_TOOLS="$WRITE_TOOLS,Bash(cargo:*)"
 # Foundry bare-names + the key-safe runner for deploy-uni-hook. Foundry is staged by
 # scripts/stage-deploy-uni-hook.sh (the sandbox denies in-run installs); the skill then
 # builds/simulates/broadcasts by bare name. `./hook-deploy.sh` hides the deployer key

--- a/scripts/stage-vuln-scanner.sh
+++ b/scripts/stage-vuln-scanner.sh
@@ -98,5 +98,24 @@ else
   record slither skipped
 fi
 
+# --- cargo-fuzz (dynamic testing, A3.5) — only useful when the cloned repo
+#     already ships its own fuzz/fuzz_targets, but we don't know the target yet
+#     at staging time (Arm A picks it after this step runs). Stage it always,
+#     same tolerance as slither above: unconditional install, conditional use.
+#     GHA hosted runners already have stable Rust; this only adds nightly
+#     (cargo-fuzz needs it for sanitizer support) + the cargo-fuzz binary.
+if command -v cargo-fuzz >/dev/null 2>&1; then
+  log "cargo-fuzz already present"
+  record cargo-fuzz installed
+elif rustup toolchain install nightly --profile minimal >/dev/null 2>&1 \
+     && cargo install cargo-fuzz --locked >/dev/null 2>&1 \
+     && command -v cargo-fuzz >/dev/null 2>&1; then
+  log "cargo-fuzz installed ($(cargo-fuzz --version 2>/dev/null | head -1))"
+  record cargo-fuzz installed
+else
+  log "cargo-fuzz not installed (optional — only used for repos shipping fuzz/fuzz_targets)"
+  record cargo-fuzz skipped
+fi
+
 log "manifest (/tmp/vuln-scan/prefetch.txt):"
 cat "$MANIFEST"


### PR DESCRIPTION
## what this is

Runtime-infrastructure half of #863 (vuln-scanner cargo-fuzz), split out per imancipate's triage on that PR — this touches the fork's trust boundary and needs its own review, separate from the skill-scope change.

This PR has no effect on its own. It only matters once #863's SKILL.md change (the A3.5 step that reaches for cargo-fuzz) is merged — until then the staged toolchain and the wider grant just sit unused.

## changes

- **`scripts/stage-vuln-scanner.sh`** — installs a nightly Rust toolchain + `cargo-fuzz` unconditionally in the pre-run staging step, same pattern as the existing slither/foundry staging in this file (the sandbox denies toolchain installs in-run, and the scan target isn't known until Arm A picks it). The skill's own `command -v cargo-fuzz` + `fuzz/fuzz_targets` check makes this a no-op on repos that don't ship a fuzz harness.
- **`scripts/skill_mode.sh`** — grants `Bash(cargo:*)` to vuln-scanner's write-tier allowlist. Flagging this explicitly: it's wider than the single-purpose scanner grants next to it (`semgrep`, `osv-scanner`, `trufflehog`, `slither`), since `cargo fuzz run` dispatches through `cargo` itself rather than a narrow binary.
- **`.github/workflows/aeon.yml`** — comment update describing the new staging step, no behavioral change.

## review note

aaronjmars already reviewed this exact code as part of #863 and flagged/confirmed the secret-scrubbing fix for the fuzz execution step (that fix lives in #863's SKILL.md, not here — this PR is only the staging + grant). Splitting per triage, not resubmitting unreviewed work.