### PR TITLE
chore: drop fable-5 from venice passthrough, refresh fork-fleet examples

### DIFF
--- a/scripts/llm-gateway.sh
+++ b/scripts/llm-gateway.sh
@@ -270,7 +270,7 @@ X-Title: ${OPENROUTER_APP_TITLE:-Aeon}"
     if [ -z "$venice_model" ]; then
       m="$(printf '%s' "${MODEL:-}" | sed -E 's/-[0-9]{8}$//')"
       case "$m" in
-        claude-opus-5|claude-sonnet-5|claude-fable-5) venice_model="$m" ;;
+        claude-opus-5|claude-sonnet-5) venice_model="$m" ;;
         *) venice_model="claude-sonnet-5" ;;
       esac
     fi

--- a/skills/fork-fleet/SKILL.md
+++ b/skills/fork-fleet/SKILL.md
@@ -352,7 +352,7 @@ For each CONFIGURED fork:
 - `category_lean`: dict `{tag -> count_of_enabled_skills_with_that_tag}` (using UPSTREAM_TAGS for upstream skills the fork enables; fork-only skills counted under tag `"fork-only"`)
 - `dominant_category`: tag with max count, or `"mixed"` if no tag holds >40% of total enabled count
 
-Rank forks by `total_overrides` desc. Top 5 = "heaviest customizers" — surface with dominant category and a one-line synthesis (e.g. `"owner/aeon — content-heavy: 14 article/digest skills enabled, 3 model overrides to claude-sonnet-4-6"`). The fingerprint is **descriptive only** — never recommend changes to individual forks.
+Rank forks by `total_overrides` desc. Top 5 = "heaviest customizers" — surface with dominant category and a one-line synthesis (e.g. `"owner/aeon — content-heavy: 14 article/digest skills enabled, 3 model overrides to claude-sonnet-5"`). The fingerprint is **descriptive only** — never recommend changes to individual forks.
 
 ### B7. Config week-over-week delta
 
@@ -423,7 +423,7 @@ Assemble this block (it becomes **Part 2** of the combined article):
 ## Fleet consensus on alternative settings
 
 ### Model overrides
-${MODEL_CONSENSUS entries: "skill X — N forks → claude-sonnet-4-6 (40% of configured)" OR "none this week"}
+${MODEL_CONSENSUS entries: "skill X — N forks → claude-sonnet-5 (40% of configured)" OR "none this week"}
 
 ### Var hotspots
 ${VAR_HOTSPOT entries: "skill X — N forks set var to '${value}'" OR "none this week"}


### PR DESCRIPTION
Follow-up to #891. Removes claude-fable-5 from the venice gateway passthrough (now falls back to sonnet-5) and refreshes the two prior-gen claude-sonnet-4-6 example strings in the fork-fleet skill to claude-sonnet-5. Both are non-runtime: venice is a niche gateway path, the fork-fleet strings are illustrative prose.