### PR TITLE
docs(readme): note the operator console installs as a Codex plugin too

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -46,7 +46,7 @@ git clone https://github.com/<you>/aeon   # skip if you used `gh repo fork --clo
 cd aeon && ./aeon
 ```
 
-Open [localhost:5555](http://localhost:5555) and follow the dashboard: **Authenticate** (any of six [harnesses](../docs/harnesses.md)) → **add a channel** → **pick skills** → **Run**. That's it - Aeon runs unattended. Everything is also an `./aeon` command ([CLI](../apps/cli/README.md)) or a `/aeon` chat command ([setup skill](../docs/aeon-setup.md), installable as a [Claude Code plugin](../docs/aeon-setup.md#install)).
+Open [localhost:5555](http://localhost:5555) and follow the dashboard: **Authenticate** (any of six [harnesses](../docs/harnesses.md)) → **add a channel** → **pick skills** → **Run**. That's it - Aeon runs unattended. Everything is also an `./aeon` command ([CLI](../apps/cli/README.md)) or a `/aeon` chat command ([setup skill](../docs/aeon-setup.md), installable as a [Claude Code or Codex plugin](../docs/aeon-setup.md#install)).
 
 <details>
 <summary><strong>No admin rights / can't install <code>gh</code>?</strong></summary>

--- a/docs/aeon-setup.md
+++ b/docs/aeon-setup.md
@@ -38,7 +38,7 @@ Every Aeon instance ships this skill at [`.claude/skills/aeon/`](../.claude/skil
 1. Open your Aeon repo folder in Claude Code — the [VS Code](https://marketplace.visualstudio.com/items?itemName=anthropic.claude-code) or JetBrains extension, or the `claude` CLI in that directory.
 2. Type **`/aeon`** (or just mention Aeon / `aeon.yml` / "schedule a skill") and answer its questions.
 
-### Option B - install as a Claude Code plugin (from any folder, one command)
+### Option B - install as a Claude Code or Codex plugin (from any folder, one command)
 
 The setup skill also ships as a [Claude Code plugin](https://code.claude.com/docs/en/plugins), so you can install it from a marketplace instead of copying files: versioned, and updatable with `/plugin update`.
 


### PR DESCRIPTION
The Codex plugin shipped in #919 (`plugin/.codex-plugin/plugin.json` + repo-scoped `.agents/plugins/marketplace.json`), but the README's only plugin reference still named just Claude Code.

- **Quick start** line now reads "installable as a Claude Code or Codex plugin".
- **aeon-setup Option B** heading now reads "install as a Claude Code or Codex plugin" so it's discoverable on a scan.

Both point at `docs/aeon-setup.md#install`, which already carries the full `codex plugin marketplace add` / `codex plugin add` commands. Docs-only, no catalog counts touched.