### PR TITLE
docs(langfuse): note v4 compatibility + ingestion-version header

### DIFF
--- a/docs/langfuse.md
+++ b/docs/langfuse.md
@@ -25,6 +25,13 @@ Code's span exporter at Langfuse's OTLP endpoint (`<host>/api/public/otel`).
   nothing is sent to an endpoint that would reject it.
 - **HTTP, not gRPC.** Langfuse only accepts OTLP over HTTP, so the shim pins
   `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`.
+- **Langfuse v4 ready.** The OTLP ingestion contract (endpoint, Basic auth, and
+  the `gen_ai.*` attributes) is unchanged from v3, so nothing here is
+  version-specific. The shim also sends `x-langfuse-ingestion-version=4`, which
+  makes directly-ingested spans show up in real time; without that header, direct
+  OTLP data can lag roughly 10-15 minutes in the Langfuse UI. (Langfuse Cloud is
+  v4-only after its Nov 2026 cutover; existing `pk-lf-…`/`sk-lf-…` keys keep
+  working across it.)
 - **Out of band.** Telemetry export is decoupled from the model call — if Langfuse
   is slow or down, the skill run is unaffected. The shim never `exit`s or fails
   the run.


### PR DESCRIPTION
One-line doc touch-up. The Langfuse integration is pure OTLP (no SDK), and v4 kept the OTLP ingestion contract identical to v3 (endpoint, Basic auth, `gen_ai.*` attributes). The shim already sends `x-langfuse-ingestion-version=4`, which v4 uses for real-time direct ingestion (without it, direct OTLP data lags ~10-15 min).

Adds a "Langfuse v4 ready" bullet to `docs/langfuse.md` recording that no version-specific config is needed and that existing `pk-lf-`/`sk-lf-` keys keep working across the Nov 2026 Cloud cutover.

No code change, no behavior change.