### PR TITLE
docs(resolve-harness): remind to sync the test + eyebrow lock on a model-pin change

### DIFF
--- a/scripts/resolve-harness.sh
+++ b/scripts/resolve-harness.sh
@@ -118,6 +118,10 @@ else
 fi
 case "$REQ_MODEL" in claude-*|grok-*|"") REQ_MODEL="" ;; esac   # aeon-native / unset → not an OpenRouter id
 
+# NOTE: changing any per-harness DEFAULT_HM below also requires updating the
+# expected values in scripts/tests/test_resolve_harness.sh (a stale codex pin
+# there broke CI once; fixed in #896). If the same model-pin pass edits skill
+# bodies, run `eyebrow scan` and commit the refreshed eyebrowlock.json too.
 case "$HARNESS" in
   codex) DEFAULT_HM="openai/gpt-5.1-codex-mini" ;;
   vibe)  DEFAULT_HM="mistralai/mistral-medium-3-5" ;;   # vibe's default (VIBE_MODELS[0])


### PR DESCRIPTION
Comment-only pointer at the `DEFAULT_HM` per-harness defaults block.

#891 refreshed the codex default there without updating `test_resolve_harness.sh`, which broke CI (fixed in #896). This leaves a one-off reminder so the next per-harness model bump also:
- updates the expected values in `scripts/tests/test_resolve_harness.sh`, and
- runs `eyebrow scan` + commits the refreshed `eyebrowlock.json` if the same pass edits skill bodies.

No behavior change; `resolve-harness.sh` isn't eyebrow-tracked, so no lock impact. Test still `ALL PASS`.