### PR TITLE
feat(chains): verdict routing on Haiku scores (when: on chain steps)

### DIFF
--- a/.github/workflows/chain-runner.yml
+++ b/.github/workflows/chain-runner.yml
@@ -178,12 +178,20 @@ jobs:
           ON_ERROR=$(echo "$CHAIN_BLOCK" | grep -oP 'on_error:\s*\K[a-z-]+' || echo "fail-fast")
           echo "Error mode: $ON_ERROR"
 
+          # Total-dispatch budget for the whole chain. Chassis lets cycles run because
+          # the operator owns the box; Aeon runs on billed Actions minutes and a shared
+          # rate limit, so a chain that routes back on itself (via when:) gets a hard
+          # cap instead of a pkill. Default low; override per chain with max_dispatches:.
+          MAX_DISPATCHES=$(echo "$CHAIN_BLOCK" | grep -oP 'max_dispatches:\s*\K[0-9]+' || echo "10")
+          DISPATCH_COUNT=0
+          echo "Dispatch budget: $MAX_DISPATCHES"
+
           # Parse steps into an ordered array
           # Each step is either:
           #   - parallel: [a, b, c]
           #   - skill: name [, var: "val"] [, consume: [a, b]]
           STEP_INDEX=0
-          declare -A STEP_TYPE STEP_SKILLS STEP_VAR STEP_CONSUME
+          declare -A STEP_TYPE STEP_SKILLS STEP_VAR STEP_CONSUME STEP_WHEN
 
           while IFS= read -r line; do
             # Skip empty lines and non-step lines
@@ -204,6 +212,10 @@ jobs:
               # Extract optional consume
               if [[ "$line" =~ consume:\ *\[([^\]]+)\] ]]; then
                 STEP_CONSUME[$STEP_INDEX]=$(echo "${BASH_REMATCH[1]}" | tr -d ' ')
+              fi
+              # Extract optional when: conditional routing on the consumed skill's score
+              if [[ "$line" =~ when:\ *\"([^\"]+)\" ]]; then
+                STEP_WHEN[$STEP_INDEX]="${BASH_REMATCH[1]}"
               fi
               STEP_INDEX=$((STEP_INDEX + 1))
             fi
@@ -229,6 +241,40 @@ jobs:
               continue
             fi
 
+            # Conditional routing: a step with when: runs only if the condition holds
+            # for the scored source skill (the first consumed skill, else the previous
+            # step's first skill). The score comes from the Haiku scorer, committed to
+            # memory/skill-health/<skill>.json by the source's own run and pulled in
+            # after the prior step completed. A missing key does NOT fire (the step is
+            # skipped, not failed), which forces every routing path to either publish a
+            # score or fall through to an unconditional step. An invalid expression
+            # hard-fails the chain rather than silently mis-routing.
+            WHEN="${STEP_WHEN[$i]:-}"
+            if [ -n "$WHEN" ]; then
+              SRC=""
+              if [ -n "$CONSUME" ]; then
+                SRC="${CONSUME%%,*}"
+              elif [ "$i" -gt 0 ]; then
+                SRC=$(echo "${STEP_SKILLS[$((i-1))]}" | cut -d, -f1)
+              fi
+              VERDICT='{}'
+              if [ -n "$SRC" ] && [ -f "memory/skill-health/${SRC}.json" ]; then
+                SC=$(jq -r '.quality_score // empty' "memory/skill-health/${SRC}.json" 2>/dev/null || true)
+                [ -n "$SC" ] && VERDICT=$(jq -cn --argjson s "$SC" '{score:$s}')
+              fi
+              WRC=0
+              printf '%s' "$VERDICT" | bash scripts/chain_when.sh "$WHEN" || WRC=$?
+              if [ "$WRC" -eq 1 ]; then
+                echo "  Skip: when \"$WHEN\" not satisfied for '${SRC:-<none>}' (verdict=$VERDICT)"
+                continue
+              elif [ "$WRC" -eq 2 ]; then
+                echo "::error::Step $((i+1)) has an invalid when expression: \"$WHEN\""
+                CHAIN_FAILED=true
+                break
+              fi
+              echo "  when \"$WHEN\" satisfied (verdict=$VERDICT)"
+            fi
+
             # Build list of skills to dispatch
             IFS=',' read -ra SKILL_LIST <<< "$SKILLS"
             RUN_IDS=()
@@ -249,6 +295,15 @@ jobs:
                     sleep "$attempt"
                   done
                 fi
+              fi
+
+              # Dispatch budget: hard-fail before overspending Actions minutes on a
+              # chain that routes back on itself.
+              DISPATCH_COUNT=$((DISPATCH_COUNT + 1))
+              if [ "$DISPATCH_COUNT" -gt "$MAX_DISPATCHES" ]; then
+                echo "::error::Chain '$CHAIN' hit its dispatch budget ($MAX_DISPATCHES) at step $((i+1)), skill '$skill'. Steps so far: $DISPATCH_COUNT dispatches. Raise max_dispatches: if this is intentional."
+                CHAIN_FAILED=true
+                break 2
               fi
 
               RUN_ID=$(dispatch_skill "$skill" "$VAR" "$CTX_FILE")

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -89,6 +89,8 @@ jobs:
         run: bash scripts/tests/test_breaker.sh
       - name: reactive-trigger when-condition tests
         run: bash scripts/tests/test_reactive_when.sh
+      - name: chain when-routing tests
+        run: bash scripts/tests/test_chain_when.sh
       - name: skill-scan calibration (fires on sinks, not benign syntax)
         run: bash scripts/tests/test_skill_scan_calibration.sh
       - name: audit-log redaction tests

--- a/aeon.yml
+++ b/aeon.yml
@@ -179,14 +179,15 @@ reactive:
 #       on_error: fail-fast          # fail-fast (default) | continue
 #       max_dispatches: 10           # optional total-dispatch cap for the chain
 #       steps:
-#         - parallel: [skill-a, skill-b]
-#         - skill: skill-c, consume: [skill-a, skill-b]
+#         # Multi-key steps use flow-brace form so they stay valid YAML when uncommented.
+#         - { parallel: [skill-a, skill-b] }
+#         - { skill: skill-c, consume: [skill-a, skill-b] }
 #         # Conditional routing on the consumed skill's Haiku score (1-5). A step
 #         # with when: runs only if the condition holds; a missing score does NOT
 #         # fire, so always pair branches with an unconditional fall-through.
 #         # Operators: == != < > <= >= (ordering needs an integer on both sides).
-#         - skill: polish,  consume: [skill-c], when: "score > 3"
-#         - skill: rewrite, consume: [skill-c], when: "score <= 3"
+#         - { skill: polish,  consume: [skill-c], when: "score > 3" }
+#         - { skill: rewrite, consume: [skill-c], when: "score <= 3" }
 chains:
   # routine:
   #   schedule: "0 7 * * *"

--- a/aeon.yml
+++ b/aeon.yml
@@ -177,9 +177,16 @@ reactive:
 #     chain-name:
 #       schedule: "cron expression"
 #       on_error: fail-fast          # fail-fast (default) | continue
+#       max_dispatches: 10           # optional total-dispatch cap for the chain
 #       steps:
 #         - parallel: [skill-a, skill-b]
 #         - skill: skill-c, consume: [skill-a, skill-b]
+#         # Conditional routing on the consumed skill's Haiku score (1-5). A step
+#         # with when: runs only if the condition holds; a missing score does NOT
+#         # fire, so always pair branches with an unconditional fall-through.
+#         # Operators: == != < > <= >= (ordering needs an integer on both sides).
+#         - skill: polish,  consume: [skill-c], when: "score > 3"
+#         - skill: rewrite, consume: [skill-c], when: "score <= 3"
 chains:
   # routine:
   #   schedule: "0 7 * * *"

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -23,6 +23,30 @@ chains:
 
 Each step runs as a separate workflow dispatch; outputs are saved to `output/.chains/{skill}.md` and injected into downstream steps that `consume:` them. `fail-fast` aborts on any failure, `continue` keeps going.
 
+### Conditional routing (`when:`)
+
+A step can run only when a condition holds for the score of the skill it consumes. Aeon already scores every run 1-5 with Haiku (`memory/skill-health/<skill>.json`); `when:` turns that number into a branch:
+
+```yaml
+chains:
+  editorial:
+    schedule: "0 9 * * *"
+    max_dispatches: 10           # optional; hard-caps total dispatches (default 10)
+    steps:
+      - skill: draft
+      - skill: review, consume: [draft]
+      - skill: polish,  consume: [review], when: "score > 3"    # good draft -> polish
+      - skill: rewrite, consume: [review], when: "score <= 3"   # weak draft -> rewrite
+```
+
+- **Operators:** `== != < > <= >=`. Equality compares as strings; ordering (`< <= > >=`) requires an integer on both sides and fails loudly otherwise (no `"10" < "9"` surprises).
+- **The score** is the consumed skill's latest quality score (the first skill in `consume:`, or the previous step's skill if the step has no `consume:`).
+- **A `when:` whose key is missing does not fire** - the step is skipped, not failed. So every routing path must either produce a score or fall through to an unconditional step; a chain where every branch is skipped is a no-op, not an error.
+- **Invalid expressions are rejected at config time** by `validate-config.js` (in CI), not at 3am.
+- **`max_dispatches:`** caps the chain's total dispatches (default 10). A chain that trips it hard-fails with the step sequence - the budget replaces chassis's `pkill`, since Aeon runs on billed Actions minutes.
+
+The expression evaluator is `scripts/chain_when.sh` (unit-tested in `scripts/tests/test_chain_when.sh`).
+
 ## Reactive triggers
 
 Skills with `schedule: "reactive"` fire on conditions, not cron. The scheduler evaluates triggers after processing cron skills:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -23,6 +23,8 @@ chains:
 
 Each step runs as a separate workflow dispatch; outputs are saved to `output/.chains/{skill}.md` and injected into downstream steps that `consume:` them. `fail-fast` aborts on any failure, `continue` keeps going.
 
+> **Note:** a real (uncommented) chain step with multiple keys must use flow-brace form -- `- { skill: review, consume: [draft], when: "score > 3" }` -- not the bare `- skill: review, consume: [...]` shown in the commented examples. The bare form is convenient in a comment but is not valid YAML once uncommented (the second `:` trips the parser). The chain runner reads either form.
+
 ### Conditional routing (`when:`)
 
 A step can run only when a condition holds for the score of the skill it consumes. Aeon already scores every run 1-5 with Haiku (`memory/skill-health/<skill>.json`); `when:` turns that number into a branch:

--- a/scripts/chain_when.sh
+++ b/scripts/chain_when.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# chain_when.sh — evaluate ONE chain-step `when:` clause against a verdict JSON
+# read on stdin. The verdict object carries the keys a step can route on; today
+# that is {"score": N} sourced from the consumed skill's memory/skill-health entry.
+#
+#   echo '{"score":7}' | scripts/chain_when.sh "score > 5"
+#
+# Exit codes:
+#   0  condition holds            (run the step)
+#   1  condition does not hold     -> skip the step; INCLUDES a missing key, so a
+#                                    `when:` on a key nothing published never fires
+#   2  the expression is invalid   (unparseable, or an ordering op on a non-integer)
+#
+# Grammar: <key> <op> <value>  — exactly one key, one operator, one value.
+#   ==  !=   compare as strings.
+#   <  <=  >  >=   require BOTH sides to be integers; anything else exits 2 (fails
+#                  loudly) rather than string-comparing "10" < "9" to true.
+# Compound expressions and boolean operators are intentionally unsupported.
+set -euo pipefail
+
+WHEN="${1:?when expression required}"
+JSON="$(cat)"
+[ -z "$JSON" ] && JSON='{}'
+
+# <  and  >  live in a quoted regex variable, not inline in [[ =~ ]], because a bare
+# < or > there is parsed as a redirection and a backslash-escaped one is a GNU
+# word-boundary anchor.
+re='^[[:space:]]*([a-zA-Z_][a-zA-Z0-9_]*)[[:space:]]*(==|!=|<=|>=|<|>)[[:space:]]*(.+)$'
+if ! [[ "$WHEN" =~ $re ]]; then
+  printf 'chain_when: unparseable expression: %s\n' "$WHEN" >&2
+  exit 2
+fi
+KEY="${BASH_REMATCH[1]}"
+OP="${BASH_REMATCH[2]}"
+VAL="${BASH_REMATCH[3]}"
+VAL="${VAL%"${VAL##*[![:space:]]}"}"   # rstrip trailing whitespace
+
+# Missing key -> does not fire (exit 1). has() tests presence regardless of the
+# value, so a real 0 / false is distinguished from an absent key.
+ACTUAL="$(printf '%s' "$JSON" | jq -r --arg k "$KEY" 'if has($k) then (.[$k]|tostring) else "__MISSING__" end')"
+[ "$ACTUAL" = "__MISSING__" ] && exit 1
+
+case "$OP" in
+  '==') [ "$ACTUAL" = "$VAL" ] ;;
+  '!=') [ "$ACTUAL" != "$VAL" ] ;;
+  '<'|'<='|'>'|'>=')
+    if ! [[ "$ACTUAL" =~ ^-?[0-9]+$ ]]; then
+      printf 'chain_when: %s=%s is not an integer; ordering needs integers\n' "$KEY" "$ACTUAL" >&2
+      exit 2
+    fi
+    if ! [[ "$VAL" =~ ^-?[0-9]+$ ]]; then
+      printf 'chain_when: value %s is not an integer; ordering needs integers\n' "$VAL" >&2
+      exit 2
+    fi
+    case "$OP" in
+      '<')  [ "$ACTUAL" -lt "$VAL" ] ;;
+      '<=') [ "$ACTUAL" -le "$VAL" ] ;;
+      '>')  [ "$ACTUAL" -gt "$VAL" ] ;;
+      '>=') [ "$ACTUAL" -ge "$VAL" ] ;;
+    esac
+    ;;
+esac

--- a/scripts/tests/test_chain_when.sh
+++ b/scripts/tests/test_chain_when.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Tests for scripts/chain_when.sh — chain-step `when:` routing evaluation.
+# Run:  bash scripts/tests/test_chain_when.sh
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/chain_when.sh"
+
+pass=0; fail=0
+# check <desc> <verdict-json> <when> <expect-exit>
+check() {
+  local desc="$1" json="$2" when="$3" expect="$4" rc
+  printf '%s' "$json" | bash "$SCRIPT" "$when" >/dev/null 2>&1; rc=$?
+  if [ "$rc" = "$expect" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1)); printf 'FAIL: %-40s got=%s want=%s\n' "$desc" "$rc" "$expect"
+  fi
+}
+
+# --- ordering on score (the plan's core case) ---
+check "score>5 fires at 7"      '{"score":7}' "score > 5"  0
+check "score>5 no fire at 5"    '{"score":5}' "score > 5"  1
+check "score<=5 fires at 5"     '{"score":5}' "score <= 5" 0
+check "score<=5 no fire at 6"   '{"score":6}' "score <= 5" 1
+check "score>=5 fires at 5"     '{"score":5}' "score >= 5" 0
+check "score<5 fires at 4"      '{"score":4}' "score < 5"  0
+check "10 vs 9 is numeric"      '{"score":10}' "score > 9" 0
+
+# --- equality compares as strings ---
+check "verdict == pass"         '{"verdict":"pass"}' "verdict == pass" 0
+check "verdict == fail no fire" '{"verdict":"pass"}' "verdict == fail" 1
+check "verdict != fail fires"   '{"verdict":"pass"}' "verdict != fail" 0
+
+# --- missing key does not fire (exit 1, NOT an error) ---
+check "missing score no fire"   '{}'          "score > 5"  1
+check "other key present"       '{"grade":9}' "score > 5"  1
+
+# --- fails loudly (exit 2) rather than string-comparing ---
+check "ordering on non-int"     '{"score":"good"}' "score > 5"   2
+check "ordering vs non-int val" '{"score":7}'      "score > abc" 2
+check "garbage expression"      '{"score":7}'      "score is big" 2
+check "empty expression body"   '{"score":7}'      "score" 2
+
+# --- real 0 is a value, not missing ---
+check "score 0 vs >0 no fire"   '{"score":0}' "score > 0"  1
+check "score 0 == 0 fires"      '{"score":0}' "score == 0" 0
+
+printf '\nchain_when: %d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/scripts/validate-config.js
+++ b/scripts/validate-config.js
@@ -24,6 +24,10 @@
 //      reactive: block resolves to a real skill, and every `when:` parses to a
 //      condition scripts/reactive_when.sh can evaluate (same dangling-reference /
 //      dead-config class as 3, for the event-driven dispatch path).
+//   5. Chain `when:` expression syntax - a chain step's routing condition
+//      (`when: "score > 5"`) must be a well-formed <key> <op> <value> expression,
+//      with ordering ops requiring an integer value, so an invalid expression is
+//      caught at config time rather than when the chain runs.
 //
 // Output contract:
 //   - Exit 0 + only PASS lines  => CLEAN
@@ -318,6 +322,32 @@ function checkReactiveRefs(lines) {
   } else {
     pass('PASS reactive: ' + targets.length + ' target(s), ' + sources.length + ' source ref(s), ' + conditions.length + ' condition(s) all valid');
   }
+// Check 5 - chain `when:` expression syntax. A chain step can route on a score
+// (`when: "score > 5"`, evaluated at runtime by scripts/chain_when.sh). Catch a
+// malformed expression here, at config time, instead of when the chain runs at
+// 3am. Grammar: <key> <op> <value>; ordering ops (< <= > >=) require an integer
+// value so the runtime never string-compares "10" < "9".
+// ---------------------------------------------------------------------------
+function validateChainWhen(expr) {
+  const m = String(expr).trim().match(/^([a-zA-Z_][a-zA-Z0-9_]*)\s*(==|!=|<=|>=|<|>)\s*(.+?)\s*$/);
+  if (!m) return false;
+  const op = m[2];
+  const val = m[3].trim();
+  if (['<', '<=', '>', '>='].includes(op)) return /^-?\d+$/.test(val);
+  return val.length > 0;
+}
+
+function checkChainWhen(lines) {
+  const problems = [];
+  for (const [i, raw] of blockLines(lines, 'chains')) {
+    if (/^\s*#/.test(raw)) continue;
+    const m = raw.match(/when:\s*"([^"]+)"/);
+    if (m && !validateChainWhen(m[1])) {
+      problems.push('FAIL: aeon.yml chain when: "' + m[1] + '" (line ' + (i + 1) + ') is not a valid <key> <op> <value> expression (ordering ops < <= > >= require an integer value)');
+    }
+  }
+  if (problems.length > 0) problems.forEach(fail);
+  else pass('PASS chain-when: all chain when: expressions are well-formed');
 }
 
 function main() {
@@ -330,6 +360,7 @@ function main() {
     checkDuplicateKeys(lines);
     checkSkillRefs(lines);
     checkReactiveRefs(lines);
+    checkChainWhen(lines);
   }
 
   out.forEach((l) => console.log(l));
@@ -344,4 +375,4 @@ function main() {
 
 if (require.main === module) main();
 
-module.exports = { analyzeCheckout, parseSteps, collectReactiveRefs, validateWhen };
+module.exports = { analyzeCheckout, parseSteps, collectReactiveRefs, validateWhen, validateChainWhen };

--- a/scripts/validate-config.js
+++ b/scripts/validate-config.js
@@ -322,6 +322,9 @@ function checkReactiveRefs(lines) {
   } else {
     pass('PASS reactive: ' + targets.length + ' target(s), ' + sources.length + ' source ref(s), ' + conditions.length + ' condition(s) all valid');
   }
+}
+
+// ---------------------------------------------------------------------------
 // Check 5 - chain `when:` expression syntax. A chain step can route on a score
 // (`when: "score > 5"`, evaluated at runtime by scripts/chain_when.sh). Catch a
 // malformed expression here, at config time, instead of when the chain runs at

--- a/scripts/validate-config.test.js
+++ b/scripts/validate-config.test.js
@@ -13,7 +13,7 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
-const { analyzeCheckout, collectReactiveRefs, validateWhen } = require('./validate-config.js');
+const { analyzeCheckout, collectReactiveRefs, validateWhen, validateChainWhen } = require('./validate-config.js');
 
 // Wrap an indented steps body in a minimal single-job workflow.
 const wf = (steps) => `name: run
@@ -158,4 +158,20 @@ test('the live aeon.yml has no uncommented reactive references', () => {
   const lines = fs.readFileSync(ymlPath, 'utf8').split('\n');
   const r = collectReactiveRefs(lines);
   assert.equal(r.targets.length, 0, 'unexpected uncommented reactive target(s)');
+// --- Check 5: chain when: expression syntax ---
+
+test('validateChainWhen: accepts score ordering and string equality', () => {
+  assert.equal(validateChainWhen('score > 5'), true);
+  assert.equal(validateChainWhen('score <= 5'), true);
+  assert.equal(validateChainWhen('score >= 10'), true);
+  assert.equal(validateChainWhen('verdict == pass'), true);
+  assert.equal(validateChainWhen('verdict != fail'), true);
+});
+
+test('validateChainWhen: rejects malformed and non-integer ordering', () => {
+  assert.equal(validateChainWhen('score > abc'), false); // ordering needs integer
+  assert.equal(validateChainWhen('score is big'), false); // no valid operator
+  assert.equal(validateChainWhen('score >'), false);      // no value
+  assert.equal(validateChainWhen('> 5'), false);          // no key
+  assert.equal(validateChainWhen(''), false);
 });

--- a/scripts/validate-config.test.js
+++ b/scripts/validate-config.test.js
@@ -158,6 +158,8 @@ test('the live aeon.yml has no uncommented reactive references', () => {
   const lines = fs.readFileSync(ymlPath, 'utf8').split('\n');
   const r = collectReactiveRefs(lines);
   assert.equal(r.targets.length, 0, 'unexpected uncommented reactive target(s)');
+});
+
 // --- Check 5: chain when: expression syntax ---
 
 test('validateChainWhen: accepts score ordering and string equality', () => {


### PR DESCRIPTION
Implements **item 2** of the chassis INTEGRATION.md plan: verdict routing on Haiku scores.

## What

Aeon already scores every run 1-5 with Haiku (`memory/skill-health/<skill>.json`). Today that number is a chart someone looks at. This turns it into a control-flow edge -- a chain step runs only when a condition holds for the score of the skill it consumes:

```yaml
chains:
  editorial:
    schedule: "0 9 * * *"
    steps:
      - skill: review, consume: [draft]
      - skill: polish,  consume: [review], when: "score > 3"     # good -> polish
      - skill: rewrite, consume: [review], when: "score <= 3"    # weak -> rewrite
```

## Scorer timing (the plan's open question, answered)

**No scorer move needed.** The scorer runs as a *post-run step inside each skill's own `aeon.yml` run* (not end-of-chain) and commits `skill-health` before that run completes. `chain-runner.yml` already `git pull`s after each step (to fetch `output/.chains/`), so the consumed skill's score is on disk before the next step dispatches. Routing reads `.quality_score` directly.

## Rules (all enforced + tested)

- Operators `== != < > <= >=`. Equality compares as strings; ordering requires integers on **both** sides and **fails loudly** (no `"10" < "9"`).
- **A `when:` whose key is missing does not fire** -> the step is *skipped, not failed*. Forces every routing path to publish a score or fall through to an unconditional step.
- **`when: "score > abc"` is rejected at config time** by `validate-config.js` in CI, not at 3am.
- **Per-chain dispatch budget** (`max_dispatches:`, default 10). A chain that routes back on itself hard-fails with the step sequence -- the plan's billed-minutes replacement for chassis's `pkill`.

## Done-when checklist

- ✅ routes to different steps on a real Haiku score
- ✅ a `when:` on an unset key skips and logs the reason
- ✅ `when: "score > abc"` rejected at validation time (`validate-config.test.js`)
- ✅ a loop halts at the budget with a legible error
- ✅ chains with no `when:` behave identically to today

## Tests

```
bash scripts/tests/test_chain_when.sh   # 18 pass (incl. missing-key, non-int, invalid)
node --test scripts/validate-config.test.js
node scripts/validate-config.js         # CLEAN (+ new PASS chain-when line)
```

Independent of the other INTEGRATION.md PRs (touches `chain-runner.yml`, not the scheduler). `validate-config.js` also changes in #907; they add different checks and will need a trivial merge in `main()`/exports. No `CLAUDE.md` / `AGENTS.md` change needed. **Out of scope** (per the plan): compound/boolean expressions -- one key, one operator, one value.
