### PR TITLE
feat: Codex plugin + repo llms.txt

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,26 @@
+{
+  "name": "aeon",
+  "description": "Aeon plugins - install the operator console for setting up and running an Aeon agent instance.",
+  "owner": {
+    "name": "Aeon Inc",
+    "url": "https://github.com/aeonfun"
+  },
+  "interface": {
+    "displayName": "Aeon"
+  },
+  "plugins": [
+    {
+      "name": "aeon",
+      "source": {
+        "source": "local",
+        "path": "./plugin"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_USE"
+      },
+      "category": "Productivity",
+      "description": "Operator console for running an Aeon agent instance from your coding agent."
+    }
+  ]
+}

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,47 @@
+# Aeon
+
+> Aeon is an autonomous agent framework. It runs your own skills on a schedule in GitHub Actions, keeps state in git-committed memory, and dispatches every run through one harness adapter that works across six coding-agent CLIs (Claude Code, Codex, Grok, Kimi, Pi, Vibe). Skills are Markdown with a spec-form frontmatter; a least-privilege `requires:` -> dashboard vault contract wires secrets. Fork the repo, turn skills on, and it runs itself.
+
+Repo: https://github.com/aeonfun/aeon
+Site: https://aeon.fun
+
+## Core entry points
+
+- [AGENTS.md](https://raw.githubusercontent.com/aeonfun/aeon/main/AGENTS.md): Start here. The instance operating manual an Aeon agent reads at runtime - how Aeon works, strategy, voice/soul hierarchy, memory, tools, capability mode, skill chaining, notifications, network/secrets, security.
+- [CLAUDE.md](https://raw.githubusercontent.com/aeonfun/aeon/main/CLAUDE.md): The same operating manual, Claude Code loads it automatically.
+- [STRATEGY.md](https://raw.githubusercontent.com/aeonfun/aeon/main/STRATEGY.md): The instance north-star: priorities, audience, hard constraints, what to optimize for and avoid.
+- [aeon.yml](https://raw.githubusercontent.com/aeonfun/aeon/main/aeon.yml): The GitHub Actions workflow that dispatches every scheduled run. What runs, when, and with which secrets.
+
+## Setup and configuration
+
+- [docs/aeon-setup.md](https://raw.githubusercontent.com/aeonfun/aeon/main/docs/aeon-setup.md): The setup skill - get an instance running from scratch.
+- [docs/CONFIGURATION.md](https://raw.githubusercontent.com/aeonfun/aeon/main/docs/CONFIGURATION.md): Configuration and advanced reference.
+- [docs/CORE.md](https://raw.githubusercontent.com/aeonfun/aeon/main/docs/CORE.md): The Core - the run loop and engine internals.
+- [docs/CAPABILITIES.md](https://raw.githubusercontent.com/aeonfun/aeon/main/docs/CAPABILITIES.md): Skill capabilities taxonomy - read-only vs write vs capability mode.
+
+## Skills and packs
+
+- [catalog/skills.json](https://raw.githubusercontent.com/aeonfun/aeon/main/catalog/skills.json): Machine-readable catalog of every bundled skill - slug, description, category, requires, mcp, install command.
+- [docs/skill-packs.md](https://raw.githubusercontent.com/aeonfun/aeon/main/docs/skill-packs.md): Skill packs - opt-in bundles so a fork only runs the handful of skills it wants.
+- [docs/community-skill-packs.md](https://raw.githubusercontent.com/aeonfun/aeon/main/docs/community-skill-packs.md): Publish and install community skill packs.
+- [docs/skill-integrity.md](https://raw.githubusercontent.com/aeonfun/aeon/main/docs/skill-integrity.md): The eyebrow lockfile that gates skill content and security drift in CI.
+
+## Harnesses and integrations
+
+- [docs/harnesses.md](https://raw.githubusercontent.com/aeonfun/aeon/main/docs/harnesses.md): Advanced harness behavior across the six supported coding-agent CLIs.
+- [harness-adapter/README.md](https://raw.githubusercontent.com/aeonfun/aeon/main/harness-adapter/README.md): The single dispatch path that translates one tool grammar to every harness.
+- [docs/mcp-oauth.md](https://raw.githubusercontent.com/aeonfun/aeon/main/docs/mcp-oauth.md): Durable dashboard OAuth for OAuth-gated MCP servers.
+- [docs/telegram-commands.md](https://raw.githubusercontent.com/aeonfun/aeon/main/docs/telegram-commands.md): The inbound Telegram command surface.
+
+## Reference
+
+- [docs/help.md](https://raw.githubusercontent.com/aeonfun/aeon/main/docs/help.md): Operator help index.
+- [docs/ECOSYSTEM.md](https://raw.githubusercontent.com/aeonfun/aeon/main/docs/ECOSYSTEM.md): Ecosystem partners and integrations.
+- [CHANGELOG.md](https://raw.githubusercontent.com/aeonfun/aeon/main/CHANGELOG.md): Release history.
+
+## Install as a plugin
+
+Aeon ships the operator console as a plugin for Claude Code and Codex.
+
+- Claude Code: `/plugin marketplace add aeonfun/aeon` then `/plugin install aeon@aeon`
+- Codex: `codex plugin marketplace add aeonfun/aeon` then `codex plugin add aeon@aeon`

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,0 +1,25 @@
+{
+  "name": "aeon",
+  "version": "0.1.0",
+  "description": "Operator console for an Aeon agent instance: enable/schedule/edit skills, wire secrets and channels, debug runs, and mine past Codex/Claude Code chats into scheduled skills.",
+  "author": {
+    "name": "Aeon Inc",
+    "url": "https://github.com/aeonfun"
+  },
+  "homepage": "https://aeon.fun",
+  "repository": "https://github.com/aeonfun/aeon",
+  "license": "MIT",
+  "keywords": ["aeon", "agent", "skills", "automation", "github-actions", "cron"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Aeon",
+    "shortDescription": "Set up and run an Aeon autonomous agent instance from your coding agent",
+    "longDescription": "Aeon is an autonomous agent framework that runs your own skills on a schedule in GitHub Actions. This plugin ships the operator console skill: get started from scratch, turn skills on or off, schedule or reschedule what runs, edit what a skill does, debug a skill that will not fire, set the STRATEGY.md north star and soul voice, and mine past coding-agent chats into new scheduled skills. Works alongside the Aeon repo (aeonfun/aeon); the skill walks the rest.",
+    "developerName": "Aeon Inc",
+    "category": "Productivity",
+    "capabilities": ["Interactive", "Write"],
+    "websiteURL": "https://aeon.fun",
+    "defaultPrompt": ["Help me set up and run an Aeon agent instance"],
+    "brandColor": "#0B0B0B"
+  }
+}


### PR DESCRIPTION
## What

Two low-effort agent-discoverability wins, no behavior change.

### 1. Codex plugin (parity with the existing Claude Code plugin)
The operator console skill already ships to Claude Code via `.claude-plugin/`. This adds the Codex lane so the same skill installs on Codex:

- `plugin/.codex-plugin/plugin.json` - Codex plugin manifest (identity copied from the Claude manifest, `skills: "./skills/"`, plus a Codex `interface` block for display).
- `.agents/plugins/marketplace.json` - repo-scoped marketplace catalog. Per the Codex plugin spec this is the preferred discovery path (`$REPO_ROOT/.agents/plugins/marketplace.json`), with `.claude-plugin/marketplace.json` as the legacy fallback.

Install:
```
codex plugin marketplace add aeonfun/aeon
codex plugin add aeon@aeon
```
Claude Code path is unchanged (`/plugin marketplace add aeonfun/aeon` then `/plugin install aeon@aeon`). The operator skill is pure gh/file/bash ops, so it runs under Codex unmodified.

### 2. `llms.txt`
Repo-root doc map with raw GitHub URLs to the core entry points (AGENTS.md, CLAUDE.md, STRATEGY.md, aeon.yml), setup/config docs, the skills catalog + packs, harness docs, and the plugin install lines. Any coding agent can fetch it first to orient. The website already ships one; the repo did not.

## Verification
- Both JSON files parse.
- `skills: "./skills/"` resolves to `plugin/skills/aeon/SKILL.md`.
- Every doc path referenced in `llms.txt` exists on `main`.
- No em dashes.

## Not in this PR
Packaging the full 76-skill library as installable, trigger-routing/resolver, and routing evals - those are larger follow-ups, tracked separately.
