### PR TITLE
fix(scheduler): make reactive success_rate condition actually fire

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -87,5 +87,7 @@ jobs:
         run: bash scripts/tests/test_cron_due.sh
       - name: circuit-breaker scheduler decision tests
         run: bash scripts/tests/test_breaker.sh
+      - name: reactive-trigger when-condition tests
+        run: bash scripts/tests/test_reactive_when.sh
       - name: skill-scan calibration (fires on sinks, not benign syntax)
         run: bash scripts/tests/test_skill_scan_calibration.sh

--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -394,22 +394,21 @@ jobs:
                 [ "${SKILL_ENABLED[$CHECK_SKILL]}" = "false" ] && continue
                 [ "$ON" != "*" ] && [ "$ON" != "$CHECK_SKILL" ] && continue
 
-                if [[ "$WHEN" =~ consecutive_failures\ *\>=\ *([0-9]+) ]]; then
-                  THRESHOLD="${BASH_REMATCH[1]}"
-                  CONSEC=$(echo "$STATE" | jq -r --arg s "$CHECK_SKILL" '.[$s].consecutive_failures // 0')
-                  if [ "$CONSEC" -ge "$THRESHOLD" ]; then
-                    echo "Reactive trigger: $RSKILL (${CHECK_SKILL} has ${CONSEC} consecutive failures >= ${THRESHOLD})"
-                    TRIGGERED=true
-                    break
-                  fi
-                elif [[ "$WHEN" =~ last_status\ *=\ *([a-z]+) ]]; then
-                  EXPECTED="${BASH_REMATCH[1]}"
-                  ACTUAL=$(echo "$STATE" | jq -r --arg s "$CHECK_SKILL" '.[$s].last_status // "none"')
-                  if [ "$ACTUAL" = "$EXPECTED" ]; then
-                    echo "Reactive trigger: $RSKILL (${CHECK_SKILL} last_status = ${EXPECTED})"
-                    TRIGGERED=true
-                    break
-                  fi
+                # Condition evaluation lives in scripts/reactive_when.sh so it can be
+                # unit-tested (scripts/tests/test_reactive_when.sh) and so all three
+                # documented conditions (consecutive_failures, last_status,
+                # success_rate) are handled in one place. success_rate was advertised
+                # in the reactive docs but had no evaluator branch here before.
+                SKILL_STATE=$(echo "$STATE" | jq -c --arg s "$CHECK_SKILL" '.[$s] // {}')
+                WRC=0
+                printf '%s' "$SKILL_STATE" | bash scripts/reactive_when.sh "$WHEN" || WRC=$?
+                if [ "$WRC" -eq 0 ]; then
+                  echo "Reactive trigger: $RSKILL (${CHECK_SKILL} matched: ${WHEN})"
+                  TRIGGERED=true
+                  break
+                elif [ "$WRC" -eq 2 ]; then
+                  echo "::warning::reactive trigger for '$RSKILL' has an unparseable condition: ${WHEN}"
+                  break
                 fi
               done
 

--- a/aeon.yml
+++ b/aeon.yml
@@ -149,10 +149,14 @@ skills:
 # evaluates their trigger rules after processing cron skills.
 #
 # Format: trigger: { on: <source-skill>, when: "<condition>" }
-# Conditions:
-#   consecutive_failures >= N    — source skill failed N+ times in a row
-#   success_rate < X             — source skill success rate below threshold
-#   last_status = success        — source skill just succeeded (for chaining)
+# Conditions (evaluated by scripts/reactive_when.sh):
+#   consecutive_failures >= N    - source skill failed N+ times in a row
+#   success_rate <op> X          - success rate vs threshold; op is < <= > >= and X
+#                                  is a 0.0-1.0 float. Only checked once the source
+#                                  skill has run at least once (a never-run skill is
+#                                  0.0 and would otherwise false-fire `< X`).
+#   last_status = <value>        - source skill's last run ended <value> (e.g.
+#                                  success), for chaining
 #
 # Multiple triggers: trigger: [{ on: a, when: "..." }, { on: b, when: "..." }]
 # Any matching trigger fires the skill (OR logic).

--- a/scripts/reactive_when.sh
+++ b/scripts/reactive_when.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# reactive_when.sh — evaluate ONE reactive-trigger `when:` condition against a
+# single skill's cron-state object, read as JSON on stdin.
+#
+#   echo "$STATE" | jq -c '.["digest"]' | scripts/reactive_when.sh "consecutive_failures >= 3"
+#
+# Exit codes:
+#   0  condition holds        (fire the reactive skill)
+#   1  condition does not hold (do not fire)
+#   2  condition is unparseable
+#
+# Supported conditions (kept in lockstep with the `reactive:` docs in aeon.yml):
+#   consecutive_failures >= N     — source skill failed N+ times in a row
+#   last_status = <value>         — source skill's last run ended <value>
+#   success_rate <op> X           — op is one of  <  <=  >  >=  (0.0-1.0 float)
+#                                   only meaningful once the skill has run at least
+#                                   once; a never-run skill sits at 0.0 and is
+#                                   reported as "no signal" (exit 1) rather than a
+#                                   breach, so `success_rate < X` does not false-fire
+#                                   on a fresh skill.
+#
+# The comparison operators live in quoted regex variables, not inline in [[ =~ ]]:
+# a bare > or < inside an inline conditional pattern is parsed as a redirection, and
+# a backslash-escaped \< / \> is a word-boundary anchor under GNU regex on the CI
+# runner. A regex held in a variable sidesteps both — the operators are passed to
+# regcomp as plain literals.
+set -euo pipefail
+
+WHEN="${1:?when condition required}"
+STATE_JSON="$(cat)"
+[ -z "$STATE_JSON" ] && STATE_JSON='{}'
+
+field() { printf '%s' "$STATE_JSON" | jq -r "$1"; }
+
+re_consec='consecutive_failures[[:space:]]*>=[[:space:]]*([0-9]+)'
+re_status='last_status[[:space:]]*=[[:space:]]*([a-z]+)'
+re_rate='success_rate[[:space:]]*(<=|>=|<|>)[[:space:]]*([0-9.]+)'
+
+if [[ "$WHEN" =~ $re_consec ]]; then
+  THRESHOLD="${BASH_REMATCH[1]}"
+  CONSEC="$(field '.consecutive_failures // 0')"
+  [ "$CONSEC" -ge "$THRESHOLD" ]
+
+elif [[ "$WHEN" =~ $re_status ]]; then
+  EXPECTED="${BASH_REMATCH[1]}"
+  ACTUAL="$(field '.last_status // "none"')"
+  [ "$ACTUAL" = "$EXPECTED" ]
+
+elif [[ "$WHEN" =~ $re_rate ]]; then
+  OP="${BASH_REMATCH[1]}"
+  THRESHOLD="${BASH_REMATCH[2]}"
+  RUNS="$(field '.total_runs // 0')"
+  RATE="$(field '.success_rate // 0')"
+  [ "$RUNS" -gt 0 ] || exit 1
+  jq -e -n --argjson a "$RATE" --argjson b "$THRESHOLD" --arg op "$OP" \
+    'if   $op=="<"  then $a <  $b
+     elif $op=="<=" then $a <= $b
+     elif $op==">"  then $a >  $b
+     else                $a >= $b end' >/dev/null
+
+else
+  printf 'reactive_when: unparseable condition: %s\n' "$WHEN" >&2
+  exit 2
+fi

--- a/scripts/tests/test_reactive_when.sh
+++ b/scripts/tests/test_reactive_when.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Tests for scripts/reactive_when.sh — single reactive-trigger `when:` evaluation.
+# Run:  bash scripts/tests/test_reactive_when.sh
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/reactive_when.sh"
+
+pass=0; fail=0
+# check <desc> <state-json> <when> <expect-exit>
+check() {
+  local desc="$1" state="$2" when="$3" expect="$4" rc
+  printf '%s' "$state" | bash "$SCRIPT" "$when" >/dev/null 2>&1; rc=$?
+  if [ "$rc" = "$expect" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1)); printf 'FAIL: %-42s got=%s want=%s\n' "$desc" "$rc" "$expect"
+  fi
+}
+
+# --- consecutive_failures >= N ---
+check "consec at threshold"      '{"consecutive_failures":3}' "consecutive_failures >= 3" 0
+check "consec above threshold"   '{"consecutive_failures":7}' "consecutive_failures >= 3" 0
+check "consec below threshold"   '{"consecutive_failures":2}' "consecutive_failures >= 3" 1
+check "consec single-failure edge" '{"consecutive_failures":1}' "consecutive_failures >= 1" 0
+check "consec missing field"     '{}'                          "consecutive_failures >= 1" 1
+check "consec tight spacing"     '{"consecutive_failures":3}' "consecutive_failures>=3"   0
+
+# --- last_status = <value> ---
+check "status matches success"   '{"last_status":"success"}'  "last_status = success"     0
+check "status matches failed"    '{"last_status":"failed"}'   "last_status = failed"      0
+check "status mismatch"          '{"last_status":"failed"}'   "last_status = success"     1
+check "status missing field"     '{}'                         "last_status = success"     1
+
+# --- success_rate <op> X  (the condition that was documented but never evaluated) ---
+check "rate below (fires)"       '{"total_runs":10,"success_rate":0.4}' "success_rate < 0.5"  0
+check "rate above (no fire)"     '{"total_runs":10,"success_rate":0.6}' "success_rate < 0.5"  1
+check "rate equal, strict lt"    '{"total_runs":10,"success_rate":0.5}' "success_rate < 0.5"  1
+check "rate equal, lte"          '{"total_runs":10,"success_rate":0.5}' "success_rate <= 0.5" 0
+check "rate gt fires"            '{"total_runs":10,"success_rate":0.9}' "success_rate > 0.8"  0
+check "rate gte fires"           '{"total_runs":10,"success_rate":0.8}' "success_rate >= 0.8" 0
+check "never-run: no false fire" '{"total_runs":0,"success_rate":0.0}'  "success_rate < 0.5"  1
+check "missing total_runs quiet" '{"success_rate":0.0}'                 "success_rate < 0.5"  1
+
+# --- unparseable ---
+check "garbage condition"        '{"consecutive_failures":9}' "explode_now > yes"         2
+check "empty state ok"           ''                           "consecutive_failures >= 1" 1
+
+printf '\nreactive_when: %d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What

Reactive triggers advertise three `when:` conditions in `aeon.yml`:

```
consecutive_failures >= N
success_rate < X
last_status = <value>
```

The scheduler's inline evaluator only handled `consecutive_failures` and `last_status`. A trigger written as `when: "success_rate < 0.5"` matched no branch and was silently dropped -- no dispatch, no error. Dead config that reads as working.

## Fix

Extract single-condition evaluation into `scripts/reactive_when.sh` (testable), covering all three documented conditions. Adds the missing `success_rate` branch with `< <= > >=` and a `total_runs > 0` guard so a never-run skill (which sits at `0.0`) does not false-fire `< X`.

## Notes

- Behaviour for the two already-working conditions is unchanged; the new unit test pins it (`scripts/tests/test_reactive_when.sh`, 20 cases, wired into `ci-tests.yml`).
- Unparseable conditions now emit a `::warning::` once instead of being silently ignored.
- **Backwards compatible:** a repo with no reactive triggers, or only `consecutive_failures` / `last_status` triggers, dispatches byte-identically.

Found while auditing an INTEGRATION.md porting plan against the repo; this is a pre-existing doc/impl drift the plan didn't catch, separate from the ported features. No `CLAUDE.md` / `AGENTS.md` change needed.

## Test

```
bash scripts/tests/test_reactive_when.sh   # 20 passed, 0 failed
node scripts/validate-config.js            # CLEAN
```
