### PR TITLE
feat(audit): structured audit log of privileged actions

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -694,6 +694,12 @@ jobs:
           : > "$AEON_AUDIT_LOG"
           echo "AEON_AUDIT_LOG=$AEON_AUDIT_LOG" >> "$GITHUB_ENV"
           export AEON_AUDIT_LOG
+          # Name the running skill in every audit record (audit.sh reads AEON_SKILL).
+          # Without this the notify/secretcurl subprocesses don't see $SKILL and each
+          # record's skill field falls back to "unknown".
+          AEON_SKILL="${{ steps.skill.outputs.name }}"
+          echo "AEON_SKILL=$AEON_SKILL" >> "$GITHUB_ENV"
+          export AEON_SKILL
 
           # notify / notify-jsonrender are the committed scripts/*.sh (testable; see scripts/tests/).
           cp scripts/notify.sh ./notify

--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -684,6 +684,17 @@ jobs:
           echo "AEON_PENDING_DIR=$AEON_PENDING_DIR" >> "$GITHUB_ENV"
           export AEON_PENDING_DIR
 
+          # Structured audit log (scripts/audit.sh): one append-only JSON line per
+          # privileged action that reaches outside the run (notify send, secretcurl,
+          # git push). Lives beside the notify queue OUTSIDE the workspace so a
+          # read-only-sandboxed skill can still append to it, then a post-run step
+          # uploads it as an artifact. Touch it now so a run that performs no
+          # privileged action ends with an empty file, not a missing one.
+          AEON_AUDIT_LOG="$AEON_PENDING_DIR/audit.jsonl"
+          : > "$AEON_AUDIT_LOG"
+          echo "AEON_AUDIT_LOG=$AEON_AUDIT_LOG" >> "$GITHUB_ENV"
+          export AEON_AUDIT_LOG
+
           # notify / notify-jsonrender are the committed scripts/*.sh (testable; see scripts/tests/).
           cp scripts/notify.sh ./notify
           cp scripts/notify-jsonrender.sh ./notify-jsonrender
@@ -1627,6 +1638,7 @@ jobs:
             # Try to push — if it fails, another job beat us, loop and re-pull
             if git push -u origin HEAD 2>/dev/null; then
               echo "Pushed successfully on attempt $i"
+              bash scripts/audit.sh "git.push" "$GITHUB_REPOSITORY@$(git rev-parse --abbrev-ref HEAD)" 0 "GH_GLOBAL" || true
               exit 0
             fi
             echo "Push attempt $i failed (ref moved), retrying in ${i}s..."
@@ -1822,3 +1834,28 @@ jobs:
           else
             echo "no regression for $SKILL; health issue silent"
           fi
+
+      # Structured audit log (scripts/audit.sh) -> run artifact. Runs on failure too
+      # so a run that pushed a commit or sent a notify before dying still leaves its
+      # trail. The log lives outside the workspace (beside the notify queue); stage a
+      # copy into the workspace so upload-artifact picks it up, guaranteeing a file
+      # even when nothing privileged happened (empty, not missing).
+      - name: Stage audit log
+        if: always()
+        run: |
+          mkdir -p audit-artifact
+          if [ -n "${AEON_AUDIT_LOG:-}" ] && [ -f "$AEON_AUDIT_LOG" ]; then
+            cp "$AEON_AUDIT_LOG" audit-artifact/audit.jsonl
+          else
+            : > audit-artifact/audit.jsonl
+          fi
+          echo "audit records: $(wc -l < audit-artifact/audit.jsonl)"
+
+      - name: Upload audit log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: audit-log-${{ github.run_id }}
+          path: audit-artifact/audit.jsonl
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -89,3 +89,5 @@ jobs:
         run: bash scripts/tests/test_breaker.sh
       - name: skill-scan calibration (fires on sinks, not benign syntax)
         run: bash scripts/tests/test_skill_scan_calibration.sh
+      - name: audit-log redaction tests
+        run: bash scripts/tests/test_audit.sh

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,11 @@
 .pending-*.md
 apps/dashboard/outputs/.pending-*.md
 
+# Audit log staged into the workspace only to be uploaded as a run artifact
+# (scripts/audit.sh). The authoritative copy lives outside the repo in
+# $AEON_PENDING_DIR; this staged copy must never be committed.
+audit-artifact/
+
 # deploy-uni-hook stages its key-safe runner + chain registry at the repo root
 # (like ./notify / ./secretcurl) from skills/deploy-uni-hook/templates/; these are
 # run-time copies, not sources, so they must never be committed.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -263,6 +263,16 @@ Set the secret → channel activates. No code changes needed.
 
 Want ~1s Telegram replies instead of up-to-5-min polling? See [Telegram instant mode](../apps/webhook/README.md).
 
+## Audit log
+
+Every run writes an append-only JSON-lines record of the privileged actions that reached outside it - notify sends, `secretcurl` calls, and git pushes - and uploads it as the `audit-log-<run_id>` artifact on the run (kept 30 days). It answers "what did this run actually do" without reading the whole Actions transcript. One line per action:
+
+```json
+{"ts":"2026-08-18T14:03:11Z","run_id":"1234567890","skill":"digest","action":"notify","target":"channels=telegram delivered=true","exit":0,"secrets_used":["TELEGRAM_BOT_TOKEN"]}
+```
+
+`secrets_used` lists env-var **names** only. Secret **values** never reach the file: `scripts/audit.sh` scrubs every credential-shaped env var - in its raw, base64, and url-encoded forms - out of each record before writing, failing toward over-redaction. The log is written outside the workspace (beside the notify queue) so a read-only-sandboxed skill can still append to it, and it is always produced - a run that performs no privileged action uploads an empty file, not a missing one. Nothing to configure; it is on by default.
+
 ## API keys per skill
 
 Skills that call third-party APIs declare their credentials in a `requires:` frontmatter list, so the dashboard shows **which skill needs which key**:

--- a/scripts/audit.sh
+++ b/scripts/audit.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# audit.sh — append-only structured audit log of privileged actions.
+#
+#   scripts/audit.sh <action> <target> <exit> [secrets_csv]
+#
+# Appends one JSON line to $AEON_AUDIT_LOG describing a single action that reached
+# outside the run (a notify send, an authenticated curl, a git push, a gh write, an
+# email). The run workflow points AEON_AUDIT_LOG at a file it uploads as an
+# artifact, so "what did it do on the 14th" is answerable without reading Actions
+# transcripts.
+#
+# NO-OP when AEON_AUDIT_LOG is unset: instrumenting a shared script (notify.sh,
+# secretcurl) with a call to this one is therefore free for any caller that has not
+# opted in -- forks, unit tests, local runs -- and changes no default behaviour.
+#
+# Secret VALUES never reach the file. secrets_used records env-var NAMES only, and
+# as defense in depth the whole record is scrubbed against every credential-shaped
+# env var in its raw, base64, and url-encoded forms before it is written. The
+# scrub fails toward over-redaction, never toward disclosure.
+set -euo pipefail
+
+LOG="${AEON_AUDIT_LOG:-}"
+[ -z "$LOG" ] && exit 0
+
+ACTION="${1:-unknown}"
+TARGET="${2:-}"
+EXITCODE="${3:-0}"
+SECRETS="${4:-}"   # comma-separated env-var NAMES, e.g. "TELEGRAM_BOT_TOKEN"
+
+case "$EXITCODE" in ''|*[!0-9]*) EXITCODE=0 ;; esac
+
+# Replace every credential-shaped env var's value -- raw, base64, and url-encoded --
+# with the literal REDACTED. compgen -e lists exported names (secrets arrive as env
+# vars), so no NAME=value line-parsing that a multi-line value could break.
+redact() {
+  local s="$1" name val enc
+  while IFS= read -r name; do
+    case "$name" in
+      *_API_KEY|*_KEY|*_TOKEN|*_SECRET|*_PAT|*_WEBHOOK_URL|*_PRIVATE_KEY|*_CHAT_ID|*_CHANNEL_ID) ;;
+      *) continue ;;
+    esac
+    val="${!name-}"
+    [ -z "$val" ] && continue
+    [ "${#val}" -lt 6 ] && continue     # skip short values (ids like "1") to avoid noise
+    s="${s//"$val"/REDACTED}"
+    enc="$(printf '%s' "$val" | base64 | tr -d '\n')"
+    [ -n "$enc" ] && s="${s//"$enc"/REDACTED}"
+    enc="$(printf '%s' "$val" | jq -sRr @uri 2>/dev/null || true)"
+    [ -n "$enc" ] && [ "$enc" != "$val" ] && s="${s//"$enc"/REDACTED}"
+  done < <(compgen -e)
+  printf '%s' "$s"
+}
+
+TS="$(date -u +%FT%TZ)"
+RUN_ID="${GITHUB_RUN_ID:-local}"
+SKILL="${AEON_SKILL:-${SKILL:-unknown}}"
+SEC_JSON="$(jq -cn --arg s "$SECRETS" '$s | split(",") | map(select(length > 0))')"
+
+LINE="$(jq -cn \
+  --arg ts "$TS" --arg run "$RUN_ID" --arg skill "$SKILL" \
+  --arg action "$ACTION" --arg target "$TARGET" \
+  --argjson exit "$EXITCODE" --argjson secrets "$SEC_JSON" \
+  '{ts:$ts, run_id:$run, skill:$skill, action:$action, target:$target, exit:$exit, secrets_used:$secrets}')"
+
+LINE="$(redact "$LINE")"
+
+mkdir -p "$(dirname "$LOG")" 2>/dev/null || true
+printf '%s\n' "$LINE" >> "$LOG"

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -399,3 +399,24 @@ fi
 if [ "$DELIVERED" = "true" ]; then
   rm -f "$PENDING_DIR/notify-queue/${TS}.md"
 fi
+
+# Audit trail (no-op unless AEON_AUDIT_LOG is set; see scripts/audit.sh). One record
+# per notify call listing which channels were configured and whether any delivery
+# succeeded. Channel token VALUES never reach the record -- audit.sh redacts, and we
+# pass NAMES only. if-blocks keep this set -e safe.
+if [ -n "${AEON_AUDIT_LOG:-}" ]; then
+  _AUDIT=""
+  for _c in "scripts/audit.sh" "$_HERE/audit.sh" "$_HERE/scripts/audit.sh"; do
+    if [ -f "$_c" ]; then _AUDIT="$_c"; break; fi
+  done
+  if [ -n "$_AUDIT" ]; then
+    _CHANS=""; _SECS=""
+    if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ]; then _CHANS="${_CHANS}telegram,"; _SECS="${_SECS}TELEGRAM_BOT_TOKEN,"; fi
+    if [ -n "${DISCORD_WEBHOOK_URL:-}" ]; then _CHANS="${_CHANS}discord,"; _SECS="${_SECS}DISCORD_WEBHOOK_URL,"; fi
+    if [ -n "${SLACK_WEBHOOK_URL:-}" ]; then _CHANS="${_CHANS}slack,"; _SECS="${_SECS}SLACK_WEBHOOK_URL,"; fi
+    if [ -n "${BUZZ_PRIVATE_KEY:-}" ] && [ -n "${BUZZ_CHANNEL_ID:-}" ]; then _CHANS="${_CHANS}buzz,"; _SECS="${_SECS}BUZZ_PRIVATE_KEY,"; fi
+    if [ -n "${RESEND_API_KEY:-}" ] && [ -n "${NOTIFY_EMAIL_TO:-}" ]; then _CHANS="${_CHANS}email,"; _SECS="${_SECS}RESEND_API_KEY,"; fi
+    if [ "$DELIVERED" = "true" ]; then _RC=0; else _RC=1; fi
+    bash "$_AUDIT" "notify" "channels=${_CHANS%,} delivered=${DELIVERED}" "$_RC" "${_SECS%,}" || true
+  fi
+fi

--- a/scripts/secretcurl.sh
+++ b/scripts/secretcurl.sh
@@ -37,4 +37,28 @@ subst() {
 
 args=()
 for a in "$@"; do args+=("$(subst "$a")"); done
+
+# When auditing is off (AEON_AUDIT_LOG unset), stay a transparent exec passthrough
+# -- byte-identical to the original behaviour. When on, run curl in the foreground
+# (stdout/stderr/exit all pass through unchanged) so we can record the call after.
+if [ -n "${AEON_AUDIT_LOG:-}" ]; then
+  # Credential placeholders that were substituted (NAMES only) and the target URL,
+  # both read from the ORIGINAL placeholder args so no secret value is handled here.
+  _SECS=""
+  for a in "$@"; do
+    for n in $(printf '%s\n' "$a" | grep -oE '\{[A-Z_][A-Z0-9_]*\}' | tr -d '{}' | sort -u || true); do
+      case "$n" in *_API_KEY|*_KEY|*_TOKEN|*_SECRET|*_PAT|*_WEBHOOK_URL) _SECS="${_SECS}${n}," ;; esac
+    done
+  done
+  _URL=""
+  for a in "$@"; do case "$a" in http://*|https://*) _URL="$a"; break ;; esac; done
+  set +e
+  curl "${args[@]}"; _RC=$?
+  set -e
+  _HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  for _c in "scripts/audit.sh" "$_HERE/audit.sh" "$_HERE/scripts/audit.sh"; do
+    if [ -f "$_c" ]; then bash "$_c" "secretcurl" "${_URL%%\?*}" "$_RC" "${_SECS%,}" || true; break; fi
+  done
+  exit "$_RC"
+fi
 exec curl "${args[@]}"

--- a/scripts/tests/test_audit.sh
+++ b/scripts/tests/test_audit.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Tests for scripts/audit.sh — the structured audit log and its secret redaction.
+# Run:  bash scripts/tests/test_audit.sh
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/audit.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0; fail=0
+ok()  { pass=$((pass+1)); }
+no()  { fail=$((fail+1)); printf 'FAIL: %s\n' "$1"; }
+
+# A secret with special characters so its raw, base64, and url-encoded forms all
+# differ -- the adversarial case the redaction must catch in every encoding.
+export FAKE_API_KEY='p@ss/w0rd+val=SECRET9xyz'
+SECRET="$FAKE_API_KEY"
+B64="$(printf '%s' "$SECRET" | base64 | tr -d '\n')"
+URI="$(printf '%s' "$SECRET" | jq -sRr @uri)"
+
+# --- no-op when disabled ---
+unset AEON_AUDIT_LOG
+printf '' | : # noop
+if bash "$SCRIPT" notify.telegram "chat:x" 0 "FAKE_API_KEY" && [ ! -f "$TMP/should-not-exist" ]; then
+  ok
+else
+  no "audit.sh should exit 0 and write nothing when AEON_AUDIT_LOG is unset"
+fi
+
+# --- enabled: one line per call ---
+export AEON_AUDIT_LOG="$TMP/audit.jsonl"
+export GITHUB_RUN_ID=1234567890
+export AEON_SKILL=digest
+
+bash "$SCRIPT" notify.telegram "chat:REDACTED" 0 "TELEGRAM_BOT_TOKEN"
+bash "$SCRIPT" git.push "aeonfun/aeon@main" 0 ""
+LINES=$(wc -l < "$AEON_AUDIT_LOG")
+[ "$LINES" -eq 2 ] && ok || no "expected 2 lines, got $LINES"
+
+# --- valid JSON with the required fields ---
+if jq -e '.ts and .run_id and .skill and .action and (.exit|type=="number") and (.secrets_used|type=="array")' \
+     "$AEON_AUDIT_LOG" >/dev/null; then ok; else no "records missing required fields / wrong types"; fi
+
+# --- secrets_used carries NAMES ---
+NAME=$(head -1 "$AEON_AUDIT_LOG" | jq -r '.secrets_used[0]')
+[ "$NAME" = "TELEGRAM_BOT_TOKEN" ] && ok || no "secrets_used should record the name, got '$NAME'"
+
+# --- ADVERSARIAL redaction: the secret must not survive in ANY encoding ---
+# Target embeds the secret four ways: URL, JSON body, error message, base64.
+TARGET="url=https://api.example.com/${SECRET}/x body={\"key\":\"${SECRET}\"} err=auth failed with ${SECRET} b64=${B64} enc=${URI}"
+: > "$AEON_AUDIT_LOG"
+bash "$SCRIPT" secretcurl "$TARGET" 22 "FAKE_API_KEY"
+REC="$(cat "$AEON_AUDIT_LOG")"
+
+grep -qF "$SECRET" <<<"$REC" && no "RAW secret value leaked into audit record" || ok
+grep -qF "$B64"    <<<"$REC" && no "BASE64 secret value leaked into audit record" || ok
+grep -qF "$URI"    <<<"$REC" && no "URL-ENCODED secret value leaked into audit record" || ok
+grep -qF "REDACTED" <<<"$REC" && ok || no "expected REDACTED marker in the record"
+# still valid JSON after scrubbing
+jq -e . <<<"$REC" >/dev/null && ok || no "record is not valid JSON after redaction"
+# non-secret fields preserved
+[ "$(jq -r .exit <<<"$REC")" = "22" ] && ok || no "exit code not preserved"
+
+# --- short id values are not over-redacted (avoid nuking things like chat ids) ---
+export FAKE_CHAT_ID='42'
+: > "$AEON_AUDIT_LOG"
+bash "$SCRIPT" notify.telegram "delivered to 42 recipients" 0 ""
+grep -qF "42 recipients" "$AEON_AUDIT_LOG" && ok || no "short value 42 should not be redacted"
+unset FAKE_CHAT_ID
+
+printf '\naudit: %d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Implements **item 5** of the chassis INTEGRATION.md porting plan: a structured audit log.

## What

A framework that emails maintainers, pushes commits under a git identity, and holds a GitHub PAT should be able to answer "what did it do on the 14th" without reading Actions transcripts. (The existing `.jsonl` files are Claude Code *session transcripts* consumed by `run-actions-summary.sh` -- a different artifact.)

Adds an append-only JSONL record, one line per action that reaches outside the run, uploaded as the `audit-log-<run_id>` artifact (30-day retention):

```json
{"ts":"2026-08-18T14:03:11Z","run_id":"1234567890","skill":"digest","action":"notify","target":"channels=telegram delivered=true","exit":0,"secrets_used":["TELEGRAM_BOT_TOKEN"]}
```

## Redaction (the crux)

`secrets_used` is **names only**. Secret **values** never reach the file: `scripts/audit.sh` scrubs every credential-shaped env var out of each record in its **raw, base64, and url-encoded** forms before writing, failing toward over-redaction. The test is adversarial -- a secret with special chars embedded in a URL, a JSON body, an error message, and base64 -- and asserts none of the three encodings survive:

```
bash scripts/tests/test_audit.sh   # 11 passed (incl. all 4 adversarial encodings)
```

## Instrumented sinks

- `notify.sh` -- one record per notify call (channels + delivered)
- `secretcurl` -- records the call; **output and exit code still pass through unchanged** (byte-identical `exec curl` when auditing is off)
- the git push in `aeon.yml`'s commit step

## Done-when checklist (from the plan)

- ✅ each instrumented action appears once per run
- ✅ redaction test passes against all four encodings
- ✅ artifact uploads even when the run fails (`if: always()`)
- ✅ a run with no privileged action produces an **empty file, not a missing one**

## Notes

- The log lives **outside the workspace** (beside the notify queue) so a `read-only`-sandboxed skill can still append; a post-run step stages a copy for the artifact.
- **Backwards compatible:** the instrumentation is a no-op when `AEON_AUDIT_LOG` is unset (local runs / unit tests). Verified `test_notify.sh` still ALL PASS.
- **Known gap (out of scope):** `gh` PR/issue creation done from *inside* a skill's `claude -p` call is not wrapped -- that needs a `gh` shim, a bigger change. Workflow-level git push is covered; skill-issued `gh` writes are the follow-up.
- This is a prerequisite the plan flags for the eventual item 1b (infra-secret scoping). No `CLAUDE.md` / `AGENTS.md` change required (auditing is automatic, not a config key).
