### PR TITLE
docs: sync PRs #874-#887 to aeon docs

### DIFF
--- a/.claude/skills/aeon/SKILL.md
+++ b/.claude/skills/aeon/SKILL.md
@@ -251,7 +251,7 @@ metadata:
 Today is ${today}. <the prompt — plain instructions, including judgment calls>
 
 ## Steps
-1. <the procedure — 43 of 73 skills lead with this>
+1. <the procedure — 43 of 75 skills lead with this>
 
 ## Network note
 <curl / WebFetch / `./secretcurl` / `gh api` — how this skill fetches>
@@ -311,9 +311,9 @@ Three at a time, not twelve. Every enabled skill is a recurring notification, an
 ./aeon packs ls                  # the six first-party packs
 ```
 
-`ls` footers with `73 skills · 1 enabled` — read it to them before proposing anything. First run installs the CLI runtime (tsx + yaml, ~12MB); the npm noise is one-time and expected. Grep-only equivalents: `references/layout.md`.
+`ls` footers with `75 skills · 1 enabled` — read it to them before proposing anything. First run installs the CLI runtime (tsx + yaml, ~12MB); the npm noise is one-time and expected. Grep-only equivalents: `references/layout.md`.
 
-Packs are a visibility filter, not a runtime switch — revealing one runs nothing. Core (12), Evolution (9) and Basics (17) show by default; Dev (11), Crypto (14) and Productivity (10) are on demand.
+Packs are a visibility filter, not a runtime switch — revealing one runs nothing. Core (12), Evolution (9) and Basics (17) show by default; Dev (11), Crypto (15) and Productivity (11) are on demand.
 
 Reasonable starting sets:
 

--- a/.claude/skills/aeon/references/layout.md
+++ b/.claude/skills/aeon/references/layout.md
@@ -12,7 +12,7 @@ Where everything lives in an Aeon repo, and the fastest way to see what's on.
 ./aeon skills ls --enabled --json # for building the Mode 2 timeline
 ```
 
-`ls` prints `SKILL / ON / SCHEDULE / PACK / DESCRIPTION` and a footer — `73 skills · 1 enabled`. First run installs the CLI runtime (tsx + yaml, ~12MB, one-time); the noise is expected.
+`ls` prints `SKILL / ON / SCHEDULE / PACK / DESCRIPTION` and a footer — `75 skills · 1 enabled`. First run installs the CLI runtime (tsx + yaml, ~12MB, one-time); the noise is expected.
 
 **The `SCHEDULE` column is populated for disabled skills too** — it's their `aeon.yml` entry, not proof anything fires. Only the `●` in `ON` means it runs.
 

--- a/.claude/skills/aeon/references/mcp.md
+++ b/.claude/skills/aeon/references/mcp.md
@@ -7,7 +7,7 @@ Two unrelated things share the name. Get this wrong and nothing works.
 | | |
 |---|---|
 | **`.mcp.json`** — *external MCP servers, called BY Aeon skills* | Wired via the dashboard MCP panel or `./aeon mcp add`. This is what you want when a skill needs a tool. |
-| **`bin/add-mcp`** — *Aeon itself AS an MCP server* | Builds `apps/mcp-server` and registers it with Claude Code / Desktop, so all 73 skills appear as `aeon-*` tools **in your local Claude**. Nothing to do with a skill calling out. |
+| **`bin/add-mcp`** — *Aeon itself AS an MCP server* | Builds `apps/mcp-server` and registers it with Claude Code / Desktop, so all 75 skills appear as `aeon-*` tools **in your local Claude**. Nothing to do with a skill calling out. |
 
 The rest of this doc is the first one. For the second: `bin/add-mcp`, `--desktop` for a Claude Desktop snippet, `--uninstall` to remove, `claude mcp list` to verify.
 

--- a/.claude/skills/aeon/references/skill-anatomy.md
+++ b/.claude/skills/aeon/references/skill-anatomy.md
@@ -1,10 +1,10 @@
 # How Aeon skills are actually written
 
-Surveyed across all 73 skills in `aeonfun/aeon`. Frequencies are real counts — match the dominant convention unless there's a reason not to. Bodies run 133–757 lines (~306 median); a skill is a prompt, not a config file, and reads as prose.
+Surveyed across all 75 skills in `aeonfun/aeon`. Frequencies are real counts — match the dominant convention unless there's a reason not to. Bodies run 133–757 lines (~306 median); a skill is a prompt, not a config file, and reads as prose.
 
 ## Frontmatter
 
-Universal — **all 73 skills** carry these five:
+Universal — **all 75 skills** carry these five:
 
 ```yaml
 name: my-skill       # the slug (matches the skills/<slug>/ directory)
@@ -113,7 +113,7 @@ There is **no network sandbox** — plain `curl` works for unauthenticated GETs.
 
 `memory/` is the durable state that survives between runs. Four conventions, in order of how often skills touch them:
 
-### `memory/logs/${today}.md` — the run log (61 of 73 skills)
+### `memory/logs/${today}.md` — the run log (62 of 75 skills)
 
 Every skill appends what it did, under **one** heading that is exactly its slug:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Added
 
+- **The `/aeon` operator skill is now installable as a Claude Code plugin.**
+  Packages the existing `.claude/skills/aeon` setup skill as a distributable
+  plugin under a self-contained `plugin/` subdirectory (`plugin/.claude-plugin/`
+  manifest + `plugin/skills/aeon/`), published through a repo-root
+  `.claude-plugin/marketplace.json`, so operators can install it from any folder
+  with `/plugin marketplace add aeonfun/aeon` then `/plugin install aeon@aeon`
+  (versioned, `/plugin update`-able) instead of copying files. Rooting the plugin
+  under `plugin/` keeps its `skills/` isolated to the one operator skill and never
+  drags the framework catalog into an installer's Claude Code; the copy is
+  byte-for-byte identical to the source except the five `mine-history.mjs` path
+  lines that resolve via `${CLAUDE_PLUGIN_ROOT}`. `docs/aeon-setup.md` gains
+  install Option B and the README notes the plugin path. (#884, #885)
+- **Five ecosystem partners listed in `docs/ECOSYSTEM.md`** - AgentLink, AI2Human,
+  Mneme, Skim, and TaskMarket, each one alphabetized row, mirrored to
+  aeon.fun/ecosystem automatically via hourly ISR. (#880)
 - **New skill: `taskmarket-delegate`** - delegates work to the TaskMarket
   agent-worker market (`tasks.taskmarket.dev` / `api.taskmarket.dev`) instead of
   burning inference on low-confidence work. `browse` ranks open tasks
@@ -165,6 +180,18 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Changed
 
+- **OpenRouter gateway traffic is now attributed to Aeon.** The `openrouter` case
+  of `scripts/llm-gateway.sh` sets `ANTHROPIC_CUSTOM_HEADERS` so every Claude Code
+  request routed through `openrouter.ai` carries `HTTP-Referer: https://aeon.fun`
+  and `X-Title: Aeon`, ranking the usage on OpenRouter's public app leaderboard
+  instead of counting as anonymous volume. Overridable per fork via the
+  `OPENROUTER_SITE_URL` / `OPENROUTER_APP_TITLE` repo vars; base URL, auth, and
+  model are untouched. (#881)
+- **Documented Langfuse v4 compatibility** in `docs/langfuse.md`: the OTLP
+  ingestion contract is identical across v3 and v4, existing `pk-lf-`/`sk-lf-` keys
+  keep working across the Nov 2026 Cloud cutover, and the shim already sends
+  `x-langfuse-ingestion-version=4` for real-time direct ingestion. No config or
+  behavior change. (#883)
 - **`vuln-scanner` now runs a repo's own `cargo-fuzz` harnesses** during scan arm A
   (new step A3.5). The static tools (semgrep, trufflehog, osv-scanner) only ever
   read files; if the scanned repo ships its own `fuzz/fuzz_targets`, the scanner
@@ -225,6 +252,23 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Fixed
 
+- **`aeon-update` no longer silently deletes a currently-enabled skill retired
+  upstream.** The 3-way classifier CLEAN-DELETEd any `skills/<name>/` path removed
+  upstream and unmodified locally without checking whether `<name>` is still
+  `enabled: true` in the operator's `aeon.yml` - so a sync PR could drop an
+  actively-scheduled skill's directory with nothing in the review flagging it, the
+  break only surfacing later at `validate-config.js` or the skill's next run. That
+  case is now downgraded to a CONFLICT (`enabled-skill-removed-upstream`): the
+  directory stays and the PR body surfaces it in a loud dedicated section so the
+  operator can't merge past it unnoticed. (#874)
+- **`pi` + OpenRouter onboarding fixed.** `aeon auth --harness pi --key sk-or-...`
+  crashed at the launcher's `exec "$TSX"` because `tsx` was a `devDependency` and
+  the container bootstrap's `npm install --omit=dev` skipped it; `tsx` is now a
+  runtime `dependency`. Separately, the dashboard "Run now" gate reported "No
+  provider key set" whenever a flaky `/api/secrets` read (GitHub `503`) threw:
+  a just-saved secret is now optimistically registered, and a failed vault read
+  shows an accurate "couldn't read repo secrets" message instead of blaming a
+  missing key. (#882)
 - **`bin/add-skill` could not install from the standard `skills/<slug>/SKILL.md`
   layout** - the one this repo's own catalog uses. Discovery globbed at
   `-maxdepth 2` (never matching the depth-3 `SKILL.md`) so every repo reported "No
@@ -480,6 +524,8 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Security
 
+- **Bumped `nanoid` to 3.3.18** (GHSA-2v37-7h3g-55p8) in the `remotion` skill's
+  bundled project lockfile - transitive, lockfile-only. (#879)
 - **`ALL_SECRETS` built from an explicit allowlist, not `toJSON(secrets)`.**
   Serializing the entire secret store into a workflow env var is the canonical
   credential-exfiltration primitive, and on 2026-07-28 GitHub began holding
@@ -509,6 +555,11 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Maintenance
 
+- Dead-code sweep from a `ponytail-audit` pass: verified cuts across the CLI,
+  dashboard, mcp-server tracing, and scripts, net -444 lines, no behavior change.
+  (#886)
+- CI: added PR-scoped concurrency to the lint/check workflows so superseded runs
+  cancel instead of piling up. (#887)
 - Dashboard Dependabot security fix: patched `nanoid` advisories (lockfile-only
   transitive bump, no `package.json` change). (#871)
 - Webhook Dependabot batch (undici, `@opentelemetry/core`) plus two CI changes:

--- a/plugin/skills/aeon/SKILL.md
+++ b/plugin/skills/aeon/SKILL.md
@@ -251,7 +251,7 @@ metadata:
 Today is ${today}. <the prompt — plain instructions, including judgment calls>
 
 ## Steps
-1. <the procedure — 43 of 73 skills lead with this>
+1. <the procedure — 43 of 75 skills lead with this>
 
 ## Network note
 <curl / WebFetch / `./secretcurl` / `gh api` — how this skill fetches>
@@ -311,9 +311,9 @@ Three at a time, not twelve. Every enabled skill is a recurring notification, an
 ./aeon packs ls                  # the six first-party packs
 ```
 
-`ls` footers with `73 skills · 1 enabled` — read it to them before proposing anything. First run installs the CLI runtime (tsx + yaml, ~12MB); the npm noise is one-time and expected. Grep-only equivalents: `references/layout.md`.
+`ls` footers with `75 skills · 1 enabled` — read it to them before proposing anything. First run installs the CLI runtime (tsx + yaml, ~12MB); the npm noise is one-time and expected. Grep-only equivalents: `references/layout.md`.
 
-Packs are a visibility filter, not a runtime switch — revealing one runs nothing. Core (12), Evolution (9) and Basics (17) show by default; Dev (11), Crypto (14) and Productivity (10) are on demand.
+Packs are a visibility filter, not a runtime switch — revealing one runs nothing. Core (12), Evolution (9) and Basics (17) show by default; Dev (11), Crypto (15) and Productivity (11) are on demand.
 
 Reasonable starting sets:
 

--- a/plugin/skills/aeon/references/layout.md
+++ b/plugin/skills/aeon/references/layout.md
@@ -12,7 +12,7 @@ Where everything lives in an Aeon repo, and the fastest way to see what's on.
 ./aeon skills ls --enabled --json # for building the Mode 2 timeline
 ```
 
-`ls` prints `SKILL / ON / SCHEDULE / PACK / DESCRIPTION` and a footer — `73 skills · 1 enabled`. First run installs the CLI runtime (tsx + yaml, ~12MB, one-time); the noise is expected.
+`ls` prints `SKILL / ON / SCHEDULE / PACK / DESCRIPTION` and a footer — `75 skills · 1 enabled`. First run installs the CLI runtime (tsx + yaml, ~12MB, one-time); the noise is expected.
 
 **The `SCHEDULE` column is populated for disabled skills too** — it's their `aeon.yml` entry, not proof anything fires. Only the `●` in `ON` means it runs.
 

--- a/plugin/skills/aeon/references/mcp.md
+++ b/plugin/skills/aeon/references/mcp.md
@@ -7,7 +7,7 @@ Two unrelated things share the name. Get this wrong and nothing works.
 | | |
 |---|---|
 | **`.mcp.json`** — *external MCP servers, called BY Aeon skills* | Wired via the dashboard MCP panel or `./aeon mcp add`. This is what you want when a skill needs a tool. |
-| **`bin/add-mcp`** — *Aeon itself AS an MCP server* | Builds `apps/mcp-server` and registers it with Claude Code / Desktop, so all 73 skills appear as `aeon-*` tools **in your local Claude**. Nothing to do with a skill calling out. |
+| **`bin/add-mcp`** — *Aeon itself AS an MCP server* | Builds `apps/mcp-server` and registers it with Claude Code / Desktop, so all 75 skills appear as `aeon-*` tools **in your local Claude**. Nothing to do with a skill calling out. |
 
 The rest of this doc is the first one. For the second: `bin/add-mcp`, `--desktop` for a Claude Desktop snippet, `--uninstall` to remove, `claude mcp list` to verify.
 

--- a/plugin/skills/aeon/references/skill-anatomy.md
+++ b/plugin/skills/aeon/references/skill-anatomy.md
@@ -1,10 +1,10 @@
 # How Aeon skills are actually written
 
-Surveyed across all 73 skills in `aeonfun/aeon`. Frequencies are real counts — match the dominant convention unless there's a reason not to. Bodies run 133–757 lines (~306 median); a skill is a prompt, not a config file, and reads as prose.
+Surveyed across all 75 skills in `aeonfun/aeon`. Frequencies are real counts — match the dominant convention unless there's a reason not to. Bodies run 133–757 lines (~306 median); a skill is a prompt, not a config file, and reads as prose.
 
 ## Frontmatter
 
-Universal — **all 73 skills** carry these five:
+Universal — **all 75 skills** carry these five:
 
 ```yaml
 name: my-skill       # the slug (matches the skills/<slug>/ directory)
@@ -113,7 +113,7 @@ There is **no network sandbox** — plain `curl` works for unauthenticated GETs.
 
 `memory/` is the durable state that survives between runs. Four conventions, in order of how often skills touch them:
 
-### `memory/logs/${today}.md` — the run log (61 of 73 skills)
+### `memory/logs/${today}.md` — the run log (62 of 75 skills)
 
 Every skill appends what it did, under **one** heading that is exactly its slug:
 


### PR DESCRIPTION
Syncs merged `aeonfun/aeon` PRs onto the downstream doc surfaces. The true watermark was #873 (the prior in-repo sync PR + the website changelog both already carried everything through #873). This batch documents the stragglers merged after it.

## PR window
**#874 - #887** (10 PRs: 7 signal, 3 maintenance). Sync PRs #861 and #873 skipped per convention (they are prior runs' own aeon-side syncs).

## Surfaces changed (this repo)
- [x] `CHANGELOG.md` `[Unreleased]`
  - **Added** - `/aeon` operator skill installable as a Claude Code plugin (#884, #885); five ecosystem partners in `docs/ECOSYSTEM.md` (#880)
  - **Changed** - OpenRouter gateway traffic attributed to Aeon via `HTTP-Referer`/`X-Title` (#881); Langfuse v4 compatibility documented (#883)
  - **Fixed** - `aeon-update` no longer silently deletes a currently-enabled skill retired upstream (#874); pi + OpenRouter onboarding, tsx runtime dep + dashboard run-gate message (#882)
  - **Security** - nanoid bumped to 3.3.18 in the remotion project lockfile (#879)
  - **Maintenance** - ponytail-audit dead-code sweep net -444 (#886); PR-scoped CI concurrency (#887)
- [x] `.claude/skills/aeon/**` setup skill - catalog count **73 -> 75** (SKILL.md, references/{layout,mcp,skill-anatomy}.md): totals, `all N skills`, `N skills / 1 enabled`, survey denominators (43 of 75 lead-with-Steps, 62 of 75 run-log; ./notify numerator 61 kept), and the pack breakdown Crypto 14 -> 15 / Productivity 10 -> 11.
- [x] `plugin/skills/aeon/**` setup-skill plugin copy - identical 73 -> 75 bumps; the two trees remain byte-identical except the 5 `${CLAUDE_PLUGIN_ROOT}` transform lines (verified: `CLAUDE_PLUGIN_ROOT` x5, `.claude/skills/aeon` x0 in the plugin copy).

## Not touched (already correct)
- README + `docs/skill-packs.md` exact counts already show **75** (each new-skill PR regenerated them on merge; `validate-readme-catalog.mjs` passes). The `60+` marketing floor (#859) left as-is per convention.
- `docs/ECOSYSTEM.md` already carries the five partners (#880 merged here); `docs/langfuse.md` already carries the v4 note (#883 merged here).

## Noise bundled as maintenance
- #879 (nanoid remotion lockfile, security), #886 (ponytail dead-code refactor), #887 (CI concurrency).

## Watermark
New sync watermark: **#887**.
