### PR TITLE
fix(workflow): bound apt installs so a dpkg-lock stall can't eat the job wall

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -245,9 +245,18 @@ jobs:
       # the same thing on all six.
       - name: Install bubblewrap (read-only sandbox)
         if: steps.work.outputs.mode != ''
+        # Bound this step. apt can block on the runner's unattended-upgrades dpkg
+        # lock, and with no cap a stall here consumed the entire 50-min job wall and
+        # the run was cancelled before the skill ever executed (nur create-skill/
+        # digest/heartbeat + data kpi-daily all self-flagged run_failed 2026-08-19,
+        # each a ~50-min hang on this exact step). timeout-minutes fails the step
+        # fast; DPkg::Lock::Timeout waits a bounded time for the lock instead of
+        # hanging indefinitely.
+        timeout-minutes: 5
         run: |
           set -euo pipefail
-          sudo apt-get update -qq && sudo apt-get install -y -qq bubblewrap
+          APT_OPTS="-o DPkg::Lock::Timeout=120"
+          sudo apt-get $APT_OPTS update -qq && sudo apt-get $APT_OPTS install -y -qq bubblewrap
           # Ubuntu 24.04 (including GitHub's ubuntu-latest) restricts unprivileged
           # user namespaces via AppArmor, so bwrap dies with 'setting up uid map:
           # Permission denied' and run-harness fails CLOSED on every read-only
@@ -472,7 +481,10 @@ jobs:
         # render_card.py's fallback picks it up. Best-effort: never fails the run; without
         # it the skill degrades to the SVG + a text notify.
         if: steps.work.outputs.mode != '' && steps.skill.outputs.name == 'weekly-aeoncard'
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq librsvg2-bin || true
+        # Best-effort, but `|| true` only catches a non-zero exit, not a hang on the
+        # dpkg lock, so bound the lock wait too and an apt stall can't eat the job wall.
+        timeout-minutes: 5
+        run: sudo apt-get -o DPkg::Lock::Timeout=120 update -qq && sudo apt-get -o DPkg::Lock::Timeout=120 install -y -qq librsvg2-bin || true
 
       # Single-source standing instructions. AGENTS.md is the full, self-contained
       # mirror of CLAUDE.md (operating manual + @STRATEGY.md inlined) that the


### PR DESCRIPTION
## What

Bound the two `apt-get` installs in `aeon.yml` so a dpkg-lock stall can no longer hang a run.

- `Install bubblewrap (read-only sandbox)`: add `timeout-minutes: 5` + `-o DPkg::Lock::Timeout=120` on both apt calls.
- `Stage weekly-aeoncard rasterizer` (librsvg2-bin): same lock timeout + step cap. Its `|| true` only catches a non-zero exit, not a hang.

## Why

The bubblewrap step ran a bare `apt-get update && apt-get install` with no timeout and no lock wait. When the runner's `unattended-upgrades` daemon holds the dpkg lock, apt blocks indefinitely, the stall consumes the entire 50-min job wall, and the run is cancelled **before the skill executes**.

On 2026-08-19 this self-flagged four `run_failed` skill-health regressions across two instances (nur create-skill/digest/heartbeat + data kpi-daily), each a ~50-min hang on this exact step. Scheduled cron stayed green because the same skills reinstalled bubblewrap in 18-114s on the next clean run - the fault is the unbounded apt call, not the skills.

## Test

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/aeon.yml'))"` - valid.
- No behavior change on the happy path; only adds a bounded lock wait and a fast-fail cap.
