### PR TITLE
fix(dashboard): fx never showed up in the harness picker

### DIFF
--- a/apps/dashboard/lib/constants.ts
+++ b/apps/dashboard/lib/constants.ts
@@ -83,21 +83,31 @@ export const PI_MODELS = [
 
 // Harnesses (agent CLIs). `claude` = Claude Code (default, AI Gateway), labelled
 // "Anthropic"; `grok` = Grok Build (own X-account/API-key auth, own models),
-// "xAI". The last four run through harness-adapter's run-harness on a single
-// OPENROUTER_API_KEY. The `id`s are the on-disk harness values (aeon.yml
-// `harness:`) and never change — only the labels do.
-// `satisfies` (not an annotation) keeps each `id` a literal for the select
-// options while making a typo'd or dropped harness a compile error against the
-// Harness union in ./types.
+// "xAI". codex/pi/vibe/kimi run through harness-adapter's run-harness on a
+// single OPENROUTER_API_KEY. `fx` also runs through run-harness but has no
+// OpenRouter fallback at all — Vercel AI Gateway key or VERCEL_OIDC_TOKEN only
+// (see lib/harness-auth.ts and resolve-harness.sh's fx case). The `id`s are the
+// on-disk harness values (aeon.yml `harness:`) and never change — only the
+// labels do. `satisfies` (not an annotation) keeps each `id` a literal for the
+// select options while making a typo'd or dropped harness a compile error
+// against the Harness union in ./types.
 export const HARNESSES = [
   { id: 'claude', label: 'Anthropic' },
   { id: 'grok', label: 'xAI' },
   { id: 'codex', label: 'Codex' },
+  { id: 'fx', label: 'fx (Vercel)' },
   { id: 'pi', label: 'Pi' },
   { id: 'vibe', label: 'Vibe' },
   { id: 'kimi', label: 'Kimi' },
 ] as const satisfies readonly { id: Harness; label: string }[]
 
+// fx has no model picker: unlike codex/pi/vibe/kimi's OpenRouter path, fx's
+// only real auth mode is native-key (AI_GATEWAY_API_KEY / VERCEL_OIDC_TOKEN),
+// and resolve-harness.sh's native-auth branch deliberately never forwards
+// --model in that mode (same as codex/pi/vibe/kimi's own native-auth path) —
+// fx always runs on its own default model. So this intentionally falls
+// through to the generic MODELS default below: whatever renders there is
+// cosmetic only for fx and never actually reaches the run.
 export function modelsForHarness(harness: string) {
   if (harness === 'grok') return GROK_MODELS
   if (harness === 'codex') return CODEX_MODELS

--- a/apps/dashboard/lib/types.ts
+++ b/apps/dashboard/lib/types.ts
@@ -65,11 +65,14 @@ export type GatewayProvider = 'auto' | 'direct' | GatewaySlug
 export const GATEWAY_PROVIDERS: GatewayProvider[] = ['auto', 'direct', ...GATEWAY_SLUGS]
 
 // Which agent CLI runs skills. `claude` = Claude Code (default, uses the gateway
-// above); `grok` = Grok Build CLI (own auth, own models). The remaining four run
+// above); `grok` = Grok Build CLI (own auth, own models). codex/pi/vibe/kimi run
 // through harness-adapter's `run-harness` on one OPENROUTER_API_KEY (see
 // harness-adapter/docs/aeon-integration.md and scripts/run-grok.sh for the seam).
-export type Harness = 'claude' | 'grok' | 'codex' | 'pi' | 'vibe' | 'kimi'
-export const HARNESSES: Harness[] = ['claude', 'grok', 'codex', 'pi', 'vibe', 'kimi']
+// `fx` also runs through run-harness but has NO OpenRouter fallback (Vercel AI
+// Gateway / VERCEL_OIDC_TOKEN only) — see lib/harness-auth.ts's fx entry and
+// resolve-harness.sh's fx case.
+export type Harness = 'claude' | 'grok' | 'codex' | 'fx' | 'pi' | 'vibe' | 'kimi'
+export const HARNESSES: Harness[] = ['claude', 'grok', 'codex', 'fx', 'pi', 'vibe', 'kimi']
 
 export interface UploadFile { path: string; content: string }
 


### PR DESCRIPTION
## what

#941 added fx as a real, working harness end to end — adapter, resolve-harness.sh, install-harness.sh, and the dashboard's harness-auth.ts auth-secret registry. but the dashboard's actual harness dropdown reads from two other places that PR never touched: `lib/types.ts`'s `Harness` union + its own duplicate `HARNESSES` array, and `lib/constants.ts`'s UI-facing `HARNESSES` array (the one the select options + `updateHarness()` actually render from). neither had fx in it, so there was genuinely no way to pick fx from the dashboard even though the backend fully supported it.

## why this got missed

`harness-auth.ts`'s `HARNESS_AUTH` registry is typed `Record<string, HarnessAuthSpec | undefined>` — a loose string-keyed record, so adding an `fx:` entry there compiled fine without the `Harness` union needing to know fx exists. `constants.ts`'s `HARNESSES` is typed `as const satisfies readonly { id: Harness; label: string }[]` on purpose (to make a dropped/typo'd harness a compile error) — which is exactly the check that would have caught this, if it had been run. #941's own PR body said as much: "not live type-checked — no node_modules in this checkout." this is that check, run for real.

## fix

added `'fx'` to the `Harness` type union and its duplicate array in `types.ts`, added an fx entry to `constants.ts`'s `HARNESSES` (label `"fx (Vercel)"`, matching the existing `"Anthropic"`/`"xAI"`/`"Codex"` naming style) between codex and pi.

`modelsForHarness()` intentionally gets **no** fx case. traced why that's correct, not an oversight: fx has no OpenRouter path at all (already documented in `resolve-harness.sh`'s fx case from #941), so its only real auth mode is native-key. `resolve-harness.sh`'s native-auth branch deliberately never forwards `--model` in that mode (the same behavior codex/pi/vibe/kimi get on *their* native-auth paths) — fx always runs on its own default model regardless of what the picker shows. so `modelsForHarness` falling through to the generic `MODELS` default for fx is cosmetic-only and never actually reaches a run. documented that reasoning inline so it doesn't look like a missed case later.

## verification

- `npx tsc --noEmit` — clean, zero errors, first real typecheck this fx work has had.
- verified **live**, not just statically: grabbed the actual compiled bundle from a running `next dev` server and confirmed the real `HARNESSES` array — `id: 'fx'`, `label: 'fx (Vercel)'`, sitting between codex and pi — is what the browser actually receives, not just what the source says:
  ```js
  {
      id: 'codex',
      label: 'Codex'
  },
  {
      id: 'fx',
      label: 'fx (Vercel)'
  },
  {
      id: 'pi',
      label: 'Pi'
  },
  ```

found this by being asked to check the dashboard directly rather than assume the backend PR covered it. it didn't, quietly, until now.