### PR TITLE
fix(cron-state): jittered backoff + 10 retries for commit-race

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -1601,7 +1601,7 @@ jobs:
           else
             git commit -m "chore($LABEL): auto-commit $(date +%Y-%m-%d)"
           fi
-          for i in 1 2 3 4 5; do
+          for i in 1 2 3 4 5 6 7 8 9 10; do
             # Pull and rebase onto latest remote
             if ! git pull --rebase origin main 2>/dev/null; then
               echo "Rebase conflict on attempt $i, auto-resolving..."
@@ -1630,7 +1630,7 @@ jobs:
               exit 0
             fi
             echo "Push attempt $i failed (ref moved), retrying in ${i}s..."
-            sleep "$i"
+            sleep "$(( (RANDOM % 4) + i ))"  # jittered backoff - a deterministic sleep re-collides lockstep writers under push contention
           done
           echo "Failed to push after 5 attempts"
           exit 1
@@ -1766,7 +1766,7 @@ jobs:
           fi
 
           git commit -m "chore(cron): $SKILL $CRON_STATUS"
-          for i in 1 2 3 4 5; do
+          for i in 1 2 3 4 5 6 7 8 9 10; do
             if git pull --rebase origin main 2>/dev/null && git push -u origin HEAD 2>/dev/null; then
               echo "Cron state updated: $SKILL=$CRON_STATUS"
               exit 0
@@ -1787,7 +1787,7 @@ jobs:
             git add "$STATE_FILE"
             git diff --staged --quiet && { echo "State already up to date"; exit 0; }
             git commit -m "chore(cron): $SKILL $CRON_STATUS"
-            sleep "$i"
+            sleep "$(( (RANDOM % 4) + i ))"  # jittered backoff - a deterministic sleep re-collides lockstep writers under push contention
           done
           echo "::warning::Failed to commit cron state (non-fatal)"
 


### PR DESCRIPTION
## Problem

The `Update cron state` and `Commit results` steps both push to `main` with a bounded retry loop:

```
for i in 1 2 3 4 5; do
  git pull --rebase origin main && git push ... || (re-apply); sleep "$i"
done
```

Two flaws under push contention (many skills + the scheduler tick all commit to `main`):
1. **Deterministic backoff** - competing writers that start their loops together sleep the *same* 1,2,3,4,5s and re-collide in lockstep, so a loser tends to keep losing.
2. **Narrow window** - 5 tries over ~15s. Observed: a real burst of 6 push attempts inside an 18s window (07:35:17-35), all rejected, then `Failed to commit cron state (non-fatal)`.

Result: the run's outcome-write is lost. For `cron-state.json` the drift self-heals next tick (a failed vuln-scanner showed as stale `dispatched`), but for `Commit results` a lost push drops the run's memory-log / output entirely. 2nd occurrence in 2 days, both on the highest-churn instance (aeon-vuln).

## Fix

- Widen both loops `5 -> 10` retries.
- **Jitter the backoff**: `sleep "$i"` -> `sleep "$(( (RANDOM % 4) + i ))"`. The random offset desynchronizes lockstep writers so they stop re-colliding, and the wider window (~55-85s) outlasts a contention burst.

Idempotent and non-fatal semantics unchanged; each retry only pushes on a successful pull+push, so no extra churn on `main`. The debt-scheduler self-heal remains as the backstop.
