### PR TITLE
fix(aeon.yml): rm ./secretcurl before commit like ./notify

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -1553,7 +1553,7 @@ jobs:
         run: |
           git config user.name "aeonframework"
           git config user.email "aeonframework@proton.me"
-          rm -f ./notify ./notify-jsonrender  # Remove generated notify scripts before committing
+          rm -f ./notify ./notify-jsonrender ./secretcurl  # Remove generated notify/secretcurl scripts before committing
 
           # Issues-as-state (hardening §3): cron-state.json was materialized from the
           # pinned Issue for this run's readers — it's a projection, not source of truth.


### PR DESCRIPTION
The Commit-results step `cp`s `scripts/secretcurl.sh` to `./secretcurl` at run start (so skills can call `./secretcurl`), but only `rm`'d `./notify` / `./notify-jsonrender` before `git add -A`. Result: every live instance commits the regenerated root `secretcurl` as a tracked artifact on its first run.

This repo looks clean only because its Actions are disabled (the skill path never runs here). Found on aeon-nur right after a canon-engine migration - the first heartbeat run re-committed `./secretcurl`.

One-line fix: add `./secretcurl` to the existing `rm -f` next to the notify scripts.