### PR TITLE
improve(memory-flush): deterministic prep + structured watermark

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -87,6 +87,8 @@ jobs:
         run: python3 scripts/tests/test_state_reduce.py
       - name: health triage tests
         run: python3 scripts/tests/test_health_triage.py
+      - name: memory-flush prep tests
+        run: python3 scripts/tests/test_memory_prep.py
       - name: validate-config unit tests
         run: node --test scripts/validate-config.test.js
       - name: validate-config aeon.yml structural check

--- a/scripts/memory_prep.py
+++ b/scripts/memory_prep.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""
+memory_prep - deterministic pre/post pass for the memory-flush skill.
+
+memory-flush used to make the model do bookkeeping every run: parse the scan
+window off a prose line, list in-window logs, and rotate memory/logs/ once it
+grew past ~45 files. That is pure code, and doing it in the LLM made it costly
+(7 instances, weekly) and unreliable (the window silently fell back to 3 days
+whenever the prose watermark was edited away, losing un-promoted entries).
+
+This module owns that mechanical work so the model is left with only the
+judgment: what to promote, dedup, and prune.
+
+Watermark source of truth is memory/memory-flush-state.json (structured,
+skill-owned) - NOT memory/cron-state.json, whose schema is a fixed shape folded
+by state_reduce.py that would drop an extra field under the Issues backend. The
+memory/MEMORY.md "*Last consolidated: <date>*" line is kept as a human mirror.
+
+Subcommands:
+  window   pre-pass: rotate old logs, then print the scan window + the exact
+           list of in-window log files to stdout for the model to read.
+  stamp    post-pass: write today's date to the watermark file and mirror it
+           into the MEMORY.md prose line.
+
+The date planners are kept pure (no clock, no I/O) so they are unit-testable;
+the today's-date reads and file writes live in the thin I/O wrappers.
+"""
+import datetime
+import json
+import os
+import re
+import subprocess
+import sys
+
+LOGS_DIR = "memory/logs"
+ARCHIVE_DIR = "memory/logs/archive"
+STATE_FILE = "memory/memory-flush-state.json"
+MEMORY_MD = "memory/MEMORY.md"
+
+ROTATE_THRESHOLD = 45   # only rotate once logs/ grows past this many dailies
+SCAN_CLAMP_DAYS = 14    # a gap longer than this clamps the scan window
+DEFAULT_LOOKBACK_DAYS = 3  # no watermark at all -> read the last 3 days
+
+_DAILY_RE = re.compile(r"^(\d{4})-(\d{2})-(\d{2})\.md$")
+_CONSOLIDATED_RE = re.compile(r"^\*Last consolidated:.*\*\s*$", re.IGNORECASE | re.MULTILINE)
+
+
+# ---------------------------------------------------------------------------
+# pure planners (unit-tested)
+# ---------------------------------------------------------------------------
+
+def parse_date(s):
+    """'2026-08-16' -> date, or None if unparseable/blank/'never'."""
+    if not s:
+        return None
+    s = s.strip()
+    if s.lower() == "never":
+        return None
+    try:
+        return datetime.date.fromisoformat(s)
+    except ValueError:
+        return None
+
+
+def watermark_from_memory_md(text):
+    """Recover the last-consolidated date from the MEMORY.md prose line."""
+    if not text:
+        return None
+    m = _CONSOLIDATED_RE.search(text)
+    if not m:
+        return None
+    inner = m.group(0).split(":", 1)[1]  # after 'Last consolidated:'
+    return parse_date(inner.strip().strip("*").strip())
+
+
+def resolve_watermark(state_json, memory_md):
+    """
+    Decide the last-consolidated date and where it came from.
+    Prefer the structured state file; fall back to the MEMORY.md prose line
+    (first-run migration); else None. Returns (date_or_None, source_str).
+    """
+    if state_json:
+        try:
+            d = parse_date(json.loads(state_json).get("last_consolidated"))
+            if d:
+                return d, "state-file"
+        except (ValueError, AttributeError):
+            pass
+    d = watermark_from_memory_md(memory_md)
+    if d:
+        return d, "memory.md"
+    return None, "none"
+
+
+def compute_window(last_consolidated, today):
+    """
+    (start_date, clamped_bool) for the log scan.
+      - no watermark          -> last DEFAULT_LOOKBACK_DAYS
+      - gap > SCAN_CLAMP_DAYS  -> clamp to last SCAN_CLAMP_DAYS (agent was dark)
+      - otherwise              -> from the watermark day (re-reading it is
+                                  idempotent thanks to the skill's dedup step)
+    """
+    if last_consolidated is None:
+        return today - datetime.timedelta(days=DEFAULT_LOOKBACK_DAYS), False
+    gap = (today - last_consolidated).days
+    if gap > SCAN_CLAMP_DAYS:
+        return today - datetime.timedelta(days=SCAN_CLAMP_DAYS), True
+    return last_consolidated, False
+
+
+def parse_daily(fname):
+    """'2026-08-16.md' -> date, or None if it is not a daily log filename."""
+    m = _DAILY_RE.match(fname)
+    if not m:
+        return None
+    try:
+        return datetime.date(int(m.group(1)), int(m.group(2)), int(m.group(3)))
+    except ValueError:
+        return None
+
+
+def select_logs(filenames, start_date, today):
+    """In-window daily log filenames (start_date <= d <= today), date-sorted."""
+    dated = [(parse_daily(f), f) for f in filenames]
+    keep = [(d, f) for d, f in dated if d is not None and start_date <= d <= today]
+    return [f for _, f in sorted(keep)]
+
+
+def rotatable_months(filenames, today, threshold=ROTATE_THRESHOLD):
+    """
+    {YYYY-MM: [date-sorted filenames]} for whole months to roll into the
+    archive. Only fires past the threshold, and only for months whose every
+    daily is older than the 14-day scan floor (so nothing still in scope is
+    touched). A month straddling the floor is left alone.
+    """
+    dailies = [(parse_daily(f), f) for f in filenames]
+    dailies = [(d, f) for d, f in dailies if d is not None]
+    if len(dailies) <= threshold:
+        return {}
+    cutoff = today - datetime.timedelta(days=SCAN_CLAMP_DAYS)
+    by_month = {}
+    for d, f in dailies:
+        by_month.setdefault("%04d-%02d" % (d.year, d.month), []).append((d, f))
+    out = {}
+    for ym, items in by_month.items():
+        if all(d < cutoff for d, _ in items):
+            out[ym] = [f for _, f in sorted(items)]
+    return out
+
+
+def stamp_memory_md(text, today):
+    """
+    Return MEMORY.md text with the '*Last consolidated: <date>*' line set to
+    today. Update in place if present, else insert under the first H1 title.
+    """
+    line = "*Last consolidated: %s*" % today.isoformat()
+    if _CONSOLIDATED_RE.search(text):
+        return _CONSOLIDATED_RE.sub(line, text, count=1)
+    lines = text.split("\n")
+    for i, ln in enumerate(lines):
+        if ln.startswith("# "):
+            lines.insert(i + 1, "")
+            lines.insert(i + 2, line)
+            return "\n".join(lines)
+    # no title -> prepend
+    return line + "\n\n" + text
+
+
+# ---------------------------------------------------------------------------
+# thin I/O wrappers
+# ---------------------------------------------------------------------------
+
+def _read(path):
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return fh.read()
+    except FileNotFoundError:
+        return None
+
+
+def _git_rm(root, relpaths):
+    """git rm the given repo-relative paths (best-effort; rm is not granted)."""
+    if not relpaths:
+        return
+    subprocess.run(["git", "-C", root, "rm", "--quiet", "--"] + relpaths, check=False)
+
+
+def do_window(root, today):
+    logs_dir = os.path.join(root, LOGS_DIR)
+    try:
+        entries = os.listdir(logs_dir)
+    except FileNotFoundError:
+        entries = []
+
+    state_json = _read(os.path.join(root, STATE_FILE))
+    memory_md = _read(os.path.join(root, MEMORY_MD))
+    last, source = resolve_watermark(state_json, memory_md)
+    start, clamped = compute_window(last, today)
+
+    # rotate before selecting so the archive never overlaps the window
+    rotated = rotatable_months(entries, today)
+    archived_months = 0
+    if rotated:
+        archive_dir = os.path.join(root, ARCHIVE_DIR)
+        os.makedirs(archive_dir, exist_ok=True)
+        for ym, files in sorted(rotated.items()):
+            chunks = []
+            for f in files:
+                body = _read(os.path.join(logs_dir, f))
+                if body is not None:
+                    chunks.append("<!-- %s -->\n%s" % (f, body.rstrip()))
+            with open(os.path.join(archive_dir, ym + ".md"), "a", encoding="utf-8") as out:
+                out.write("\n\n".join(chunks) + "\n")
+            _git_rm(root, [os.path.join(LOGS_DIR, f) for f in files])
+            archived_months += 1
+        # drop rotated files from the in-memory listing before selecting
+        rolled = {f for files in rotated.values() for f in files}
+        entries = [e for e in entries if e not in rolled]
+
+    in_window = select_logs(entries, start, today)
+
+    out = []
+    out.append("SCAN WINDOW for memory-flush")
+    out.append("Watermark: %s (source: %s)" % (last.isoformat() if last else "none", source))
+    out.append("Scan start: %s   Today: %s%s" % (
+        start.isoformat(), today.isoformat(), "   [CLAMPED: >14d gap, older entries unrecoverable]" if clamped else ""))
+    if in_window:
+        out.append("Read these %d in-window log file(s):" % len(in_window))
+        out.extend("  %s/%s" % (LOGS_DIR, f) for f in in_window)
+    else:
+        out.append("No in-window log files. If nothing to promote, log MEMORY_FLUSH_OK.")
+    remaining = len([e for e in entries if parse_daily(e) is not None])
+    out.append("Log rotation: archived %d month(s); %d daily file(s) remain (threshold %d)." % (
+        archived_months, remaining, ROTATE_THRESHOLD))
+    out.append("Do NOT recompute the window or rotate logs yourself. Run "
+               "`python3 scripts/memory_prep.py stamp` as your final step.")
+    print("\n".join(out))
+    return 0
+
+
+def do_stamp(root, today):
+    # structured watermark = source of truth
+    state_path = os.path.join(root, STATE_FILE)
+    with open(state_path, "w", encoding="utf-8") as fh:
+        json.dump({
+            "last_consolidated": today.isoformat(),
+            "updated_at": datetime.datetime.now(datetime.timezone.utc)
+                .strftime("%Y-%m-%dT%H:%M:%SZ"),
+        }, fh, indent=2)
+        fh.write("\n")
+
+    # mirror into the human-readable MEMORY.md line
+    memory_path = os.path.join(root, MEMORY_MD)
+    text = _read(memory_path)
+    if text is not None:
+        with open(memory_path, "w", encoding="utf-8") as fh:
+            fh.write(stamp_memory_md(text, today))
+
+    print("Stamped last_consolidated=%s (%s + MEMORY.md mirror)." % (today.isoformat(), STATE_FILE))
+    return 0
+
+
+def main(argv):
+    root = os.environ.get("AEON_REPO_ROOT", ".")
+    if "--root" in argv:
+        root = argv[argv.index("--root") + 1]
+    today = datetime.date.today()
+    cmd = argv[0] if argv else ""
+    if cmd == "window":
+        return do_window(root, today)
+    if cmd == "stamp":
+        return do_stamp(root, today)
+    sys.stderr.write("usage: memory_prep.py {window|stamp} [--root DIR]\n")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/tests/test_memory_prep.py
+++ b/scripts/tests/test_memory_prep.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Unit tests for memory_prep. Run: python3 scripts/tests/test_memory_prep.py"""
+import datetime
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import memory_prep as mp  # noqa: E402
+
+D = datetime.date
+
+
+class TestWatermark(unittest.TestCase):
+    def test_parse_date(self):
+        self.assertEqual(mp.parse_date("2026-08-16"), D(2026, 8, 16))
+        self.assertIsNone(mp.parse_date(""))
+        self.assertIsNone(mp.parse_date("never"))
+        self.assertIsNone(mp.parse_date("garbage"))
+
+    def test_from_memory_md(self):
+        self.assertEqual(mp.watermark_from_memory_md("x\n*Last consolidated: 2026-08-16*\ny"),
+                         D(2026, 8, 16))
+        self.assertEqual(mp.watermark_from_memory_md("*Last Consolidated: 2026-01-02*"),
+                         D(2026, 1, 2))
+        self.assertIsNone(mp.watermark_from_memory_md("no marker here"))
+        self.assertIsNone(mp.watermark_from_memory_md("*Last consolidated: never*"))
+
+    def test_resolve_prefers_state_file(self):
+        state = json.dumps({"last_consolidated": "2026-08-20"})
+        md = "*Last consolidated: 2026-08-10*"
+        self.assertEqual(mp.resolve_watermark(state, md), (D(2026, 8, 20), "state-file"))
+
+    def test_resolve_falls_back_to_md(self):
+        self.assertEqual(mp.resolve_watermark(None, "*Last consolidated: 2026-08-10*"),
+                         (D(2026, 8, 10), "memory.md"))
+        self.assertEqual(mp.resolve_watermark("{bad json", "*Last consolidated: 2026-08-10*"),
+                         (D(2026, 8, 10), "memory.md"))
+
+    def test_resolve_none(self):
+        self.assertEqual(mp.resolve_watermark(None, "nothing"), (None, "none"))
+
+
+class TestWindow(unittest.TestCase):
+    def test_no_watermark_is_3day(self):
+        start, clamped = mp.compute_window(None, D(2026, 8, 22))
+        self.assertEqual(start, D(2026, 8, 19))
+        self.assertFalse(clamped)
+
+    def test_normal_gap_starts_at_watermark(self):
+        start, clamped = mp.compute_window(D(2026, 8, 16), D(2026, 8, 22))
+        self.assertEqual(start, D(2026, 8, 16))
+        self.assertFalse(clamped)
+
+    def test_large_gap_clamps_to_14(self):
+        start, clamped = mp.compute_window(D(2026, 6, 1), D(2026, 8, 22))
+        self.assertEqual(start, D(2026, 8, 8))
+        self.assertTrue(clamped)
+
+    def test_exactly_14_not_clamped(self):
+        start, clamped = mp.compute_window(D(2026, 8, 8), D(2026, 8, 22))
+        self.assertEqual(start, D(2026, 8, 8))
+        self.assertFalse(clamped)
+
+    def test_select_logs_filters_and_sorts(self):
+        files = ["2026-08-22.md", "2026-08-15.md", "2026-08-16.md",
+                 "not-a-log.md", "README.md", "2026-08-16.txt"]
+        self.assertEqual(
+            mp.select_logs(files, D(2026, 8, 16), D(2026, 8, 22)),
+            ["2026-08-16.md", "2026-08-22.md"])
+
+
+class TestRotation(unittest.TestCase):
+    def _dailies(self, start, n):
+        return ["%s.md" % (start + datetime.timedelta(days=i)).isoformat() for i in range(n)]
+
+    def test_below_threshold_no_rotation(self):
+        files = self._dailies(D(2026, 1, 1), 10)
+        self.assertEqual(mp.rotatable_months(files, D(2026, 3, 1)), {})
+
+    def test_rotates_only_whole_old_months(self):
+        # 60 consecutive days from 2026-01-01; today far in the future
+        files = self._dailies(D(2026, 1, 1), 60)
+        out = mp.rotatable_months(files, D(2026, 6, 1))
+        self.assertIn("2026-01", out)
+        self.assertIn("2026-02", out)
+        self.assertEqual(out["2026-01"][0], "2026-01-01.md")
+        self.assertEqual(out["2026-01"][-1], "2026-01-31.md")
+
+    def test_does_not_touch_month_inside_window(self):
+        # today 2026-08-22, cutoff = 2026-08-08; August straddles -> excluded
+        files = self._dailies(D(2026, 7, 20), 50)  # crosses into August
+        out = mp.rotatable_months(files, D(2026, 8, 22))
+        self.assertNotIn("2026-08", out)
+        self.assertIn("2026-07", out)  # July is entirely before the cutoff
+
+    def test_current_partial_month_never_rotated(self):
+        files = self._dailies(D(2026, 6, 1), 80)  # runs into current month
+        out = mp.rotatable_months(files, D(2026, 8, 22))
+        self.assertNotIn("2026-08", out)
+
+
+class TestStampText(unittest.TestCase):
+    def test_updates_existing_line(self):
+        text = "# Title\n\n*Last consolidated: 2026-06-11*\n\nbody"
+        self.assertIn("*Last consolidated: 2026-08-22*",
+                      mp.stamp_memory_md(text, D(2026, 8, 22)))
+        self.assertNotIn("2026-06-11", mp.stamp_memory_md(text, D(2026, 8, 22)))
+
+    def test_inserts_under_title_when_missing(self):
+        out = mp.stamp_memory_md("# Title\n\nbody", D(2026, 8, 22))
+        lines = out.split("\n")
+        self.assertEqual(lines[0], "# Title")
+        self.assertIn("*Last consolidated: 2026-08-22*", out)
+        # marker precedes the body
+        self.assertLess(out.index("Last consolidated"), out.index("body"))
+
+    def test_idempotent(self):
+        text = "# T\n\n*Last consolidated: 2026-08-22*\n"
+        once = mp.stamp_memory_md(text, D(2026, 8, 22))
+        twice = mp.stamp_memory_md(once, D(2026, 8, 22))
+        self.assertEqual(once, twice)
+        self.assertEqual(twice.count("Last consolidated"), 1)
+
+
+class TestStampIO(unittest.TestCase):
+    def test_stamp_writes_state_and_mirrors(self):
+        with tempfile.TemporaryDirectory() as root:
+            os.makedirs(os.path.join(root, "memory"))
+            with open(os.path.join(root, mp.MEMORY_MD), "w") as fh:
+                fh.write("# Aeon Memory\n\n*Last consolidated: never*\n")
+            mp.do_stamp(root, D(2026, 8, 22))
+            with open(os.path.join(root, mp.STATE_FILE)) as fh:
+                state = json.load(fh)
+            self.assertEqual(state["last_consolidated"], "2026-08-22")
+            self.assertIn("updated_at", state)
+            with open(os.path.join(root, mp.MEMORY_MD)) as fh:
+                md = fh.read()
+            self.assertIn("*Last consolidated: 2026-08-22*", md)
+            self.assertNotIn("never", md)
+
+
+class TestWindowIO(unittest.TestCase):
+    def test_window_rotates_and_selects_in_git_repo(self):
+        with tempfile.TemporaryDirectory() as root:
+            logs = os.path.join(root, mp.LOGS_DIR)
+            os.makedirs(logs)
+            subprocess.run(["git", "-C", root, "init", "-q"], check=True)
+            subprocess.run(["git", "-C", root, "config", "user.email", "t@t"], check=True)
+            subprocess.run(["git", "-C", root, "config", "user.name", "t"], check=True)
+            # 50 old daily files (Jan-Feb 2026) + 2 recent, past threshold
+            old = [(D(2026, 1, 1) + datetime.timedelta(days=i)) for i in range(50)]
+            recent = [D(2026, 8, 20), D(2026, 8, 22)]
+            for d in old + recent:
+                with open(os.path.join(logs, d.isoformat() + ".md"), "w") as fh:
+                    fh.write("log %s\n" % d)
+            with open(os.path.join(root, mp.MEMORY_MD), "w") as fh:
+                fh.write("# M\n\n*Last consolidated: 2026-08-20*\n")
+            subprocess.run(["git", "-C", root, "add", "-A"], check=True)
+            subprocess.run(["git", "-C", root, "commit", "-qm", "seed"], check=True)
+
+            rc = mp.do_window(root, D(2026, 8, 22))
+            self.assertEqual(rc, 0)
+            # old months archived and removed
+            self.assertTrue(os.path.exists(os.path.join(root, mp.ARCHIVE_DIR, "2026-01.md")))
+            self.assertFalse(os.path.exists(os.path.join(logs, "2026-01-01.md")))
+            # recent files survive
+            self.assertTrue(os.path.exists(os.path.join(logs, "2026-08-22.md")))
+            # archive preserves content
+            with open(os.path.join(root, mp.ARCHIVE_DIR, "2026-01.md")) as fh:
+                arch = fh.read()
+            self.assertIn("log 2026-01-01", arch)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/memory-flush/SKILL.md
+++ b/skills/memory-flush/SKILL.md
@@ -9,82 +9,83 @@ metadata:
   tags:
     - meta
 ---
-> **${var}** — Topic to focus on. If empty, flushes all recent activity.
+> **${var}** - Topic to focus on. If empty, flushes all recent activity.
 
-If `${var}` is set, only promote entries related to that topic. Pruning (step 3) and the timestamp/index/rotation upkeep (steps 4, 7) still run globally — a focused flush must never leave the rest of the store stale.
+If `${var}` is set, only promote entries related to that topic. Pruning (step 3), the index upkeep (step 6), and the deterministic watermark + rotation (steps 0 and 8) still run globally - a focused flush must never leave the rest of the store stale.
 
-Read `memory/MEMORY.md` for current memory state.
-
-**Scan window — read logs since the last consolidation, not a fixed 3 days.** Look at the `*Last consolidated: <date>*` line near the top of `MEMORY.md`:
-- A real date → read every `memory/logs/` file dated *on or after* that date (re-reading the last consolidated day is fine; the dedup check in step 2 makes it idempotent).
-- `never`, missing, or unparseable → read the last 3 days.
-- A gap longer than 14 days (agent was dark) → read the last 14 days only and note the gap in your step 6 log. Older un-promoted entries are unrecoverable; don't pretend otherwise.
-
-This closes two holes in the old fixed 3-day window: entries older than 3 days were lost whenever the agent skipped runs, and a daily schedule re-scanned the same 3 days every time.
+Read `memory/MEMORY.md` for current memory state. **The scan window and log rotation are computed for you in step 0** - you no longer parse the watermark or rotate logs by hand.
 
 ## Steps
+
+### 0. Prepare (deterministic bookkeeping - run this first)
+
+Run `python3 scripts/memory_prep.py window` and read its stdout. It:
+- computes your **scan window** from the structured watermark `memory/memory-flush-state.json` (fallback for a first-run migration: the MEMORY.md `*Last consolidated:*` line; then the last 3 days; a gap over 14 days is clamped to 14 and flagged), and prints the exact in-window log files to read;
+- has **already rotated** whole old months out of `memory/logs/` into `memory/logs/archive/YYYY-MM.md` (content-preserving) once the directory passed ~45 files.
+
+Read exactly the files it lists. Do not recompute the window or rotate logs yourself - that work is now deterministic and unit-tested (`scripts/memory_prep.py`), so it never silently falls back to 3 days or gets skipped. This closed two old holes: entries older than 3 days were lost whenever the agent skipped runs, and a daily schedule re-scanned the same 3 days every time.
 
 ### 1. Scan the in-window logs for entries worth promoting to long-term memory
 
 - New lessons learned (errors encountered, workarounds found)
-- Topics covered (articles, digests) — add to the recent output/articles/digests tables
+- Topics covered (articles, digests) - add to the recent output/articles/digests tables
 - Features built or tools created
 - Important findings from monitors (on-chain, GitHub, papers)
 - Ideas captured that are still relevant
 - Goals completed or progress milestones
 
-### 2. Check each candidate against existing MEMORY.md content — dedup precisely
+### 2. Check each candidate against existing MEMORY.md content - dedup precisely
 
 Skip if already recorded. Dedup by the fact's **subject**, not by string match:
 - Identify what each candidate is *about* (a skill, a token, a repo, a lesson, a priority).
-- If MEMORY.md already carries that subject, **edit the existing line in place** (merge the new detail, bump any date). Never append a second bullet that paraphrases an existing one — that near-duplicate drift is what a memory flush exists to prevent.
+- If MEMORY.md already carries that subject, **edit the existing line in place** (merge the new detail, bump any date). Never append a second bullet that paraphrases an existing one - that near-duplicate drift is what a memory flush exists to prevent.
 - Only add a new bullet when the subject is genuinely absent.
 
-### 3. Remove stale entries — this is as important as adding new ones
+### 3. Remove stale entries - this is as important as adding new ones
 
 a. **Open Improvement PRs section**: Run `gh pr list --state open --search "improve:" --json number,title,url` and compare against any "Open Improvement PRs" section in MEMORY.md.
    - If all listed PRs are now merged/closed, remove the section entirely.
    - If some PRs are merged, update the list to reflect only current open ones.
 b. **Next Priorities section**: Cross-check each listed priority against recent logs and current repo state. Remove priorities that are already done (e.g., "Merge open PRs" if 0 open PRs exist). Add any newly urgent priorities surfaced by recent logs.
 c. **Lessons Learned**: Remove lessons that are now outdated or resolved (e.g., a workaround for a bug that was later fixed).
-d. **Overflow any section that outgrows its budget** (keeps MEMORY.md an index, not a ledger): if a section has grown past the last ~10–15 rows — the Skills Built table is the usual first offender, but the rule is general — archive the oldest rows to `memory/topics/<section>-history.md` (e.g. `skills-history.md`) and leave a one-line pointer to that file. Trim newest-kept, oldest-archived.
+d. **Overflow any section that outgrows its budget** (keeps MEMORY.md an index, not a ledger): if a section has grown past the last ~10-15 rows - the Skills Built table is the usual first offender, but the rule is general - archive the oldest rows to `memory/topics/<section>-history.md` (e.g. `skills-history.md`) and leave a one-line pointer to that file. Trim newest-kept, oldest-archived.
 
 ### 4. Update memory
 
 - Add brief entries to MEMORY.md (keep it under ~50 lines as an index).
-- If a topic needs more detail, write to `memory/topics/<topic>.md` instead (see step 7 — register it in the index).
+- If a topic needs more detail, write to `memory/topics/<topic>.md` instead (see step 6 - register it in the index).
 - Update tables (recent articles, recent digests) with new rows.
-- Before adding a section, check whether its `## Heading` already exists anywhere in MEMORY.md — if it does, update that section in place. Never prepend a duplicate heading.
-- **Stamp the consolidation date.** Update the `*Last consolidated: <date>*` line near the top to today's date (`${today}`). If the line is missing, add it directly under the title. This drives the step-scan window above and is how other skills (e.g. `action-converter`) tell a live, consolidated store from an untouched template — leaving it at `never` after a real flush is a bug.
+- Before adding a section, check whether its `## Heading` already exists anywhere in MEMORY.md - if it does, update that section in place. Never prepend a duplicate heading.
+- **Do not hand-edit the consolidation date.** It is stamped by step 8 (`memory_prep.py stamp`), which writes the structured watermark `memory/memory-flush-state.json` (the source of truth) and mirrors it into the MEMORY.md `*Last consolidated:*` line. Skipping step 8 after a real flush is a bug - other skills (e.g. `action-converter`) read that line to tell a live, consolidated store from an untouched template.
 
 ### 5. Make targeted edits only
 
-Do NOT rewrite the whole file — make targeted additions and removals.
+Do NOT rewrite the whole file - make targeted additions and removals.
 
 ### 6. Register any new topic files in the index
 
 If step 4 created a new `memory/topics/<topic>.md` (or a `*-history.md` archive in step 3d), add a one-line pointer to it under the `# Reference` section of `memory/topics/index.md`, matching the existing row format. New topic notes that aren't linked from the index become orphans no other run can find.
 
-### 7. Rotate the log journal so `memory/logs/` stays bounded
+### 7. (Automated) Log rotation
 
-`memory/logs/` is append-only and grows one file per day forever. Once its durable content has been promoted, roll old dailies up so the directory doesn't grow without limit — **content-preserving, never a bare delete** (`rm` isn't granted; use `git rm`):
-- Only act when there are more than ~45 daily files.
-- Pick whole calendar months that are entirely **older than the current 14-day scan window** (so nothing still in scope is touched). For each such month, append its dailies in date order into `memory/logs/archive/YYYY-MM.md` (create the dir if needed), then `git rm` the dailies you just rolled up.
-- The archive preserves every line — this respects the append-only contract while bounding the file count. Never touch a log inside the scan window, and never edit a daily's existing content.
+Log rotation now runs deterministically in step 0 (`memory_prep.py window`): whole calendar months entirely older than the 14-day scan floor are appended to `memory/logs/archive/YYYY-MM.md` and `git rm`'d once `memory/logs/` passes ~45 files. The archive preserves every line, respecting the append-only contract while bounding the file count. Nothing to do here by hand; a log inside the scan window is never touched.
 
-### 8. Log to `memory/logs/${today}.md`
+### 8. Log the run, then stamp the watermark
 
-Log what you promoted, pruned, archived, and the scan window you used (start date → today). If a >14-day gap was clamped, say so.
+Log what you promoted, pruned, and archived, plus the scan window you used (start date to today; note if a >14-day gap was clamped), to `memory/logs/${today}.md`.
 
-If nothing worth promoting or removing and no rotation was due, log `MEMORY_FLUSH_OK` and end (still stamp the `Last consolidated` date in step 4 — a clean flush is still a consolidation).
+Then run `python3 scripts/memory_prep.py stamp` as your **final** action - it writes today's date to `memory/memory-flush-state.json` and mirrors it into the MEMORY.md `*Last consolidated:*` line.
+
+If nothing was worth promoting or removing, log `MEMORY_FLUSH_OK` - but still run `memory_prep.py stamp`: a clean flush is still a consolidation and must advance the watermark.
 
 ## Network note
 
-`gh pr list` uses the `gh` CLI's built-in auth — no curl env-var expansion. All other work is local file I/O against `memory/` (plus `git rm` for log rotation).
+`gh pr list` uses the `gh` CLI's built-in auth - no curl env-var expansion. `python3 scripts/memory_prep.py` and all other work is local file I/O against `memory/` (plus `git rm` for log rotation).
 
 ## Constraints
 
 - Keep MEMORY.md an index (~50 lines). Detail lives in `memory/topics/`.
-- Never duplicate an existing `## Heading` or an existing fact — update in place.
+- Never duplicate an existing `## Heading` or an existing fact - update in place.
 - Pruning stale entries is as important as adding new ones.
+- The watermark and log rotation are owned by `scripts/memory_prep.py` (steps 0 and 8), not by hand. The model's job is judgment: what to promote, dedup, and prune.
 - **This skill owns MEMORY.md consolidation.** Other skills (e.g. `self-improve`) may *flag* memory-hygiene problems, but structural pruning and archiving of MEMORY.md should land here to avoid two skills thrashing the same file. If `self-improve` prunes in an audit, treat it as a stopgap, not a reason to skip the next flush.


### PR DESCRIPTION
## What

Move memory-flush's mechanical bookkeeping out of the LLM into a deterministic, unit-tested script, and give it a structured watermark.

Today the whole flush is one model run - across 7 instances, weekly. The model parses the scan window off a prose line, lists in-window logs, and rotates `memory/logs/` once it passes ~45 files. All of that is pure code, so doing it in the LLM is both a recurring token cost and a reliability hole: the scan window silently fell back to 3 days whenever the `*Last consolidated:*` prose line got edited away, dropping un-promoted entries.

## Changes

- **`scripts/memory_prep.py`** (new)
  - `window` - rotates whole old-month logs into `memory/logs/archive/YYYY-MM.md` (content-preserving, `git rm`), computes the scan window, and prints the exact in-window log files for the model to read.
  - `stamp` - writes today's date to `memory/memory-flush-state.json` and mirrors it into the MEMORY.md `*Last consolidated:*` line.
- **`memory/memory-flush-state.json`** - new structured watermark, the source of truth. Not folded into `cron-state.json` on purpose: `state_reduce.py` reduces cron-state to a fixed schema and would drop an extra field under the Issues backend. First-run migration reads the old prose line, so no manual backfill.
- **`skills/memory-flush/SKILL.md`** - step 0 runs `window`; step 8 runs `stamp`; the old hand-rolled scan-window and rotation prose is gone. The model now does only judgment (promote / dedup / prune).
- **`scripts/tests/test_memory_prep.py`** + a `ci-tests` step - 19 tests over the pure planners (watermark resolution, window/clamp, in-window selection, whole-month rotation safety, stamp idempotency) plus git-backed integration for rotate + stamp.

## Verify

`python3 scripts/tests/test_memory_prep.py` - 19 passing. Behavior-preserving: same 3-day default, same 14-day clamp, same >45-file rotation rule, same MEMORY.md line format - just deterministic and testable instead of improvised each run.

Propagates to the fleet via `aeon-update`.
