### PR TITLE
security: bump nanoid to 3.3.18 (GHSA-2v37-7h3g-55p8)

### DIFF
--- a/skills/remotion/project/package-lock.json
+++ b/skills/remotion/project/package-lock.json
@@ -2974,9 +2974,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Resolves Dependabot alert GHSA-2v37-7h3g-55p8 (nanoid < 3.3.8, HIGH). Lockfile-only bump of the transitive nanoid to 3.3.18. No manifest range change.