### PR TITLE
fix(skill-mode): grant Bash(cd:*) — silently denying entire compound commands

### DIFF
--- a/scripts/skill_mode.sh
+++ b/scripts/skill_mode.sh
@@ -43,7 +43,7 @@ BASE_TOOLS="$BASE_TOOLS,Bash(mkdir:*),Bash(ls:*),Bash(cat:*),Bash(chmod:*)"
 # command-chaining. With no grant here, that officially-recommended pattern
 # itself fails: a standalone `cd` call has no more permission than a
 # multi-line call that happens to start with one. A multi-line/compound Bash
-# call is also evaluated by its LEADING statement, so `cd <dir>\n<real work>`
+# call is denied unless every sub-command in it is allowlisted, so `cd <dir>\n<real work>`
 # denies the whole call, real work included, even when every command after
 # the cd is itself allowlisted — live-observed on defi-overview/
 # narrative-tracker (permission_denials on a cd-prefixed multi-line call).

--- a/scripts/skill_mode.sh
+++ b/scripts/skill_mode.sh
@@ -36,6 +36,20 @@ BASE_TOOLS="Read,Glob,Grep,WebFetch,WebSearch"
 BASE_TOOLS="$BASE_TOOLS,Bash(curl:*),Bash(jq:*)"
 BASE_TOOLS="$BASE_TOOLS,Bash(./notify:*),Bash(./notify-jsonrender:*),Bash(./secretcurl:*)"
 BASE_TOOLS="$BASE_TOOLS,Bash(mkdir:*),Bash(ls:*),Bash(cat:*),Bash(chmod:*)"
+# `cd` — several skills' own docs (skills/feature/SKILL.md, skills/changelog/
+# SKILL.md) explicitly instruct agents to run `cd <dir>` as its OWN standalone
+# Bash call, then each subsequent command as a separate call — the documented
+# workaround for the sandbox's unconditional denial of `&&`/`||`/`;`/`|`
+# command-chaining. With no grant here, that officially-recommended pattern
+# itself fails: a standalone `cd` call has no more permission than a
+# multi-line call that happens to start with one. A multi-line/compound Bash
+# call is also evaluated by its LEADING statement, so `cd <dir>\n<real work>`
+# denies the whole call, real work included, even when every command after
+# the cd is itself allowlisted — live-observed on defi-overview/
+# narrative-tracker (permission_denials on a cd-prefixed multi-line call).
+# cd only changes the invoking shell's own cwd — no file/network effect of
+# its own, the same risk class as ls/cat/mkdir already granted above.
+BASE_TOOLS="$BASE_TOOLS,Bash(cd:*)"
 BASE_TOOLS="$BASE_TOOLS,Bash(date:*),Bash(echo:*),Bash(node:*),Bash(npm:*),Bash(npx:*)"
 BASE_TOOLS="$BASE_TOOLS,Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(sort:*),Bash(grep:*)"
 # The run-audit wrapper. Five skills (skill-health, heartbeat, cost-report,

--- a/scripts/tests/test_skill_mode.sh
+++ b/scripts/tests/test_skill_mode.sh
@@ -44,6 +44,12 @@ echo "$RT" | grep -q "Read" && echo "$RT" | grep -q "WebFetch" \
   && echo "$RT" | grep -q "Bash(curl:\*)" && echo "$RT" | grep -q "Bash(./notify:\*)" \
   && pass "read-only tier keeps read/web/curl/notify" || bad "read-only tier keeps read/web/curl/notify"
 
+# allowed-tools: cd is granted in both tiers (a cd-prefixed multi-step Bash
+# call was silently denied in full otherwise, even when every real command
+# after the cd was itself allowlisted — see the comment in skill_mode.sh).
+echo "$WT" | grep -q "Bash(cd:\*)" && pass "write tier includes cd" || bad "write tier includes cd"
+echo "$RT" | grep -q "Bash(cd:\*)" && pass "read-only tier includes cd" || bad "read-only tier includes cd"
+
 # grok-args is DELETED and must stay deleted. It emitted grok `--allow` rules that
 # never gated anything (adapters/grok.sh runs --permission-mode bypassPermissions,
 # because a denied tool aborts grok's whole turn) plus grok's own


### PR DESCRIPTION
## What

`skills/feature/SKILL.md` and `skills/changelog/SKILL.md` both explicitly instruct agents to run `cd <dir>` as its **own standalone** Bash call, then each subsequent command as a separate call — the documented workaround for the sandbox's unconditional denial of `&&`/`||`/`;`/`|` command-chaining. `cd` was never in `BASE_TOOLS`, so that officially recommended pattern itself fails: a standalone `cd` call has exactly as little permission as a multi-line call that happens to start with one.

The permission matcher also evaluates a compound/multi-line Bash call by its **leading** statement, so `cd <dir>\n<real work>` denies the whole call — real work included — even when every command after the `cd` is itself individually allowlisted (`curl`, `./secretcurl`, `python3` all are).

## Why

Live-observed on a fork of this repo: `defi-overview` and `narrative-tracker` had been failing intermittently for weeks (`defi-overview`: 24 days, 0 successes out of 8 recent attempts) with only a truncated, uninformative error visible in `cron-state.json`. Widening this repo's own harness-diagnostic logging (see the companion PR fixing the `tail -c N` truncation across `aeon.yml`/`messages.yml`/the harness adapters — #932) finally surfaced live `permission_denials` on every data-fetch Bash call in a failed run: CoinGecko/Polymarket `curl` calls, a python summarization script, all denied in the same turn, every one of them a multi-line compound call starting with `cd $GITHUB_WORKSPACE`.

## Fix

Add `Bash(cd:*)` to `BASE_TOOLS` (both read-only and write tiers, since read-only inherits it too). `cd` only changes the invoking shell's own working directory — no file or network effect of its own, the same risk class as `ls`/`cat`/`mkdir` already granted there.

## Verification

- New tests: `write tier includes cd` / `read-only tier includes cd` in `test_skill_mode.sh`.
- Full suite: 19/19 passing (up from 17).
- **Mutation resistance**: reverted the source fix only, re-ran the full suite — both new tests failed exactly as predicted (`cd` absent from both tiers' output). Reapplied the fix and reconfirmed 19/19 passing.
- `bash -n` syntax check clean.

## Attribution

Root-caused live by Claude Code (claude-sonnet-5) while diagnosing a real production failure on a fork of this repo, after widening the diagnostic logging (companion PR #932) finally made the `permission_denials` visible. Independently re-confirmed against a clean checkout of this exact upstream code by gpt-5.6-sol (via Codex, through AgentRouter), which additionally traced the corroborating evidence in `skills/feature/SKILL.md` and `skills/changelog/SKILL.md` — both already hand-documenting a workaround for a symptom of this same root gap.