### PR TITLE
chore(harness): 30m skill-run timeout (harness 1800s, job 50m)

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -109,7 +109,7 @@ jobs:
   run:
     if: github.event_name != 'issues' || github.event.label.name == 'ai-build'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 50
 
     steps:
       - name: Early checkout
@@ -823,7 +823,7 @@ jobs:
           # refused outright.
           CLAUDE_OK=0
           RH="${GITHUB_WORKSPACE}/harness-adapter/run-harness"
-          RH_ARGS=(--mode "$SKILL_MODE" --allowed-tools "$ALLOWED" --timeout 900)
+          RH_ARGS=(--mode "$SKILL_MODE" --allowed-tools "$ALLOWED" --timeout 1800)
           # Pass --mcp-config only when the MCP preflight actually ENABLED MCP (every
           # required ${VAR} resolved) — MCP_FLAGS is set to the flags in that case and
           # left empty otherwise, so it doubles as the "MCP on" gate. run-harness does


### PR DESCRIPTION
## What

Raise the skill-run harness wall-clock guard and the job cap so heavy audit skills get a real 30 minutes.

- `RH_ARGS ... --timeout 900` -> `--timeout 1800` (harness agent budget: 15m -> 30m)
- job `timeout-minutes: 30` -> `50`

## Why

`vuln-scanner` and `sc-audit` intermittently exceed the 900s (15m) harness guard and are killed with `provider 'claude' failed - error: harness run exceeded --timeout 900s`, then the run fails. Observed on aaronjmars/aeon-vuln (3 fails in one 6h window).

The job cap must move too. The job runs setup (checkout, toolchain stage, target clone) + the harness turn + the post-run scorer (`--timeout 300`) in one job. A `vuln-scanner` success was already observed using the full 30m job wall around a <=15m harness, so non-harness overhead is ~15m. Leaving `timeout-minutes: 30` while the harness can now run 30m would just re-cancel the same runs at the job wall. `50` clears 30m harness + ~15m overhead with headroom; the harness still hard-kills the agent at 30m, so a genuinely hung run cannot run away.

The scorer's own `--timeout 300` and the `messages.yml` interactive responder (`--timeout 600`) are unchanged - different purpose, not affected.
