### PR TITLE
docs(readme): drop harness list from agent callout

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -16,7 +16,7 @@
   <strong>No approval loops. No babysitting. Configure once, forget forever.</strong>
 </p>
 
-> **🤖 Using a coding agent?** Point it here: **read https://www.aeon.fun/skills/aeon.md and follow the instructions to set up your Aeon agent.** Works with **Claude Code**, **Codex**, **Hermes**, and **OpenClaw**.
+> **🤖 Using a coding agent?** Point it here: **read https://www.aeon.fun/skills/aeon.md and follow the instructions to set up your Aeon agent.**
 
 <div align="center">
 


### PR DESCRIPTION
Remove the "Works with Claude Code, Codex, Hermes, and OpenClaw" sentence from the agent-onboarding callout.

https://claude.ai/code/session_01DLZB2ZufcdmUn9oWvcVihP