### PR TITLE
docs: sync PRs #795-#871 to aeon docs

### DIFF
--- a/.claude/skills/aeon/references/secrets.md
+++ b/.claude/skills/aeon/references/secrets.md
@@ -91,6 +91,8 @@ Each is opt-in. Unset means the skills that want it skip or degrade.
 | `REPLICATE_API_TOKEN` | `article --visual` hero images | replicate.com/account/api-tokens |
 | `ADMANAGE_API_KEY` | `schedule-ads` | admanage.ai/api-docs |
 | `RESEND_API_KEY` | `send-email`, `vuln-scanner` disclosures | resend.com |
+| `YDC_API_KEY` | `you-web-search` (required for it) | api.you.com — optional `YOUCOM_FRESHNESS` / `YOUCOM_LIVECRAWL` variables tune freshness + full-page crawl |
+| `TASKMARKET_API_KEY` | `taskmarket-delegate` — only `create`/`submit`; `browse` works without | tasks.taskmarket.dev — optional `TASKMARKET_WORKER_ADDRESS` tags submissions |
 
 ## 5. Observability — optional
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ from or pin to; the template keeps serving the latest `main` to new forks.
   unset. Ships a zero-dependency node client and a 6-test suite (live read-only
   browse, no spend). `crypto` pack, disabled by default; brings the catalog to
   **75 skills** (74 -> 75; Crypto 14 -> 15). (#865)
+- **New skill: `hunter-22`** - calls ClawHunter's free bounty-discovery API,
+  matches candidates against the agent's real demonstrated capabilities (code,
+  security research, research, writing, dependency analysis), and triages honestly
+  - dropping content/social-growth work wearing a bounty costume, keeping
+  deliverable work. Discovery only: no wallet, never claims or submits. When a kept
+  candidate is audit-shaped (a `code`/`onchain` bounty linking a GitHub repo), the
+  notification carries a one-tap "Audit owner/repo" button that dispatches
+  `vuln-scanner` straight at that repo, closing discovery to audit in one motion.
+  `productivity` pack, disabled by default; catalog 73 -> 74. (#864)
 - **New skill: `you-web-search`** - an optional You.com-backed web search against
   the documented `https://api.you.com/v1/search` contract, giving operators a
   structured, current web source without changing default behavior. Parses

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Added
 
+- **New skill: `taskmarket-delegate`** - delegates work to the TaskMarket
+  agent-worker market (`tasks.taskmarket.dev` / `api.taskmarket.dev`) instead of
+  burning inference on low-confidence work. `browse` ranks open tasks
+  winnable-first with no key; `create`/`submit` sit behind an explicit operator
+  authorization gate and degrade cleanly to read-only when `TASKMARKET_API_KEY` is
+  unset. Ships a zero-dependency node client and a 6-test suite (live read-only
+  browse, no spend). `crypto` pack, disabled by default; brings the catalog to
+  **75 skills** (74 -> 75; Crypto 14 -> 15). (#865)
+- **New skill: `you-web-search`** - an optional You.com-backed web search against
+  the documented `https://api.you.com/v1/search` contract, giving operators a
+  structured, current web source without changing default behavior. Parses
+  `snippets[]` and `page_age` from the response shape You.com documents today;
+  `YDC_API_KEY` required, with optional `YOUCOM_FRESHNESS` and `YOUCOM_LIVECRAWL`
+  tuning. `basics` pack, disabled by default. (#795)
+- **Finance District listed in `docs/ECOSYSTEM.md`** - its Agent Wallet is in the
+  core catalog (`skills/finance-district-mcp`, #791) and launched as a supported
+  wallet on aeon; one alphabetized row, mirrored to aeon.fun/ecosystem
+  automatically via hourly ISR. (#869)
 - **Five new skills, ported from the `aeon-dev` instance and generalized for any
   operator** (frontmatter converted to Agent Skills spec-form, OKF references
   removed, private product/instance references genericized): **`spend-watch`** (dev
@@ -138,6 +156,18 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Changed
 
+- **`vuln-scanner` now runs a repo's own `cargo-fuzz` harnesses** during scan arm A
+  (new step A3.5). The static tools (semgrep, trufflehog, osv-scanner) only ever
+  read files; if the scanned repo ships its own `fuzz/fuzz_targets`, the scanner
+  now seeds the corpus from its `tests/fixtures`, runs each target ~90s (capped at
+  8 targets), and triages a crash with the same rigor as any scanner hit before it
+  counts as a finding. A `command -v cargo-fuzz` + `fuzz/fuzz_targets` guard keeps
+  it a clean no-op on repos without a harness. The runtime half stages a nightly
+  Rust toolchain + `cargo-fuzz` in `stage-vuln-scanner.sh` (the sandbox denies
+  toolchain installs in-run) and widens the write-tier allowlist with
+  `Bash(cargo:*)` - a deliberate step up from read-only static scanning to
+  compiling and running the target's own code inside the sandboxed run. (#863,
+  #868)
 - **Dashboard catalog wiring for the five new skills** (#860): the Higgsfield hosted
   OAuth MCP is registered in `mcp-catalog.ts` (one-click Connect, secrets + OAuth
   refresh derived generically from the slug); `secrets-catalog.ts` adds
@@ -186,6 +216,13 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Fixed
 
+- **`bin/add-skill` could not install from the standard `skills/<slug>/SKILL.md`
+  layout** - the one this repo's own catalog uses. Discovery globbed at
+  `-maxdepth 2` (never matching the depth-3 `SKILL.md`) so every repo reported "No
+  skills found", and install resolved `$REPO_DIR/$skill` without the `skills/`
+  subdir. Discovery now searches `-maxdepth 3` and install resolves `skills/<slug>`
+  first, falling back to the flatter legacy layout. Verified end-to-end installing
+  `tx-explain` from `aeonfun/aeon`. (#866)
 - **Stale "Proof of work" numbers corrected** on the README to match
   aeon.fun/security and `ECOSYSTEM.md`: ~2M stars secured, 69 repos, 68 ecosystem
   products (community packs stay 12). (#843)
@@ -454,6 +491,8 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Maintenance
 
+- Dashboard Dependabot security fix: patched `nanoid` advisories (lockfile-only
+  transitive bump, no `package.json` change). (#871)
 - Webhook Dependabot batch (undici, `@opentelemetry/core`) plus two CI changes:
   dropped the daily cron from Setup Telegram Commands, and stated the egress-parser
   scope with a lockfile-coverage gate. (#826, #827, #839)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -480,6 +480,15 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Security
 
+- **`ALL_SECRETS` built from an explicit allowlist, not `toJSON(secrets)`.**
+  Serializing the entire secret store into a workflow env var is the canonical
+  credential-exfiltration primitive, and on 2026-07-28 GitHub began holding
+  public-repo runs that match it for per-run, web-session-only approval - silently
+  taking the public instances `aeon-agent` and `miroshark-aeon` dark from
+  2026-07-30 (the `Aeon · Scheduler` workflow kept running green on `schedule`
+  events, so they looked alive while doing nothing). `ALL_SECRETS` now serializes
+  only the named secrets the workflow already references. Private forks were
+  unaffected - the GitHub feature is public-repo-only. (#819)
 - **Skill-scan recalibrated to fire on operations, not syntax.** The HIGH tier now
   matches dangerous sinks (code execution, secret exfiltration, destruction) and
   prompt injection rather than ordinary shell syntax, adds a `curl | sh` RCE


### PR DESCRIPTION
Syncs the merged `aeonfun/aeon` PRs that had gone undocumented on the downstream doc surfaces. The docs-sync ledger was stale at #792, but prior in-repo sync PRs (#793, #804, #807, #825, #858, #861) and the website changelog had already carried most of the window; this catches the stragglers the true watermark (website changelog, #864) had left behind.

## PR window
Undocumented-everywhere set: **#795, #863, #865, #866, #868, #869, #871** (7 PRs: 6 signal, 1 noise).

## Surfaces changed (this repo)
- [x] `CHANGELOG.md` `[Unreleased]`
  - **Added** — `taskmarket-delegate` skill (#865, catalog 74 -> 75), `hunter-22` skill (#864, catalog 73 -> 74; backfilled — was on the website changelog but not this repo's), `you-web-search` skill (#795, previously undocumented), Finance District ecosystem row (#869)
  - **Changed** — `vuln-scanner` runs a repo's own `cargo-fuzz` harnesses in scan arm A (#863, #868)
  - **Fixed** — `bin/add-skill` install for the standard `skills/<slug>/SKILL.md` layout (#866)
  - **Security** — `ALL_SECRETS` allowlist, not `toJSON(secrets)` (#819, backfilled — was on the website changelog but not this repo's; the fix that took two public instances dark Jul 30)
  - **Maintenance** — nanoid advisory patch (#871)
- [x] `.claude/skills/aeon/references/secrets.md` — added `YDC_API_KEY` (you-web-search) and `TASKMARKET_API_KEY` (taskmarket-delegate) to the skill-specific keys table

## Not touched (already correct)
- README + `docs/skill-packs.md` exact skill counts already show **75** (each new-skill PR regenerated them on merge; `validate-readme-catalog.mjs` passes: 6 packs / 75 skills). The `60+` marketing floor (#859) is left as-is per convention.
- `docs/ECOSYSTEM.md` already carries Finance District (#869 merged here).

## Noise bundled as maintenance
- #871 — `fix(deps): patch nanoid security advisories` (dashboard lockfile-only)

## Watermark
New sync watermark: **#871** (undocumented set through the highest merged PR).
