### PR TITLE
docs: sync PRs #890-#925 to aeon docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,56 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Added
 
+- **Codex plugin parity + a repo-root `llms.txt`.** The `/aeon` operator skill now
+  installs on Codex too (`plugin/.codex-plugin/plugin.json` +
+  `.agents/plugins/marketplace.json`: `codex plugin marketplace add aeonfun/aeon`
+  then `codex plugin add aeon@aeon`), and a new repo-root `llms.txt` gives any
+  coding agent a doc map of the core entry points, setup/config docs, catalog, and
+  harness docs. (#919)
+- **Generated harness capability manifest (`harness-adapter/harnesses.json`).** A
+  queryable, CI-validated file of capability facts for the six adapters (claude,
+  grok, codex, pi, vibe, kimi) - token-cost reporting, read-only enforcement, MCP
+  flavor, auth - sourced from an `rh-meta` block in each `adapters/<h>.sh`. The CLI
+  analog of a UHP `GET /v1/harnesses` discovery response. (#916)
+- **Chain steps can route on Haiku quality scores (`when:` on chain steps).** The
+  1-5 score Aeon already writes to `memory/skill-health/<skill>.json` becomes a
+  control-flow edge: a chain step runs only when a condition holds for the score of
+  the skill it consumes (e.g. `when: "score > 3"`). A `when:` whose key is missing
+  skips the step rather than failing it. Chassis INTEGRATION.md item 2. (#911)
+- **Dry-run gate for self-authored skills before auto-merge.** `create-skill` and
+  `self-improve` now run a candidate with synthetic `DRYRUN`-marked secrets and a
+  structural pass check (exit 0, output present, no write outside declared mode, no
+  secret used outside `requires:`) before its PR opens - the live model credential
+  is the only real secret allowed near the run. Chassis INTEGRATION.md item 4.
+  (#914)
+- **Structured audit log of privileged actions.** An append-only JSONL record (one
+  line per action that reaches outside the run: notify, secretcurl) uploaded as the
+  `audit-log-<run_id>` artifact. `secrets_used` is names only - values are scrubbed
+  in raw, base64, and url-encoded forms before writing, failing toward
+  over-redaction. Chassis INTEGRATION.md item 5. (#908)
+- **Reactive failure handlers learn which skill tripped them.** A handler fired by
+  `on: "*"` now receives the matched source skill as its `var` (unless it declares
+  its own), so `skill-repair` no longer re-derives the failed skill. Reactive is
+  documented as the blessed per-skill failure edge in `docs/CONFIGURATION.md`.
+  Chassis INTEGRATION.md item 3. (#910)
+- **`validate-config` checks reactive triggers.** Every reactive target and
+  non-wildcard `on:` source must resolve to a real skill, and every `when:` must
+  parse to a condition the runtime evaluator understands - a dangling reference or
+  mistyped condition now fails CI instead of being a silent no-op. (#907)
+- **`aeon-update` 3-way merges OWNED conflicts.** An operator-customized file that
+  upstream also changed (commonly a hand-narrowed `aeon.yml`) now attempts a real
+  `git merge-file --diff3`: disjoint hunks merge cleanly and keep the customization,
+  genuine overlaps still surface as CONFLICT. Adds an eyebrow-lock fail-safe. (#903)
+- **`vuln-scanner` A3.6 agentic logic audit.** A new source-to-sink reasoning pass
+  over a repo's real entrypoints (threat model, ranked entrypoint inventory,
+  deep-review of the top N by a size budget) that catches authorization,
+  business-logic, and trust-boundary bugs the syntactic (A3) and fuzz (A3.5) passes
+  miss. Candidates go through the same A4 triage. (#894)
+- **`vuln-scanner` deliverability gate before autonomous disclosure email.** A new
+  fail-closed DoH MX/A check (dns.google, then Cloudflare) confirms a resolved
+  maintainer domain can actually receive mail before Arm C spends its one daily send
+  slot; an unreachable domain flips the draft to `contact-unverified` and surfaces
+  to the operator without burning the budget. (#895)
 - **The `/aeon` operator skill is now installable as a Claude Code plugin.**
   Packages the existing `.claude/skills/aeon` setup skill as a distributable
   plugin under a self-contained `plugin/` subdirectory (`plugin/.claude-plugin/`
@@ -180,6 +230,31 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Changed
 
+- **GitHub token model corrected to a single classic PAT.** `GH_GLOBAL` is now
+  documented as one classic PAT with `repo` + `workflow` scopes (was fine-grained
+  Contents/PRs/Issues); `GH_READ_PAT` / `GH_SECRETS_PAT` are reframed as legacy and
+  optional, both folding into `GH_GLOBAL`. `read:org` / `admin:org` are not needed,
+  and classic is preferred because the advisories / PVR API is unreliable with
+  fine-grained tokens. Updated in `docs/CONFIGURATION.md`, the README, and the aeon
+  setup skill's `references/secrets.md` (plus its plugin copy and the hosted
+  mirror). (#905)
+- **README agent-onboarding callout + harness section.** A top-of-README line
+  points any coding agent at `read https://www.aeon.fun/skills/aeon.md and follow
+  the instructions` (Claude Code, Codex, Hermes, OpenClaw), and a new "Six engines,
+  one socket" section illustrates the `run-harness` contract across the six CLIs;
+  plus an image-optimization pass trimming ~2.6M of oversized banner assets. (#922)
+- **Security and dependency hardening.** All GitHub Actions are SHA-pinned to
+  immutable commit refs, codex install scripts are blocked and the eyebrow download
+  is SHA256-pinned, and the `messages.yml` `ALL_SECRETS` dump was narrowed to a
+  named allowlist. (#904, #917, #918)
+- **Maintenance.** Model pins refreshed to the current generation (Opus 5 to
+  opus-4-8, fable-5 dropped from the Venice passthrough), the skill-run harness
+  timeout raised to 30m (job cap 50m), cron-state commit given a jittered backoff,
+  `skill_mode` grants `./scripts/skill-runs` in the base tier, `./notify` and
+  `./secretcurl` cleanup plus a usage-probe guard, bounded apt installs, a dashboard
+  feed-card layout fix, a main-CI unbreak, and README harness-section iterations.
+  (#891, #892, #893, #896, #897, #898, #899, #900, #901, #902, #915, #920, #923,
+  #924, #925)
 - **OpenRouter gateway traffic is now attributed to Aeon.** The `openrouter` case
   of `scripts/llm-gateway.sh` sets `ANTHROPIC_CUSTOM_HEADERS` so every Claude Code
   request routed through `openrouter.ai` carries `HTTP-Referer: https://aeon.fun`
@@ -252,6 +327,28 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Fixed
 
+- **Reactive `success_rate` conditions now actually fire.** The scheduler's inline
+  evaluator only handled `consecutive_failures` and `last_status`; a trigger written
+  as `when: "success_rate < 0.5"` matched no branch and was silently dropped.
+  Single-condition evaluation moved to a tested `scripts/reactive_when.sh` covering
+  all three documented conditions, with a `total_runs > 0` guard so a never-run
+  skill does not false-fire. (#906)
+- **`bd-radar` / `fleet-control` read private forks on the single-key setup.** With
+  `GH_READ_PAT` optional and unset fleet-wide, `bd-radar` logged a false source-miss
+  every run and read zero forks/issues; it now falls back to the run's `GH_GLOBAL`
+  (which reads the same private data) and treats an unset `GH_READ_PAT` as the
+  normal one-key config instead of a 401 / rotation follow-up. (#909)
+- **Post-run quality scorer grades the full output, aligned to STRATEGY.** The judge
+  previously saw only the first 3000 bytes (grading the intro, never the payoff); it
+  now samples head 10KB + tail 4KB of large output, injects `STRATEGY.md` so
+  correctness and verifiability outrank looks-finished polish, and adds a
+  fabrication flag for invented IDs / URLs / figures. (#921)
+- **`vuln-tracker` / `vuln-scanner` correctness ports from `aeon-vuln`.** The tracker
+  now reads a flat-array `vuln-scanned.json` (not just the legacy `{scans:[...]}`
+  shape, which silently yielded zero rows) and matches `fix(deps)` / `fix(security)`
+  / bare `security:` PR titles on the `security/` branch (was `fix(security):`-only,
+  dropping most in-flight PRs); the scanner installs osv-scanner v2 and scans
+  gitignored lockfiles. (#890)
 - **`aeon-update` no longer silently deletes a currently-enabled skill retired
   upstream.** The 3-way classifier CLEAN-DELETEd any `skills/<name>/` path removed
   upstream and unmodified locally without checking whether `<name>` is still

--- a/docs/aeon-setup.md
+++ b/docs/aeon-setup.md
@@ -49,6 +49,13 @@ The setup skill also ships as a [Claude Code plugin](https://code.claude.com/doc
 
 Then type `/aeon` in any session and point it at your instance when it asks which repo. Update later with `/plugin update aeon@aeon`, or remove it with `/plugin uninstall aeon@aeon`. (The plugin lives in the [`plugin/`](../plugin) subdirectory of this repo, a self-contained copy of the setup skill, so installing it never pulls in the unattended `skills/` catalog.)
 
+The same plugin installs on **Codex** too - it ships a Codex manifest and a repo-scoped marketplace catalog (`.agents/plugins/marketplace.json`):
+
+```
+codex plugin marketplace add aeonfun/aeon
+codex plugin add aeon@aeon
+```
+
 ### Option C - install it globally by hand (use it from any folder)
 
 Prefer to copy files instead of using the plugin? Drop the skill into your personal Claude Code skills directory so `/aeon` works in every session:

--- a/plugin/skills/aeon/references/secrets.md
+++ b/plugin/skills/aeon/references/secrets.md
@@ -68,11 +68,13 @@ Telegram is the fastest to set up and the only one with inline buttons and slash
 | Secret | Where to get it |
 |---|---|
 | `GITHUB_TOKEN` | Built in — nothing to set. Scoped to this repo only |
-| `GH_GLOBAL` | github.com/settings/tokens → Fine-grained → select repos → Contents, Pull requests, Issues (read/write). Needed for anything cross-repo (`github-monitor`, `pr-review`, `feature`, `changelog push-to`). Auto-promoted to the run's `GITHUB_TOKEN` |
-| `GH_READ_PAT` | Same page, read-only. Optional — enriches cross-repo/private reads (`bd-radar`) without granting write |
-| `GH_SECRETS_PAT` | github.com/settings/personal-access-tokens → **add this repo under Repository access** (a PAT without it 404s) → Repository permissions → Secrets: Read and write. Only needed for OAuth-connected MCP servers or the Grok X-account harness |
+| `GH_GLOBAL` | github.com/settings/tokens -> **Tokens (classic)** -> scopes **`repo`** + **`workflow`** -> add as `GH_GLOBAL`. One token covers everything cross-repo (`github-monitor`, `pr-review`, `feature`, `changelog` push-to), private reads, repository security advisories / PVR (disclosure skills), and secrets writeback. Auto-promoted to the run's `GITHUB_TOKEN` |
+| `GH_READ_PAT` | *Legacy / optional.* Folded into `GH_GLOBAL`. Keep a separate read-only PAT only to give `bd-radar`'s private cross-repo enrichment a read token without granting the run write |
+| `GH_SECRETS_PAT` | *Optional.* Folds into `GH_GLOBAL` (its `repo` scope already writes secrets). Set a dedicated PAT only to isolate secrets-write from the main token: github.com/settings/personal-access-tokens -> add this repo under Repository access (a PAT without it 404s) -> Repository permissions -> Secrets: Read and write. Used by OAuth-connected MCP servers or the Grok X-account harness |
 
 `GH_SECRETS_PAT` gotcha: providers rotate the refresh token every run, and the runner needs this PAT to save each rotation back. Without it, auth breaks exactly one run after you connect. After adding it, re-connect any already-connected server once.
+
+**Scope summary (one classic PAT as `GH_GLOBAL`):** `repo` = cross-repo + private read/write, security advisories / PVR, and secrets writeback; `workflow` = pushing `.github/workflows/` changes (`aeon-update`, `spawn-instance`, `auto-workflow`). `read:org` / `admin:org` are not needed. Use a **classic** PAT - the advisories / PVR API is unreliable with fine-grained tokens.
 
 ## 4. Skill API keys — all optional
 


### PR DESCRIPTION
Syncs merged `aeonfun/aeon` PRs **#890-#925** into the in-repo docs. Source of truth = merged PRs; this is the downstream propagation. (#888/#889 skipped: prior run's own sync artifacts.)

**16 signal, 18 noise.** No catalog change (still 75 skills).

## Surfaces touched
- **`CHANGELOG.md`** - Unreleased Added/Changed/Fixed entries for every signal PR:
  - Added: Codex plugin + repo llms.txt (#919), harnesses.json manifest (#916), chain verdict routing (#911), dry-run gate (#914), audit log (#908), reactive handler var (#910), validate-config reactive checks (#907), aeon-update 3-way merge (#903), vuln-scanner A3.6 (#894), vuln-scanner deliverability gate (#895).
  - Changed: single-classic-PAT GH_GLOBAL model (#905), README onboarding/harness section (#922), security hardening (#904/#917/#918), one Maintenance line for the rest.
  - Fixed: reactive success_rate (#906), bd-radar/fleet-control GH_GLOBAL fallback (#909), scorer full-output grade (#921), vuln-tracker/scanner ports (#890).
- **`plugin/skills/aeon/references/secrets.md`** - re-synced from the upstream setup skill. #905 updated `.claude/skills/aeon/references/secrets.md` but not this byte-for-byte plugin copy, so it was left on the stale fine-grained token model. Now byte-equal to upstream (plugin transform holds: 5 CLAUDE_PLUGIN_ROOT lines, 0 stale paths).
- **`docs/aeon-setup.md`** - Option B now documents the Codex plugin install path (`codex plugin marketplace add` / `codex plugin add`) shipped by #919, which touched only the manifests.

## Noise bundled (Maintenance / Security)
#891, #892, #893 (model pins), #896, #897 (CI/model-pin doc), #898, #899, #900, #901, #902 (ops guards/timeouts), #904, #917, #918 (security hardening), #915 (apt bound), #920 (dashboard layout), #923, #924, #925 (README harness-section iterations).

Watermark moves 887 -> 925.
