### PR TITLE
chore: refresh hardcoded model pins to current generation

### DIFF
--- a/apps/dashboard/lib/constants.ts
+++ b/apps/dashboard/lib/constants.ts
@@ -44,17 +44,16 @@ export const KIMI_MODELS = [
   { id: 'moonshotai/kimi-k2.7-code', label: 'Kimi K2.7 Code' },
 ]
 
-// codex needs its own list: it fails DETERMINISTICALLY on gpt-5-nano (it emits a
+// codex needs its own list. It fails DETERMINISTICALLY on gpt-5-nano (it emits a
 // shell tool call with a duplicated `cmd` field, its strict parser rejects it,
-// and with no --max-turns it spins to the run guard). So its cheapest working
-// model is mini — measured on a real runner — which stays the default (first entry,
-// matched by aeon.yml's DEFAULT_HM). The rest are the codex-tuned line
-// (gpt-5.1-codex-mini, gpt-5.3-codex) and the general gpt-5.6 family (luna, terra),
-// which drive codex via OpenRouter. gpt-5.1-codex-mini + gpt-5.6-luna verified live
-// 2026-07-22; gpt-5.3-codex/gpt-5.6-terra inferred from their same-family siblings.
+// and with no --max-turns it spins to the run guard), so nano is never offered.
+// The default (first entry, matched by aeon.yml's DEFAULT_HM) is the codex-tuned
+// gpt-5.1-codex-mini, verified live 2026-07-22. gpt-5-mini is the prior default
+// and stays as a universally-safe fallback; the rest are the fuller codex line
+// (gpt-5.3-codex) and the general gpt-5.6 family (luna, terra), all via OpenRouter.
 export const CODEX_MODELS = [
-  { id: 'openai/gpt-5-mini', label: 'GPT-5 Mini' },
   { id: 'openai/gpt-5.1-codex-mini', label: 'GPT-5.1 Codex Mini' },
+  { id: 'openai/gpt-5-mini', label: 'GPT-5 Mini' },
   { id: 'openai/gpt-5.3-codex', label: 'GPT-5.3 Codex' },
   { id: 'openai/gpt-5.6-luna', label: 'GPT-5.6 Luna' },
   { id: 'openai/gpt-5.6-terra', label: 'GPT-5.6 Terra' },

--- a/harness-adapter/adapters/pi.sh
+++ b/harness-adapter/adapters/pi.sh
@@ -27,7 +27,7 @@ command -v pi >/dev/null 2>&1 || {
 ARGS=(--mode json --no-session --approve)
 
 # model: pi is multi-provider — pass anything through (its registry matches
-# patterns like "claude-sonnet-5", "openai/gpt-4o", or bare "sonnet")
+# patterns like "claude-sonnet-5", "openai/gpt-5-mini", or bare "sonnet")
 [ -n "${RH_MODEL:-}" ] && [ "${RH_MODEL}" != "default" ] && ARGS+=(--model "$RH_MODEL")
 
 # read-only -> tool subsetting (pi's only native lever; advisory without the

--- a/scripts/install-harness.sh
+++ b/scripts/install-harness.sh
@@ -147,7 +147,7 @@ api_key = "$MOONSHOT_API_KEY"
 
 [models.kimi-native]
 provider = "moonshot"
-model = "kimi-k2-0711-preview"
+model = "kimi-k2.5"
 max_context_size = 131072
 TOML
         chmod 600 "$HOME/.kimi-code/config.toml"

--- a/scripts/llm-gateway.sh
+++ b/scripts/llm-gateway.sh
@@ -270,8 +270,7 @@ X-Title: ${OPENROUTER_APP_TITLE:-Aeon}"
     if [ -z "$venice_model" ]; then
       m="$(printf '%s' "${MODEL:-}" | sed -E 's/-[0-9]{8}$//')"
       case "$m" in
-        claude-opus-5|claude-sonnet-5|claude-fable-5|claude-opus-4-8|claude-opus-4-7|\
-        claude-opus-4-6|claude-opus-4-5|claude-sonnet-4-6|claude-sonnet-4-5) venice_model="$m" ;;
+        claude-opus-5|claude-sonnet-5|claude-fable-5) venice_model="$m" ;;
         *) venice_model="claude-sonnet-5" ;;
       esac
     fi

--- a/scripts/resolve-harness.sh
+++ b/scripts/resolve-harness.sh
@@ -119,7 +119,7 @@ fi
 case "$REQ_MODEL" in claude-*|grok-*|"") REQ_MODEL="" ;; esac   # aeon-native / unset → not an OpenRouter id
 
 case "$HARNESS" in
-  codex) DEFAULT_HM="openai/gpt-5-mini" ;;
+  codex) DEFAULT_HM="openai/gpt-5.1-codex-mini" ;;
   vibe)  DEFAULT_HM="mistralai/mistral-medium-3-5" ;;   # vibe's default (VIBE_MODELS[0])
   pi)    DEFAULT_HM="deepseek/deepseek-v4-flash" ;;     # pi's default (PI_MODELS[0])
   kimi)  DEFAULT_HM="moonshotai/kimi-k2.5" ;;           # kimi's default (KIMI_MODELS[0])

--- a/skills/bd-radar/SKILL.md
+++ b/skills/bd-radar/SKILL.md
@@ -85,7 +85,7 @@ For ecosystem/extension repos, note the owner (potential partner).
 FROM_DATE=$(date -u -d "3 days ago" +%Y-%m-%d 2>/dev/null || date -u -v-3d +%Y-%m-%d)
 TERMS="<OR-joined product names + @handles read from memory/products.md>"
 jq -n --arg terms "$TERMS" --arg fd "$FROM_DATE" \
-  '{model:"grok-4.3", input:[{role:"user",content:("Search X since "+$fd+" for posts mentioning any of: "+$terms+". For each post return: @handle, full text, date, whether the author reads as a project or builder (from bio/links), engagement counts, and the direct link https://x.com/handle/status/ID.")}], tools:[{type:"x_search"}]}' \
+  '{model:"grok-4.6", input:[{role:"user",content:("Search X since "+$fd+" for posts mentioning any of: "+$terms+". For each post return: @handle, full text, date, whether the author reads as a project or builder (from bio/links), engagement counts, and the direct link https://x.com/handle/status/ID.")}], tools:[{type:"x_search"}]}' \
   > /tmp/xai-bd-payload.json
 HTTP=$(./secretcurl -s -o /tmp/xai-bd.json -w '%{http_code}' --max-time 150 -X POST "https://api.x.ai/v1/responses" \
   -H "Content-Type: application/json" -H "Authorization: Bearer {XAI_API_KEY}" -d @/tmp/xai-bd-payload.json)

--- a/skills/digest/SKILL.md
+++ b/skills/digest/SKILL.md
@@ -65,7 +65,7 @@ Pull from the source classes selected by `${var}`. Never rely on a single one â€
    TO_DATE=$(date -u +%Y-%m-%d)
    PROMPT="Search X for substantive, recent posts about: ${topic:-the most notable technology, AI, and crypto stories today}. Date range: $FROM_DATE to $TO_DATE. Return up to 10 high-signal posts â€” prioritize verifiable claims, launches, funding, releases, exploits, or hard data over hot takes. For EACH post return: @handle, the full text, date posted, exact engagement counts (likes, retweets, replies; 0 if unknown), and the direct link https://x.com/handle/status/ID. Return a numbered list."
    jq -n --arg p "$PROMPT" --arg fd "$FROM_DATE" --arg td "$TO_DATE" \
-     '{model:"grok-4.3", input:[{role:"user",content:$p}], tools:[{type:"x_search",from_date:$fd,to_date:$td}]}' \
+     '{model:"grok-4.6", input:[{role:"user",content:$p}], tools:[{type:"x_search",from_date:$fd,to_date:$td}]}' \
      > /tmp/xai-digest-payload.json
    HTTP=$(./secretcurl -s -o /tmp/xai-digest.json -w '%{http_code}' --max-time 150 -X POST "https://api.x.ai/v1/responses" \
      -H "Content-Type: application/json" -H "Authorization: Bearer {XAI_API_KEY}" -d @/tmp/xai-digest-payload.json)

--- a/skills/feature/SKILL.md
+++ b/skills/feature/SKILL.md
@@ -80,8 +80,9 @@ All branches read operator-controlled files under `memory/` (runtime config — 
   ## Current models (suggest these as replacements)
   - claude-sonnet-5
   - claude-opus-5
-  - gpt-4o
-  - gemini-2.0
+  - gpt-5
+  - gemini-3
+  - grok-4.6
   ```
 
   If the file is missing, the **dormant** branch skips the "stale model" fix category entirely (other categories still apply) and logs `REPO_REVIVE_NO_MODEL_CONFIG: skipping model audit`.

--- a/skills/fetch-tweets/SKILL.md
+++ b/skills/fetch-tweets/SKILL.md
@@ -78,7 +78,7 @@ Search X for tweets matching `ARG` and produce a curated digest grouped by sub-n
    FROM_DATE=$(date -u -d "yesterday" +%Y-%m-%d 2>/dev/null || date -u -v-1d +%Y-%m-%d)
    TO_DATE=$(date -u +%Y-%m-%d)
    PROMPT="Search X for tweets about: ${ARG}. Date range: ${FROM_DATE} to ${TO_DATE}. Return at least 15-20 candidate tweets — mix of high-engagement posts and smaller accounts that add a distinct angle. For each tweet include: @handle, the full text, date posted, exact engagement counts (likes, retweets, replies — never N/A; if unknown, say 0), and the direct link (https://x.com/handle/status/ID). Return as a numbered list."
-   jq -n --arg p "$PROMPT" '{model:"grok-4.3", input:[{role:"user",content:$p}], tools:[{type:"x_search"}]}' > /tmp/xai-ft-keyword.json
+   jq -n --arg p "$PROMPT" '{model:"grok-4.6", input:[{role:"user",content:$p}], tools:[{type:"x_search"}]}' > /tmp/xai-ft-keyword.json
    HTTP=$(./secretcurl -s -o /tmp/xai.json -w '%{http_code}' --max-time 150 -X POST "https://api.x.ai/v1/responses" \
      -H "Content-Type: application/json" \
      -H "Authorization: Bearer {XAI_API_KEY}" \
@@ -149,7 +149,7 @@ Gist of the latest X chatter on one or more configurable topics.
    FROM_DATE=$(date -u -d "yesterday" +%Y-%m-%d 2>/dev/null || date -u -v-1d +%Y-%m-%d)
    TO_DATE=$(date -u +%Y-%m-%d)
    PROMPT="Search X for recent tweets about: ${TOPIC}. Date range: ${FROM_DATE} to ${TO_DATE}. Return up to 8 substantive tweets. For each: @handle, full text, date, exact engagement counts (likes, retweets, replies; 0 if unknown), and the direct link https://x.com/handle/status/ID."
-   jq -n --arg p "$PROMPT" '{model:"grok-4.3", input:[{role:"user",content:$p}], tools:[{type:"x_search"}]}' > /tmp/xai-ft-topic.json
+   jq -n --arg p "$PROMPT" '{model:"grok-4.6", input:[{role:"user",content:$p}], tools:[{type:"x_search"}]}' > /tmp/xai-ft-topic.json
    ./secretcurl -s -o /tmp/xai-topic-out.json -X POST "https://api.x.ai/v1/responses" \
      -H "Content-Type: application/json" \
      -H "Authorization: Bearer {XAI_API_KEY}" \
@@ -201,7 +201,7 @@ Two sub-modes: **single handle** (decision-ready gist of one account) vs. **all 
    - **Path A — X.AI API** (primary): search this account's recent tweets via Grok's `x_search`.
      ```bash
      PROMPT="Search X for the latest tweets, replies, and quote tweets from @${ACCOUNT} in the last 2 days. Return each with full text, timestamp, type (original|reply|quote), what it replies to/quotes if any, exact engagement counts (likes, retweets, replies; 0 if unknown), and the permalink https://x.com/${ACCOUNT}/status/ID. Skip retweets of others. Return chronological."
-     jq -n --arg p "$PROMPT" '{model:"grok-4.3", input:[{role:"user",content:$p}], tools:[{type:"x_search"}]}' > /tmp/xai-ft-account.json
+     jq -n --arg p "$PROMPT" '{model:"grok-4.6", input:[{role:"user",content:$p}], tools:[{type:"x_search"}]}' > /tmp/xai-ft-account.json
      ./secretcurl -m 30 -s -o /tmp/xai-account-out.json -X POST "https://api.x.ai/v1/responses" \
        -H "Content-Type: application/json" \
        -H "Authorization: Bearer {XAI_API_KEY}" \
@@ -261,7 +261,7 @@ Use this to answer "what did *these specific people* post" across a watchlist.
    - **Path A — live curl** (primary, `XAI_API_KEY` is injected and set):
      ```bash
      PROMPT="Search X for the latest tweets from:${HANDLE} in the last 3 days. Return the 5 most interesting or substantive tweets. For each: full text, date, direct link (https://x.com/${HANDLE}/status/ID). Skip retweets of others."
-     jq -n --arg p "$PROMPT" '{model:"grok-4.3", input:[{role:"user",content:$p}], tools:[{type:"x_search"}]}' > /tmp/xai-ft-acct1.json
+     jq -n --arg p "$PROMPT" '{model:"grok-4.6", input:[{role:"user",content:$p}], tools:[{type:"x_search"}]}' > /tmp/xai-ft-acct1.json
      ./secretcurl -m 30 -s -o /tmp/xai-acct1-out.json -X POST "https://api.x.ai/v1/responses" \
        -H "Content-Type: application/json" \
        -H "Authorization: Bearer {XAI_API_KEY}" \
@@ -325,7 +325,7 @@ Cross-list narrative resonance + signal-scored top tweets from tracked X lists i
    TO_DATE=$(date -u +%Y-%m-%d)
    PROMPT="Look at X list https://x.com/i/lists/${LIST_ID}. Step 1: report the list name and a one-line description. Step 2: identify the most engaging tweets posted by members of this list between ${FROM_DATE} and ${TO_DATE} UTC. Return the top 12 tweets ranked by engagement (likes, retweets, replies). For EACH tweet you MUST return: (a) @handle, (b) the full tweet text (not a paraphrase), (c) explicit engagement counts as separate fields — likes:N, retweets:N, replies:N, views:N if available, (d) the direct permalink in the form https://x.com/<handle>/status/<id>, (e) media type (image|video|none), (f) one-line context if it's a reply or quote tweet (who/what). Skip retweets of accounts NOT on this list. If a tweet has an image and you can analyze it, include a one-line image description."
    jq -n --arg p "$PROMPT" --arg fd "$FROM_DATE" --arg td "$TO_DATE" \
-     '{model:"grok-4.3", input:[{role:"user",content:$p}], tools:[{type:"x_search", from_date:$fd, to_date:$td, enable_image_understanding:true}]}' \
+     '{model:"grok-4.6", input:[{role:"user",content:$p}], tools:[{type:"x_search", from_date:$fd, to_date:$td, enable_image_understanding:true}]}' \
      > /tmp/xai-ft-list.json
    ./secretcurl -s -o /tmp/xai-list-out.json --max-time 180 -X POST "https://api.x.ai/v1/responses" \
      -H "Content-Type: application/json" \
@@ -405,7 +405,7 @@ A topic-filtered preset: a curated, narrative-aware read on what the AI-agent sc
    ```bash
    PROMPT="Search X from ${FROM_DATE} to ${TO_DATE} for tweets in the AI-agents conversation: autonomous agents, agent frameworks, MCP / agent protocols, agent products, agent benchmarks, agent research papers. Return up to 40 candidates. For EACH candidate you MUST return: @handle, follower_count (integer or null), role_guess (builder|founder|researcher|investor|commentator|anon), one-line claim (what they actually said — not a paraphrase, the thesis), likes (int), retweets (int), replies (int), posted_at (ISO), direct_link (https://x.com/username/status/ID). Prefer builders/founders/researchers. Skip obvious engagement-farming threads (\"RT if you agree\", reply-guy pileons, giveaways)."
    jq -n --arg p "$PROMPT" --arg fd "$FROM_DATE" --arg td "$TO_DATE" \
-     '{model:"grok-4.3", input:[{role:"user",content:$p}], tools:[{type:"x_search", from_date:$fd, to_date:$td}]}' \
+     '{model:"grok-4.6", input:[{role:"user",content:$p}], tools:[{type:"x_search", from_date:$fd, to_date:$td}]}' \
      > /tmp/xai-ft-buzz.json
    ./secretcurl -s -o /tmp/xai-buzz-out.json -X POST "https://api.x.ai/v1/responses" \
      -H "Content-Type: application/json" \

--- a/skills/last30/SKILL.md
+++ b/skills/last30/SKILL.md
@@ -112,7 +112,7 @@ curl -sL -A "$UA" \
 [ -n "$XAI_API_KEY" ] && echo KEY_PRESENT || echo KEY_UNSET   # prints KEY_PRESENT — Path A is required
 # Build the payload to a file with jq --arg (no heredoc into a var) so the ./secretcurl command stays 100% literal:
 jq -n --arg topic "$TOPIC" --arg variants "$SEARCH_VARIANTS" --arg fd "$FROM_DATE" --arg td "$TO_DATE" \
-  '{model:"grok-4.3", input:[{role:"user",content:("Search X for tweets about: "+$topic+" (also try: "+$variants+"). Date range: "+$fd+" to "+$td+". Return 15-25 substantive tweets — mix high-engagement posts with smaller accounts that add a distinct angle. For each: @handle, full text, date posted, exact engagement counts (likes, retweets, replies; 0 if unknown), follower count if available, and the direct link https://x.com/handle/status/ID. Skip retweets and reply-guy near-duplicates.")}], tools:[{type:"x_search",from_date:$fd,to_date:$td}]}' \
+  '{model:"grok-4.6", input:[{role:"user",content:("Search X for tweets about: "+$topic+" (also try: "+$variants+"). Date range: "+$fd+" to "+$td+". Return 15-25 substantive tweets — mix high-engagement posts with smaller accounts that add a distinct angle. For each: @handle, full text, date posted, exact engagement counts (likes, retweets, replies; 0 if unknown), follower count if available, and the direct link https://x.com/handle/status/ID. Skip retweets and reply-guy near-duplicates.")}], tools:[{type:"x_search",from_date:$fd,to_date:$td}]}' \
   > /tmp/xai-last30-topic-payload.json
 HTTP=$(./secretcurl -s -o /tmp/xai-last30-topic.json -w '%{http_code}' --max-time 150 -X POST "https://api.x.ai/v1/responses" \
   -H "Content-Type: application/json" \
@@ -130,7 +130,7 @@ jq -r '.output[]|select(.type=="message")|.content[]|select(.type=="output_text"
 ```bash
 # Build the handle-restricted payload to its own file with jq --arg (keeps the ./secretcurl command literal):
 jq -n --arg topic "$TOPIC" --arg handles "$RESOLVED_HANDLES" --arg fd "$FROM_DATE" --arg td "$TO_DATE" \
-  '{model:"grok-4.3", input:[{role:"user",content:("Search X for tweets from these accounts about "+$topic+": "+$handles+". Date range: "+$fd+" to "+$td+". For each: @handle, full text, date, engagement counts (likes, retweets, replies; 0 if unknown), and the direct link https://x.com/handle/status/ID.")}], tools:[{type:"x_search",from_date:$fd,to_date:$td}]}' \
+  '{model:"grok-4.6", input:[{role:"user",content:("Search X for tweets from these accounts about "+$topic+": "+$handles+". Date range: "+$fd+" to "+$td+". For each: @handle, full text, date, engagement counts (likes, retweets, replies; 0 if unknown), and the direct link https://x.com/handle/status/ID.")}], tools:[{type:"x_search",from_date:$fd,to_date:$td}]}' \
   > /tmp/xai-last30-handles-payload.json
 HTTP=$(./secretcurl -s -o /tmp/xai-last30-handles.json -w '%{http_code}' --max-time 150 -X POST "https://api.x.ai/v1/responses" \
   -H "Content-Type: application/json" \
@@ -369,7 +369,7 @@ For `LAST30_EMPTY` or `LAST30_ERROR`, skip the verdict/narrative lines and inste
 
 ## Fetching
 
-`XAI_API_KEY` is **injected into this skill's environment** (declared in `requires:`) and is present and valid. The **primary** X/Twitter source is a direct `curl` to `https://api.x.ai/v1/responses` with `Authorization: Bearer {XAI_API_KEY}`, model `grok-4.3`, `"tools":[{"type":"x_search"}]`. There is **no** network sandbox blocking this — just make the call (see step 3).
+`XAI_API_KEY` is **injected into this skill's environment** (declared in `requires:`) and is present and valid. The **primary** X/Twitter source is a direct `curl` to `https://api.x.ai/v1/responses` with `Authorization: Bearer {XAI_API_KEY}`, model `grok-4.6`, `"tools":[{"type":"x_search"}]`. There is **no** network sandbox blocking this — just make the call (see step 3).
 
 **You MUST attempt the direct curl before any fallback:**
 1. **Check, don't assume.** `[ -n "$XAI_API_KEY" ] && echo KEY_PRESENT || echo KEY_UNSET`. If `KEY_PRESENT` (it will be), Path A is required.

--- a/skills/mention-radar/SKILL.md
+++ b/skills/mention-radar/SKILL.md
@@ -39,7 +39,7 @@ Read the last 3 days of memory/logs/ to avoid re-surfacing already-noted mention
    TO_DATE=$(date -u +%Y-%m-%d)
    PROMPT="Search X for posts by OTHER people mentioning the project \"${NAME}\" (also its site ${DOMAIN} and repo ${REPO} when given), posted between ${FROM_DATE} and ${TO_DATE}. Exclude posts by the operator @${OPERATOR} and by the project's own accounts. For each mention return: @handle, the full post text, date, exact engagement counts (likes, retweets, replies; 0 if unknown), the poster's approximate follower count if visible, and the direct link https://x.com/handle/status/ID. Prioritize people discovering it for the first time, asking confused questions, hitting friction (setup/docs/missing feature), comparing it to a competitor, or requesting a feature. Return a numbered list; if nobody is talking about it, say so explicitly."
    jq -n --arg p "$PROMPT" --arg fd "$FROM_DATE" --arg td "$TO_DATE" \
-     '{model:"grok-4.3", input:[{role:"user",content:$p}], tools:[{type:"x_search",from_date:$fd,to_date:$td}]}' \
+     '{model:"grok-4.6", input:[{role:"user",content:$p}], tools:[{type:"x_search",from_date:$fd,to_date:$td}]}' \
      > /tmp/xai-mr-payload.json
    HTTP=$(./secretcurl -s -o /tmp/xai-mr.json -w '%{http_code}' --max-time 150 -X POST "https://api.x.ai/v1/responses" \
      -H "Content-Type: application/json" \

--- a/skills/narrative-tracker/SKILL.md
+++ b/skills/narrative-tracker/SKILL.md
@@ -42,7 +42,7 @@ TO_DATE=$(date -u +%Y-%m-%d)
 # The `>` redirect to /tmp is fine in read-only mode (it is not a repo path; nothing reverts it).
 PROMPT="Search X for the dominant crypto and tech narratives from ${FROM_DATE} to ${TO_DATE}. Return 12-15 distinct narrative threads. For each: 1) short label, 2) 3-5 representative @handles driving it, 3) 2-3 tweet permalinks, 4) rough mention-volume descriptor (niche / growing / saturating / cooling), 5) the strongest one-line bear case against it."
 jq -n --arg p "$PROMPT" --arg fd "$FROM_DATE" --arg td "$TO_DATE" \
-  '{model:"grok-4.3", input:[{role:"user",content:$p}], tools:[{type:"x_search",from_date:$fd,to_date:$td}]}' \
+  '{model:"grok-4.6", input:[{role:"user",content:$p}], tools:[{type:"x_search",from_date:$fd,to_date:$td}]}' \
   > /tmp/xai-nt-payload.json
 HTTP=$(./secretcurl -s -o /tmp/xai-nt.json -w '%{http_code}' --max-time 150 -X POST "https://api.x.ai/v1/responses" \
   -H "Content-Type: application/json" \
@@ -142,7 +142,7 @@ Append a `### narrative-tracker` section with the full structured output (not ju
 
 ## Fetching
 
-`XAI_API_KEY` is **injected into this skill's environment** (declared in `requires:`). It is present and valid. **The primary fetch path is a direct `curl` to `https://api.x.ai/v1/responses` with `Authorization: Bearer {XAI_API_KEY}`** (model `grok-4.3`, `"tools":[{"type":"x_search"}]`). There is **no network sandbox** blocking this — earlier versions of this skill claimed there was, and that is stale and false. Just make the call.
+`XAI_API_KEY` is **injected into this skill's environment** (declared in `requires:`). It is present and valid. **The primary fetch path is a direct `curl` to `https://api.x.ai/v1/responses` with `Authorization: Bearer {XAI_API_KEY}`** (model `grok-4.6`, `"tools":[{"type":"x_search"}]`). There is **no network sandbox** blocking this — earlier versions of this skill claimed there was, and that is stale and false. Just make the call.
 
 Rules:
 1. **Check, don't assume.** Run `[ -n "${XAI_API_KEY:+x}" ] && echo KEY_PRESENT || echo KEY_UNSET` (the `${VAR:+x}` form, not bare `$XAI_API_KEY` — the bare form trips the secret-expansion analyzer and falsely reads as unset). If `KEY_PRESENT` (it will be), Path A (the curl in step 1a) is required before any fallback.

--- a/skills/reply-maker/SKILL.md
+++ b/skills/reply-maker/SKILL.md
@@ -103,7 +103,7 @@ jq -r '.output[] | select(.type == "message") | .content[] | select(.type == "ou
 ```bash
 LIST_ID="${var}"
 jq -n --arg list_id "$LIST_ID" --arg from "$FROM_DATE" --arg to "$TO_DATE" '{
-  model: "grok-4.3",
+  model: "grok-4.6",
   input: [{role: "user", content: ("Look at X list https://x.com/i/lists/" + $list_id + ". Return the 12 most reply-worthy original posts (not retweets, not replies) by members of this list between " + $from + " and " + $to + ". Reply-worthy = has a take, claim, question, or framing worth engaging — NOT pure self-promo, breaking news without analysis, or threads already past 500 replies. For each: @handle, full tweet text, tweet URL, posted_at ISO timestamp, like/reply/retweet counts.")}],
   tools: [{type: "x_search", from_date: $from, to_date: $to}]
 }' > /tmp/xai-rm-payload.json
@@ -113,7 +113,7 @@ jq -n --arg list_id "$LIST_ID" --arg from "$FROM_DATE" --arg to "$TO_DATE" '{
 ```bash
 HANDLE="${var}"
 jq -n --arg handle "$HANDLE" --arg from "$FROM_DATE" --arg to "$TO_DATE" '{
-  model: "grok-4.3",
+  model: "grok-4.6",
   input: [{role: "user", content: ("Look at recent original posts (not retweets, not replies) by " + $handle + " on X between " + $from + " and " + $to + ". Return the 12 most reply-worthy. Reply-worthy = has a take, claim, question, or framing worth engaging — NOT pure self-promo, breaking news without analysis, or threads already past 500 replies. For each: @handle, full tweet text, tweet URL, posted_at ISO timestamp, like/reply/retweet counts.")}],
   tools: [{type: "x_search", from_date: $from, to_date: $to}]
 }' > /tmp/xai-rm-payload.json
@@ -123,7 +123,7 @@ jq -n --arg handle "$HANDLE" --arg from "$FROM_DATE" --arg to "$TO_DATE" '{
 ```bash
 TOPIC="${var}"   # when empty, substitute the top 2–3 topics from memory/MEMORY.md
 jq -n --arg topic "$TOPIC" --arg from "$FROM_DATE" --arg to "$TO_DATE" '{
-  model: "grok-4.3",
+  model: "grok-4.6",
   input: [{role: "user", content: ("Search X for the 12 most reply-worthy original posts (not retweets, not replies) about " + $topic + " between " + $from + " and " + $to + ". Reply-worthy = has a take, claim, question, or framing worth engaging — NOT pure self-promo, breaking news without analysis, or threads already past 500 replies. For each: @handle, full tweet text, tweet URL, posted_at ISO timestamp, like/reply/retweet counts.")}],
   tools: [{type: "x_search", from_date: $from, to_date: $to}]
 }' > /tmp/xai-rm-payload.json

--- a/skills/shiplog/SKILL.md
+++ b/skills/shiplog/SKILL.md
@@ -117,7 +117,7 @@ There are two X sources here — the **operator** handle (`$OPERATOR_HANDLE`, th
 
 *Operator posts* (`SRC=operator`):
 ```bash
-jq -n --arg h "$OPERATOR_HANDLE" --arg sd "$SINCE_DATE" --arg td "$TODAY" '{model:"grok-4.3", input:[{role:"user", content:("Search X for posts by @" + $h + " between " + $sd + " and " + $td + ". Return each post with full text, date, type (original|reply|RT — an RT text starts with \"RT @\"), exact engagement counts (likes, retweets, replies; 0 if unknown), and the direct link https://x.com/" + $h + "/status/ID. Return chronological.")}], tools:[{type:"x_search"}]}' > /tmp/xai-shiplog-operator-payload.json
+jq -n --arg h "$OPERATOR_HANDLE" --arg sd "$SINCE_DATE" --arg td "$TODAY" '{model:"grok-4.6", input:[{role:"user", content:("Search X for posts by @" + $h + " between " + $sd + " and " + $td + ". Return each post with full text, date, type (original|reply|RT — an RT text starts with \"RT @\"), exact engagement counts (likes, retweets, replies; 0 if unknown), and the direct link https://x.com/" + $h + "/status/ID. Return chronological.")}], tools:[{type:"x_search"}]}' > /tmp/xai-shiplog-operator-payload.json
 HTTP=$(./secretcurl -s -o /tmp/xai-shiplog-operator.json -w '%{http_code}' --max-time 150 -X POST "https://api.x.ai/v1/responses" \
   -H "Content-Type: application/json" -H "Authorization: Bearer {XAI_API_KEY}" -d @/tmp/xai-shiplog-operator-payload.json)
 echo "xai http=$HTTP bytes=$(wc -c </tmp/xai-shiplog-operator.json)"
@@ -125,7 +125,7 @@ echo "xai http=$HTTP bytes=$(wc -c </tmp/xai-shiplog-operator.json)"
 
 *Product/project accounts* (`SRC=projects`):
 ```bash
-jq -n --arg sd "$SINCE_DATE" --arg td "$TODAY" --arg ph "$PRODUCT_HANDLES" '{model:"grok-4.3", input:[{role:"user", content:("Search X for posts between " + $sd + " and " + $td + " from these accounts: " + $ph + ". Focus on launches, announcements, and any brag about a security fix merged into another project. For each: @handle, full text, date, exact engagement counts (likes, retweets, replies; 0 if unknown), and the direct link https://x.com/handle/status/ID. Skip retweets of others.")}], tools:[{type:"x_search"}]}' > /tmp/xai-shiplog-projects-payload.json
+jq -n --arg sd "$SINCE_DATE" --arg td "$TODAY" --arg ph "$PRODUCT_HANDLES" '{model:"grok-4.6", input:[{role:"user", content:("Search X for posts between " + $sd + " and " + $td + " from these accounts: " + $ph + ". Focus on launches, announcements, and any brag about a security fix merged into another project. For each: @handle, full text, date, exact engagement counts (likes, retweets, replies; 0 if unknown), and the direct link https://x.com/handle/status/ID. Skip retweets of others.")}], tools:[{type:"x_search"}]}' > /tmp/xai-shiplog-projects-payload.json
 HTTP=$(./secretcurl -s -o /tmp/xai-shiplog-projects.json -w '%{http_code}' --max-time 150 -X POST "https://api.x.ai/v1/responses" \
   -H "Content-Type: application/json" -H "Authorization: Bearer {XAI_API_KEY}" -d @/tmp/xai-shiplog-projects-payload.json)
 echo "xai http=$HTTP bytes=$(wc -c </tmp/xai-shiplog-projects.json)"
@@ -145,7 +145,7 @@ From the **operator** text, separate **original posts** from **RTs** (RT text st
 
 - **Ecosystem mentions** — only if `ecosystem_scouts` (`scouts:`) is configured. Fetch with the same **Path A** X.AI curl as Step 3, into its own tmp file (`SRC=ecosystem`):
   ```bash
-  jq -n --arg sd "$SINCE_DATE" --arg td "$TODAY" --arg es "$ECOSYSTEM_SCOUTS" --arg ph "$PRODUCT_HANDLES" '{model:"grok-4.3", input:[{role:"user", content:("Search X between " + $sd + " and " + $td + " for posts from these recap/scout accounts: " + $es + " that mention any of these products: " + $ph + ". Return each mention with @handle, follower_count, full text, date, and the direct link https://x.com/handle/status/ID — recaps, rankings, partner shares.")}], tools:[{type:"x_search"}]}' > /tmp/xai-shiplog-ecosystem-payload.json
+  jq -n --arg sd "$SINCE_DATE" --arg td "$TODAY" --arg es "$ECOSYSTEM_SCOUTS" --arg ph "$PRODUCT_HANDLES" '{model:"grok-4.6", input:[{role:"user", content:("Search X between " + $sd + " and " + $td + " for posts from these recap/scout accounts: " + $es + " that mention any of these products: " + $ph + ". Return each mention with @handle, follower_count, full text, date, and the direct link https://x.com/handle/status/ID — recaps, rankings, partner shares.")}], tools:[{type:"x_search"}]}' > /tmp/xai-shiplog-ecosystem-payload.json
   HTTP=$(./secretcurl -s -o /tmp/xai-shiplog-ecosystem.json -w '%{http_code}' --max-time 150 -X POST "https://api.x.ai/v1/responses" \
     -H "Content-Type: application/json" -H "Authorization: Bearer {XAI_API_KEY}" -d @/tmp/xai-shiplog-ecosystem-payload.json)
   echo "xai http=$HTTP bytes=$(wc -c </tmp/xai-shiplog-ecosystem.json)"

--- a/skills/soul-builder/SKILL.md
+++ b/skills/soul-builder/SKILL.md
@@ -56,7 +56,7 @@ Gather from **every** source provided and **merge** everything useful — more s
    # with -d @file so the secretcurl command itself stays 100% literal (no shell
    # var expansion in the curl argv — the permission analyzer blocks that).
    jq -n --arg h "$HANDLE" '{
-     model: "grok-4.3",
+     model: "grok-4.6",
      input: [{role: "user", content: ("Build a voice and identity profile of X/Twitter account @" + $h + ". Step 1: return their profile — display name, bio/description, location, website, and what they pin or lead with. Step 2: return a WIDE, DIVERSE sample of 40-60 of their OWN ORIGINAL posts across a long window (not just the last day, not only the viral ones): mix short reactions, medium takes, and longer threads; span different topics, tones, and engagement levels; include some high-engagement and some quiet posts so their full range shows. Include representative replies and quote-tweets — they carry voice and opinion — but skip pure retweets of others. For EACH post return: the full text VERBATIM (never a paraphrase), the date, the type (original|reply|quote|thread-part), and the direct permalink https://x.com/" + $h + "/status/ID. Favour breadth of register over recency.")}],
      tools: [{type: "x_search"}]
    }' > /tmp/xai-soul-payload.json
@@ -256,7 +256,7 @@ Append to `memory/logs/${today}.md`:
 
 ## Fetching the X account
 
-`XAI_API_KEY` is **injected into this skill's environment** (declared in `requires:`). When it is present, **the primary way to read the X account is a direct `curl` to `https://api.x.ai/v1/responses` with `Authorization: Bearer {XAI_API_KEY}`** (Grok's `x_search`, model `grok-4.3`). There is no network sandbox blocking this — just make the call. The rules:
+`XAI_API_KEY` is **injected into this skill's environment** (declared in `requires:`). When it is present, **the primary way to read the X account is a direct `curl` to `https://api.x.ai/v1/responses` with `Authorization: Bearer {XAI_API_KEY}`** (Grok's `x_search`, model `grok-4.6`). There is no network sandbox blocking this — just make the call. The rules:
 
 1. **Check, don't assume.** Run `[ -n "$XAI_API_KEY" ] && echo KEY_PRESENT || echo KEY_UNSET`. If `KEY_PRESENT` (it will be on a normal run), you are required to try Path A before any fallback.
 2. **Allow enough time.** The `x_search` call typically takes 30–120s (it searches X live). When you invoke the Bash tool for the curl, **set the tool's `timeout` to at least 180000 (180s)**, and the curl carries **`--max-time 150`** so it fails cleanly instead of hanging. A curl that is slow is **not** a missing key — never treat a timeout as "key unavailable".

--- a/skills/token-movers/SKILL.md
+++ b/skills/token-movers/SKILL.md
@@ -588,7 +588,7 @@ Save to `output/articles/token-report-${today}.md`:
 If `XAI_API_KEY` is set:
 
 ```bash
-jq -n '{model:"grok-4.3", input:[{role:"user",content:"Search X for TOKEN_SYMBOL or CONTRACT_ADDRESS mentions in the last 24 hours with at least 10 likes. Return up to 5 notable tweets with @handle, engagement counts, and a one-line summary of the claim or vibe. Exclude obvious bots and generic shill posts."}], tools:[{type:"x_search"}]}' > /tmp/xai-tm-payload.json
+jq -n '{model:"grok-4.6", input:[{role:"user",content:"Search X for TOKEN_SYMBOL or CONTRACT_ADDRESS mentions in the last 24 hours with at least 10 likes. Return up to 5 notable tweets with @handle, engagement counts, and a one-line summary of the claim or vibe. Exclude obvious bots and generic shill posts."}], tools:[{type:"x_search"}]}' > /tmp/xai-tm-payload.json
 ./secretcurl -s -X POST "https://api.x.ai/v1/responses" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer {XAI_API_KEY}" \

--- a/skills/write-tweet/SKILL.md
+++ b/skills/write-tweet/SKILL.md
@@ -79,7 +79,7 @@ If the topic needs fresher context, use WebSearch to verify or expand.
 
 If `XAI_API_KEY` is set, search X for what people are already saying about the topic. A direct `curl` to the X.AI Responses API is the **primary** path for this X read (see **Fetching**; set the Bash tool `timeout` ≥180000):
 ```bash
-jq -n '{model:"grok-4.3", input:[{role:"user",content:"Search X for what people are saying about TOPIC in the last 24 hours. Return the 5 most notable tweets with @handle and summary."}], tools:[{type:"x_search"}]}' > /tmp/xai-wt-payload.json
+jq -n '{model:"grok-4.6", input:[{role:"user",content:"Search X for what people are saying about TOPIC in the last 24 hours. Return the 5 most notable tweets with @handle and summary."}], tools:[{type:"x_search"}]}' > /tmp/xai-wt-payload.json
 HTTP=$(./secretcurl -s -o /tmp/xai-wt.json -w '%{http_code}' --max-time 150 -X POST "https://api.x.ai/v1/responses" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer {XAI_API_KEY}" \
@@ -429,7 +429,7 @@ Each query must request for every tweet: full text, date posted, engagement stat
 # Replace HANDLE with the resolved handle. Set the Bash tool timeout ≥180000 (see Fetching).
 Q1_PROMPT="Search X for original tweets (exclude replies, retweets, quote tweets) posted by @HANDLE from ${FROM_DATE} to ${TO_DATE}. I want OPINION/TAKE posts — tweets that state a view, principle, or observation (not news announcements, not project updates, not single-link posts). Return up to 15. For each: full tweet text, date (YYYY-MM-DD), likes, retweets, replies, direct link https://x.com/HANDLE/status/ID. Format as numbered list."
 jq -n --arg p "$Q1_PROMPT" --arg fd "$FROM_DATE" --arg td "$TO_DATE" \
-  '{model:"grok-4.3", input:[{role:"user",content:$p}], tools:[{type:"x_search", allowed_x_handles:["HANDLE"], from_date:$fd, to_date:$td}]}' \
+  '{model:"grok-4.6", input:[{role:"user",content:$p}], tools:[{type:"x_search", allowed_x_handles:["HANDLE"], from_date:$fd, to_date:$td}]}' \
   > /tmp/xai-wt-q1-payload.json
 HTTP=$(./secretcurl -s -o /tmp/xai-wt-q1.json -w '%{http_code}' --max-time 150 -X POST "https://api.x.ai/v1/responses" \
   -H "Content-Type: application/json" \
@@ -624,7 +624,7 @@ Append **one** entry to `memory/logs/${today}.md` under a single `### write-twee
 
 ## Fetching
 
-`XAI_API_KEY` is **injected into this skill's environment** (declared in `requires:`). It is present and valid. **The primary way to fetch X/Twitter context — the DRAFTS "what people are saying" search and the REMIX tweet pull — is a direct `curl` to `https://api.x.ai/v1/responses` with `Authorization: Bearer {XAI_API_KEY}`, model `grok-4.3`, and `"tools":[{"type":"x_search"}]`.** There is no network sandbox blocking this; earlier versions of this skill claimed there was — that is stale and wrong. Just make the call.
+`XAI_API_KEY` is **injected into this skill's environment** (declared in `requires:`). It is present and valid. **The primary way to fetch X/Twitter context — the DRAFTS "what people are saying" search and the REMIX tweet pull — is a direct `curl` to `https://api.x.ai/v1/responses` with `Authorization: Bearer {XAI_API_KEY}`, model `grok-4.6`, and `"tools":[{"type":"x_search"}]`.** There is no network sandbox blocking this; earlier versions of this skill claimed there was — that is stale and wrong. Just make the call.
 
 **You MUST attempt the direct curl before any fallback.** The rules:
 


### PR DESCRIPTION
## What

Refresh hardcoded model pins to current-generation ids. Audit of every hardcoded model string in the repo found all live except two stale pins; also bumps the X-signal skills off a two-gen-old Grok.

## Changes

- **grok-4.3 -> grok-4.6** across 11 X-signal skills (`x_search` REST calls to `api.x.ai`): bd-radar, digest, fetch-tweets, last30, mention-radar, narrative-tracker, reply-maker, shiplog, soul-builder, token-movers, write-tweet. grok-4.3 still served but two generations behind (current flagship is 4.6).
- **codex default gpt-5-mini -> gpt-5.1-codex-mini** (`constants.ts` CODEX_MODELS + `resolve-harness.sh` DEFAULT_HM). Codex-tuned, verified live. gpt-5-mini kept in the list as the universally-safe fallback (still the generic non-codex fallback).
- **kimi native pin kimi-k2-0711-preview -> kimi-k2.5** (`install-harness.sh`, Moonshot-key path). The 0711 preview is retired on Moonshot; k2.5 matches the fleet's OpenRouter default.
- **Drop dead 4.x Claude ids** from the venice gateway passthrough (`llm-gateway.sh`): removed opus-4-8/4-7/4-6/4-5 and sonnet-4-6/4-5; kept current opus-5 / sonnet-5 / fable-5.
- **Refresh dated examples**: feature skill "current models" reference list (gpt-4o/gemini-2.0 -> gpt-5/gemini-3/grok-4.6) and the pi adapter comment example.

## Not changed (intentional)

- Harness `grok-4.5` pins (`aeon.yml`, GROK_MODELS): the grok Build CLI's X-account OAuth login only accepts grok-4.5 as a `--model` value, so 4.6 would break it there. Correct as-is.
- Both Haiku forms: `claude-haiku-4-5-20251001` (native, claude harness) and `claude-haiku-4.5` (OpenRouter alias, gateway) are each correct for their surface.

## Verification

- All 4 shell scripts pass `bash -n`.
- `constants.ts` parses; `modelsForHarness('codex')[0]` = `openai/gpt-5.1-codex-mini`.
- Every switched-to id verified live against the OpenRouter catalog (2026-08-17); grok-4.6 confirmed served on api.x.ai via xAI docs.
