### PR TITLE
Tag OpenRouter traffic for the app leaderboard

### DIFF
--- a/scripts/llm-gateway.sh
+++ b/scripts/llm-gateway.sh
@@ -193,6 +193,13 @@ case "${GATEWAY:-direct}" in
     export ANTHROPIC_DEFAULT_SONNET_MODEL="${OPENROUTER_MODEL_SONNET:-anthropic/claude-sonnet-5}"
     export ANTHROPIC_DEFAULT_HAIKU_MODEL="${OPENROUTER_MODEL_HAIKU:-anthropic/claude-haiku-4.5}"
     MODEL="$ANTHROPIC_DEFAULT_OPUS_MODEL"
+    # App attribution: HTTP-Referer + X-Title make aeon's OpenRouter traffic show
+    # up on openrouter.ai's public app leaderboard. Claude Code forwards
+    # ANTHROPIC_CUSTOM_HEADERS (one "Name: Value" per line) to the upstream even on
+    # a third-party gateway base URL. Override per fork with the repo vars
+    # OPENROUTER_SITE_URL / OPENROUTER_APP_TITLE.
+    export ANTHROPIC_CUSTOM_HEADERS="HTTP-Referer: ${OPENROUTER_SITE_URL:-https://aeon.fun}
+X-Title: ${OPENROUTER_APP_TITLE:-Aeon}"
     echo "::notice::Routing through OpenRouter (Anthropic-native) as ${MODEL}"
     ;;
 


### PR DESCRIPTION
## What

Sets `ANTHROPIC_CUSTOM_HEADERS` in the `openrouter` gateway case of `scripts/llm-gateway.sh` so every Claude Code request routed through `openrouter.ai` carries two attribution headers:

```
HTTP-Referer: https://aeon.fun
X-Title: Aeon
```

## Why

OpenRouter uses `HTTP-Referer` + `X-Title` to attribute API traffic to an app and rank it on the public app leaderboard (https://openrouter.ai/rankings). Without them, aeon's OpenRouter usage is anonymous volume. This one-spot add makes it show up as Aeon.

## Notes

- Claude Code forwards `ANTHROPIC_CUSTOM_HEADERS` (one `Name: Value` per line) to the upstream even on a third-party gateway base URL, so the existing base URL (`https://openrouter.ai/api`, the Anthropic-native skin) and auth are untouched.
- Overridable per fork via the repo vars `OPENROUTER_SITE_URL` / `OPENROUTER_APP_TITLE` (default `https://aeon.fun` / `Aeon`).
- Scope is the gateway (claude harness) path only. The non-claude harnesses (codex/pi/vibe/kimi) also default to OpenRouter via `scripts/install-harness.sh`, but header injection there is per-CLI and not uniformly supported, so it is left out of this small change.
- Verified: `bash -n` clean; simulated the openrouter block and confirmed the header renders as two lines with the base URL and model unchanged.
