### PR TITLE
fix(bd-radar,fleet-control): GH_GLOBAL fallback for private reads + silence false unset-GH_READ_PAT alarms

### DIFF
--- a/scripts/fleet-scorecard.mjs
+++ b/scripts/fleet-scorecard.mjs
@@ -4,10 +4,11 @@
 // Pricing, aggregation and table generation are deterministic, so they live in
 // committed code rather than being left to the model — the skill run just invokes this.
 //
-// Auth: reads its token from the environment — GH_READ_PAT (a read-only PAT injected via
-// the skill's `requires:`, needed to read PRIVATE managed instances) is preferred, else
-// GH_TOKEN / GITHUB_TOKEN. The token is read from process.env INSIDE this script, so no
-// secret ever touches a command line (the caller runs a bare `node scripts/fleet-scorecard.mjs`).
+// Auth: reads its token from the environment — GH_READ_PAT (an optional read-only PAT injected
+// via the skill's `requires:`) is preferred; otherwise it falls back to GH_GLOBAL / GH_TOKEN /
+// GITHUB_TOKEN (the run's repo-wide token), which reads the same PRIVATE managed instances — the
+// normal single-key setup, not a degraded path. The token is read from process.env INSIDE this
+// script, so no secret ever touches a command line (the caller runs a bare `node scripts/fleet-scorecard.mjs`).
 //
 // Writes /tmp/fleet-scorecard/{scorecard-body.md,metrics.json} — the same shape the
 // fleet-control scorecard view consumes. Token mapping + pricing match skills/cost-report:
@@ -15,7 +16,7 @@
 //   cost   = input·in + output·out + cache_creation·cw + cache_read·cr  (per-1M list price)
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
 
-const TOKEN = process.env.GH_READ_PAT || process.env.GH_TOKEN || process.env.GITHUB_TOKEN || '';
+const TOKEN = process.env.GH_READ_PAT || process.env.GH_GLOBAL || process.env.GH_TOKEN || process.env.GITHUB_TOKEN || '';
 const DIR = '/tmp/fleet-scorecard';
 const WINDOW_DAYS = 14;
 mkdirSync(DIR, { recursive: true });
@@ -64,7 +65,7 @@ if (!repos.length) {
   console.error('fleet-scorecard: no repos resolved (no GITHUB_REPOSITORY, empty registry) — skipping');
   process.exit(0);
 }
-console.error(`fleet-scorecard: fleet = ${repos.join(' ')}${TOKEN ? '' : ' (UNAUTHENTICATED — set GH_READ_PAT)'}`);
+console.error(`fleet-scorecard: fleet = ${repos.join(' ')}${TOKEN ? '' : ' (UNAUTHENTICATED — set GH_READ_PAT or GH_GLOBAL)'}`);
 
 // ---- 1. fetch runs + defined-skill counts + token-usage.csv ----------------
 const runs = [];          // {repo,name,conclusion,created_at,head_branch}

--- a/skills/bd-radar/SKILL.md
+++ b/skills/bd-radar/SKILL.md
@@ -52,25 +52,29 @@ mkdir -p memory/topics output/articles
 
 **GitHub forks + issues — direct GitHub API, in-run.** The default runner token is integration-scoped to this instance's own repo, so cross-repo forks/issues of your other (esp. private) repos **403/404** from inside the skill (the `forking` + `integrating` signals). `GH_READ_PAT` — a read-only PAT, declared in `requires:` and injected into this run — reads them. Call `api.github.com` directly through `./secretcurl`'s `{GH_READ_PAT}` placeholder so no bare `$SECRET` ever hits the command line (the Bash permission analyzer refuses those). Iterate your configured `owner/repo`s:
 ```bash
-# Only when the PAT is set (a bare $GH_READ_PAT would be refused → use the placeholder).
-if [ -n "${GH_READ_PAT:+x}" ]; then
-  for repo in <owner/repo …from memory/products.md>; do
-    slug="${repo//\//-}"
+# When GH_READ_PAT is set, read via the {GH_READ_PAT} placeholder (a bare $GH_READ_PAT would be refused).
+# When it is unset (the default single-key setup) the run's GH_TOKEN (= GH_GLOBAL, a repo-scoped classic
+# PAT) reads the SAME cross-repo/private forks + issues via `gh api`. This is normal, not a degraded path;
+# gh takes the token from the env, never the command line.
+for repo in <owner/repo …from memory/products.md>; do
+  slug="${repo//\//-}"
+  if [ -n "${GH_READ_PAT:+x}" ]; then
     ./secretcurl -s -H "Authorization: Bearer {GH_READ_PAT}" -H "Accept: application/vnd.github+json" \
       "https://api.github.com/repos/${repo}/forks?sort=newest&per_page=40"  > "/tmp/bd-forks-${slug}.json"
     ./secretcurl -s -H "Authorization: Bearer {GH_READ_PAT}" -H "Accept: application/vnd.github+json" \
       "https://api.github.com/repos/${repo}/issues?state=open&per_page=40"  > "/tmp/bd-issues-${slug}.json"
-  done
-else
-  echo "BD_RADAR_SOURCE_MISS: github-forks-issues (no GH_READ_PAT)"
-fi
+  else
+    gh api "repos/${repo}/forks?sort=newest&per_page=40"  > "/tmp/bd-forks-${slug}.json"  2>/dev/null || echo '[]' > "/tmp/bd-forks-${slug}.json"
+    gh api "repos/${repo}/issues?state=open&per_page=40" > "/tmp/bd-issues-${slug}.json" 2>/dev/null || echo '[]' > "/tmp/bd-issues-${slug}.json"
+  fi
+done
 ```
 Parse each repo's results (the `type=="array"` guard skips a 404/error object cleanly):
 ```bash
 jq 'if type=="array" then .[] else empty end | {repo:.full_name, owner:.owner.login, created:.created_at, pushed:.pushed_at, size:.size}' /tmp/bd-forks-*.json
 jq 'if type=="array" then .[] else empty end | select(.pull_request|not) | {n:.number, title:.title, user:.user.login, created:.created_at, body:.body}' /tmp/bd-issues-*.json
 ```
-Keep forks with their own activity (`pushed` meaningfully after `created`) — drive-by forks are noise. Issues whose title/body asks to integrate/partner/build-on are `integrating` leads (the `/issues` endpoint also returns PRs — the `select(.pull_request|not)` drops them). If `GH_READ_PAT` is unset, or scoped so a repo returns 404, log `BD_RADAR_SOURCE_MISS: github-forks-issues (no GH_READ_PAT)` and continue on `gh search` alone.
+Keep forks with their own activity (`pushed` meaningfully after `created`) — drive-by forks are noise. Issues whose title/body asks to integrate/partner/build-on are `integrating` leads (the `/issues` endpoint also returns PRs — the `select(.pull_request|not)` drops them). An unset or empty `GH_READ_PAT` is the normal single-key setup: the `gh api` fallback (authenticated by the run's `GH_TOKEN` = `GH_GLOBAL`) reads the same forks + issues, so **never report an unset `GH_READ_PAT` as a 401, a source miss, or a follow-up to rotate or add a token**. Only log `BD_RADAR_SOURCE_MISS: github-forks-issues (<repo> 404)` when a `gh api` call itself fails for a specific repo (token lacks access), and lean on `gh search` for that one.
 
 **GitHub discovery — `gh search`** (works with the default token). For each `term` in `memory/products.md`:
 ```bash

--- a/skills/fleet-control/SKILL.md
+++ b/skills/fleet-control/SKILL.md
@@ -418,11 +418,11 @@ Every run logs exactly one of these to memory:
 
 **Control view (health / status / dispatch):** always use `gh api` over raw curl (it handles auth internally, so no `$SECRET` appears on the command line for the Bash permission layer to refuse). All cross-repo calls go through `gh api` or `gh workflow run`. No outbound HTTP needed beyond what `gh` does internally.
 
-**Scorecard view:** gathers its data **in-run** by executing `node scripts/fleet-scorecard.mjs` (step 0), which fetches workflow runs + token usage from the GitHub API and computes the tables into `/tmp/fleet-scorecard/`. The collector authenticates with `GH_READ_PAT` when set (a read-only PAT with cross-repo scope, declared in this skill's `requires:` and injected into the run) so **private** managed instances are readable; without it, only self + public repos resolve. It reads the token from `process.env` internally, so the secret never appears on a command line. A repo the token can't read is simply absent from the tables rather than crashing the collector.
+**Scorecard view:** gathers its data **in-run** by executing `node scripts/fleet-scorecard.mjs` (step 0), which fetches workflow runs + token usage from the GitHub API and computes the tables into `/tmp/fleet-scorecard/`. The collector authenticates with `GH_READ_PAT` when set (a read-only PAT with cross-repo scope, declared in this skill's `requires:` and injected into the run) so **private** managed instances are readable; when unset, the run's `GH_TOKEN` (= `GH_GLOBAL`) reads the same private members, the standard single-key setup. It reads the token from `process.env` internally, so the secret never appears on a command line. A repo the token can't read is simply absent from the tables rather than crashing the collector.
 
 ## Required env vars
 
-`GH_READ_PAT` (optional, read-only) — declared in `requires:` and read from `process.env` by `scripts/fleet-scorecard.mjs` (scorecard view) to reach private managed instances; it falls back to `GH_TOKEN`/`GITHUB_TOKEN` (self + public only) when unset, and reads `GITHUB_REPOSITORY` to resolve "self". The control view relies on the workflow-provided `GITHUB_TOKEN` for its live `gh` calls.
+`GH_READ_PAT` (optional, read-only) — declared in `requires:` and read from `process.env` by `scripts/fleet-scorecard.mjs` (scorecard view) to reach private managed instances; it falls back to `GH_GLOBAL`/`GH_TOKEN`/`GITHUB_TOKEN` (the run's repo-wide token, which also reads private members) when unset, and reads `GITHUB_REPOSITORY` to resolve "self". The control view relies on the workflow-provided `GITHUB_TOKEN` for its live `gh` calls.
 
 ## Constraints
 


### PR DESCRIPTION
GH_READ_PAT is optional and unset fleet-wide, so bd-radar logged a false BD_RADAR_SOURCE_MISS (no GH_READ_PAT) every run and read zero forks/issues (canon had no fallback). This adds the gh api / GH_GLOBAL fallback (the run's repo-wide token already reads the same private forks+issues), instructs the agent to treat an unset GH_READ_PAT as the normal single-key setup (never report it as a 401 / source miss / rotation follow-up), adds GH_GLOBAL to the scorecard token chain, and corrects fleet-control prose that wrongly claimed the fallback resolves self+public only. No secret changes; one-key (GH_GLOBAL) is the intended config.