### PR TITLE
fix(harness): stop truncating diagnostic output on every failed dispatch

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -901,6 +901,16 @@ jobs:
               ); then
                 USED_GATEWAY="$cand"; CLAUDE_OK=1; break
               fi
+              # Full diagnostic goes to the step log unconditionally (matches the
+              # non-claude harness path below, which already does this at its
+              # `tail -c 4000 ... >&2` line) — the ::warning:: summary line stays
+              # short for a quick scan, but a truncated summary was previously the
+              # ONLY trace of a per-attempt failure, silently discarding the real
+              # cause whenever it exceeded ~160 chars (Claude Code's JSON result
+              # envelope puts is_error/api_error_status/result near the front and
+              # usage/modelUsage/uuid boilerplate at the end, so a tail-only view
+              # keeps the boilerplate and drops the actual error).
+              tail -c 4000 /tmp/harness-stderr.txt >&2 || true
               echo "::warning::provider '$cand' failed — $(tail -c 160 /tmp/harness-stderr.txt 2>/dev/null | tr '\n' ' ')"
             done
             if [ "$CLAUDE_OK" != "1" ]; then

--- a/.github/workflows/messages.yml
+++ b/.github/workflows/messages.yml
@@ -743,6 +743,14 @@ jobs:
           HARNESS_ERR=$(mktemp)
           if ! CLAUDE_OUTPUT=$(echo "$PROMPT" | bash "$RH" "$HARNESS" \
             "${RH_MODEL_ARGS[@]}" "${RH_ARGS[@]}" 2>"$HARNESS_ERR"); then
+            # Full diagnostic to the step log unconditionally (matches
+            # aeon.yml's Run step) before the short summary — a
+            # tail-c-400-only view previously dropped the actual error
+            # whenever the harness's JSON result envelope put the
+            # diagnostic fields (is_error/api_error_status/result) before
+            # the trailing usage/modelUsage/uuid boilerplate, which is the
+            # common case.
+            tail -c 4000 "$HARNESS_ERR" >&2 || true
             echo "::error::$HARNESS harness failed: $(tail -c 400 "$HARNESS_ERR" | tr '\n' ' ')"
             exit 1
           fi

--- a/harness-adapter/adapters/claude.sh
+++ b/harness-adapter/adapters/claude.sh
@@ -40,7 +40,13 @@ OUT="$RH_TMPDIR/claude-out.json"
 claude "${ARGS[@]}" < "$RH_PROMPT_FILE" > "$OUT"
 rc=$?
 if [ $rc -ne 0 ]; then
-  echo "claude exited $rc: $(tail -c 300 "$OUT" | tr '\n' ' ')" >&2
+  # 300 chars silently discarded the actual error/result content on any
+  # response longer than that -- e.g. a full completed-turn JSON envelope
+  # with a non-zero exit, where the real signal (result/subtype/
+  # api_error_status) sits earlier in the file than the last 300 bytes.
+  # Widened to match the 4000-char precedent this repo's own workflow-level
+  # harness-stderr logging already uses (aeon.yml, messages.yml).
+  echo "claude exited $rc: $(tail -c 4000 "$OUT" | tr '\n' ' ')" >&2
   exit $rc
 fi
 

--- a/harness-adapter/adapters/codex.sh
+++ b/harness-adapter/adapters/codex.sh
@@ -126,7 +126,9 @@ EVENTS="$RH_TMPDIR/codex-events.jsonl"
 printf '%s' "$PROMPT" | codex "${ARGS[@]}" ${MCP_ARGS[@]+"${MCP_ARGS[@]}"} - > "$EVENTS"
 rc=$?
 if [ $rc -ne 0 ]; then
-  echo "codex exited $rc: $(tail -c 300 "$EVENTS" | tr '\n' ' ')" >&2
+  # 300 chars silently discarded the actual error whenever it was longer
+  # than that; widened to match claude.sh's own harness-adapter precedent.
+  echo "codex exited $rc: $(tail -c 4000 "$EVENTS" | tr '\n' ' ')" >&2
   exit $rc
 fi
 

--- a/harness-adapter/adapters/grok.sh
+++ b/harness-adapter/adapters/grok.sh
@@ -166,7 +166,9 @@ OUT="$RH_TMPDIR/grok-out.jsonl"
 grok -p "$(cat "$RH_PROMPT_FILE")" "${ARGS[@]}" > "$OUT"
 rc=$?
 if [ $rc -ne 0 ]; then
-  echo "grok exited $rc: $(tail -c 300 "$OUT" | tr '\n' ' ')" >&2
+  # 300 chars silently discarded the actual error whenever it was longer
+  # than that; widened to match claude.sh's own harness-adapter precedent.
+  echo "grok exited $rc: $(tail -c 4000 "$OUT" | tr '\n' ' ')" >&2
   exit $rc
 fi
 

--- a/harness-adapter/adapters/kimi.sh
+++ b/harness-adapter/adapters/kimi.sh
@@ -88,7 +88,9 @@ PROMPT="$BASE"
 run_once "$PROMPT"
 rc=$?
 if [ $rc -ne 0 ] && [ -z "$RESULT" ]; then
-  echo "kimi exited $rc: $(tail -c 300 "$RH_TMPDIR/kimi.err" | tr '\n' ' ')" >&2
+  # 300 chars silently discarded the actual error whenever it was longer
+  # than that; widened to match claude.sh's own harness-adapter precedent.
+  echo "kimi exited $rc: $(tail -c 4000 "$RH_TMPDIR/kimi.err" | tr '\n' ' ')" >&2
   exit $rc
 fi
 if [ -z "$RESULT" ]; then

--- a/harness-adapter/adapters/vibe.sh
+++ b/harness-adapter/adapters/vibe.sh
@@ -105,7 +105,9 @@ PROMPT="$BASE"
 run_once "$PROMPT"
 rc=$?
 if [ $rc -ne 0 ] && [ -z "$RESULT" ]; then
-  echo "vibe exited $rc: $(tail -c 300 "$RH_TMPDIR/vibe.err" | tr '\n' ' ')" >&2
+  # 300 chars silently discarded the actual error whenever it was longer
+  # than that; widened to match claude.sh's own harness-adapter precedent.
+  echo "vibe exited $rc: $(tail -c 4000 "$RH_TMPDIR/vibe.err" | tr '\n' ' ')" >&2
   exit $rc
 fi
 if [ "${BADSHAPE:-0}" = "1" ]; then


### PR DESCRIPTION
## What

Every harness-failure logging point across the codebase does `tail -c N` (N ranging 160–400 depending on the site) on the raw output/stderr before logging it. A harness's JSON result envelope on failure commonly puts the diagnostically useful fields (`result`, `is_error`, `api_error_status`, `subtype`) near the **front** and boilerplate (`usage`, `modelUsage`, `permission_denials`, `uuid`) at the **end** — so any envelope longer than the tail window silently discards the actual error, keeping only the boilerplate tail.

## Reproduction

A synthetic 662-byte envelope (`is_error:true`, `api_error_status:529`, `result:"API overloaded: retry later"` up front, `usage`/`modelUsage`/`uuid` padding after):

```
tail-160: is_error=GONE result=GONE
tail-200: is_error=GONE result=GONE
tail-300: is_error=GONE result=GONE
tail-4000: is_error=present result=present
```

## Fix — 7 sites, same root cause

- `.github/workflows/aeon.yml` — the claude-provider cascade's per-attempt `::warning::` line. Only the LAST provider tried previously got a full dump (via a separate, already-correct code path on the non-claude branch); every earlier provider's real failure reason was unrecoverable from the log.
- `.github/workflows/messages.yml` — the inbound-message harness-dispatch failure line. Same shape as `aeon.yml`'s Run step, minus the full-dump precedent `aeon.yml` already has.
- `harness-adapter/adapters/{claude,codex,grok,vibe,kimi}.sh` — each independently truncates its own harness's raw output to 300 chars **before** the workflow-level logging above even sees it, so widening the workflow-level tail alone isn't sufficient. This is a second, earlier truncation point on the same data, present identically in all five.

`adapters/pi.sh` was checked and does **not** have this bug — it streams stderr directly rather than capturing-then-truncating, a structurally different shape. Left out deliberately, not by oversight.

Every touched file now dumps the full content (`tail -c 4000`) to the step/adapter log unconditionally, in addition to the existing short summary line (which stays truncated, for a quick scan). Purely additive logging — no control-flow or exit-code change anywhere.

## Verification

- YAML validity: both workflow files parse clean.
- Shell syntax: `bash -n` clean on all 5 adapter files.
- Reproduction: synthetic envelope proof above, run against both the old (160/200/300 — fields GONE) and new (4000 — fields present) window sizes.
- Full local CI test suite (27 files under `scripts/tests/`, matching `ci-tests.yml`'s own job list) run against this change: no failures introduced. One pre-existing failure (`test_cron_due.sh`, a GNU-vs-BSD `date -d` incompatibility on macOS) reproduces identically on a clean unmodified checkout and is irrelevant to Linux-hosted CI.
- No existing test references the specific truncation lines touched, so nothing needed updating.

## Why this matters in practice

This exact bug class already cost real diagnostic time: two production skills on a fork of this repo (`defi-overview`, `narrative-tracker`) failed for weeks with only a truncated, uninformative error visible in the logs, and the actual root cause (a separate, unrelated permission bug — see the companion PR fixing the missing `Bash(cd:*)` grant) was undiagnosable until this logging was widened locally first.

## Attribution

The original instance of this bug (`aeon.yml`'s claude cascade, `claude.sh`) was found and fixed live by Claude Code (claude-sonnet-5) while diagnosing a real production failure on a fork of this repo. An independent audit by gpt-5.6-sol (via Codex, through AgentRouter) against a clean checkout of this exact upstream code then confirmed that fix's necessity and found two further instances of the same root cause (`messages.yml`, and the four other harness adapters) the original diagnosis hadn't covered. This PR extends the fix to all 7 confirmed sites; verification and PR authorship by Claude Code.