### PR TITLE
security: SHA-pin all GitHub Actions to immutable commit refs

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -114,7 +114,7 @@ jobs:
     steps:
       - name: Early checkout
         if: github.event_name == 'issues'
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           token: ${{ secrets.GH_GLOBAL || secrets.GITHUB_TOKEN }}
 
@@ -145,7 +145,7 @@ jobs:
 
       - name: Checkout repo
         if: steps.work.outputs.mode != ''
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           token: ${{ secrets.GH_GLOBAL || secrets.GITHUB_TOKEN }}
 
@@ -157,7 +157,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.work.outputs.mode != ''
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '22'
 
@@ -168,7 +168,7 @@ jobs:
         # ~100% hit after the first run of a version, shared with messages.yml). The
         # restore-keys prefix degrades gracefully on a version bump. Keep the version
         # in the key in sync with the pin below.
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.npm
           key: claude-code-${{ runner.os }}-2.1.168
@@ -457,7 +457,7 @@ jobs:
         # sufficient key; bump the -vN salt to force-bust. Only restores/saves for
         # the remotion skill (path is empty for every other skill = cheap no-op).
         if: steps.work.outputs.mode != '' && steps.skill.outputs.name == 'remotion'
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: skills/remotion/project/node_modules
           key: remotion-${{ runner.os }}-v1-${{ hashFiles('skills/remotion/project/package-lock.json') }}
@@ -1205,7 +1205,7 @@ jobs:
         # Multi-subject: one attestation over both run-scoped artifacts (the output
         # snapshot and its manifest). Both paths are ${GITHUB_RUN_ID}-unique, so the
         # committed bytes always match what was attested.
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4
         with:
           subject-path: |
             ${{ steps.manifest.outputs.snapshot }}
@@ -1871,7 +1871,7 @@ jobs:
 
       - name: Upload audit log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: audit-log-${{ github.run_id }}
           path: audit-artifact/audit.jsonl

--- a/.github/workflows/chain-runner.yml
+++ b/.github/workflows/chain-runner.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           token: ${{ secrets.GH_GLOBAL || secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci-agents-md.yml
+++ b/.github/workflows/ci-agents-md.yml
@@ -40,6 +40,6 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Check AGENTS.md is regenerated from STRATEGY.md
         run: node scripts/gen-agents-md.js --check

--- a/.github/workflows/ci-apps.yml
+++ b/.github/workflows/ci-apps.yml
@@ -53,8 +53,8 @@ jobs:
       run:
         working-directory: apps/dashboard
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '22'
           cache: npm
@@ -73,8 +73,8 @@ jobs:
     name: cli — typecheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '22'
           cache: npm
@@ -103,8 +103,8 @@ jobs:
       run:
         working-directory: apps/mcp-server
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '22'
       # No package-lock.json is committed for this app, so `npm ci` is not
@@ -126,8 +126,8 @@ jobs:
     env:
       WRANGLER_SEND_METRICS: 'false'
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '22'
       - name: Syntax check the Worker

--- a/.github/workflows/ci-capabilities-parity.yml
+++ b/.github/workflows/ci-capabilities-parity.yml
@@ -42,6 +42,6 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Check capabilities taxonomy parity
         run: bash scripts/check-capabilities-parity.sh

--- a/.github/workflows/ci-packs-json.yml
+++ b/.github/workflows/ci-packs-json.yml
@@ -40,7 +40,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Regenerate packs.json and diff (ignoring timestamp)
         run: |
           set -euo pipefail

--- a/.github/workflows/ci-readme-catalog.yml
+++ b/.github/workflows/ci-readme-catalog.yml
@@ -48,6 +48,6 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Validate the README skill tables against the first-party catalog
         run: node scripts/validate-readme-catalog.mjs

--- a/.github/workflows/ci-skill-category.yml
+++ b/.github/workflows/ci-skill-category.yml
@@ -31,6 +31,6 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Every SKILL.md declares a valid category
         run: bash scripts/check-skill-categories.sh

--- a/.github/workflows/ci-skill-integrity.yml
+++ b/.github/workflows/ci-skill-integrity.yml
@@ -63,7 +63,7 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       # A skill added without regenerating the lockfile would otherwise be
       # silently ungated (drift is advisory by policy, and a brand-new skill has
       # no baseline to expand against). This makes coverage itself a hard gate.

--- a/.github/workflows/ci-skill-packs.yml
+++ b/.github/workflows/ci-skill-packs.yml
@@ -57,6 +57,6 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Validate the community pack registry and its README parity
         run: node scripts/validate-skill-packs.mjs

--- a/.github/workflows/ci-skills-json.yml
+++ b/.github/workflows/ci-skills-json.yml
@@ -49,7 +49,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0          # full history for the generator; git-derived fields are normalized out of the diff
       - name: Regenerate skills.json and diff (ignoring timestamp + per-skill sha/updated)

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -33,7 +33,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install deps
         run: pip install pyyaml==6.0.2
       - name: notify_format unit tests

--- a/.github/workflows/messages.yml
+++ b/.github/workflows/messages.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           token: ${{ secrets.GH_GLOBAL || secrets.GITHUB_TOKEN }}
 
@@ -289,7 +289,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           token: ${{ secrets.GH_GLOBAL || secrets.GITHUB_TOKEN }}
 
@@ -386,7 +386,7 @@ jobs:
 
       - name: Checkout repo
         if: steps.msg.outputs.source != ''
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           token: ${{ secrets.GH_GLOBAL || secrets.GITHUB_TOKEN }}
 
@@ -398,7 +398,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.msg.outputs.source != ''
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '22'
 
@@ -406,7 +406,7 @@ jobs:
         if: steps.msg.outputs.source != ''
         # Shares the pinned-version cache with aeon.yml so the global install runs
         # offline. Keep the version in the key in sync with the pin below.
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.npm
           key: claude-code-${{ runner.os }}-2.1.168

--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           token: ${{ secrets.GH_GLOBAL || secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/setup-commands.yml
+++ b/.github/workflows/setup-commands.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Push command list + menu button
         env:


### PR DESCRIPTION
security: SHA-pin all GitHub Actions to immutable commit refs

Replace mutable tag refs (checkout@v7, setup-node@v7, cache@v6,
attest-build-provenance@v4, upload-artifact@v4) with their pinned
commit SHA across every workflow. A tag can be re-pointed at
malicious code by whoever controls the action repo; a commit SHA
cannot, so this removes a silent supply-chain swap vector on the
runner that executes skill runs with the full secret env.

Only eyebrow's action was previously SHA-pinned, which contradicted
ci-skill-integrity.yml's own claim that every action in this repo is
pinned by commit SHA. This makes that claim true.

32 refs pinned across 15 workflow files. The tag is preserved in a
trailing comment for readability and future version bumps.

## What
- 32 action refs across 15 workflow files repinned from mutable tags to commit SHAs.
- Actions pinned: `actions/checkout` v7, `actions/setup-node` v7, `actions/cache` v6, `actions/attest-build-provenance` v4, `actions/upload-artifact` v4.
- `alexverify/eyebrow/action` was already SHA-pinned; untouched.

## Why
A `@v7`-style tag is mutable: whoever controls the action repo can re-point it at new code, and every workflow that references the tag runs that code on the next run. The Run step in `aeon.yml` executes with the full infra-secret env (GH_GLOBAL, provider + notify keys), so a swapped action there is a direct exfil path. SHA pinning closes it.

## Verify
```
grep -rnE 'uses: [^ ]+@v[0-9]' .github/workflows/   # -> no matches
```
No logic changed; only ref strings. Tag kept in a trailing comment for future bumps.