### PR TITLE
test(state-store,health-issue): skip before-side unless base ref is truly pre-fix

### DIFF
--- a/scripts/tests/test_health_issue.sh
+++ b/scripts/tests/test_health_issue.sh
@@ -87,7 +87,12 @@ run_two_ensures() {
   rm -f "$store" "$store.calls"
 }
 
-if [ -s "$ORIG_H" ]; then
+# Only a source that actually DIFFERS from the live (fixed) script can prove the
+# "before" fork. On a pull_request the resolved base ref is the real pre-fix
+# code; on a push-to-main run origin/main already points at the merged fix (so
+# the candidate == the fixed script), and a shallow checkout has no candidate at
+# all -- both skip rather than assert a fork the fixed code no longer produces.
+if [ -s "$ORIG_H" ] && ! cmp -s "$ORIG_H" "$H"; then
   RESULT=$(run_two_ensures "$ORIG_H" 2)
   A_N=$(echo "$RESULT" | cut -d' ' -f1); B_N=$(echo "$RESULT" | cut -d' ' -f2)
   if [ -n "$A_N" ] && [ -n "$B_N" ] && [ "$A_N" != "$B_N" ]; then
@@ -96,7 +101,7 @@ if [ -s "$ORIG_H" ]; then
     bad "race setup didn't reproduce the fork precondition on pre-fix code (got #$A_N / #$B_N) -- can't validate the fix meaningfully"
   fi
 else
-  echo "SKIP - pre-fix source not reachable from this checkout (shallow CI); fixed-side assertion below still gates"
+  echo "SKIP - no distinct pre-fix source (shallow CI, or a push-on-main run whose base ref already has the fix); fixed-side assertion below still gates"
 fi
 
 RESULT2=$(run_two_ensures "$H" 2)

--- a/scripts/tests/test_state_store.sh
+++ b/scripts/tests/test_state_store.sh
@@ -102,7 +102,12 @@ run_two_ensures() {
 
 # Both callers' first list lands in the stale window (both see "not found"),
 # exactly modeling two racing processes that both check before either creates.
-if [ -s "$ORIG_S" ]; then
+# Only a source that actually DIFFERS from the live (fixed) script can prove the
+# "before" fork. On a pull_request the resolved base ref is the real pre-fix
+# code; on a push-to-main run origin/main already points at the merged fix (so
+# the candidate == the fixed script), and a shallow checkout has no candidate at
+# all -- both skip rather than assert a fork the fixed code no longer produces.
+if [ -s "$ORIG_S" ] && ! cmp -s "$ORIG_S" "$S"; then
   RESULT=$(run_two_ensures "$ORIG_S" 2)
   A_N=$(echo "$RESULT" | cut -d' ' -f1); B_N=$(echo "$RESULT" | cut -d' ' -f2)
   if [ -n "$A_N" ] && [ -n "$B_N" ] && [ "$A_N" != "$B_N" ]; then
@@ -111,7 +116,7 @@ if [ -s "$ORIG_S" ]; then
     bad "race setup didn't reproduce the fork precondition on pre-fix code (got #$A_N / #$B_N) -- can't validate the fix meaningfully"
   fi
 else
-  echo "SKIP - pre-fix source not reachable from this checkout (shallow CI); fixed-side assertion below still gates"
+  echo "SKIP - no distinct pre-fix source (shallow CI, or a push-on-main run whose base ref already has the fix); fixed-side assertion below still gates"
 fi
 
 # Identical race, through the FIXED _ensure (which re-lists after its own


### PR DESCRIPTION
Follow-up to #936. That PR's ensure-race tests went red on `main` at the squash (f91b023) while the PR check was green.

**Cause:** the tests fetch a base ref to reproduce the "before" fork. On a `pull_request` the resolved `origin/main` is genuinely pre-fix, so the fork reproduces. On a `push` to `main` the same ref already points at the merged fix, so the before-side ran the FIXED code, the race converged (`#1 / #1`), and the "must fork" precondition assertion failed.

**Fix:** gate the before-side on `! cmp -s "$ORIG" "$SCRIPT"` so it runs only when the resolved source actually differs from the live (fixed) script. Push-on-main (candidate == fixed) and shallow checkout (no candidate) both SKIP; a real PR (base differs) still reproduces the fork. The fixed-side convergence assertion is self-contained and always gates.

Verified locally: with `origin/main` == fixed both suites SKIP the before-side and pass; with a genuine pre-fix source the before-side still reproduces the fork.
