### PR TITLE
ci: add PR-scoped concurrency to lint/check workflows

### DIFF
--- a/.github/workflows/ci-agents-md.yml
+++ b/.github/workflows/ci-agents-md.yml
@@ -30,6 +30,12 @@ on:
 permissions:
   contents: read
 
+# Cancel a superseded in-progress run when a newer commit is pushed to the same PR
+# (reclaims runner-minutes on stacked PR pushes). Never cancels push/main/tag runs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-capabilities-parity.yml
+++ b/.github/workflows/ci-capabilities-parity.yml
@@ -32,6 +32,12 @@ on:
 permissions:
   contents: read
 
+# Cancel a superseded in-progress run when a newer commit is pushed to the same PR
+# (reclaims runner-minutes on stacked PR pushes). Never cancels push/main/tag runs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-packs-json.yml
+++ b/.github/workflows/ci-packs-json.yml
@@ -30,6 +30,12 @@ on:
 permissions:
   contents: read
 
+# Cancel a superseded in-progress run when a newer commit is pushed to the same PR
+# (reclaims runner-minutes on stacked PR pushes). Never cancels push/main/tag runs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-readme-catalog.yml
+++ b/.github/workflows/ci-readme-catalog.yml
@@ -38,6 +38,12 @@ on:
 permissions:
   contents: read
 
+# Cancel a superseded in-progress run when a newer commit is pushed to the same PR
+# (reclaims runner-minutes on stacked PR pushes). Never cancels push/main/tag runs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-skill-category.yml
+++ b/.github/workflows/ci-skill-category.yml
@@ -21,6 +21,12 @@ on:
 permissions:
   contents: read
 
+# Cancel a superseded in-progress run when a newer commit is pushed to the same PR
+# (reclaims runner-minutes on stacked PR pushes). Never cancels push/main/tag runs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-skill-integrity.yml
+++ b/.github/workflows/ci-skill-integrity.yml
@@ -53,6 +53,12 @@ on:
 permissions:
   contents: read
 
+# Cancel a superseded in-progress run when a newer commit is pushed to the same PR
+# (reclaims runner-minutes on stacked PR pushes). Never cancels push/main/tag runs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   verify:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-skill-packs.yml
+++ b/.github/workflows/ci-skill-packs.yml
@@ -47,6 +47,12 @@ on:
 permissions:
   contents: read
 
+# Cancel a superseded in-progress run when a newer commit is pushed to the same PR
+# (reclaims runner-minutes on stacked PR pushes). Never cancels push/main/tag runs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-skills-json.yml
+++ b/.github/workflows/ci-skills-json.yml
@@ -39,6 +39,12 @@ on:
 permissions:
   contents: read
 
+# Cancel a superseded in-progress run when a newer commit is pushed to the same PR
+# (reclaims runner-minutes on stacked PR pushes). Never cancels push/main/tag runs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -23,6 +23,12 @@ on:
 permissions:
   contents: read
 
+# Cancel a superseded in-progress run when a newer commit is pushed to the same PR
+# (reclaims runner-minutes on stacked PR pushes). Never cancels push/main/tag runs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Adds a PR-scoped `concurrency` group to the 9 `pull_request`-triggered lint/check workflows that lacked one:
`ci-agents-md`, `ci-capabilities-parity`, `ci-packs-json`, `ci-readme-catalog`, `ci-skill-integrity`, `ci-skill-category`, `ci-skill-packs`, `ci-skills-json`, `ci-tests`.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

## Why

These workflows declared no concurrency group, so pushing new commits to a PR left the superseded lint runs occupying runners until they finished. Cancelling them on the next push reclaims runner-minutes. Surfaced by a CI audit across the aeon fleet.

## Safety

- `cancel-in-progress` is gated on `github.event_name == 'pull_request'`, so **only PR runs are cancelled** - push/main/tag runs are never interrupted mid-flight (no risk to a release/publish path).
- Cancelling a superseded PR run does not strand a required status check: merge evaluates the head commit, whose run completes normally. (The "required check stuck Pending" failure mode is caused by path/branch trigger filters, not by concurrency.)
- The scheduled workflows (`aeon`, `messages`, `scheduler`, `chain-runner`, `ci-apps`) already carry a concurrency group and are untouched.

Workflows validated with `actionlint`.
