### PR TITLE
feat(scheduler): reactive handler learns which skill tripped it (item 3)

### DIFF
--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -405,6 +405,7 @@ jobs:
                 if [ "$WRC" -eq 0 ]; then
                   echo "Reactive trigger: $RSKILL (${CHECK_SKILL} matched: ${WHEN})"
                   TRIGGERED=true
+                  MATCHED_SOURCE="$CHECK_SKILL"   # the skill that tripped this trigger
                   break
                 elif [ "$WRC" -eq 2 ]; then
                   echo "::warning::reactive trigger for '$RSKILL' has an unparseable condition: ${WHEN}"
@@ -419,6 +420,13 @@ jobs:
                 MINUTES_SINCE=$(( (NOW_EPOCH - LAST_DISPATCH_EPOCH) / 60 ))
                 if [ "$MINUTES_SINCE" -ge 90 ]; then
                   ORDERED+=("$RSKILL")
+                  # Hand the handler the skill that tripped it, so a reactive handler
+                  # (e.g. skill-repair on `on: "*"`) knows WHICH skill to act on. Only
+                  # when the handler declares no var of its own -- an explicit var wins.
+                  if [ -z "${SKILL_VAR[$RSKILL]:-}" ] && [ -n "${MATCHED_SOURCE:-}" ]; then
+                    SKILL_VAR["$RSKILL"]="$MATCHED_SOURCE"
+                    echo "Reactive $RSKILL var <- source skill '$MATCHED_SOURCE'"
+                  fi
                 else
                   echo "Skipping reactive $RSKILL (dispatched ${MINUTES_SINCE}m ago)"
                 fi

--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -373,7 +373,10 @@ jobs:
               REACTIVE_SKILL="${BASH_REMATCH[1]}"
               continue
             fi
-            if [ -n "$REACTIVE_SKILL" ] && [[ "$line" =~ on:\ *\"([^\"]+)\".*when:\ *\"([^\"]+)\" ]]; then
+            # Accept both quoted and unquoted `on:` values (`on: "digest"` and
+            # `on: digest`). The docs' own examples use the unquoted form, so the
+            # strict quoted-only regex silently dropped a trigger written that way.
+            if [ -n "$REACTIVE_SKILL" ] && [[ "$line" =~ on:\ *\"?([^\",\}\ ]+)\"?.*when:\ *\"([^\"]+)\" ]]; then
               ON="${BASH_REMATCH[1]}"
               WHEN="${BASH_REMATCH[2]}"
               REACTIVE_TRIGGERS["$REACTIVE_SKILL"]+="${ON}:${WHEN};"

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -25,7 +25,7 @@ Each step runs as a separate workflow dispatch; outputs are saved to `output/.ch
 
 ## Reactive triggers
 
-Skills with `schedule: "reactive"` fire on conditions, not cron. The scheduler evaluates triggers after processing cron skills:
+Skills with `schedule: "reactive"` fire on conditions, not cron. The scheduler evaluates triggers after processing cron skills, reading each source skill's state from `memory/cron-state.json`:
 
 ```yaml
 reactive:
@@ -33,6 +33,27 @@ reactive:
     trigger:
       - { on: "*", when: "consecutive_failures >= 3" }
 ```
+
+`on:` is a source skill name (or `*` for any skill); `when:` is one of three conditions, evaluated by `scripts/reactive_when.sh`:
+
+| Condition | Fires when |
+|-----------|-----------|
+| `consecutive_failures >= N` | the source skill has failed N+ times in a row |
+| `success_rate <op> X` | the source's success rate crosses `X` (a `0.0`-`1.0` float; `op` is `<` `<=` `>` `>=`); only after the source has run at least once |
+| `last_status = <value>` | the source's last run ended `<value>` (e.g. `success`), for chaining |
+
+**This is the per-skill failure edge.** Rather than waiting for the daily `heartbeat` audit to open a `health:` issue, a reactive trigger acts on the next scheduler tick after the source's state changes. A single-failure handler is one line:
+
+```yaml
+reactive:
+  notify-operator:                 # any skill you want to run on failure
+    trigger:
+      - { on: digest, when: "consecutive_failures >= 1" }
+```
+
+The handler is dispatched with **the source skill's name as its `var`** (so `skill-repair` knows *which* skill tripped it), unless the handler declares a `var` of its own, which wins. The `heartbeat` -> `health:` issue path still runs in parallel and remains the catch-all for skills that fail silently.
+
+**Loop safety.** A reactive dispatch is deduped per handler for 90 minutes, so a source that stays broken can't re-fire its handler every tick, and a handler that itself fails can't spin a tight loop. (Reactive runs on billed Actions minutes and a shared rate limit, so this bound matters -- there is no `pkill` off-switch here.)
 
 ## Scheduler frequency
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -53,6 +53,8 @@ reactive:
 
 The handler is dispatched with **the source skill's name as its `var`** (so `skill-repair` knows *which* skill tripped it), unless the handler declares a `var` of its own, which wins. The `heartbeat` -> `health:` issue path still runs in parallel and remains the catch-all for skills that fail silently.
 
+**The source skill must be enabled.** A trigger's `on:` source is evaluated only while that skill is `enabled: true` (a disabled skill never runs, so its state never changes). Point a trigger at a skill you have turned off and it silently never fires. `on:` may be written quoted or bare (`on: "digest"` or `on: digest`).
+
 **Loop safety.** A reactive dispatch is deduped per handler for 90 minutes, so a source that stays broken can't re-fire its handler every tick, and a handler that itself fails can't spin a tight loop. (Reactive runs on billed Actions minutes and a shared rate limit, so this bound matters -- there is no `pkill` off-switch here.)
 
 ## Scheduler frequency


### PR DESCRIPTION
Implements **item 3** of the chassis INTEGRATION.md plan (per-skill `on_failure` edges) -- reframed after reading the code.

> ⚠️ **Stacked on #906.** This branch includes #906's commit; review the second commit (`feat(scheduler): pass the tripping skill...`) for this PR's change. Rebase onto main after #906 merges.

## Why not a new `on_failure:` key

Aeon already has a per-skill failure edge: the `reactive:` mechanism dispatches a handler when a `when:` condition holds for a source skill (evaluated in `scheduler.yml`, present since #649). A single-failure handler is expressible **today**:

```yaml
reactive:
  notify-operator:
    trigger:
      - { on: digest, when: "consecutive_failures >= 1" }
```

Building a parallel `on_failure:` system would duplicate this. So this PR closes the one real gap instead and documents reactive as the blessed failure edge.

## The gap

A handler fired by `on: "*"` was never told **which** skill tripped it -- `skill-repair` had to re-derive the failed skill. Now the scheduler passes the matched source skill to the handler as its `var` (the plan's "handler receives var set to the failed skill's name"), unless the handler declares its own `var`, which wins.

## Also

`docs/CONFIGURATION.md` now documents reactive as the per-skill failure edge: the three conditions, the single-failure example, the source-as-var behaviour, and the **90-minute per-handler dedup** that bounds failure loops (the plan's "budget" -- already present; there is no `pkill` off-switch on Actions).

## Scope notes vs the plan's item 3

- **Same-run latency:** not built. Reactive fires on the next scheduler tick (≤5 min), not in the same run. The ≤5 min saving isn't worth a run-path change; the `heartbeat` -> `health:` issue path still backstops silent failures.
- **Depth-1 guard:** the 90-min dedup is the loop bound rather than a strict depth counter. Called out in the docs.
- **Backwards compatible:** a handler with an explicit var is unchanged; a repo with no reactive triggers is unaffected. Config validation of these refs ships in #907.

No `CLAUDE.md` / `AGENTS.md` change needed.
