### PR TITLE
fix(scorer): grade full output, align to strategy, flag fabrication

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -1252,8 +1252,15 @@ jobs:
         run: |
           SKILL="${{ steps.skill.outputs.name }}"
 
-          # Skip analysis for meta skills (they don't produce scorable output)
-          case "$SKILL" in heartbeat|skill-health|skill-analytics|reflect|memory-flush|self-review|cost-report) echo "Skipping analysis for meta skill"; exit 0;; esac
+          # Skip skills that declare `scorable: false` in their frontmatter - meta
+          # skills that produce no gradable output. Frontmatter-driven so a new meta
+          # skill opts out in its own SKILL.md instead of by editing a name regex
+          # here (which had drifted: skill-analytics/reflect/self-review/cost-report
+          # no longer exist as skills).
+          SKILL_MD="skills/${SKILL}/SKILL.md"
+          if [ -f "$SKILL_MD" ] && [ -n "$(awk 'NR==1&&/^---/{f=1;next} f&&/^---/{exit} f&&/^scorable:[[:space:]]*false([[:space:]#]|$)/{print 1;exit}' "$SKILL_MD")" ]; then
+            echo "Skipping analysis for non-scorable skill"; exit 0
+          fi
 
           HARNESS="${{ steps.run.outputs.HARNESS }}"
           # Route the scorer's claude call through the gateway (claude harness only).
@@ -1268,30 +1275,54 @@ jobs:
             AEON_OTEL_COMPONENT=scorer source "${GITHUB_WORKSPACE}/scripts/langfuse-otel.sh"
           fi
 
-          # Read and truncate skill output for analysis
+          # Read skill output for analysis. Sample head + tail so the judge sees the
+          # conclusion of long outputs, not just the intro - a flat 3KB head-truncate
+          # graded only the opening and biased the score against skills that build to
+          # their payoff (articles, digests, research compendia routinely exceed a few
+          # KB). `iconv -c` drops any partial UTF-8 char left at a byte cut.
           OUTPUT=""
           if [ -f /tmp/skill-result.txt ] && [ -s /tmp/skill-result.txt ]; then
-            OUTPUT=$(head -c 3000 /tmp/skill-result.txt)
+            BYTES=$(wc -c < /tmp/skill-result.txt)
+            if [ "$BYTES" -le 14000 ]; then
+              OUTPUT=$(iconv -f UTF-8 -t UTF-8 -c < /tmp/skill-result.txt)
+            else
+              OHEAD=$(head -c 10000 /tmp/skill-result.txt | iconv -f UTF-8 -t UTF-8 -c)
+              OTAIL=$(tail -c 4000 /tmp/skill-result.txt | iconv -f UTF-8 -t UTF-8 -c)
+              OUTPUT=$(printf '%s\n\n[... middle truncated ...]\n\n%s' "$OHEAD" "$OTAIL")
+            fi
           fi
           [ -z "$OUTPUT" ] && { echo "No output to analyze"; exit 0; }
+
+          # Ground the rubric in the operator's north-star so the judge grades
+          # strategic alignment and correctness, not just surface polish. STRATEGY.md
+          # is short by design; inject it whole (byte-capped for safety). Absent or
+          # placeholder file leaves the block empty and grading falls back to generic.
+          STRATEGY_CTX=""
+          [ -f STRATEGY.md ] && STRATEGY_CTX=$(head -c 4000 STRATEGY.md)
 
           ANALYSIS_PROMPT="Score this autonomous agent skill output on a 1-5 scale. Respond with ONLY valid JSON.
 
           Scoring:
           1 = Failed/empty/error output
-          2 = Ran but low quality, generic, or boilerplate
-          3 = Acceptable — completed the task adequately
-          4 = Good — substantive, well-structured, useful
-          5 = Excellent — insightful, well-sourced, actionable
+          2 = Ran but low quality, generic, boilerplate, or fluent-but-unverifiable
+          3 = Acceptable - completed the task adequately
+          4 = Good - substantive, well-structured, useful, and verifiable
+          5 = Excellent - insightful, well-sourced, actionable
 
-          Flag any issues from: api_error, empty_output, low_quality, stale_data, generic_content, rate_limited
+          Correctness and verifiability outrank polish: a well-written output that invents specifics scores no higher than 2. Grade alignment to the operator strategy below - reward work that serves the stated priorities, not work that merely looks finished.
 
-          Flag strictly against the FINAL output above — not against sources or steps it merely mentions:
-          - empty_output: ONLY when the skill produced no usable result (no report, analysis, or draft). A legitimate no-op — an empty inbox, an empty watchlist, 'nothing met the threshold', a clean scan with no findings — is a COMPLETED task, not empty_output. A run that delivered its output is not empty_output even if its log notes an upstream source came back empty.
-          - api_error / rate_limited: ONLY when the error blocked the skill's output — not for a sub-call that was retried or fell back cleanly.
+          Operator strategy:
+          $STRATEGY_CTX
+
+          Flag any issues from: api_error, empty_output, low_quality, stale_data, generic_content, rate_limited, unverifiable_claim
+
+          Flag strictly against the FINAL output above - not against sources or steps it merely mentions:
+          - empty_output: ONLY when the skill produced no usable result (no report, analysis, or draft). A legitimate no-op - an empty inbox, an empty watchlist, 'nothing met the threshold', a clean scan with no findings - is a COMPLETED task, not empty_output. A run that delivered its output is not empty_output even if its log notes an upstream source came back empty.
+          - api_error / rate_limited: ONLY when the error blocked the skill's output - not for a sub-call that was retried or fell back cleanly.
+          - unverifiable_claim: the output asserts specific facts, IDs, URLs, figures, or quotes that read as invented or that the skill could not plausibly have obtained from a real source. Cap such an output at 2 and set this flag.
 
           Skill: $SKILL
-          Output (truncated):
+          Output:
           $OUTPUT
 
           JSON format: {\"score\": N, \"assessment\": \"one line\", \"flags\": []}"
@@ -1363,9 +1394,12 @@ jobs:
           ASSESSMENT=$(echo "$PARSED" | jq -r '.assessment // "analysis incomplete"')
           FLAGS=$(echo "$PARSED" | jq -c '.flags // []')
 
-          # Validate score range
-          if [ "$SCORE" -lt 1 ] || [ "$SCORE" -gt 5 ] 2>/dev/null; then
-            SCORE=0
+          # A missing or out-of-range score means the judge malformed its reply, not
+          # that the skill scored zero. Treat it as unscored and skip the write, so a
+          # judge error can't append a 0 to history and drag avg_score down. (`.score
+          # // 0` above makes an absent field 0, which fails the >=1 test here.)
+          if ! { [ "$SCORE" -ge 1 ] && [ "$SCORE" -le 5 ]; } 2>/dev/null; then
+            echo "::notice::Judge returned no valid score - skipping write (non-fatal)."; exit 0
           fi
 
           echo "QUALITY_SCORE=$SCORE" >> "$GITHUB_OUTPUT"

--- a/skills/heartbeat/SKILL.md
+++ b/skills/heartbeat/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: heartbeat
 description: Ambient fleet-health check that surfaces anything worth attention (default), or an on-demand priority brief - the 3 things to focus on, why now, and what moved (var=brief)
+scorable: false  # meta skill: no gradable output, skip the post-run quality scorer
 metadata:
   title: Heartbeat
   category: core

--- a/skills/memory-flush/SKILL.md
+++ b/skills/memory-flush/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: memory-flush
 description: Promote important recent log entries into MEMORY.md and prune stale ones
+scorable: false  # meta skill: no gradable output, skip the post-run quality scorer
 metadata:
   title: Memory Flush
   category: core

--- a/skills/skill-health/SKILL.md
+++ b/skills/skill-health/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: skill-health
 description: Fleet skill observability with two views - health audits per-skill metrics and files/resolves issues in memory/issues/; analytics ranks the fleet by 7d runs, success rates, and anomaly flags.
+scorable: false  # meta skill: no gradable output, skip the post-run quality scorer
 metadata:
   title: Skill Health
   category: evolution


### PR DESCRIPTION
## What

Five fixes to the post-run quality scorer (`.github/workflows/aeon.yml`, the step that grades each run's captured output 1-5 and writes `memory/skill-health/<skill>.json`). That score feeds chain routing (`when: score > N`), skill-health issue filing, and skill-analytics - so a miscalibrated grade silently misroutes chains and files noise.

### QW1 - judge only saw the first 3000 bytes (bug)
`OUTPUT=$(head -c 3000 …)` graded the **intro, never the body**. Any output that builds to its payoff (articles, digests, research compendia routinely exceed a few KB) was judged on its opening. Now samples **head 10KB + tail 4KB** for anything over 14KB, whole file otherwise. `iconv -c` drops a partial UTF-8 char left at the byte cut.

Verified on a 42KB mock: the conclusion line (previously invisible) is now in the sampled text.

### QW2 - rubric was strategy-blind
The prompt was a generic "1=fail … 5=excellent" rubric that never saw `STRATEGY.md`, so it rewarded *looks-finished* polish - while STRATEGY priority #1 is literally "correct, verifiable work over work that merely looks finished." Now injects `STRATEGY.md` and makes correctness/verifiability outrank polish.

### QW3 - no fabrication flag
Flags were `api_error, empty_output, low_quality, stale_data, generic_content, rate_limited` - none catch plausible-but-fabricated output (invented IDs/URLs/figures, e.g. a harness hallucinating item IDs). Added `unverifiable_claim`, which caps such an output at 2.

### Minor 1 - frontmatter-driven meta-skill skip
The skip was a hardcoded name regex that had drifted: `skill-analytics|reflect|self-review|cost-report` no longer exist as skills. Replaced with a `scorable: false` frontmatter opt-out (a new meta skill opts out in its own SKILL.md), and tagged the 3 real meta skills: `heartbeat`, `skill-health`, `memory-flush`.

### Minor 2 - invalid score polluted avg
A judge reply missing or out-of-range on `.score` wrote `0` into the 30-entry history and dragged `avg_score`. Now an invalid score is treated as **unscored** (skip the write) rather than recorded as a real 0 - consistent with the other non-fatal early-exits.

## Verification
- Workflow YAML parses; the 3 edited frontmatters parse; awk opt-out detector returns true for the 3 tagged skills and false for normal skills.
- Bash logic runtime-tested with mocks: 42KB output → head+tail sample with conclusion retained; score `0/6/""/null/abc` → skip write, `1/3/5` → write.
- No catalog regen: `scorable` is not a generator field (skills.json content unchanged); only git-derived `sha`/`updated` shift, which `ci-skills-json` normalizes. `eyebrow` allows frontmatter/prose drift (no new egress host, no new CRITICAL).

## Follow-up (not in this PR)
QW4 - the scorer is uncalibrated and grades "through the same harness the skill ran on," so a `4` from Haiku, grok, and kimi are written to the same `quality_score` field and compared fleet-wide without any proof they're comparable or match the operator's judgment. A calibration fixture (label ~15 real outputs, run each harness's scorer, measure MAE + cross-harness spread) is the cheap-but-not-instant next step that makes the scores mean something.
