### PR TITLE
feat(aeon-update): 3-way merge OWNED conflicts + eyebrow-lock fail-safe

### DIFF
--- a/skills/aeon-update/SKILL.md
+++ b/skills/aeon-update/SKILL.md
@@ -24,7 +24,7 @@ Today is ${today}. This is the fleet's **downstream updater** - the counterpart 
 
 - **PR, never push to `main`.** Every framework change ships as one reviewable PR. The operator merges.
 - **Never clobber operator config.** `aeon.yml`, `STRATEGY.md`, `soul/`, `memory/`, `output/`, `.mcp.json` and the git-derived catalogs are instance-owned. Upstream changes to them are **surfaced for manual review in the PR body**, never written into the tree.
-- **3-way, not blind overwrite.** A framework file the operator has already customized is a **conflict** - it is listed with the upstream diff for a human to merge, not overwritten.
+- **3-way, not blind overwrite.** A framework file the operator has already customized is **auto-merged** when its local edits and upstream's edits touch disjoint regions (a real `git merge-file` 3-way, S6); it is only listed as a **conflict** for a human when the same lines changed on both sides. This is what lets a hand-narrowed workflow keep receiving unrelated upstream fixes without a manual merge every run.
 - **Silent when in sync.** Baseline == upstream HEAD ⇒ nothing to do, no notification.
 - **The baseline is the watermark, and it advances by merge.** The new baseline SHA is written *into the PR branch*, so the watermark only moves when the operator merges the PR. Unresolved conflicts are tracked separately so advancing the baseline can never silently drop them.
 
@@ -117,7 +117,7 @@ Decide `f`'s disposition from its `status` and a content 3-way (local-current vs
 | `added` | path present locally (collision, e.g. a fork-only skill) | **CONFLICT** |
 | `modified` | `sha256(local) == sha256(HEAD blob)` | already synced → **SKIP** |
 | `modified` | `sha256(local) == sha256(BASELINE blob)` (operator never touched it) | **CLEAN-UPDATE** (write HEAD blob) |
-| `modified` | otherwise (operator customized it) | **CONFLICT** |
+| `modified` | otherwise (operator customized it) | **3-WAY MERGE** → CLEAN-MERGE or CONFLICT (see below) |
 | `removed` | `sha256(local) == sha256(BASELINE blob)` | **CLEAN-DELETE** (`git rm`) |
 | `removed` | local differs or absent | **CONFLICT** (or already gone → SKIP if absent) |
 | `renamed` | treat as `removed previous_filename` + `added filename` under the rules above | per-part |
@@ -125,6 +125,21 @@ Decide `f`'s disposition from its `status` and a content 3-way (local-current vs
 Never CLEAN-DELETE a `skills/<name>/` directory whose `<name>` is not present in upstream's tree - fork-only skills are operator work and are structurally untouched (upstream's compare can only reference paths that exist upstream).
 
 Also never CLEAN-DELETE a `skills/<name>/` directory if `<name>` is currently `enabled: true` in the operator's `aeon.yml` (`grep -E "^  ${name}: *\{[^}]*enabled: true" aeon.yml`) - upstream retiring a skill the operator has actively scheduled is exactly the case `validate-config.js`'s skill-refs check exists to catch, but only *after* the PR is merged; nothing in the PR review itself would otherwise flag it. Downgrade this case to **CONFLICT** (reason: `enabled-skill-removed-upstream`) instead of deleting - the directory stays, and S9 surfaces it as its own loud PR-body section rather than folding it into "Applied cleanly" or the generic conflict list.
+
+**3-way content merge (OWNED files only).** A `modified` file that reached the `otherwise` row means the operator diverged from BASELINE *and* upstream changed the file too. Do not give up on it - most of the time the two sets of edits are in different parts of the file (e.g. the operator narrowed the workflow's `env:` secrets block while upstream bumped a `timeout` and a retry loop elsewhere), and a real 3-way merge combines both losslessly. Attempt it before declaring a conflict:
+
+```bash
+fetch "$f" "$BASELINE"  > "$WORK/base"    # upstream@BASELINE (the common ancestor)
+fetch "$f" "$HEAD_SHA"  > "$WORK/head"    # upstream@HEAD (what to bring in)
+cp "$f" "$WORK/local"                      # operator's current copy (ours)
+if git merge-file -p --diff3 "$WORK/local" "$WORK/base" "$WORK/head" > "$WORK/merged.$$" 2>/dev/null; then
+  disposition=CLEAN-MERGE   # exit 0 = disjoint hunks; the merged file carries BOTH edits - write it in S7
+else
+  disposition=CONFLICT      # exit >0 = the same lines changed on both sides; surface for a human as before
+fi
+```
+
+`git merge-file` exits `0` only when the merge is clean (operator and upstream touched disjoint regions); the merged output preserves the operator's customization AND applies upstream's change. A non-zero exit means a genuine overlap - keep it a **CONFLICT** and list it with the upstream diff (S9). **Only OWNED files are ever 3-way-merged; OPERATOR-owned paths are always surfaced, never written.** A merged file gets the same S7 YAML/JSON parse-check as any written file - if the merge produced something that no longer parses, abort that file back to CONFLICT rather than committing it.
 
 ### S7. Apply CLEAN changes on a branch (sync mode only)
 
@@ -135,7 +150,7 @@ BR="aeon-update/sync-$(echo "$HEAD_SHA" | cut -c1-7)"
 git checkout -b "$BR"
 ```
 
-Write every **CLEAN-ADD** / **CLEAN-UPDATE** (`mkdir -p "$(dirname f)"` then write the HEAD blob to `f`) and `git rm` every **CLEAN-DELETE**. **CONFLICT** and **OPERATOR** files are *not* touched - they go in the PR body only.
+Write every **CLEAN-ADD** / **CLEAN-UPDATE** (`mkdir -p "$(dirname f)"` then write the HEAD blob to `f`), write every **CLEAN-MERGE** (the merged file `$WORK/merged.$$` from S6, over the existing `f`), and `git rm` every **CLEAN-DELETE**. **CONFLICT** and **OPERATOR** files are *not* touched - they go in the PR body only. (CLEAN-MERGE counts as a clean apply for the "nothing CLEAN applied" test below.)
 
 If any `skills/**` path was applied, regenerate the derived catalogs from the synced sources (never copy them from upstream):
 
@@ -144,7 +159,21 @@ bin/generate-skills-json && bin/generate-packs-json && bin/generate-skill-icons
 node scripts/gen-agents-md.js || true
 ```
 
-Refresh the integrity lock so `ci-skill-integrity` stays green for any added/edited skill, then validate config:
+**Refresh the eyebrow integrity lock for any NEWLY-ADDED skill.** `ci-skill-integrity` fails a PR when a present skill's `skills/<slug>/SKILL.md` has no `"discoveredFrom": "skills/<slug>/SKILL.md"` entry in `eyebrowlock.json`. That entry is produced only by the `eyebrow` binary, which is **not preinstalled in this run** - so a CLEAN-ADD of a new skill would otherwise land the PR CI-red. Fetch the binary (the version `ci-skill-integrity.yml` pins - currently `v0.4.1` from `alexverify/eyebrow`; read `gh release view -R alexverify/eyebrow` for the asset matching this runner's OS/arch), then rescan:
+
+```bash
+EYEBROW_OK=0
+EB=$(command -v eyebrow || true)
+if [ -z "$EB" ]; then
+  gh release download v0.4.1 -R alexverify/eyebrow -D "$WORK/eb" 2>/dev/null \
+    && EB=$(find "$WORK/eb" -type f -name 'eyebrow*' | head -1) && chmod +x "$EB" 2>/dev/null || true
+fi
+[ -n "$EB" ] && "$EB" scan --path . --lockfile eyebrowlock.json 2>/dev/null && EYEBROW_OK=1
+```
+
+**Fail-safe - guarantees a green PR without the binary.** If `EYEBROW_OK` is still `0` (binary unavailable or scan failed) and this run has any **CLEAN-ADD of a `skills/**` SKILL.md**, do not ship a skill the lock cannot cover: revert each such new skill from the branch (`git rm -r --cached skills/<slug>` + drop it from the working tree) and re-classify it as **CONFLICT** with reason `needs-eyebrowlock-scan`. S9 surfaces it with the exact operator command (`eyebrow scan --path . --lockfile eyebrowlock.json` then commit). A **CLEAN-UPDATE / CLEAN-MERGE of an existing** skill needs no rescan - `eyebrow verify` allows content drift (it fails only on a new egress host or a new CRITICAL), and the skill already has a lock entry. This trades auto-installing a brand-new upstream skill (rare) for never landing a red PR; the skill still arrives, just as a one-line manual step in the PR.
+
+Then validate config:
 
 ```bash
 node scripts/validate-config.js aeon.yml || echo "validate-config flagged (may be pre-existing drift; note, do not abort on it)"
@@ -154,7 +183,7 @@ If **nothing CLEAN applied** (every upstream change was CONFLICT or OPERATOR): o
 
 ### S8. Advance the baseline + reconcile conflicts (in the branch)
 
-Recompute `PENDING`: for every CONFLICT file this run **plus** every prior `PENDING` entry, keep it only if `sha256(local) != sha256(HEAD blob)` (still genuinely divergent). Drop the rest (resolved). Exception: `enabled-skill-removed-upstream` entries have no HEAD blob to diff (the path is deleted upstream) - resolve them instead when the skill is no longer `enabled: true` in the operator's current `aeon.yml` (they disabled it, so the CLEAN-DELETE rule can now apply next run) or upstream re-adds a path of that name (re-classify as CONFLICT/modified or CLEAN-UPDATE under the normal rules).
+Recompute `PENDING`: for every CONFLICT file this run **plus** every prior `PENDING` entry, keep it only if `sha256(local) != sha256(HEAD blob)` (still genuinely divergent). Drop the rest (resolved). **A file that was CLEAN-MERGE-applied this run is resolved - never carry it as pending** (its `sha256(local) != sha256(HEAD blob)` because it still holds the operator's edits, but the upstream change is now merged in, so the naive test would wrongly keep it forever; a 3-way-merged file is only a CONFLICT again if a *future* upstream change overlaps the operator's lines). Likewise drop any prior PENDING entry whose file was CLEAN-MERGE- or CLEAN-UPDATE-applied this run. Exception: `enabled-skill-removed-upstream` entries have no HEAD blob to diff (the path is deleted upstream) - resolve them instead when the skill is no longer `enabled: true` in the operator's current `aeon.yml` (they disabled it, so the CLEAN-DELETE rule can now apply next run) or upstream re-adds a path of that name (re-classify as CONFLICT/modified or CLEAN-UPDATE under the normal rules).
 
 Write `memory/topics/aeon-update-state.json` and commit it **with** the sync so merging advances the watermark:
 
@@ -202,6 +231,7 @@ PR body (`/tmp/aeon-update-pr-body.md`) - only include sections that have conten
 - **Modified skills:** `baz`
 - **Scripts / harness:** `scripts/notify.sh`, ...
 - **Workflows:** `.github/workflows/...`
+- **Auto-merged (3-way):** `.github/workflows/aeon.yml`, ...  _(your local customization kept; upstream's disjoint changes applied - review the merged hunks)_
 - **Docs / other:** `docs/...`, `CLAUDE.md`, ...
 
 ### ⚠️ Currently-enabled skills removed upstream


### PR DESCRIPTION
## What

Two fixes to the `aeon-update` downstream sync, both in `skills/aeon-update/SKILL.md` (prose-only; frontmatter unchanged).

### 1. 3-way merge OWNED conflicts instead of blanket CONFLICT (S6/S7/S8)

Today, an OWNED file the operator has customized AND upstream also changed falls straight to **CONFLICT** (whole-file). The commonest case is a hand-narrowed `.github/workflows/aeon.yml` (the public-instance `toJSON(secrets)` narrowing): every unrelated upstream fix to that file (timeout bumps, cron-state retry loops, etc) lands as a manual conflict and resurfaces as a pending conflict every run until merged by hand.

Now S6 attempts a real `git merge-file -p --diff3 local base head` first:
- clean (disjoint hunks) -> **CLEAN-MERGE**, written to the branch: operator customization kept, upstream change applied.
- genuine overlap (same lines both sides) -> **CONFLICT**, surfaced with the upstream diff as before.

Only OWNED files are ever merged; OPERATOR-owned paths are still always surfaced, never written. Merged files get the same YAML/JSON parse-check; a merge that breaks parsing aborts to CONFLICT. S8 treats a CLEAN-MERGE as resolved (won't carry it as pending forever despite `local != HEAD`).

Verified against the real `b1d90797..73010088` delta on a live instance's narrowed workflow: the timeout (#900) / cron-state (#901) / secretcurl (#898) edits merge **cleanly** over the operator's `env:` narrowing, zero overlap.

### 2. eyebrow-lock fail-safe so a new-skill sync never lands CI-red (S7)

S7 previously said "refresh the integrity lock" but the `eyebrow` binary isn't preinstalled in a run, so a CLEAN-ADD of a new upstream skill would land the PR CI-red on `ci-skill-integrity` (missing `discoveredFrom` entry in `eyebrowlock.json`). Now S7:
- fetches the pinned `eyebrow` release (`v0.4.1`, `alexverify/eyebrow`) and runs `eyebrow scan --path . --lockfile eyebrowlock.json`; else
- **fail-safe:** if the binary is unavailable, reverts each newly-ADDED skill and re-classifies it as CONFLICT `needs-eyebrowlock-scan`, surfaced in the PR body with the one-line command to run. The PR stays green; the new skill still arrives, just as a manual step.

Existing-skill CLEAN-UPDATE / CLEAN-MERGE needs no rescan (`eyebrow verify` allows content drift).

## Why here

`aeon-update` is canon-owned and byte-identical across all live instances, so landing this in canon propagates it to every instance via the sync mechanism itself. No behavior change for a clean/in-sync run.

## Risk

Prose-only edit to one SKILL.md; no new secret/egress, so `eyebrow verify` sees content drift only and `ci-skills-json` sees an unchanged file count. Strictly widens auto-apply (CONFLICT -> CLEAN-MERGE only when `git merge-file` exits 0) and only ever downgrades a new-skill add to a surfaced manual step.
