### PR TITLE
docs: single classic PAT (repo+workflow) for GH_GLOBAL

### DIFF
--- a/.claude/skills/aeon/references/secrets.md
+++ b/.claude/skills/aeon/references/secrets.md
@@ -68,11 +68,13 @@ Telegram is the fastest to set up and the only one with inline buttons and slash
 | Secret | Where to get it |
 |---|---|
 | `GITHUB_TOKEN` | Built in — nothing to set. Scoped to this repo only |
-| `GH_GLOBAL` | github.com/settings/tokens → Fine-grained → select repos → Contents, Pull requests, Issues (read/write). Needed for anything cross-repo (`github-monitor`, `pr-review`, `feature`, `changelog push-to`). Auto-promoted to the run's `GITHUB_TOKEN` |
-| `GH_READ_PAT` | Same page, read-only. Optional — enriches cross-repo/private reads (`bd-radar`) without granting write |
-| `GH_SECRETS_PAT` | github.com/settings/personal-access-tokens → **add this repo under Repository access** (a PAT without it 404s) → Repository permissions → Secrets: Read and write. Only needed for OAuth-connected MCP servers or the Grok X-account harness |
+| `GH_GLOBAL` | github.com/settings/tokens -> **Tokens (classic)** -> scopes **`repo`** + **`workflow`** -> add as `GH_GLOBAL`. One token covers everything cross-repo (`github-monitor`, `pr-review`, `feature`, `changelog` push-to), private reads, repository security advisories / PVR (disclosure skills), and secrets writeback. Auto-promoted to the run's `GITHUB_TOKEN` |
+| `GH_READ_PAT` | *Legacy / optional.* Folded into `GH_GLOBAL`. Keep a separate read-only PAT only to give `bd-radar`'s private cross-repo enrichment a read token without granting the run write |
+| `GH_SECRETS_PAT` | *Optional.* Folds into `GH_GLOBAL` (its `repo` scope already writes secrets). Set a dedicated PAT only to isolate secrets-write from the main token: github.com/settings/personal-access-tokens -> add this repo under Repository access (a PAT without it 404s) -> Repository permissions -> Secrets: Read and write. Used by OAuth-connected MCP servers or the Grok X-account harness |
 
 `GH_SECRETS_PAT` gotcha: providers rotate the refresh token every run, and the runner needs this PAT to save each rotation back. Without it, auth breaks exactly one run after you connect. After adding it, re-connect any already-connected server once.
+
+**Scope summary (one classic PAT as `GH_GLOBAL`):** `repo` = cross-repo + private read/write, security advisories / PVR, and secrets writeback; `workflow` = pushing `.github/workflows/` changes (`aeon-update`, `spawn-instance`, `auto-workflow`). `read:org` / `admin:org` are not needed. Use a **classic** PAT - the advisories / PVR API is unreliable with fine-grained tokens.
 
 ## 4. Skill API keys — all optional
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -153,6 +153,8 @@ skills:
 
 Full reference - scheduling, `var`, models, [authentication](../docs/CONFIGURATION.md#authentication), [notification channels](../docs/CONFIGURATION.md#notifications), API keys, guardrails: **[Configuration](../docs/CONFIGURATION.md)**.
 
+**GitHub permissions:** the built-in `GITHUB_TOKEN` covers same-repo work; add **one classic PAT** as `GH_GLOBAL` with **`repo`** + **`workflow`** scopes to drive every cross-repo, private, disclosure, and workflow-editing skill. No `read:org` / `admin:org`. See [Cross-repo access](../docs/CONFIGURATION.md#cross-repo-access).
+
 ---
 
 ## Integrate Aeon

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -85,7 +85,14 @@ Or skip the file entirely: the dashboard's **MCP** tab writes `.mcp.json` for yo
 
 ## Cross-repo access
 
-The built-in `GITHUB_TOKEN` is scoped to this repo only. For `github-monitor`, `pr-review`, and `feature` to work on your other repos, add a `GH_GLOBAL` personal access token: github.com/settings/tokens → Fine-grained → set repo access → grant Contents, Pull requests, Issues (read/write) → add as `GH_GLOBAL` secret. Skills use it when available and fall back to `GITHUB_TOKEN` automatically.
+The built-in `GITHUB_TOKEN` is scoped to this repo only. For skills that reach other repos (`github-monitor`, `pr-review`, `feature`, `changelog` push-to, cross-repo reads) add **one classic** personal access token as the `GH_GLOBAL` secret: github.com/settings/tokens -> **Tokens (classic)** -> scopes **`repo`** + **`workflow`** -> add as `GH_GLOBAL`. Skills use it when available and fall back to `GITHUB_TOKEN` automatically, and it is auto-promoted to the run's `GITHUB_TOKEN`.
+
+One classic PAT covers the whole instance - no separate read or secrets PAT is needed:
+
+- **`repo`** - cross-repo and private-repo read/write, repository security advisories + private vulnerability reports (the disclosure/PVR skills), and writing Actions secrets back (the OAuth-MCP / Grok refresh path).
+- **`workflow`** - required only for skills that push changes under `.github/workflows/` (`aeon-update`, `spawn-instance`, `auto-workflow`); without it those pushes 403.
+
+`read:org` and `admin:org` are **not** needed - listing an org's repos (e.g. fleet KPIs) works on `repo` scope plus org membership, and nothing administers an org. If your org enforces SAML SSO, authorize the token for the org from the token page. **Classic** (not fine-grained) is recommended: the repository-advisories / PVR API is unreliable with fine-grained PATs.
 
 ## Durable state without the churn
 


### PR DESCRIPTION
## What

Corrects the GitHub-token docs to the **single classic PAT** model.

- `GH_GLOBAL` = one **classic** PAT with **`repo`** + **`workflow`** scopes (was documented as fine-grained + Contents/PRs/Issues).
- `GH_READ_PAT` / `GH_SECRETS_PAT` reframed as legacy/optional - both fold into `GH_GLOBAL`.
- Documents what each scope covers, and that **`read:org` / `admin:org` are not needed** (org repo listing works on `repo` + membership).
- Notes **classic over fine-grained** (repository-advisories / PVR API is unreliable with fine-grained tokens) and the SAML-SSO authorize step.

## Why

The multi-token split (`GH_GLOBAL` write + `GH_READ_PAT` read + `GH_OPERATOR_TOKEN`) was consolidated to one classic PAT per instance. Verified live: heartbeat + advisory-read (`vuln-tracker`) green fleet-wide on the single token; `repo` covers checkout, cross-repo PRs, forks, advisories / PVR `/reports`, `/notifications`, and Actions secrets writeback; `workflow` covers `aeon-update` / `spawn-instance` / `auto-workflow` pushes to `.github/workflows/`.

Files: `docs/CONFIGURATION.md`, `.claude/skills/aeon/references/secrets.md`, `.github/README.md`.