### PR TITLE
security: block codex install scripts + SHA256-pin eyebrow download

### DIFF
--- a/scripts/install-harness.sh
+++ b/scripts/install-harness.sh
@@ -70,7 +70,12 @@ case "$H" in
     # PINNED, like aeon pins claude-code. Unpinned, this step silently tracked
     # latest: two cells that passed on 2026-07-21 failed hours later with an
     # OpenRouter 400 and nothing in the repo had changed.
-    npm install -g @openai/codex@0.144.6
+    # --ignore-scripts (same hardening as pi/kimi): codex ships its binary via
+    # optional platform packages (@openai/codex-<os>-<arch>), NOT a postinstall
+    # fetch, so blocking lifecycle scripts is safe and denies a compromised
+    # release an auto-run install hook in the run's secret env. If a future pin
+    # needs a postinstall binary fetch, drop this flag (keep the pin).
+    npm install -g --ignore-scripts @openai/codex@0.144.6
     mkdir -p "$HOME/.codex"
     case "$AUTH_MODE" in
       native-oauth)

--- a/skills/aeon-update/SKILL.md
+++ b/skills/aeon-update/SKILL.md
@@ -186,7 +186,12 @@ if [ -z "$EB" ]; then
     fi
   fi
 fi
-[ -n "$EB" ] && "$EB" scan --path . --lockfile eyebrowlock.json 2>/dev/null && EYEBROW_OK=1
+# Run with a SCRUBBED env (allowlist PATH+HOME only). eyebrow scan is a local
+# file-hasher - it needs no secrets and no network - so denying it the run's
+# secret env (GH_GLOBAL + provider/notify keys) means even a bad binary that
+# slipped the SHA pin cannot read or exfiltrate them. If the scan fails, EYEBROW_OK
+# stays 0 and the fail-safe below covers it.
+[ -n "$EB" ] && env -i PATH="$PATH" HOME="$HOME" "$EB" scan --path . --lockfile eyebrowlock.json 2>/dev/null && EYEBROW_OK=1
 ```
 
 **Fail-safe - guarantees a green PR without the binary.** If `EYEBROW_OK` is still `0` (binary unavailable or scan failed) and this run has any **CLEAN-ADD of a `skills/**` SKILL.md**, do not ship a skill the lock cannot cover: revert each such new skill from the branch (`git rm -r --cached skills/<slug>` + drop it from the working tree) and re-classify it as **CONFLICT** with reason `needs-eyebrowlock-scan`. S9 surfaces it with the exact operator command (`eyebrow scan --path . --lockfile eyebrowlock.json` then commit). A **CLEAN-UPDATE / CLEAN-MERGE of an existing** skill needs no rescan - `eyebrow verify` allows content drift (it fails only on a new egress host or a new CRITICAL), and the skill already has a lock entry. This trades auto-installing a brand-new upstream skill (rare) for never landing a red PR; the skill still arrives, just as a one-line manual step in the PR.

--- a/skills/aeon-update/SKILL.md
+++ b/skills/aeon-update/SKILL.md
@@ -159,14 +159,32 @@ bin/generate-skills-json && bin/generate-packs-json && bin/generate-skill-icons
 node scripts/gen-agents-md.js || true
 ```
 
-**Refresh the eyebrow integrity lock for any NEWLY-ADDED skill.** `ci-skill-integrity` fails a PR when a present skill's `skills/<slug>/SKILL.md` has no `"discoveredFrom": "skills/<slug>/SKILL.md"` entry in `eyebrowlock.json`. That entry is produced only by the `eyebrow` binary, which is **not preinstalled in this run** - so a CLEAN-ADD of a new skill would otherwise land the PR CI-red. Fetch the binary (the version `ci-skill-integrity.yml` pins - currently `v0.4.1` from `alexverify/eyebrow`; read `gh release view -R alexverify/eyebrow` for the asset matching this runner's OS/arch), then rescan:
+**Refresh the eyebrow integrity lock for any NEWLY-ADDED skill.** `ci-skill-integrity` fails a PR when a present skill's `skills/<slug>/SKILL.md` has no `"discoveredFrom": "skills/<slug>/SKILL.md"` entry in `eyebrowlock.json`. That entry is produced only by the `eyebrow` binary, which is **not preinstalled in this run** - so a CLEAN-ADD of a new skill would otherwise land the PR CI-red. Fetch the binary (the version `ci-skill-integrity.yml` pins - currently `v0.4.1` from `alexverify/eyebrow`), verifying the release asset against a **pinned SHA256** (the tag is mutable, and this runs in the full secret env), then rescan:
 
 ```bash
 EYEBROW_OK=0
 EB=$(command -v eyebrow || true)
 if [ -z "$EB" ]; then
-  gh release download v0.4.1 -R alexverify/eyebrow -D "$WORK/eb" 2>/dev/null \
-    && EB=$(find "$WORK/eb" -type f -name 'eyebrow*' | head -1) && chmod +x "$EB" 2>/dev/null || true
+  # SHA256-pin the release asset (trust-on-first-pin). The v0.4.1 tag is mutable -
+  # a re-uploaded asset would otherwise be fetched AND executed in this run's full
+  # secret env. Verify the tarball hash against the constant below BEFORE extract
+  # or exec; a mismatch means the tag moved, so do NOT run it - fall through to the
+  # fail-safe. Linux runner (ubuntu-latest) assumed; unknown arch => skip.
+  case "$(uname -m)" in
+    x86_64)        A=amd64; EB_SHA=f1b6b88f80565082dfc37e3b91d3579c87dc6aaf0de70874ef41f461f711a48c ;;
+    aarch64|arm64) A=arm64; EB_SHA=a848055492dd545ad3f73890379098e103b5bed4f18009d81d3a4bbbf1f985b6 ;;
+    *)             A=; EB_SHA= ;;
+  esac
+  TB="eyebrow_0.4.1_linux_${A}.tar.gz"
+  if [ -n "$EB_SHA" ] && gh release download v0.4.1 -R alexverify/eyebrow -p "$TB" -D "$WORK/eb" 2>/dev/null; then
+    GOT=$(sha256sum "$WORK/eb/$TB" | awk '{print $1}')
+    if [ "$GOT" = "$EB_SHA" ]; then
+      tar xzf "$WORK/eb/$TB" -C "$WORK/eb" 2>/dev/null \
+        && EB=$(find "$WORK/eb" -type f -name eyebrow | head -1) && chmod +x "$EB" 2>/dev/null || true
+    else
+      echo "::warning::eyebrow $TB sha256 mismatch (got $GOT, pinned $EB_SHA) - tag moved, not executing"; EB=
+    fi
+  fi
 fi
 [ -n "$EB" ] && "$EB" scan --path . --lockfile eyebrowlock.json 2>/dev/null && EYEBROW_OK=1
 ```


### PR DESCRIPTION
security: block codex install scripts + SHA256-pin eyebrow download

Two "fetch-and-run in the secret env" hardenings, complementing the
GitHub Actions SHA-pin (PR #917):

1. install-harness.sh: add --ignore-scripts to the codex CLI install,
   the same guard pi and kimi already use. codex ships its binary via
   optional platform packages (@openai/codex-<os>-<arch>), not a
   postinstall fetch, so no lifecycle script is needed. Blocking them
   denies a compromised codex release an auto-run install hook on the
   runner. If a future pin needs a postinstall, drop the flag.

2. skills/aeon-update: SHA256-pin the eyebrow release download. The
   v0.4.1 tag is mutable, and this skill fetched and executed whatever
   asset currently sits on it, in the one run that holds the full secret
   env (GH_GLOBAL + provider/notify keys). The tarball is now verified
   against a pinned hash before extract or exec; a mismatch (tag moved)
   skips execution and falls through to the existing fail-safe. This
   also fixes a latent bug: the old find -name 'eyebrow*' matched the
   .tar.gz asset and would chmod+exec a tarball.

Pinned hashes (eyebrow 0.4.1, from the release checksums.txt):
  linux_amd64  f1b6b88f80565082dfc37e3b91d3579c87dc6aaf0de70874ef41f461f711a48c
  linux_arm64  a848055492dd545ad3f73890379098e103b5bed4f18009d81d3a4bbbf1f985b6

## Verify
- codex: install script list is empty (`npm view @openai/codex@0.144.6 scripts` -> none); binary arrives via optionalDependencies, so `--ignore-scripts` does not break it.
- eyebrow: hashes above are from the v0.4.1 release `checksums.txt`; the block fails closed on mismatch or unknown arch.

Companion to #917 (SHA-pin all Actions). Same theme: no unverified third-party code runs in the secret env.