### PR TITLE
chore: switch Opus pins from opus-5 to opus-4-8

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -24,7 +24,7 @@ on:
         options:
           - '(config default)'
           - claude-sonnet-5
-          - claude-opus-5
+          - claude-opus-4-8
           - claude-haiku-4-5-20251001
           - grok-4.5
           - openai/gpt-5-mini

--- a/aeon.yml
+++ b/aeon.yml
@@ -26,7 +26,7 @@ skills:
   # --- Hound onchain investigation (on-demand; var = address / tx hash) ---
   investigation-report: { enabled: false, schedule: "workflow_dispatch", var: "" } # var: <token-address> [--checks=rug,contract,deployer,holders,honeypot,lp] [--depth=quick|deep] — composite investigation (folds in rug-scan/contract-audit/deployer-trace/holder-concentration/honeypot-check/lp-lock). read-only
   tx-explain: { enabled: false, schedule: "workflow_dispatch", var: "" } # var: tx hash — plain-English decode
-  deploy-uni-hook: { enabled: false, schedule: "workflow_dispatch", harness: "claude", model: "claude-opus-5", var: "" } # generate+audit+simulate+deploy a Uniswap v4 hook + test pool on any v4 chain. var: [arm:][template:dynamic|noop|skim] [chain:base-sepolia] <brief>. Dry-run by default; arm: to broadcast (needs HOOK_DEPLOYER_PRIVATE_KEY burner). Testnet default; mainnet behind arm:+explicit chain:+HOOK_MAINNET_OK=1. Opus-pinned: freeform hook-gen is hard.
+  deploy-uni-hook: { enabled: false, schedule: "workflow_dispatch", harness: "claude", model: "claude-opus-4-8", var: "" } # generate+audit+simulate+deploy a Uniswap v4 hook + test pool on any v4 chain. var: [arm:][template:dynamic|noop|skim] [chain:base-sepolia] <brief>. Dry-run by default; arm: to broadcast (needs HOOK_DEPLOYER_PRIVATE_KEY burner). Testnet default; mainnet behind arm:+explicit chain:+HOOK_MAINNET_OK=1. Opus-pinned: freeform hook-gen is hard.
 
   monitor-polymarket: { enabled: false, schedule: "30 12 * * *", var: "" } # prediction-market monitor (Polymarket + Kalshi) — 24h moves, volume, comments, conviction alerts. var: empty=both | polymarket | kalshi | polymarket:<slug> | kalshi:<ticker>
   token-pick: { enabled: false, schedule: "0 12 * * *" }
@@ -185,7 +185,7 @@ chains:
   #     - skill: routine, consume: [token-movers, hn-digest, issue-triage, github-trending]
 
 # Default model for all skills. Override per-run via workflow_dispatch.
-# Options: claude-sonnet-5, claude-opus-5, claude-haiku-4-5-20251001
+# Options: claude-sonnet-5, claude-opus-4-8, claude-haiku-4-5-20251001
 # (Grok harness model: grok-4.5, the flagship reasoning model and grok's current
 #  default, run with --no-subagents in CI. It's the only id the grok CLI accepts on an
 #  X-account login, and it's the gateway default too. The older coding ids

--- a/apps/dashboard/lib/config.test.ts
+++ b/apps/dashboard/lib/config.test.ts
@@ -35,7 +35,7 @@ skills:
   market-pulse: { enabled: true, schedule: "0 12 * * *", model: "claude-sonnet-5" }
   heartbeat: { enabled: true, schedule: "0 12 * * *" }
 
-model: claude-opus-5
+model: claude-opus-4-8
 
 gateway:
   provider: direct
@@ -65,7 +65,7 @@ describe("parseConfig", () => {
     assert.equal(config.skills["morning-brief"].schedule, "0 7 * * *");
     assert.equal(config.skills["market-pulse"].enabled, true);
     assert.equal(config.skills["market-pulse"].model, "claude-sonnet-5");
-    assert.equal(config.model, "claude-opus-5");
+    assert.equal(config.model, "claude-opus-4-8");
     assert.equal(config.gateway.provider, "direct");
     assert.equal(config.jsonrenderEnabled, true);
   });
@@ -164,9 +164,9 @@ describe("updateSkillInConfig", () => {
 
 describe("updateModelInConfig", () => {
   it("updates the top-level model", () => {
-    const updated = updateModelInConfig(MINIMAL_YAML, "claude-opus-5");
+    const updated = updateModelInConfig(MINIMAL_YAML, "claude-opus-4-8");
     const config = parseConfig(updated);
-    assert.equal(config.model, "claude-opus-5");
+    assert.equal(config.model, "claude-opus-4-8");
   });
 
   it("replaces an existing model", () => {
@@ -353,9 +353,9 @@ describe("round-trip config mutations", () => {
   });
 
   it("update model and gateway independently", () => {
-    let yaml = updateModelInConfig(MINIMAL_YAML, "claude-opus-5");
+    let yaml = updateModelInConfig(MINIMAL_YAML, "claude-opus-4-8");
     const config1 = parseConfig(yaml);
-    assert.equal(config1.model, "claude-opus-5");
+    assert.equal(config1.model, "claude-opus-4-8");
 
     // Model change should not affect skills
     assert.equal(config1.skills["heartbeat"].enabled, true);

--- a/apps/dashboard/lib/constants.ts
+++ b/apps/dashboard/lib/constants.ts
@@ -7,7 +7,7 @@ import type { Harness } from './types'
 // sync with the config default in lib/config.ts and aeon.yml `model:`.
 export const MODELS = [
   { id: 'claude-sonnet-5', label: 'Sonnet 5' },
-  { id: 'claude-opus-5', label: 'Opus 5' },
+  { id: 'claude-opus-4-8', label: 'Opus 4.8' },
   { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5' },
 ]
 

--- a/docs/ADK.md
+++ b/docs/ADK.md
@@ -188,7 +188,7 @@ Everything on-demand goes through one workflow - `aeon.yml` accepts `workflow_di
 |---|---|
 | `skill` | required; must match `^[a-zA-Z0-9_-]+$` and a directory under `skills/` |
 | `var` | the skill's input for this run |
-| `model` | override, e.g. `claude-opus-5` - must be one of the workflow's `choice` options or GitHub rejects with **422** |
+| `model` | override, e.g. `claude-opus-4-8` - must be one of the workflow's `choice` options or GitHub rejects with **422** |
 | `harness` | `claude` (default) or `grok` - see [Harnesses](harnesses.md) |
 
 ```ts

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -210,7 +210,7 @@ The default model for all skills is set in `aeon.yml` (or from the dashboard hea
 model: claude-sonnet-5
 ```
 
-Options: `claude-sonnet-5` (default), `claude-opus-5`, `claude-haiku-4-5-20251001`. Per-run overrides are available via workflow dispatch, and individual skills can override to optimize cost:
+Options: `claude-sonnet-5` (default), `claude-opus-4-8`, `claude-haiku-4-5-20251001`. Per-run overrides are available via workflow dispatch, and individual skills can override to optimize cost:
 
 ```yaml
 skills:

--- a/docs/attestation.md
+++ b/docs/attestation.md
@@ -201,7 +201,7 @@ To read the richer metadata, verify the manifest and inspect its bytes:
 ```bash
 gh attestation verify output/.attest/<skill>-<run_id>.json --repo <owner>/<repo>
 cat output/.attest/<skill>-<run_id>.json
-# { "skill": "...", "model": "claude-opus-5", "mode": "read-only",
+# { "skill": "...", "model": "claude-opus-4-8", "mode": "read-only",
 #   "trigger": "schedule", "commit": "<sha>", "run_id": "<id>",
 #   "output": { "path": "output/.attest/<skill>-<run_id>.md", "sha256": "<digest>" } }
 ```

--- a/scripts/llm-gateway.sh
+++ b/scripts/llm-gateway.sh
@@ -183,13 +183,13 @@ case "${GATEWAY:-direct}" in
     echo "::notice::Routing through Bankr Gateway (https://llm.bankr.bot)"
     ;;
 
-  openrouter)  # NATIVE — Anthropic "skin", carries Opus 5
+  openrouter)  # NATIVE — Anthropic "skin", carries Opus 4.8
     require_secret OPENROUTER_API_KEY
     export ANTHROPIC_BASE_URL="https://openrouter.ai/api"   # NOT /api/v1
     export ANTHROPIC_AUTH_TOKEN="$OPENROUTER_API_KEY"       # Bearer; API_KEY must be blank
     unset ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN
     # Map EVERY model slot Claude Code uses to OpenRouter slugs (opus/sonnet/haiku).
-    export ANTHROPIC_DEFAULT_OPUS_MODEL="${OPENROUTER_MODEL:-anthropic/claude-opus-5}"
+    export ANTHROPIC_DEFAULT_OPUS_MODEL="${OPENROUTER_MODEL:-anthropic/claude-opus-4.8}"
     export ANTHROPIC_DEFAULT_SONNET_MODEL="${OPENROUTER_MODEL_SONNET:-anthropic/claude-sonnet-5}"
     export ANTHROPIC_DEFAULT_HAIKU_MODEL="${OPENROUTER_MODEL_HAIKU:-anthropic/claude-haiku-4.5}"
     MODEL="$ANTHROPIC_DEFAULT_OPUS_MODEL"
@@ -208,7 +208,7 @@ X-Title: ${OPENROUTER_APP_TITLE:-Aeon}"
     export ANTHROPIC_BASE_URL="https://api.usepod.ai/proxy/${USEPOD_TOKEN}"
     export ANTHROPIC_AUTH_TOKEN="unused"    # UsePod auths via the path token
     unset ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN
-    # UsePod mirrors the upstream Anthropic surface, so aeon's claude-opus-5 id
+    # UsePod mirrors the upstream Anthropic surface, so aeon's claude-opus-4-8 id
     # is passed through by default. If UsePod needs marketplace-specific ids, set
     # USEPOD_MODEL (+ _SONNET / _HAIKU) to override.
     if [ -n "${USEPOD_MODEL:-}" ]; then MODEL="$USEPOD_MODEL"; fi
@@ -246,14 +246,14 @@ X-Title: ${OPENROUTER_APP_TITLE:-Aeon}"
     # uses dot-form ids: drop any trailing -YYYYMMDD date, then convert each
     # <digit>-<digit> to <digit>.<digit>. SURPLUS_MODEL overrides; opus-4.8 is the
     # fallback when $MODEL is unset.
-    surplus_model="${SURPLUS_MODEL:-$(printf '%s' "${MODEL:-claude-opus-5}" | sed -E 's/-[0-9]{8}$//; s/([0-9])-([0-9])/\1.\2/g')}"
+    surplus_model="${SURPLUS_MODEL:-$(printf '%s' "${MODEL:-claude-opus-4-8}" | sed -E 's/-[0-9]{8}$//; s/([0-9])-([0-9])/\1.\2/g')}"
     start_ccr_sidecar surplus \
       "https://www.surplusintelligence.ai/api/inference/v1/chat/completions" \
       "$SURPLUS_API_KEY" "$surplus_model"
     echo "::notice::Routing through Surplus via claude-code-router (${surplus_model})"
     ;;
 
-  venice)  # SIDECAR — OpenAI-compatible (dash-form ids); carries Opus 5, no haiku
+  venice)  # SIDECAR — OpenAI-compatible (dash-form ids); carries Opus 4.8, no haiku
     require_secret VENICE_API_KEY
     # Set VENICE_CLEANCACHE=1 to add the cleancache transformer (1h TTL, avoids
     # the shared 4-block prompt-cache limit) if you hit cache errors.
@@ -270,7 +270,7 @@ X-Title: ${OPENROUTER_APP_TITLE:-Aeon}"
     if [ -z "$venice_model" ]; then
       m="$(printf '%s' "${MODEL:-}" | sed -E 's/-[0-9]{8}$//')"
       case "$m" in
-        claude-opus-5|claude-sonnet-5) venice_model="$m" ;;
+        claude-opus-4-8|claude-sonnet-5) venice_model="$m" ;;
         *) venice_model="claude-sonnet-5" ;;
       esac
     fi

--- a/skills/create-skill/SKILL.md
+++ b/skills/create-skill/SKILL.md
@@ -70,7 +70,7 @@ Today is ${today}. Your task is to generate a complete, production-ready skill f
    - **Variable behavior** — what `${var}` controls; what happens when empty (sane default OR clean abort with notify).
    - **Steps** — 4-8 numbered, following the standard pattern: read context → fetch/search → process/analyze → write output → log → notify.
    - **Schedule suggestion** — choose a cron slot. Read existing schedules in `aeon.yml`; avoid co-scheduling at the same minute as heavy skills (article, repo-scanner, deep-research, telegram-digest) unless the new skill is lightweight (<30s expected). Prefer a `:30` minute offset if the natural hour is already crowded.
-   - **Model** — default `claude-sonnet-5`. Pick `claude-haiku-4-5-20251001` if the skill is high-frequency aggregation/digestion (cost optimization), or `claude-opus-5` if it needs the strongest reasoning. Document the choice in the PR body.
+   - **Model** — default `claude-sonnet-5`. Pick `claude-haiku-4-5-20251001` if the skill is high-frequency aggregation/digestion (cost optimization), or `claude-opus-4-8` if it needs the strongest reasoning. Document the choice in the PR body.
    - **Category** — the pack the skill joins. Pick one: `research` `dev` `crypto` `onchain-security` `social` `productivity` `meta`. (`core` and `fleet` are curated in `packs.config.json`, not chosen here.) If none fits, omit it and the skill lands in the **Lab** catch-all for later triage. See `docs/skill-packs.md`.
 
 6. **Write the SKILL.md draft** at `skills/{skill-name}/SKILL.md` with this exact structure:
@@ -145,7 +145,7 @@ Today is ${today}. Your task is to generate a complete, production-ready skill f
 
 9. **Register in `aeon.yml`.** Insert the new skill in the appropriate time-slot section:
    - Format: `  {skill-name}: { enabled: false, schedule: "{suggested_cron}" }`
-   - Add `model: "claude-haiku-4-5-20251001"` (or `"claude-opus-5"`) if chosen in step 5.
+   - Add `model: "claude-haiku-4-5-20251001"` (or `"claude-opus-4-8"`) if chosen in step 5.
    - Add `var: ""` if the skill takes a default var.
    - Add a brief trailing comment if the name doesn't make purpose obvious.
    - Place near related skills (crypto with crypto, content with content, etc.).

--- a/skills/feature/SKILL.md
+++ b/skills/feature/SKILL.md
@@ -79,7 +79,7 @@ All branches read operator-controlled files under `memory/` (runtime config — 
 
   ## Current models (suggest these as replacements)
   - claude-sonnet-5
-  - claude-opus-5
+  - claude-opus-4-8
   - gpt-5
   - gemini-3
   - grok-4.6


### PR DESCRIPTION
Repoints every Claude Opus reference from `claude-opus-5` to `claude-opus-4-8` across dashboard picker + workflow choice (kept in sync to avoid a 422), the deploy-uni-hook skill pin, gateway defaults (OpenRouter dot-form `anthropic/claude-opus-4.8`, native dash id for surplus/venice), docs, skill prose, and config test fixtures. Note: opus-4.8 is prior-gen relative to opus-5 - intentional per request.