### PR TITLE
fix(secretcurl): keep substituted secrets out of curl's own argv

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -105,3 +105,5 @@ jobs:
         run: bash scripts/tests/test_audit.sh
       - name: dry-run gate (synthetic secrets, no real leak, pass criteria)
         run: bash scripts/tests/test_dry_run.sh
+      - name: secretcurl argv-exposure tests
+        run: bash scripts/tests/test_secretcurl.sh

--- a/scripts/secretcurl.sh
+++ b/scripts/secretcurl.sh
@@ -38,9 +38,61 @@ subst() {
 args=()
 for a in "$@"; do args+=("$(subst "$a")"); done
 
-# When auditing is off (AEON_AUDIT_LOG unset), stay a transparent exec passthrough
-# -- byte-identical to the original behaviour. When on, run curl in the foreground
-# (stdout/stderr/exit all pass through unchanged) so we can record the call after.
+# Substituted args still land in curl's OWN process argv (visible to any other
+# process on the box via `ps`/`/proc/<pid>/cmdline`) if handed to curl directly
+# -- defeating the whole point of substituting inside this script rather than in
+# the caller's command line. Route them through curl's -K/--config instead: a
+# config file (or, here, stdin) is the one form of curl invocation where secret
+# values never appear in argv at all.
+#
+# cfg_quote: -K's double-quoted strings only recognize \\, \", \t, \n, \r, \v as
+# real escapes -- backslash before anything else is dropped verbatim -- so a
+# literal backslash must become \\ before a value goes in quotes, or arbitrary
+# content is corrupted.
+cfg_quote() {
+  local v="$1"
+  v="${v//\\/\\\\}"
+  v="${v//\"/\\\"}"
+  printf '"%s"' "$v"
+}
+is_url() { case "$1" in http://*|https://*) return 0 ;; *) return 1 ;; esac; }
+
+# build_config: turn a curl-style argv array into -K config-file text. Every
+# real call site in this repo is one of: a bare target URL, a boolean flag
+# (-s/-fsS/-sS), or a flag with a value (-H/-X/-o/-w/-m/--max-time) -- including
+# `-d @file` (curl itself interprets the leading @, unchanged by going through
+# -K). No flag in this codebase takes a URL-shaped value, so a bare http(s)://
+# token is always the target url, never mistaken for another flag's argument.
+build_config() {
+  local -a a=("$@")
+  local i=0 n=${#a[@]}
+  while [ "$i" -lt "$n" ]; do
+    local tok="${a[$i]}"
+    if is_url "$tok"; then
+      printf 'url = %s\n' "$(cfg_quote "$tok")"
+      i=$((i + 1))
+    elif [[ "$tok" == -* ]]; then
+      local next=$((i + 1))
+      if [ "$next" -lt "$n" ] && [[ "${a[$next]}" != -* ]] && ! is_url "${a[$next]}"; then
+        printf '%s %s\n' "$tok" "$(cfg_quote "${a[$next]}")"
+        i=$((i + 2))
+      else
+        printf '%s\n' "$tok"
+        i=$((i + 1))
+      fi
+    else
+      echo "secretcurl: cannot classify argument '$tok' (not a flag, not a URL) -- refusing to guess" >&2
+      return 1
+    fi
+  done
+}
+
+CONFIG="$(build_config "${args[@]}")" || exit 1
+
+# When auditing is off (AEON_AUDIT_LOG unset), stay a transparent passthrough --
+# byte-identical output/exit behaviour to a plain curl call. When on, run curl in
+# the foreground (stdout/stderr/exit all pass through unchanged) so we can record
+# the call after.
 if [ -n "${AEON_AUDIT_LOG:-}" ]; then
   # Credential placeholders that were substituted (NAMES only) and the target URL,
   # both read from the ORIGINAL placeholder args so no secret value is handled here.
@@ -53,7 +105,8 @@ if [ -n "${AEON_AUDIT_LOG:-}" ]; then
   _URL=""
   for a in "$@"; do case "$a" in http://*|https://*) _URL="$a"; break ;; esac; done
   set +e
-  curl "${args[@]}"; _RC=$?
+  printf '%s' "$CONFIG" | curl -K -
+  _RC=$?
   set -e
   _HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   for _c in "scripts/audit.sh" "$_HERE/audit.sh" "$_HERE/scripts/audit.sh"; do
@@ -61,4 +114,4 @@ if [ -n "${AEON_AUDIT_LOG:-}" ]; then
   done
   exit "$_RC"
 fi
-exec curl "${args[@]}"
+printf '%s' "$CONFIG" | curl -K -

--- a/scripts/tests/test_secretcurl.sh
+++ b/scripts/tests/test_secretcurl.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Tests for scripts/secretcurl.sh. Run: bash scripts/tests/test_secretcurl.sh
+#
+# secretcurl exists to keep secret values off any command line an external
+# observer (ps, /proc/<pid>/cmdline) could read. Substituting {ENV_NAME} inside
+# this script was only half of that -- the substituted value still had to reach
+# curl somehow, and handing it to curl as an argv element puts it right back in
+# curl's OWN process argv. These tests check the actual curl subprocess argv,
+# not just secretcurl's own behaviour, since that subprocess is the exposure
+# surface this fix closes. All requests go to a local echo server -- no network
+# dependency, no flakiness.
+set -uo pipefail
+cd "$(dirname "$0")/../.." || exit 1
+S="./scripts/secretcurl.sh"
+fail=0
+pass() { echo "ok   - $1"; }
+bad()  { echo "FAIL - $1"; fail=1; }
+
+export TEST_SECRETCURL_API_KEY='marker-secret-do-not-leak\"quote'
+
+PORT=$((20000 + RANDOM % 20000))
+ECHO_SRV=$(mktemp)
+cat > "$ECHO_SRV" <<'PYEOF'
+import http.server, json, sys
+class H(http.server.BaseHTTPRequestHandler):
+    def _reply(self):
+        length = int(self.headers.get('Content-Length', 0))
+        body = self.rfile.read(length).decode('utf-8', 'replace') if length else ''
+        payload = json.dumps({'headers': dict(self.headers), 'body': body}).encode()
+        self.send_response(200)
+        self.send_header('Content-Length', str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+    def do_GET(self):
+        if self.path == '/slow-enough':
+            open(sys.argv[2], 'w').close()
+            import time; time.sleep(2)
+        self._reply()
+    def do_POST(self): self._reply()
+    def log_message(self, *a): pass
+http.server.HTTPServer(('127.0.0.1', int(sys.argv[1])), H).serve_forever()
+PYEOF
+MARKER=$(mktemp -u)
+rm -f "$MARKER"
+python3 "$ECHO_SRV" "$PORT" "$MARKER" &
+SRV_PID=$!
+cleanup() { kill "$SRV_PID" 2>/dev/null; wait "$SRV_PID" 2>/dev/null; rm -f "$ECHO_SRV" "$MARKER"; }
+trap cleanup EXIT
+for _ in 1 2 3 4 5; do
+  curl -s -o /dev/null --max-time 1 "http://127.0.0.1:$PORT/" && break
+  sleep 0.2
+done
+
+# --- argv exposure: the real gap this fix closes ----------------------------
+# The server touches $MARKER the instant it starts handling /slow-enough, then
+# blocks for 2s before replying -- so once the marker exists, the curl process
+# handling this request is guaranteed to still be alive and blocked server-side,
+# with no race between "request sent" and "ps snapshot taken".
+"$S" -s -o /dev/null --max-time 5 "http://127.0.0.1:$PORT/slow-enough" \
+  -H "Authorization: Bearer {TEST_SECRETCURL_API_KEY}" &
+SC_PID=$!
+for _ in $(seq 1 50); do [ -e "$MARKER" ] && break; sleep 0.1; done
+SNAPSHOT=$(ps -ef 2>/dev/null || ps aux 2>/dev/null)
+wait "$SC_PID" 2>/dev/null
+
+if printf '%s' "$SNAPSHOT" | grep -q 'marker-secret-do-not-leak'; then
+  bad "secret value must not appear in any process argv (found: $(printf '%s' "$SNAPSHOT" | grep 'marker-secret' | head -1))"
+else
+  pass "secret value does not appear in any process argv while the request is in flight"
+fi
+if printf '%s' "$SNAPSHOT" | grep -q '[c]url -K -'; then
+  pass "curl subprocess invoked via -K (config on stdin), not inline args"
+else
+  bad "expected a 'curl -K -' subprocess in the ps snapshot (got: $(printf '%s' "$SNAPSHOT" | grep '[c]url'))"
+fi
+
+# --- functional correctness: substitution, headers, and -d @file all still work
+OUT=$(mktemp)
+"$S" -s -o "$OUT" --max-time 5 "http://127.0.0.1:$PORT/hdr" \
+  -H "Authorization: Bearer {TEST_SECRETCURL_API_KEY}"
+RESP=$(cat "$OUT")
+case "$RESP" in
+  *'marker-secret-do-not-leak\\\"quote'*) pass "substituted secret (incl. backslash+quote) reaches curl and the server intact" ;;
+  *) bad "substituted header value did not round-trip intact (got: $RESP)" ;;
+esac
+
+PAYLOAD_FILE=$(mktemp)
+printf '{"k":"v","n":1}' > "$PAYLOAD_FILE"
+"$S" -s -o "$OUT" --max-time 5 -X POST "http://127.0.0.1:$PORT/body" -d "@$PAYLOAD_FILE"
+case "$(cat "$OUT")" in
+  *'{\"k\": \"v\", \"n\": 1}'*|*'{\"k\":\"v\",\"n\":1}'*) pass "'-d @file' still reads payload from file through -K" ;;
+  *) bad "'-d @file' payload did not reach the server (got: $(cat "$OUT"))" ;;
+esac
+rm -f "$PAYLOAD_FILE"
+
+"$S" -s -o "$OUT" --max-time 5 -X POST "http://127.0.0.1:$PORT/body" -d '{"inline":true}'
+case "$(cat "$OUT")" in
+  *'inline'*) pass "inline -d JSON payload still reaches the server" ;;
+  *) bad "inline -d payload did not reach the server (got: $(cat "$OUT"))" ;;
+esac
+rm -f "$OUT"
+
+# --- exit-code fidelity: a real curl failure still propagates -------------
+"$S" -s -o /dev/null --max-time 2 "http://127.0.0.1:1/refused" >/dev/null 2>&1
+RC=$?
+[ "$RC" -ne 0 ] && pass "curl failure (connection refused) propagates as a real non-zero exit" \
+  || bad "expected non-zero exit against a closed port, got 0"
+
+# --- unclassifiable argument is refused, not silently mishandled -----------
+ERR=$("$S" "bare-non-flag-non-url" 2>&1 >/dev/null)
+RC=$?
+if [ "$RC" -ne 0 ] && printf '%s' "$ERR" | grep -q "cannot classify"; then
+  pass "an argument that is neither a flag nor a URL is refused, not guessed at"
+else
+  bad "expected a 'cannot classify' refusal for an unclassifiable argument (rc=$RC, err=$ERR)"
+fi
+
+echo "---"
+[ "$fail" = "0" ] && echo "ALL PASS" || echo "SOME FAILED"
+exit "$fail"


### PR DESCRIPTION
## What

`secretcurl.sh` substitutes `{ENV_NAME}` placeholders inside the script so the caller's command line (and the Bash permission analyzer that inspects it) never sees a literal `$SECRET`. But the substituted args were then handed straight to curl as argv (`curl "${args[@]}"` / `exec curl "${args[@]}"`), so the real secret value landed in **curl's own process argv** instead — visible to any other process on the box via `ps` or `/proc/<pid>/cmdline`.

## Why this is exploitable, not just theoretical

Every write-tier skill grants `Bash(ls:*)` and `Bash(cat:*)` (`scripts/skill_mode.sh` `BASE_TOOLS`, present in every tier including read-only). A malicious or injected skill could scan `/proc` for a live `secretcurl` subprocess's cmdline using tools already on the allowlist — no privilege escalation needed. The substitution mechanism did exactly half its job: it kept the secret out of the command *this script* evaluates, but not out of the command *curl* evaluates.

## Fix

Route the substituted args through curl's `-K`/`--config` on stdin instead of argv — the one curl invocation form where values never appear in argv at all. Added:
- `is_url()` — classifies a bare `http(s)://` token as the target URL.
- `cfg_quote()` — escapes backslash and double-quote per `-K`'s own quoting rules (only `\\`, `\"`, `\t`, `\n`, `\r`, `\v` are real escapes inside a quoted `-K` value; any other backslash-prefixed char is silently dropped otherwise, which would corrupt un-escaped content).
- `build_config()` — walks the argv array and emits `-K` config lines: a bare URL, a boolean flag alone, or a flag+value pair (verified against every real call-site shape in this repo: `-H`, `-X`, `-o`, `-w`, `-m`/`--max-time`, `-s`/`-fsS`/`-sS`, and `-d @file` — curl interprets the `@file` prefix itself, unchanged by going through `-K`). An argument that's neither a recognized flag nor a URL is **refused outright**, not guessed at — a wrong guess here is a security-relevant bug class, not a UX one.

The `AEON_AUDIT_LOG` branch (records secret *names* + target URL, never values) is adapted to the same `-K` invocation and re-verified to still capture the correct exit code.

## Verification

Added `scripts/tests/test_secretcurl.sh` — fully local, no network dependency (a Python `http.server` echo target on `127.0.0.1`):

- **Live `ps` snapshot, synchronized via a marker file** (the echo server touches a marker the instant it starts handling a slow endpoint, then blocks 2s before replying) so the check is deterministic rather than racing a fast localhost round-trip:
  - Against the **original** script: `curl -s ... -H Authorization: Bearer <secret> ...` — secret in plain view.
  - Against the **fixed** script: only `curl -K -` — secret nowhere in any process argv.
- **Functional parity**: substituted header values (including a value containing a backslash *and* a quote), inline `-d` JSON, and `-d @file` payloads all still reach the target server intact.
- A real curl failure (connection refused) still propagates as a non-zero exit.
- **Mutation-resistance**: reverted the fix and confirmed 3 of 7 checks fail for exactly the predicted reason (secret visible in argv, no `-K` subprocess, no "cannot classify" refusal path) before reapplying.

```
$ bash scripts/tests/test_secretcurl.sh
ok   - secret value does not appear in any process argv while the request is in flight
ok   - curl subprocess invoked via -K (config on stdin), not inline args
ok   - substituted secret (incl. backslash+quote) reaches curl and the server intact
ok   - '-d @file' still reads payload from file through -K
ok   - inline -d JSON payload still reaches the server
ok   - curl failure (connection refused) propagates as a real non-zero exit
ok   - an argument that is neither a flag nor a URL is refused, not guessed at
---
ALL PASS
```

## Attribution

Flagged by gpt-5.6-sol (via Codex/AgentRouter) in a round-2 audit of this repo focused on `scripts/` and `harness-adapter/lib/` surface not covered by round 1 (#932, #933, #934). Claude Code (claude-sonnet-5) independently verified the finding, escalated the severity by cross-referencing the actual granted tool tiers in `scripts/skill_mode.sh` to establish a concrete no-privilege-escalation exploitation path, and designed/implemented/tested the fix.