### PR TITLE
feat(vuln-scanner): DoH MX/A deliverability gate before autonomous disclosure email

### DIFF
--- a/eyebrowlock.json
+++ b/eyebrowlock.json
@@ -109,13 +109,15 @@
       "capabilities": {
         "network": [
           "api.resend.com",
+          "cloudflare-dns.com",
+          "dns.google",
           "github.com"
         ]
       },
       "files": [
         {
           "path": "SKILL.md",
-          "hash": "89f69623e9b3eada3d99d2efdfd49adf2d5ae2bf22994d8e3216cf98c0d42276"
+          "hash": "a48fb63798be19f958820e880efc6f1f5cf0d242d6937eb26c4c02b79bb32bd5"
         }
       ],
       "findings": [
@@ -151,12 +153,12 @@
           "severity": "critical",
           "owasp": "ASK-01",
           "file": "SKILL.md",
-          "line": 863,
+          "line": 872,
           "snippet": "1. **Install** \u2014 the binaries (`semgrep`, `trufflehog`, `osv-scanner`, `slither`) are **not pre-installed**. Stage the\u2026",
           "explanation": "downloads and executes remote code via a pipe to a shell"
         }
       ],
-      "contentHash": "sha256-7aec47b988db3c4df8b31755af9d062f0c1715c8704e6880095fcc1cc20f6fde",
+      "contentHash": "sha256-a9cdb0547fa559f53196eef12f5459c6d1f8bace3a56fa257f809e4f309cb1c5",
       "discoveredFrom": "skills/vuln-scanner/SKILL.md"
     },
     {

--- a/skills/vuln-scanner/SKILL.md
+++ b/skills/vuln-scanner/SKILL.md
@@ -679,7 +679,7 @@ A `.md` file in `memory/pending-disclosures/` is eligible iff:
    plausible email (`^[^@\s]+@[^@\s]+\.[^@\s]+$`).
 3. **Still pending:** `status:` is one of `pending-operator-send`, `auto-send-ready`,
    `pending`, or blank. Anything else (`email-sent`, `email-failed`, `hold`, `sent`,
-   `submitted`, `withdrawn`, `superseded-upstream`) → **skip**. (`email-failed` means
+   `submitted`, `withdrawn`, `superseded-upstream`, `contact-unverified`) → **skip**. (`email-failed` means
    the sender gave up after repeated failures — leave it for the operator.)
 4. **Sendable body present:** the email body can be cleanly isolated (see step C3).
 5. **Not already sent:** no row in `memory/email-log.json` matches this draft
@@ -756,6 +756,15 @@ sending. Only `./secretcurl`, `jq`, `python3`, `grep`, `date`, `echo`, `mkdir`, 
 **Per draft (stop the loop once `BUDGET` sends have gone out):**
 4. **Dedup / status.** Skip if `slug` (repo with `/`→`-`) is already a row in `memory/email-log.json`, or the draft's own `status:` is already `email-sent`/`email-failed`.
 5. **Recipient sanity.** `to` must match `^[^@[:space:]]+@[^@[:space:]]+\.[^@[:space:]]+$` (`grep -qE`) — else skip + warn.
+5b. **Deliverability (MX/A), fail-closed.** A syntactically valid address can still be a dead or mistyped domain. Before an autonomous send, confirm the recipient **domain can actually receive mail** at the DNS level (port-25 SMTP probing is blocked on hosted runners, so verify over DNS-over-HTTPS - a plain GET, so `./secretcurl` passes the placeholder-free URL straight through):
+   ```bash
+   DOMAIN="${TO#*@}"
+   DNS=$(./secretcurl -sS --max-time 10 "https://dns.google/resolve?name=${DOMAIN}&type=MX")
+   MXN=$(echo "$DNS" | jq -r '[.Answer[]? | select(.type==15)] | length' 2>/dev/null)
+   ```
+   - `MXN >= 1` (domain publishes MX) → **verified, proceed.**
+   - `MXN == 0`: retry once against Cloudflare (`./secretcurl -sS --max-time 10 -H 'accept: application/dns-json' "https://cloudflare-dns.com/dns-query?name=${DOMAIN}&type=MX"`). Still none → look up an A record (`&type=A`, `.type==1`): a domain with an A but no MX still accepts mail at that host (RFC 5321 §5.1), so treat a resolvable A as deliverable.
+   - **No MX and no A, or both lookups error / time out → do NOT send (fail closed).** Flip the draft to `status: contact-unverified` and add a `deliverability: no-mx` frontmatter line so it drops out of the eligible set and surfaces to the operator; do not consume the budget.
 6. **Cooldown.** If this `to` was emailed within `${DISCLOSURE_EMAIL_COOLDOWN_DAYS:-7}` days (latest `.to`→`.sent_at` in the ledger, `python3` datetime diff) → skip, leave queued, retry after the window. A cooled-down draft does **not** consume the budget — move to the next.
 7. **Secret tripwire.** If subject+body match `grep -qE '(sk-[A-Za-z0-9]{20}|re_[A-Za-z0-9]{8}[A-Za-z0-9_]{12}|gh[pousr]_[A-Za-z0-9]{20}|AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z_-]{20}|-----BEGIN [A-Z ]*PRIVATE KEY-----)'` → **do not send**, log `BLOCKED: possible secret in body`, leave for operator review.
 8. **Build cc** = the draft's `cc` (array or comma-string) + `$RESEND_CC` (operator audit copy), minus blanks and the `to`, deduped (`jq`).


### PR DESCRIPTION
Adds a DNS-level deliverability check before `vuln-scanner`'s Arm C sends a disclosure email autonomously.

## Why
Arm C resolves a maintainer contact from a scanned repo (SECURITY.md / README / package metadata) and sends **autonomously** behind fail-closed caps. The existing gates confirm the address is **syntactically** valid (regex) and not rate-limited, but nothing confirms the **domain can actually receive mail**. A dead or mistyped contact silently burns the one daily send slot and the disclosure never lands.

## What
New per-draft gate **5b** (between recipient-sanity and cooldown), fail-closed:
- Query **MX** via `dns.google` over DNS-over-HTTPS (port-25 SMTP probing is blocked on hosted runners).
- `MXN >= 1` → verified, proceed.
- 0 MX → retry **Cloudflare** DoH → fall back to an **A** record (a domain with an A but no MX still accepts mail, RFC 5321 §5.1).
- No MX and no A, or both lookups error/time out → **do not send**; flip the draft to `status: contact-unverified` + `deliverability: no-mx` so it drops out of the eligible set and surfaces to the operator, **without** consuming the daily budget.
- `contact-unverified` added to the C2 non-sendable status list so it's skipped on later runs.

## Notes
- Uses only `./secretcurl` (placeholder-free GET, no secret) + `jq` — both already in the Arm C toolset.
- Adds `dns.google` + `cloudflare-dns.com` as egress hosts; `eyebrowlock.json` re-baselined (scoped to `vuln-scanner`) so the new capability is recorded in the lock diff for review. `verify --ci` passes locally.
- Ported from the `aeon-vuln` `disclosure-emailer`.

> Note: this and #894 both edit `vuln-scanner` + its lock entry. SKILL.md changes are in different sections (A3.6 vs C4) so content should auto-merge, but the `eyebrowlock.json` vuln-scanner entry will conflict — whichever merges second needs a one-command lock re-baseline. Happy to rebase on request.
