### PR TITLE
fix(aeon): scope the skill-runner concurrency group by target too

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -102,7 +102,28 @@ env:
   FLEET_TOKEN:    ${{ secrets.FLEET_TOKEN }}
 
 concurrency:
-  group: aeon-${{ inputs.skill || github.event.action || github.run_id }}
+  # Keyed by skill name alone, `var` was ignored entirely: dispatching the
+  # same skill at two different explicit targets (e.g. vuln-scanner against
+  # two different owner/repo values, or digest against two different topics)
+  # collided into the same group. With cancel-in-progress:false, GitHub only
+  # keeps ONE run queued behind the currently-active one at a time -- so a
+  # burst of dispatches to the same skill with different targets silently
+  # cancelled every run except the first and whichever landed last. The ones
+  # in between never executed at all, with no error surfaced anywhere.
+  # Live-observed: 10 vuln-scanner dispatches, 8 silently cancelled, only 2
+  # ever ran. Appending inputs.var to the group key when it's set fixes that
+  # without changing behavior for the common case (var empty/unset):
+  # same-skill scheduled/manual runs with no target still serialize exactly
+  # as before, preserving the original guard against a genuine duplicate run.
+  #
+  # Known remaining gap, not fixed by this change: a skill invoked
+  # repeatedly with an EMPTY var that auto-selects a different target
+  # internally on each run (e.g. vuln-scanner's "auto-select a trending
+  # repo" mode) still collides, since the workflow trigger layer has no
+  # visibility into what the skill will pick once it's running -- that
+  # would need a client-side distinguishing value (e.g. a per-dispatch
+  # nonce), a separate, narrower change.
+  group: aeon-${{ inputs.skill || github.event.action || github.run_id }}${{ inputs.var && format('-{0}', inputs.var) || '' }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## What

The concurrency group was keyed by skill name alone (`aeon-${{ inputs.skill }}`), completely ignoring `inputs.var`. Dispatching the same skill at two different explicit targets (e.g. `vuln-scanner` against two different `owner/repo` values, or `digest` against two different topics) collided into the same group. With `cancel-in-progress: false`, GitHub only keeps **one** run queued behind the currently-active one at a time — so a burst of dispatches to the same skill with different targets silently cancelled every run except the first and whichever landed last. The ones in between never executed at all, with no error surfaced anywhere.

## Reproduction

Live-observed on a fork of this repo: 10 `vuln-scanner` dispatches (different repos, back to back), 8 silently cancelled, only 2 ever ran.

## Fix

Append `inputs.var` to the group key when it's set. Same-skill scheduled/manual runs with no target (the common case — `heartbeat`, `digest`'s daily default, etc.) are unaffected and still serialize exactly as before, preserving the original guard against a genuine duplicate run of identical work. Only dispatches that differ by an explicit `var` now get independent concurrency groups.

**Known remaining gap, not fixed by this change** (documented in the workflow comment): a skill invoked repeatedly with an **empty** `var` that auto-selects a different target internally on each run (e.g. `vuln-scanner`'s "auto-select a trending repo" mode) still collides, since the workflow trigger layer has no visibility into what the skill will pick once it's running. That would need a client-side distinguishing value (a per-dispatch nonce) — a separate, narrower change than this one.

## Verification

- YAML validity: parses clean.
- GitHub's concurrency-group semantics (one queued run max per group when `cancel-in-progress` is false) are documented platform behavior, not something reproducible in a local test harness — no existing test in this repo covers concurrency config, and this PR doesn't add one for the same reason. Stated plainly rather than overclaiming local verification that isn't possible here.

## Attribution

Found and fixed live by Claude Code (claude-sonnet-5) after observing the real cancellation pattern on a fork of this repo during a burst-dispatch test. Independently re-confirmed against a clean checkout of this exact upstream code by gpt-5.6-sol (via Codex, through AgentRouter), which verified the group expression has no `var` reference and cited this repo's own harness-adapter integration docs describing the one-pending-run-per-group semantics.