### PR TITLE
feat(validate-config): validate reactive-trigger references and conditions

### DIFF
--- a/scripts/validate-config.js
+++ b/scripts/validate-config.js
@@ -20,6 +20,10 @@
 //      exists. This validates the full reference surface a forker edits by hand: the
 //      whole skills: block (enabled or not, inline `{ }` or multi-line) AND every
 //      skill wired into a chains: pipeline (parallel / skill / consume).
+//   4. Reactive-trigger integrity - every target skill and `on:` source in the
+//      reactive: block resolves to a real skill, and every `when:` parses to a
+//      condition scripts/reactive_when.sh can evaluate (same dangling-reference /
+//      dead-config class as 3, for the event-driven dispatch path).
 //
 // Output contract:
 //   - Exit 0 + only PASS lines  => CLEAN
@@ -248,6 +252,74 @@ function checkSkillRefs(lines) {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Check 4 - reactive-trigger integrity. The `reactive:` block wires event-driven
+// dispatch: a target skill fires when a `when:` condition holds for a source
+// skill (scripts/reactive_when.sh evaluates the condition at scheduler time).
+// Nothing validated these references before, so a reactive trigger naming a
+// pruned skill, or a mistyped `when:`, was a silent no-op that only showed up as
+// a dispatch that never happened. Mirror the skill-refs check for both the target
+// and the `on:` source, and reject a `when:` the evaluator cannot parse.
+// ---------------------------------------------------------------------------
+
+// A `when:` the scheduler's evaluator (scripts/reactive_when.sh) can parse. Keep
+// these three patterns in lockstep with that script.
+function validateWhen(when) {
+  const w = String(when).trim();
+  return /^consecutive_failures\s*>=\s*\d+$/.test(w)
+    || /^last_status\s*=\s*[a-z]+$/.test(w)
+    || /^success_rate\s*(<=|>=|<|>)\s*[0-9]+(\.[0-9]+)?$/.test(w);
+}
+
+// Pure: returns { targets, sources, conditions }, each an array of {name/when, lineNum}.
+// Skips comment lines so the documented (commented-out) example doesn't register.
+function collectReactiveRefs(lines) {
+  const targets = [];
+  const sources = [];
+  const conditions = [];
+  for (const [i, raw] of blockLines(lines, 'reactive')) {
+    if (/^\s*#/.test(raw)) continue;
+    let m;
+    // A target skill is a 2-space key with nothing after the colon (`trigger:` is
+    // deeper-indented and the `- { on:, when: }` rows carry no bare 2-space key).
+    if ((m = raw.match(/^ {2}([a-z][a-z0-9-]+):\s*$/))) targets.push({ name: m[1], lineNum: i + 1 });
+    if ((m = raw.match(/\bon:\s*"?([a-zA-Z0-9_*-]+)"?/))) sources.push({ name: m[1], lineNum: i + 1 });
+    if ((m = raw.match(/\bwhen:\s*"([^"]+)"/))) conditions.push({ when: m[1], lineNum: i + 1 });
+  }
+  return { targets, sources, conditions };
+}
+
+function checkReactiveRefs(lines) {
+  if (!fs.existsSync(SKILLS_DIR)) return; // checkSkillRefs already failed on this
+  const { targets, sources, conditions } = collectReactiveRefs(lines);
+  const problems = [];
+
+  for (const t of targets) {
+    if (!skillExists(t.name)) {
+      problems.push('FAIL: aeon.yml reactive target "' + t.name + '" (line ' + t.lineNum + ') has no skills/' + t.name + '/SKILL.md');
+    }
+  }
+  for (const s of sources) {
+    if (s.name === '*') continue; // wildcard: any source skill
+    if (!skillExists(s.name)) {
+      problems.push('FAIL: aeon.yml reactive trigger on: "' + s.name + '" (line ' + s.lineNum + ') names no skills/' + s.name + '/SKILL.md');
+    }
+  }
+  for (const c of conditions) {
+    if (!validateWhen(c.when)) {
+      problems.push('FAIL: aeon.yml reactive when: "' + c.when + '" (line ' + c.lineNum + ') is not a condition reactive_when.sh can evaluate (consecutive_failures >= N | last_status = <v> | success_rate <op> X)');
+    }
+  }
+
+  if (problems.length > 0) {
+    problems.forEach(fail);
+  } else if (targets.length === 0) {
+    pass('PASS reactive: no reactive triggers defined');
+  } else {
+    pass('PASS reactive: ' + targets.length + ' target(s), ' + sources.length + ' source ref(s), ' + conditions.length + ' condition(s) all valid');
+  }
+}
+
 function main() {
   checkCheckoutOrdering();
 
@@ -257,6 +329,7 @@ function main() {
   } else {
     checkDuplicateKeys(lines);
     checkSkillRefs(lines);
+    checkReactiveRefs(lines);
   }
 
   out.forEach((l) => console.log(l));
@@ -271,4 +344,4 @@ function main() {
 
 if (require.main === module) main();
 
-module.exports = { analyzeCheckout, parseSteps };
+module.exports = { analyzeCheckout, parseSteps, collectReactiveRefs, validateWhen };

--- a/scripts/validate-config.test.js
+++ b/scripts/validate-config.test.js
@@ -13,7 +13,7 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
-const { analyzeCheckout } = require('./validate-config.js');
+const { analyzeCheckout, collectReactiveRefs, validateWhen } = require('./validate-config.js');
 
 // Wrap an indented steps body in a minimal single-job workflow.
 const wf = (steps) => `name: run
@@ -102,4 +102,60 @@ test('PASS: the live .github/workflows/aeon.yml', () => {
   const wfPath = path.resolve(__dirname, '..', '.github', 'workflows', 'aeon.yml');
   const r = analyzeCheckout(fs.readFileSync(wfPath, 'utf8'));
   assert.equal(r.ok, true, r.line);
+});
+
+// --- Check 4: reactive-trigger reference + condition parsing ---
+
+// A reactive: block with one target, one wildcard source, and a valid condition.
+const reactiveBlock = (body) => `reactive:
+${body}
+chains:
+  # example
+`.split('\n');
+
+test('collectReactiveRefs: parses target, on: source, and when:', () => {
+  const r = collectReactiveRefs(reactiveBlock(
+`  skill-repair:
+    trigger:
+      - { on: "*", when: "consecutive_failures >= 3" }
+  autoresearch:
+    trigger:
+      - { on: skill-health, when: "last_status = success" }`));
+  assert.deepEqual(r.targets.map((t) => t.name), ['skill-repair', 'autoresearch']);
+  assert.deepEqual(r.sources.map((s) => s.name), ['*', 'skill-health']);
+  assert.deepEqual(r.conditions.map((c) => c.when), ['consecutive_failures >= 3', 'last_status = success']);
+});
+
+test('collectReactiveRefs: ignores commented-out example rows', () => {
+  const r = collectReactiveRefs(reactiveBlock(
+`  # skill-repair:
+  #   trigger:
+  #     - { on: "*", when: "consecutive_failures >= 3" }`));
+  assert.equal(r.targets.length, 0);
+  assert.equal(r.sources.length, 0);
+  assert.equal(r.conditions.length, 0);
+});
+
+test('validateWhen: accepts the three documented condition forms', () => {
+  assert.equal(validateWhen('consecutive_failures >= 3'), true);
+  assert.equal(validateWhen('last_status = success'), true);
+  assert.equal(validateWhen('success_rate < 0.5'), true);
+  assert.equal(validateWhen('success_rate >= 0.9'), true);
+});
+
+test('validateWhen: rejects malformed / unsupported conditions', () => {
+  assert.equal(validateWhen('score > abc'), false);
+  assert.equal(validateWhen('consecutive_failures > 3'), false); // only >= supported
+  assert.equal(validateWhen('success_rate = 0.5'), false);       // no = for rate
+  assert.equal(validateWhen('last_status = 5'), false);          // value not [a-z]+
+  assert.equal(validateWhen(''), false);
+});
+
+// The live aeon.yml ships the reactive examples commented out, so it must parse to
+// zero references (and therefore never fail the reactive check).
+test('the live aeon.yml has no uncommented reactive references', () => {
+  const ymlPath = path.resolve(__dirname, '..', 'aeon.yml');
+  const lines = fs.readFileSync(ymlPath, 'utf8').split('\n');
+  const r = collectReactiveRefs(lines);
+  assert.equal(r.targets.length, 0, 'unexpected uncommented reactive target(s)');
 });


### PR DESCRIPTION
## What

`validate-config.js` checks the reference surface a forker edits by hand -- the `skills:` block and every skill wired into a `chains:` pipeline -- so a dangling reference fails CI instead of surfacing when a cron fires. The `reactive:` block was the one dispatch path it never looked at.

A reactive trigger whose target or `on:` source names a pruned skill, or whose `when:` is mistyped, was a **silent no-op**: no dispatch, no error at config time, none at run time.

## Change

Adds a fourth check mirroring the skill-refs one for the reactive path:

- every reactive **target** skill resolves to `skills/<name>/SKILL.md`
- every non-wildcard **`on:` source** resolves too (`*` is allowed)
- every **`when:`** parses to a condition `scripts/reactive_when.sh` can evaluate: `consecutive_failures >= N` | `last_status = <v>` | `success_rate <op> X`

`collectReactiveRefs()` and `validateWhen()` are exported and unit-tested. The `when:` grammar is kept deliberately in lockstep with the runtime evaluator.

## Notes

- The live `aeon.yml` ships the reactive examples commented out -> parses to zero references -> stays `CLEAN`. Verified by a test.
- **Backwards compatible:** a repo defining no reactive triggers validates identically.
- This is the same validation the INTEGRATION.md plan wants for its proposed `on_failure` / chain `when:` keys, applied to the reactive mechanism that already ships. No `CLAUDE.md` / `AGENTS.md` change.

## Test

```
node --test scripts/validate-config.test.js   # 12 pass
node scripts/validate-config.js               # CLEAN (+ new PASS reactive line)
```
