### PR TITLE
docs: add Finance District to ECOSYSTEM.md

### DIFF
--- a/docs/ECOSYSTEM.md
+++ b/docs/ECOSYSTEM.md
@@ -39,6 +39,7 @@ These are the projects we know of that run Aeon, extend it, or integrate with th
 | <img src="https://pbs.twimg.com/profile_images/2075170344957083648/AR-5asAz_400x400.jpg" width="36" height="36" alt="CTRL logo"> | CTRL | [@CTRL_automation](https://x.com/CTRL_automation) |
 | <img src="https://pbs.twimg.com/profile_images/2070145040882544640/P8NilHgr_400x400.jpg" width="36" height="36" alt="DarkSol logo"> | DarkSol | [@Darks0l_](https://x.com/Darks0l_) |
 | <img src="https://pbs.twimg.com/profile_images/2057284361066569728/K5ZhxKXY_400x400.png" width="36" height="36" alt="Echo Oracle logo"> | Echo Oracle | [@BuiltByEcho](https://x.com/BuiltByEcho) · [builtbyecho.xyz](https://www.builtbyecho.xyz/) |
+| <img src="https://pbs.twimg.com/profile_images/2058778503957590016/3Uo13Pxy_400x400.jpg" width="36" height="36" alt="Finance District logo"> | Finance District | [@FD_XYZ](https://x.com/FD_XYZ) · [fd.xyz](https://fd.xyz) |
 | <img src="https://pbs.twimg.com/profile_images/2078808241430306817/oCW2y8Q-_400x400.jpg" width="36" height="36" alt="GitBlock logo"> | GitBlock | [@gitblock_](https://x.com/gitblock_) |
 | <img src="https://pbs.twimg.com/profile_images/2069099785936891904/fbvZqtoT_400x400.jpg" width="36" height="36" alt="GitKernal logo"> | GitKernal | [@gitkernal](https://x.com/gitkernal) |
 | <img src="https://pbs.twimg.com/profile_images/2056261441192419328/X6pFHgHc_400x400.jpg" width="36" height="36" alt="Gitlawb Terminal logo"> | Gitlawb Terminal | [@terminalgitlawb](https://x.com/terminalgitlawb) |


### PR DESCRIPTION
## What

Adds Finance District to `docs/ECOSYSTEM.md` — one row, alphabetized between Echo Oracle and GitBlock, following the "Add your project" format (36×36 logo, @handle · site).

## Why

Finance District's Agent Wallet is in the core skill catalog (`skills/finance-district-mcp`, merged in #791) and launched as a supported wallet on aeon on Aug 5 — listing us per the ecosystem page's operator self-disclosure guidelines.

## Type of change

- [x] Core fix (dashboard / scripts / workflows / docs)

---

### Core fix

Docs-only: single row added to the ecosystem table, no code touched. Preview of the row renders identically to neighboring entries.