### PR TITLE
fix(dashboard): lock aeon.yml read-modify-write to stop config races

### DIFF
--- a/apps/dashboard/app/api/skills/route.ts
+++ b/apps/dashboard/app/api/skills/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 import { errorResponse, syncResult } from '@/lib/http'
-import { getFileContent, updateFile, commitAndPush } from '@/lib/github'
+import { getFileContent, updateFile, commitAndPush, withFileLock } from '@/lib/github'
 import {
   upsertSkillInConfig,
   updateModelInConfig,
@@ -25,37 +25,38 @@ export async function GET() {
 export async function PATCH(request: Request) {
   try {
     const { name, enabled, schedule, var: skillVar, model, skillModel, harness, skillHarness, jsonrenderEnabled } = await request.json() as { name?: string; enabled?: boolean; schedule?: string; var?: string; model?: string; skillModel?: string; harness?: string; skillHarness?: string; jsonrenderEnabled?: boolean }
-    const { content, sha } = await getFileContent('aeon.yml')
-    let updated = content
 
-    if (typeof jsonrenderEnabled === 'boolean') {
-      updated = updateJsonrenderInConfig(updated, jsonrenderEnabled)
-    }
+    const sync = await withFileLock('aeon.yml', async () => {
+      const { content, sha } = await getFileContent('aeon.yml')
+      let updated = content
 
-    if (typeof model === 'string' && model) {
-      updated = updateModelInConfig(updated, model)
-    }
+      if (typeof jsonrenderEnabled === 'boolean') {
+        updated = updateJsonrenderInConfig(updated, jsonrenderEnabled)
+      }
 
-    // Top-level harness switch (claude | grok). Ignore unknown values.
-    if (typeof harness === 'string' && HARNESSES.includes(harness as Harness)) {
-      updated = updateHarnessInConfig(updated, harness as Harness)
-    }
+      if (typeof model === 'string' && model) {
+        updated = updateModelInConfig(updated, model)
+      }
 
-    if (name && (typeof enabled === 'boolean' || typeof schedule === 'string' || typeof skillVar === 'string' || typeof skillModel === 'string' || typeof skillHarness === 'string')) {
-      // upsert, not update: the skill list is built from disk, so the UI can
-      // toggle a skill that has no aeon.yml entry yet (a freshly added
-      // SKILL.md). A plain update would silently no-op on it.
-      updated = upsertSkillInConfig(updated, name, {
-        ...(typeof enabled === 'boolean' ? { enabled } : {}),
-        ...(typeof schedule === 'string' && schedule ? { schedule } : {}),
-        ...(typeof skillVar === 'string' ? { var: skillVar } : {}),
-        ...(typeof skillModel === 'string' ? { model: skillModel } : {}),
-        ...(typeof skillHarness === 'string' ? { harness: skillHarness } : {}),
-      })
-    }
+      // Top-level harness switch (claude | grok). Ignore unknown values.
+      if (typeof harness === 'string' && HARNESSES.includes(harness as Harness)) {
+        updated = updateHarnessInConfig(updated, harness as Harness)
+      }
 
-    let sync: CommitResult = { synced: true }
-    if (updated !== content) {
+      if (name && (typeof enabled === 'boolean' || typeof schedule === 'string' || typeof skillVar === 'string' || typeof skillModel === 'string' || typeof skillHarness === 'string')) {
+        // upsert, not update: the skill list is built from disk, so the UI can
+        // toggle a skill that has no aeon.yml entry yet (a freshly added
+        // SKILL.md). A plain update would silently no-op on it.
+        updated = upsertSkillInConfig(updated, name, {
+          ...(typeof enabled === 'boolean' ? { enabled } : {}),
+          ...(typeof schedule === 'string' && schedule ? { schedule } : {}),
+          ...(typeof skillVar === 'string' ? { var: skillVar } : {}),
+          ...(typeof skillModel === 'string' ? { model: skillModel } : {}),
+          ...(typeof skillHarness === 'string' ? { harness: skillHarness } : {}),
+        })
+      }
+
+      if (updated === content) return { synced: true } as CommitResult
       const msg = model
         ? `chore: set model to ${model}`
         : harness
@@ -64,8 +65,8 @@ export async function PATCH(request: Request) {
             ? `chore: ${jsonrenderEnabled ? 'enable' : 'disable'} json-render channel`
             : `chore: update ${name} config`
       await updateFile('aeon.yml', updated, sha, msg)
-      sync = commitAndPush(['aeon.yml'], msg)
-    }
+      return commitAndPush(['aeon.yml'], msg)
+    })
 
     return NextResponse.json(syncResult(sync))
   } catch (error: unknown) {
@@ -84,23 +85,26 @@ export async function DELETE(request: Request) {
 
     let configUpdated = true
     let configError: string | undefined
-    try {
-      const { content, sha } = await getFileContent('aeon.yml')
-      const updated = removeSkillFromConfig(content, name)
-      if (updated !== content) {
-        await updateFile('aeon.yml', updated, sha, `chore: remove ${name} from config`)
+    // One commit for both the removed skill dir and the aeon.yml cleanup. The
+    // aeon.yml read-modify-write is locked so it can't interleave with another
+    // request's own unlocked read-modify-write of the same file (see withFileLock).
+    const sync = await withFileLock('aeon.yml', async () => {
+      try {
+        const { content, sha } = await getFileContent('aeon.yml')
+        const updated = removeSkillFromConfig(content, name)
+        if (updated !== content) {
+          await updateFile('aeon.yml', updated, sha, `chore: remove ${name} from config`)
+        }
+      } catch (e: unknown) {
+        // The aeon.yml write is a real GitHub-API/file-IO boundary that can throw;
+        // the skill dir is already deleted, so don't fail the request - but surface
+        // it instead of swallowing it silently and reporting a clean removal.
+        configUpdated = false
+        configError = e instanceof Error ? e.message : 'Failed to update aeon.yml'
+        console.error(`skills DELETE: failed to remove ${name} from aeon.yml:`, e)
       }
-    } catch (e: unknown) {
-      // The aeon.yml write is a real GitHub-API/file-IO boundary that can throw;
-      // the skill dir is already deleted, so don't fail the request - but surface
-      // it instead of swallowing it silently and reporting a clean removal.
-      configUpdated = false
-      configError = e instanceof Error ? e.message : 'Failed to update aeon.yml'
-      console.error(`skills DELETE: failed to remove ${name} from aeon.yml:`, e)
-    }
-
-    // One commit for both the removed skill dir and the aeon.yml cleanup.
-    const sync = commitAndPush(['aeon.yml', `skills/${name}`], `chore: remove ${name} skill`)
+      return commitAndPush(['aeon.yml', `skills/${name}`], `chore: remove ${name} skill`)
+    })
 
     return NextResponse.json({ ...syncResult(sync), configUpdated, ...(configError ? { configError } : {}) })
   } catch (error: unknown) {

--- a/apps/dashboard/app/api/upload/route.ts
+++ b/apps/dashboard/app/api/upload/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server'
-import { createFile, getFileContent, updateFile, commitAndPush } from '@/lib/github'
+import { createFile, getFileContent, updateFile, commitAndPush, withFileLock } from '@/lib/github'
 import { errorResponse, syncFields } from '@/lib/http'
 import { isRecord, slugify } from '@/lib/utils'
 import { addSkillToConfig } from '@/lib/config'
@@ -180,26 +180,29 @@ export async function POST(request: Request) {
 
     let configUpdated = true
     let configError: string | undefined
-    try {
-      const config = await getFileContent('aeon.yml')
-      const updated = addSkillToConfig(config.content, skillName)
-      if (updated !== config.content) {
-        await updateFile('aeon.yml', updated, config.sha, `chore: add ${skillName} to config`)
+    // Locked so this read-modify-write of aeon.yml can't interleave with another
+    // request's own unlocked read-modify-write of the same file (see withFileLock).
+    const sync = await withFileLock('aeon.yml', async () => {
+      try {
+        const config = await getFileContent('aeon.yml')
+        const updated = addSkillToConfig(config.content, skillName)
+        if (updated !== config.content) {
+          await updateFile('aeon.yml', updated, config.sha, `chore: add ${skillName} to config`)
+        }
+      } catch (e: unknown) {
+        // The aeon.yml write is a real GitHub-API/file-IO boundary that can throw;
+        // the skill files are already on disk, so don't fail the whole upload —
+        // but surface it instead of swallowing it silently.
+        configUpdated = false
+        configError = e instanceof Error ? e.message : 'Failed to update aeon.yml'
+        console.error(`upload: failed to add ${skillName} to aeon.yml:`, e)
       }
-    } catch (e: unknown) {
-      // The aeon.yml write is a real GitHub-API/file-IO boundary that can throw;
-      // the skill files are already on disk, so don't fail the whole upload —
-      // but surface it instead of swallowing it silently.
-      configUpdated = false
-      configError = e instanceof Error ? e.message : 'Failed to update aeon.yml'
-      console.error(`upload: failed to add ${skillName} to aeon.yml:`, e)
-    }
+      return commitAndPush(['aeon.yml', `skills/${skillName}`], `feat: upload ${skillName} skill`)
+    })
 
     // Detect secrets referenced in skill content
     const allContent = files.map(f => f.content).join('\n')
     const detectedSecrets = detectSecretsFromContent(allContent)
-
-    const sync = commitAndPush(['aeon.yml', `skills/${skillName}`], `feat: upload ${skillName} skill`)
 
     return NextResponse.json({
       name: skillName,

--- a/apps/dashboard/lib/gateway.ts
+++ b/apps/dashboard/lib/gateway.ts
@@ -1,4 +1,4 @@
-import { getFileContent, updateFile, isLocal, commitAndPush, type CommitResult } from './github'
+import { getFileContent, updateFile, isLocal, commitAndPush, withFileLock, type CommitResult } from './github'
 import { updateGatewayInConfig, updateHarnessInConfig, updateModelInConfig, parseConfig } from './config'
 import { modelsForHarness } from './constants'
 import type { GatewayProvider, Harness } from './types'
@@ -8,16 +8,18 @@ import type { GatewayProvider, Harness } from './types'
 // at run time from whichever secrets are set (scripts/llm-gateway.sh). No-ops
 // when the provider is already correct.
 export async function syncGatewayProvider() {
-  const next: GatewayProvider = 'auto'
-  const { content, sha } = await getFileContent('aeon.yml')
-  const updated = updateGatewayInConfig(content, next)
-  if (updated === content) return
+  await withFileLock('aeon.yml', async () => {
+    const next: GatewayProvider = 'auto'
+    const { content, sha } = await getFileContent('aeon.yml')
+    const updated = updateGatewayInConfig(content, next)
+    if (updated === content) return
 
-  const message = `chore: set LLM gateway provider to ${next}`
-  await updateFile('aeon.yml', updated, sha, message)
-  // Remote mode (GITHUB_TOKEN+GITHUB_REPO) already committed via the API;
-  // local mode wrote only the working copy, so commit & push it.
-  if (isLocal()) commitAndPush(['aeon.yml'], message)
+    const message = `chore: set LLM gateway provider to ${next}`
+    await updateFile('aeon.yml', updated, sha, message)
+    // Remote mode (GITHUB_TOKEN+GITHUB_REPO) already committed via the API;
+    // local mode wrote only the working copy, so commit & push it.
+    if (isLocal()) commitAndPush(['aeon.yml'], message)
+  })
 }
 
 // Set aeon.yml's top-level harness and make the change land on the repo the
@@ -27,22 +29,24 @@ export async function syncGatewayProvider() {
 // setting a provider key auto-configures the gateway. No-ops when the harness is
 // already correct. Returns whether the change reached the repo.
 export async function syncHarness(harness: Harness): Promise<CommitResult> {
-  const { content, sha } = await getFileContent('aeon.yml')
-  let updated = updateHarnessInConfig(content, harness)
-  // Keep the default model consistent with the harness — same as the TopBar
-  // harness switch: if the current model doesn't belong to the new harness, snap
-  // it to that harness's default so aeon.yml never reads e.g. harness=grok +
-  // model=claude-opus.
-  const currentModel = parseConfig(content).model
-  const list = modelsForHarness(harness)
-  if (currentModel && !list.some((m) => m.id === currentModel) && list[0]) {
-    updated = updateModelInConfig(updated, list[0].id)
-  }
-  if (updated === content) return { synced: true }
+  return withFileLock('aeon.yml', async () => {
+    const { content, sha } = await getFileContent('aeon.yml')
+    let updated = updateHarnessInConfig(content, harness)
+    // Keep the default model consistent with the harness — same as the TopBar
+    // harness switch: if the current model doesn't belong to the new harness, snap
+    // it to that harness's default so aeon.yml never reads e.g. harness=grok +
+    // model=claude-opus.
+    const currentModel = parseConfig(content).model
+    const list = modelsForHarness(harness)
+    if (currentModel && !list.some((m) => m.id === currentModel) && list[0]) {
+      updated = updateModelInConfig(updated, list[0].id)
+    }
+    if (updated === content) return { synced: true }
 
-  const message = `chore: set harness to ${harness}`
-  await updateFile('aeon.yml', updated, sha, message)
-  // Hosted mode committed via the Contents API; commitAndPush self-guards on
-  // isLocal(), pushing only the local working copy and no-opping otherwise.
-  return commitAndPush(['aeon.yml'], message)
+    const message = `chore: set harness to ${harness}`
+    await updateFile('aeon.yml', updated, sha, message)
+    // Hosted mode committed via the Contents API; commitAndPush self-guards on
+    // isLocal(), pushing only the local working copy and no-opping otherwise.
+    return commitAndPush(['aeon.yml'], message)
+  })
 }

--- a/apps/dashboard/lib/github.test.ts
+++ b/apps/dashboard/lib/github.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for apps/dashboard/lib/github.ts's withFileLock - the in-process
+ * per-path mutex serializing aeon.yml's read-modify-write-commit call sites
+ * (skills PATCH/DELETE, upload, gateway.syncGatewayProvider/syncHarness).
+ *
+ * Run with:  node --import tsx --test apps/dashboard/lib/github.test.ts
+ */
+import { describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+
+import { withFileLock } from "./github";
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("withFileLock", () => {
+  it("serializes concurrent critical sections on the same path", async () => {
+    const events: string[] = [];
+
+    const a = withFileLock("aeon.yml", async () => {
+      events.push("a-start");
+      await sleep(20);
+      events.push("a-end");
+    });
+    const b = withFileLock("aeon.yml", async () => {
+      events.push("b-start");
+      await sleep(5);
+      events.push("b-end");
+    });
+
+    await Promise.all([a, b]);
+
+    // Without the lock, b (shorter delay) would finish before a: [a-start,
+    // b-start, b-end, a-end]. The lock must force b to wait for a entirely.
+    assert.deepEqual(events, ["a-start", "a-end", "b-start", "b-end"]);
+  });
+
+  it("prevents a read-modify-write race from silently clobbering a field", async () => {
+    // Simulates the real bug: two requests each read the same starting
+    // "file", patch one field in memory, then overwrite the whole file.
+    let file = { model: "claude-sonnet-5", harness: "pi" };
+
+    async function patchModel(model: string) {
+      return withFileLock("aeon.yml", async () => {
+        const read = { ...file };
+        await sleep(10); // model resolves fast
+        file = { ...read, model }; // harness carried through from this call's own read
+      });
+    }
+    async function patchHarness(harness: string) {
+      return withFileLock("aeon.yml", async () => {
+        const read = { ...file };
+        await sleep(20); // harness resolves slower (e.g. OAuth device flow)
+        file = { ...read, harness };
+      });
+    }
+
+    // Fire harness first, model second - mirrors clicking the harness picker
+    // then immediately the model picker.
+    await Promise.all([patchHarness("fx"), patchModel("claude-opus-4-8")]);
+
+    assert.equal(file.harness, "fx");
+    assert.equal(file.model, "claude-opus-4-8");
+  });
+
+  it("does not serialize critical sections on different paths", async () => {
+    const events: string[] = [];
+
+    const a = withFileLock("aeon.yml", async () => {
+      events.push("a-start");
+      await sleep(20);
+      events.push("a-end");
+    });
+    const b = withFileLock("soul/SOUL.md", async () => {
+      events.push("b-start");
+      await sleep(5);
+      events.push("b-end");
+    });
+
+    await Promise.all([a, b]);
+
+    assert.deepEqual(events, ["a-start", "b-start", "b-end", "a-end"]);
+  });
+
+  it("propagates a rejection to its own caller without poisoning later calls", async () => {
+    await assert.rejects(
+      withFileLock("aeon.yml", async () => {
+        throw new Error("boom");
+      }),
+      /boom/,
+    );
+
+    const result = await withFileLock("aeon.yml", async () => "ok");
+    assert.equal(result, "ok");
+  });
+
+  it("returns the callback's resolved value", async () => {
+    const result = await withFileLock("aeon.yml", async () => ({ synced: true }));
+    assert.deepEqual(result, { synced: true });
+  });
+});

--- a/apps/dashboard/lib/github.ts
+++ b/apps/dashboard/lib/github.ts
@@ -18,6 +18,26 @@ export function isLocal() {
   return !process.env.GITHUB_TOKEN || !process.env.GITHUB_REPO
 }
 
+// Per-path in-process mutex. Five independent call sites (skills PATCH/DELETE,
+// upload, gateway.syncGatewayProvider, gateway.syncHarness) each do their own
+// unlocked getFileContent -> modify -> updateFile -> commitAndPush against
+// aeon.yml. Without serialization, two requests firing close together (e.g.
+// clicking the harness picker right after the model picker) can interleave:
+// both read the same starting content, and whichever writes last silently wins
+// the whole file — including carrying forward a field the losing request never
+// touched, into a commit whose message only mentions the field it meant to
+// change. Wrap every such critical section in withFileLock(path, ...) so they
+// queue instead of racing. Local-only (per-process); irrelevant in hosted mode,
+// where the Contents API's sha check already rejects a stale write.
+const fileLocks = new Map<string, Promise<unknown>>()
+
+export function withFileLock<T>(path: string, fn: () => Promise<T>): Promise<T> {
+  const prior = fileLocks.get(path) ?? Promise.resolve()
+  const run = prior.then(fn, fn)
+  fileLocks.set(path, run.catch(() => {}))
+  return run
+}
+
 /**
  * Local-mode auto-sync. After a dashboard edit writes a file to disk, stage
  * exactly those paths, commit, and push so the change lands on GitHub


### PR DESCRIPTION
## what

five different write paths in the dashboard each did their own **unlocked**
read → modify → write → commit against `aeon.yml` in local mode:

- `app/api/skills/route.ts` PATCH
- `app/api/skills/route.ts` DELETE
- `app/api/upload/route.ts` POST
- `lib/gateway.ts` `syncGatewayProvider()`
- `lib/gateway.ts` `syncHarness()`

## why

local mode (`isLocal()` — no `GITHUB_TOKEN`/`GITHUB_REPO`, the dashboard's own
dev-machine mode) reads/writes `aeon.yml` straight off the local filesystem
with no locking. two requests landing close together — e.g. clicking the
harness picker right after the model picker — interleave: both read the same
starting content, whichever writes last wins the *whole file* (it's a full
overwrite, not a merge), silently carrying forward whatever the earlier
request already wrote for fields it never touched.

concrete case this surfaced from: on a fork running the dashboard locally, a
`"chore: set model to claude-sonnet-5"` commit's diff also contained an
undocumented second hunk flipping `harness: pi -> fx`. nobody clicked fx
twice — two dropdown clicks a few ms apart just raced, and the model-only
request happened to read the file after the harness-only request's write had
already landed on disk but before that request's own git commit did, so the
model commit ended up carrying (and taking credit for) the harness change too.

hosted mode isn't affected — the Contents API's sha-based optimistic
concurrency already rejects a stale write there. this is local-mode only.

## fix

`withFileLock(path, fn)` in `lib/github.ts` — an in-process per-path mutex
(chained promise, no external deps). wrapped all five critical sections above
in it so concurrent requests touching the same path queue instead of
interleaving. scoped per-path so writes to unrelated files (soul.md,
strategy.md, mcp.json) never block on an aeon.yml write.

## verification

- `lib/github.test.ts` (new): serialization ordering under contention, a
  direct repro of the harness/model clobber scenario (mirrors the real
  incident — both fields land correctly under the lock), path independence,
  rejection from one call doesn't poison later calls on the same path.
- mutation-tested: temporarily stripped `withFileLock` back to a bare
  passthrough (`return fn()`) — the clobber-repro test failed with the exact
  predicted wrong value (`model` landed but `harness` reverted). confirms the
  test actually catches the regression, not just green-by-default.
- `tsc --noEmit` clean, `npm test` 195/195 (190 pre-existing + 5 new), all
  independently re-run in this worktree after applying the patch fresh off
  `upstream/main`.

## not in scope

didn't add a similar lock to `soul.md`/`strategy.md`/`mcp.json` writes —
those only have one writer each right now, no race exists to fix. flag if
that's wrong.