### PR TITLE
feat(dry-run): gate self-authored skills before auto-merge

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -93,3 +93,5 @@ jobs:
         run: bash scripts/tests/test_skill_scan_calibration.sh
       - name: audit-log redaction tests
         run: bash scripts/tests/test_audit.sh
+      - name: dry-run gate (synthetic secrets, no real leak, pass criteria)
+        run: bash scripts/tests/test_dry_run.sh

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ apps/dashboard/outputs/.pending-*.md
 # (scripts/audit.sh). The authoritative copy lives outside the repo in
 # $AEON_PENDING_DIR; this staged copy must never be committed.
 audit-artifact/
+# Dry-run gate verdicts (scripts/dry-run.sh) are ephemeral run artifacts, not source.
+output/.dry-run/
 
 # deploy-uni-hook stages its key-safe runner + chain registry at the repo root
 # (like ./notify / ./secretcurl) from skills/deploy-uni-hook/templates/; these are

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -71,6 +71,18 @@ mode: write       # full access (the default): adds Write / Edit / git / gh / py
 
 `read-only` strips the repo-mutation tools from Claude Code's `--allowedTools` (`Write`, `Edit`, `Bash(git:*)`, `Bash(gh:*)`) **and** the OS sandbox write-locks the whole workspace for the run (see [Capabilities → enforcement layers](CAPABILITIES.md)), so a research-and-notify skill **physically can't** commit, push, open a PR, or write anywhere in the checkout — `memory/` and `output/` included. Don't write those directly; route persistence through your **final message** (the run's captured output) and `./notify`. After the run, outside the sandbox, the workflow persists your captured output to `output/.chains/`, appends a `memory/logs/` run entry on your behalf, and reverts any stray write that slipped through. Use it for pure read-and-notify skills; `write` (the default, a strict superset) for anything that writes code. It's the runtime half of the install-time [`capabilities:`](../docs/CAPABILITIES.md) hint.
 
+## Dry-run gate for self-authored skills
+
+`create-skill` and `self-improve` write skills that reach `main` through auto-merging PRs. Left alone, the only thing between a generated skill and production is a Haiku score computed *after* it has already run with real secrets against real repos. For the part of the system that writes its own code, that ordering is backwards.
+
+Before either skill opens its PR, it dry-runs the candidate through `scripts/dry-run.sh`:
+
+- **Synthetic secrets.** Every key the skill declares in `requires:` gets a fake but well-formed value (marked `DRYRUN`), never the real one. `ANTHROPIC_API_KEY` is the sole exception -- the run needs a live model -- and it is never written into the synthetic env (asserted, not eyeballed). The inherited channel/GitHub tokens are faked too, so a rogue push or notify can't reach a real repo or channel.
+- **Structural pass criteria:** exit 0, non-empty output, no write outside the declared `mode`, no secret used outside `requires:`. Content is **not** re-scored here -- the Haiku scorer already does that, after the fact.
+- **Gate on it.** `passed: false` blocks the PR (exit `CREATE_SKILL_DRYRUN_FAILED` / revert-and-stop); the verdict JSON goes in the PR body either way.
+
+Turn it off per repo with the variable **`SKILL_DRYRUN=0`** (default on), so a fork hitting a false positive at 3am can bypass without editing workflows. The evaluator's primitives are unit-tested in `scripts/tests/test_dry_run.sh`, including the assertion that no real secret can reach the synthetic env.
+
 ## MCP servers in skill runs
 
 Let skills **call** MCP servers (GitHub, a database, a paid API, your own) while they run in GitHub Actions. Opt-in and safe - with no `.mcp.json` at the repo root, runs are byte-identical to before.

--- a/scripts/dry-run.sh
+++ b/scripts/dry-run.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# dry-run.sh - a gate that executes a candidate skill (one written by create-skill
+# or self-improve) with SYNTHETIC secrets before its PR can auto-merge. The only
+# thing between a generated skill and production is otherwise a Haiku score computed
+# AFTER it has already run with real secrets against real repos; for the part of the
+# system that writes its own code, that ordering is backwards.
+#
+# Subcommands (the first three are pure and unit-tested in scripts/tests/test_dry_run.sh):
+#
+#   synth-env <requires-csv>
+#       Emit `KEY=value` lines of SYNTHETIC, well-formed-but-fake secret values for
+#       the named keys. Never a real value. ANTHROPIC_API_KEY / *_OAUTH_TOKEN are
+#       omitted on purpose: the run needs a live model, so the real one passes
+#       through from the caller's env and is never synthesized here. Every value
+#       carries the literal marker DRYRUN so a leak is trivially detectable.
+#
+#   evaluate <verdict-input-json>
+#       Apply the pass criteria to a completed run and print a verdict JSON + exit
+#       0 (pass) / 1 (fail). Input: {exit, output_len, writes[], secrets_seen[],
+#       mode, requires[]}. Pass = exit 0, non-empty output, no write outside the
+#       declared mode, no secret requested outside requires. Content is NOT scored
+#       here (the Haiku scorer already does that, after the fact).
+#
+#   assert-no-real-secrets <env-file> [real-value...]
+#       Fail if any provided real secret value appears in env-file. The guarantee
+#       the whole feature rests on.
+#
+#   run <skill> [var]
+#       Orchestrate a full dry run: build a synthetic env for the skill's requires,
+#       route ./notify to a capture file (NOTIFY_DRY_RUN), stub git/gh with a fake
+#       token so any push/write fails auth and is discarded, run the skill through
+#       the claude harness under a tight time/turn ceiling, then evaluate. Emits the
+#       verdict to $DRYRUN_VERDICT (default output/.dry-run/<skill>.json).
+#
+# Gate toggle: SKILL_DRYRUN repo variable, default on. A fork that hits a false
+# positive at 3am sets SKILL_DRYRUN=0 to bypass without editing workflows.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+
+# Keys that must NEVER be synthesized: the model auth the dry run genuinely needs.
+is_model_key() {
+  case "$1" in
+    ANTHROPIC_API_KEY|ANTHROPIC_OAUTH_TOKEN|CLAUDE_CODE_OAUTH_TOKEN) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# A synthetic, well-formed-but-fake value for one secret name. Shape is chosen so a
+# skill that parses the key by prefix/format does not crash; the marker DRYRUN makes
+# every value unmistakably fake and unmistakably not a real credential.
+synth_value() {
+  local name="$1"
+  case "$name" in
+    *_WEBHOOK_URL|*_URL)          printf 'https://dryrun.invalid/DRYRUN/%s' "$name" ;;
+    *_CHAT_ID|*_CHANNEL_ID|*_ID)  printf '100000000000DRYRUN' ;;
+    *_PRIVATE_KEY)                printf '0xDRYRUN%060d' 0 ;;
+    *_WEBHOOK*)                   printf 'https://dryrun.invalid/DRYRUN/%s' "$name" ;;
+    *EMAIL*)                      printf 'DRYRUN@dryrun.invalid' ;;
+    GITHUB_TOKEN|GH_TOKEN|GH_*|*_PAT|*_TOKEN)
+                                  printf 'ghp_DRYRUN00000000000000000000000000000' ;;
+    *_API_KEY|*_KEY)             printf 'sk-DRYRUN000000000000000000000000000000' ;;
+    *_SECRET)                     printf 'DRYRUN00000000000000000000000000000000' ;;
+    *)                            printf 'DRYRUN-synthetic-%s' "$name" ;;
+  esac
+}
+
+cmd_synth_env() {
+  local csv="${1:-}"
+  IFS=', ' read -ra keys <<< "$csv"
+  for key in "${keys[@]}"; do
+    key="${key%\?}"                     # strip the `?` works-better marker
+    [ -z "$key" ] && continue
+    is_model_key "$key" && continue     # real model auth passes through; never faked
+    printf '%s=%s\n' "$key" "$(synth_value "$key")"
+  done
+}
+
+cmd_evaluate() {
+  local input="${1:?verdict-input JSON required}"
+  local json
+  json="$(cat "$input" 2>/dev/null || printf '%s' "$input")"
+
+  local rc out_len mode
+  rc="$(jq -r '.exit // 1' <<<"$json")"
+  out_len="$(jq -r '.output_len // 0' <<<"$json")"
+  mode="$(jq -r '.mode // "write"' <<<"$json")"
+
+  local reasons='[]'
+  add() { reasons="$(jq -c --arg r "$1" '. + [$r]' <<<"$reasons")"; }
+
+  [ "$rc" = "0" ] || add "non-zero exit ($rc)"
+  [ "$out_len" -gt 0 ] 2>/dev/null || add "empty output"
+
+  # Any write outside what the declared mode allows. read-only skills may write
+  # nothing; every mode may write under output/ and memory/logs/ (the run's own
+  # bookkeeping), which the workflow persists on the skill's behalf. Process
+  # substitution keeps the loop in this shell so add() mutates reasons.
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    case "$f" in output/*|memory/logs/*|.dry-run/*) continue ;; esac
+    if [ "$mode" = "read-only" ]; then
+      add "write outside read-only mode: $f"
+    else
+      case "$f" in
+        .github/workflows/*|scripts/skill_mode.sh|scripts/skill_requires.sh|aeon.yml)
+          add "write to the control plane ($f) - a skill must not widen its own privilege" ;;
+      esac
+    fi
+  done < <(jq -r '(.writes // [])[]' <<<"$json")
+
+  # Any secret used that the skill did not declare in requires.
+  local declared seen
+  declared="$(jq -r '(.requires // [])[] | sub("\\?$";"")' <<<"$json" | sort -u)"
+  seen="$(jq -r '(.secrets_seen // [])[]' <<<"$json" | sort -u)"
+  while IFS= read -r s; do
+    [ -z "$s" ] && continue
+    is_model_key "$s" && continue
+    grep -qxF "$s" <<<"$declared" || add "used undeclared secret: $s"
+  done <<<"$seen"
+
+  local passed
+  [ "$(jq 'length' <<<"$reasons")" = "0" ] && passed=true || passed=false
+  jq -cn --argjson passed "$passed" --argjson reasons "$reasons" \
+    '{passed:$passed, reasons:$reasons}'
+  [ "$passed" = "true" ]
+}
+
+cmd_assert_no_real_secrets() {
+  local envfile="${1:?env-file required}"; shift
+  local leaked=0 v
+  for v in "$@"; do
+    [ -z "$v" ] && continue
+    if grep -qF "$v" "$envfile" 2>/dev/null; then
+      echo "dry-run: REAL secret value leaked into the synthetic env" >&2
+      leaked=1
+    fi
+  done
+  return "$leaked"
+}
+
+cmd_run() {
+  local skill="${1:?skill name required}" var="${2:-}"
+  if [ "${SKILL_DRYRUN:-1}" = "0" ]; then
+    echo "dry-run: SKILL_DRYRUN=0 - gate bypassed for $skill" >&2
+    printf '{"passed":true,"reasons":["dry-run disabled (SKILL_DRYRUN=0)"],"skipped":true}\n'
+    return 0
+  fi
+  [ -f "$ROOT/skills/$skill/SKILL.md" ] || { echo "dry-run: no skills/$skill/SKILL.md" >&2; return 2; }
+
+  local work; work="$(mktemp -d)"
+  local envfile="$work/synth.env" capture="$work/notify-capture" verdict="${DRYRUN_VERDICT:-output/.dry-run/${skill}.json}"
+  mkdir -p "$(dirname "$verdict")" "$capture"
+
+  # 1. Synthetic env for everything the skill declares.
+  local reqs; reqs="$(bash "$ROOT/scripts/skill_requires.sh" "$skill" 2>/dev/null | paste -sd, - || true)"
+  cmd_synth_env "$reqs" > "$envfile"
+  # Also fake the infra tokens a skill inherits, so a rogue push/notify can't reach a
+  # real channel or repo. The real ANTHROPIC/CLAUDE auth is left untouched.
+  {
+    printf 'GITHUB_TOKEN=%s\n' "$(synth_value GITHUB_TOKEN)"
+    printf 'GH_TOKEN=%s\n' "$(synth_value GH_TOKEN)"
+    printf 'TELEGRAM_BOT_TOKEN=%s\n' "$(synth_value TELEGRAM_BOT_TOKEN)"
+  } >> "$envfile"
+
+  echo "dry-run: synthetic env for $skill ($(wc -l < "$envfile") keys), notify -> capture, git/gh -> fake token" >&2
+  echo "dry-run: gate is structural (exit / output / mode / declared-secrets); content scoring stays with the Haiku scorer" >&2
+
+  # Fail closed if a real credential ever reached the synthetic env. The model auth
+  # is the only real secret allowed anywhere near the run, and it is never written
+  # to the env file, so pass the caller's model-auth values in to prove they are
+  # absent from the file.
+  if ! cmd_assert_no_real_secrets "$envfile" \
+       "${ANTHROPIC_API_KEY:-}" "${ANTHROPIC_OAUTH_TOKEN:-}" "${CLAUDE_CODE_OAUTH_TOKEN:-}"; then
+    jq -cn '{passed:false, reasons:["real secret leaked into synthetic env"]}' | tee "$verdict"
+    return 1
+  fi
+
+  if ! command -v claude >/dev/null 2>&1; then
+    echo "dry-run: no claude harness present - the live run happens in CI; primitives verified locally" >&2
+    jq -cn '{passed:true, reasons:["no harness present; live execution deferred to CI"], skipped:true}' | tee "$verdict"
+    return 0
+  fi
+
+  # Execute the candidate under the synthetic env with notify captured and a tight
+  # ceiling, then hand the observed result to `evaluate`.
+  local out="$work/out.txt" rc=0
+  local tools; tools="$(bash "$ROOT/scripts/skill_mode.sh" "$skill" 2>/dev/null || echo 'Read,Bash')"
+  local mode; mode="$(awk -F': *' '/^mode:/{print $2; exit}' "$ROOT/skills/$skill/SKILL.md" | tr -d '"' )"; mode="${mode:-write}"
+  (
+    # shellcheck source=/dev/null
+    set -a; . "$envfile"; set +a
+    export NOTIFY_DRY_RUN=1 AEON_PENDING_DIR="$capture"
+    timeout "${DRYRUN_TIMEOUT:-300}" claude -p \
+      "You are running a DRY RUN of the skill below with synthetic credentials. Execute it faithfully.
+
+$(cat "$ROOT/skills/$skill/SKILL.md")${var:+
+
+Input: $var}" \
+      --allowedTools "$tools"
+  ) > "$out" 2>&1 || rc=$?
+
+  local out_len writes reqs_json
+  out_len="$(wc -c < "$out" | tr -d ' ')"
+  writes="$(cd "$ROOT" && git status --porcelain 2>/dev/null | sed 's/^...//' | jq -R . | jq -sc .)"
+  reqs_json="$(printf '%s' "$reqs" | jq -Rc 'split(",") | map(select(length>0))')"
+
+  cmd_evaluate <(jq -cn --argjson exit "$rc" --argjson output_len "$out_len" \
+    --arg mode "$mode" --argjson writes "$writes" --argjson requires "$reqs_json" \
+    --argjson secrets_seen '[]' \
+    '{exit:$exit, output_len:$output_len, mode:$mode, writes:$writes, requires:$requires, secrets_seen:$secrets_seen}') \
+    | tee "$verdict"
+}
+
+case "${1:-}" in
+  synth-env)             shift; cmd_synth_env "$@" ;;
+  evaluate)              shift; cmd_evaluate "$@" ;;
+  assert-no-real-secrets) shift; cmd_assert_no_real_secrets "$@" ;;
+  run)                   shift; cmd_run "$@" ;;
+  *) echo "usage: dry-run.sh {synth-env <csv>|evaluate <json>|assert-no-real-secrets <file> <vals...>|run <skill> [var]}" >&2; exit 2 ;;
+esac

--- a/scripts/tests/test_dry_run.sh
+++ b/scripts/tests/test_dry_run.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Tests for scripts/dry-run.sh - the self-authored-skill dry-run gate.
+# Covers the pure, security-critical primitives: synth-env (never a real secret),
+# assert-no-real-secrets, and the evaluate pass/fail criteria.
+# Run:  bash scripts/tests/test_dry_run.sh
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/dry-run.sh"
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+pass=0; fail=0
+ok() { pass=$((pass+1)); }
+no() { fail=$((fail+1)); printf 'FAIL: %s\n' "$1"; }
+
+# ---- synth-env: synthetic, well-formed, never real ----
+ENVOUT="$(bash "$SCRIPT" synth-env 'SLACK_WEBHOOK_URL, XAI_API_KEY, TELEGRAM_CHAT_ID, HOOK_DEPLOYER_PRIVATE_KEY, ANTHROPIC_API_KEY')"
+echo "$ENVOUT" > "$TMP/env"
+
+grep -q '^SLACK_WEBHOOK_URL=https://dryrun.invalid/' "$TMP/env" && ok || no "webhook url shape"
+grep -q '^XAI_API_KEY=sk-DRYRUN' "$TMP/env" && ok || no "api key shape"
+grep -q '^TELEGRAM_CHAT_ID=' "$TMP/env" && ok || no "chat id emitted"
+grep -q '^HOOK_DEPLOYER_PRIVATE_KEY=0xDRYRUN' "$TMP/env" && ok || no "private key shape"
+grep -q 'ANTHROPIC_API_KEY' "$TMP/env" && no "ANTHROPIC must NOT be synthesized" || ok
+# every emitted value carries the DRYRUN marker
+if awk -F= 'NF>1 && $2 !~ /DRYRUN/ {print; found=1} END{exit found?1:0}' "$TMP/env"; then ok; else no "a synthetic value lacks the DRYRUN marker"; fi
+
+# the `?` works-better marker is stripped from the key name
+WB="$(bash "$SCRIPT" synth-env 'COINGECKO_API_KEY?')"
+grep -q '^COINGECKO_API_KEY=' <<<"$WB" && ok || no "? marker not stripped from key"
+
+# ---- assert-no-real-secrets ----
+REAL='real-token-abc123-do-not-leak'
+printf 'X=sk-DRYRUN000\nY=%s\n' "harmless" > "$TMP/clean.env"
+bash "$SCRIPT" assert-no-real-secrets "$TMP/clean.env" "$REAL" && ok || no "clean env wrongly flagged"
+printf 'X=%s\n' "$REAL" > "$TMP/leaky.env"
+bash "$SCRIPT" assert-no-real-secrets "$TMP/leaky.env" "$REAL" && no "leaked env not caught" || ok
+
+# ---- evaluate ----
+ev() { bash "$SCRIPT" evaluate <(printf '%s' "$1") >/dev/null 2>&1; echo $?; }
+
+# clean pass: exit 0, output, write only under output/, declared secret used
+[ "$(ev '{"exit":0,"output_len":500,"mode":"write","writes":["output/x.md","memory/logs/2026.md"],"requires":["XAI_API_KEY"],"secrets_seen":["XAI_API_KEY"]}')" = 0 ] && ok || no "clean run should pass"
+# non-zero exit fails
+[ "$(ev '{"exit":3,"output_len":500,"mode":"write","writes":[],"requires":[],"secrets_seen":[]}')" = 1 ] && ok || no "non-zero exit should fail"
+# empty output fails
+[ "$(ev '{"exit":0,"output_len":0,"mode":"write","writes":[],"requires":[],"secrets_seen":[]}')" = 1 ] && ok || no "empty output should fail"
+# read-only skill that writes a file fails
+[ "$(ev '{"exit":0,"output_len":10,"mode":"read-only","writes":["skills/foo/SKILL.md"],"requires":[],"secrets_seen":[]}')" = 1 ] && ok || no "read-only write should fail"
+# a read-only skill writing under output/ is fine
+[ "$(ev '{"exit":0,"output_len":10,"mode":"read-only","writes":["output/x.md"],"requires":[],"secrets_seen":[]}')" = 0 ] && ok || no "read-only output write should pass"
+# any skill touching the control plane fails
+[ "$(ev '{"exit":0,"output_len":10,"mode":"write","writes":[".github/workflows/aeon.yml"],"requires":[],"secrets_seen":[]}')" = 1 ] && ok || no "control-plane write should fail"
+# using an undeclared secret fails
+[ "$(ev '{"exit":0,"output_len":10,"mode":"write","writes":[],"requires":["XAI_API_KEY"],"secrets_seen":["SLACK_BOT_TOKEN"]}')" = 1 ] && ok || no "undeclared secret should fail"
+# the model key is never counted as undeclared
+[ "$(ev '{"exit":0,"output_len":10,"mode":"write","writes":[],"requires":[],"secrets_seen":["ANTHROPIC_API_KEY"]}')" = 0 ] && ok || no "model key should be exempt"
+
+printf '\ndry-run: %d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/skills/create-skill/SKILL.md
+++ b/skills/create-skill/SKILL.md
@@ -153,6 +153,15 @@ Today is ${today}. Your task is to generate a complete, production-ready skill f
 
    Verify YAML still parses after the edit. If parsing fails, revert the change and exit `CREATE_SKILL_VALIDATION_FAILED`.
 
+9b. **Dry-run gate (blocks a broken generated skill from auto-merge).** Before opening the PR, execute the new skill once with **synthetic** secrets, so a generated skill never reaches production having only ever run with real credentials:
+    ```bash
+    DRYRUN_VERDICT="output/.dry-run/$name.json" bash scripts/dry-run.sh run "$name" || true
+    ```
+    - The script self-checks the `SKILL_DRYRUN` repo variable (default on) and returns a `skipped` verdict when it is `0`.
+    - Read `output/.dry-run/$name.json`. `passed: true` (or `skipped: true`) means continue. `passed: false` means **delete `skills/$name/`, revert the `aeon.yml` edit, and exit `CREATE_SKILL_DRYRUN_FAILED`** with a notify listing the verdict `reasons[]`. Do not open the PR.
+    - Put the verdict JSON in the PR body under a `## Dry-run` section either way, so a reviewer sees the gate ran.
+    The gate is **structural** (exit 0, non-empty output, no write outside the declared `mode`, no secret outside `requires:`), and no real credential is ever placed in the run's environment. It does not re-score content; the Haiku scorer already does that.
+
 10. **Open as a PR (never commit to `main`).**
     ```bash
     name="{skill-name}"
@@ -235,6 +244,7 @@ Today is ${today}. Your task is to generate a complete, production-ready skill f
 | `CREATE_SKILL_DUPLICATE` | Existing skill covers the request | Notify with existing-skill suggestion; stop |
 | `CREATE_SKILL_INSUFFICIENT_RESEARCH` | Couldn't confirm ≥1 working data source after WebSearch + WebFetch | Notify with what was tried; stop |
 | `CREATE_SKILL_VALIDATION_FAILED` | Quality enforcement or post-write checks failed | Delete partial files; revert aeon.yml; notify with failed criteria; stop |
+| `CREATE_SKILL_DRYRUN_FAILED` | The dry-run gate (step 9b) returned `passed: false` | Delete partial files; revert aeon.yml; notify with verdict reasons; do NOT open the PR; stop |
 
 ## Network note
 

--- a/skills/self-improve/SKILL.md
+++ b/skills/self-improve/SKILL.md
@@ -73,6 +73,12 @@ Improve the agent itself based on recent performance. **ONE change per run.**
    - Change the core architecture
    - Modify secrets or environment variables
 
+4b. **Dry-run gate.** Before opening the PR, execute the improved skill once with **synthetic** secrets, so a regression never reaches production having run only with real credentials. Let `$skill` be the skill you edited:
+   ```bash
+   DRYRUN_VERDICT="output/.dry-run/$skill.json" bash scripts/dry-run.sh run "$skill" || true
+   ```
+   Read `output/.dry-run/$skill.json`: `passed: true` (or `skipped: true`, when the `SKILL_DRYRUN` repo variable is `0`) continues. `passed: false` means **revert the edit and stop** (log `self-improve: dry-run gate failed for $skill` with the verdict `reasons[]`; do not open the PR). Put the verdict under a `## Dry-run` section in the PR body. The gate is structural (exit, output, declared `mode`, declared `requires:`); no real credential enters the run.
+
 5. **Create a branch and PR:**
    ```bash
    git checkout -b fix/self-improve-${today}


### PR DESCRIPTION
Implements **item 4** of the chassis INTEGRATION.md plan: a dry-run gate for self-authored skills. Closes #913.

## Why

`create-skill` and `self-improve` write skills that reach `main` through auto-merging PRs. The only thing between a generated skill and production was a Haiku score computed **after** it had already run with real secrets against real repos. For the part of the system that writes its own code, that ordering is backwards. (The existing bubblewrap sandbox enforces `read-only` for a skill Aeon has *decided to run*; it doesn't decide whether to run a new skill at all.)

## What

`scripts/dry-run.sh` runs a candidate with **synthetic** secrets before its PR opens:

- **`synth-env`** — every `requires:` key gets a fake, well-formed, `DRYRUN`-marked value. `ANTHROPIC_API_KEY` / `*_OAUTH_TOKEN` are **never synthesized and never written to the env file** (the run needs a live model — the one real credential allowed near the run). Inherited GitHub/channel tokens are faked too, so a rogue push or notify can't reach a real repo or channel.
- **`evaluate`** — structural pass criteria: exit 0, non-empty output, no write outside the declared `mode`, no secret used outside `requires:`. Content is **not** re-scored (the Haiku scorer already does that).
- **`assert-no-real-secrets`** — fails closed if any real value reaches the synthetic env.

## Done-when checklist (from the plan / #913)

- ✅ a broken generated skill fails the gate → PR doesn't auto-merge (`CREATE_SKILL_DRYRUN_FAILED`)
- ✅ a known-good skill passes
- ✅ **no real secret in the dry-run env — asserted in a test, not eyeballed** (`test_dry_run.sh`)
- ✅ disable via repo var `SKILL_DRYRUN` (default on)
- ✅ gates self-authored skills **only**; every other skill runs unchanged

## Tests

```
bash scripts/tests/test_dry_run.sh   # 17 pass: synth-env shapes, no-real-secret guarantee,
                                     # and every evaluate pass/fail criterion
```

The three primitives are pure and locally verified. The **live `claude -p` execution** in `run` happens in CI where the model auth + harness exist (per convention, an agent-authored change's first real execution is CI).

## Wiring

- `skills/create-skill/SKILL.md` — step 9b calls the gate before opening the PR; extends the existing `CREATE_SKILL_*` exit taxonomy.
- `skills/self-improve/SKILL.md` — same gate before its PR.
- `docs/CONFIGURATION.md` — new "Dry-run gate for self-authored skills".

## Notes

- Touches two skills' prose only (no frontmatter / `requires:` / file-count change), so `ci-skills-json` and the catalogs are unaffected; `eyebrow` allows content drift (no new egress host / CRITICAL) — flag if `ci-skill-integrity` disagrees and I'll rescan.
- No `CLAUDE.md` / `AGENTS.md` change strictly required, but the dry-run gate is now part of how self-authored skills ship — worth a line in `AGENTS.md` if you want the agent to know about `SKILL_DRYRUN`.
