### PR TITLE
Egress audit hardening (iron-proxy) - opt-in

### DIFF
--- a/.github/actions/egress-audit/action.yml
+++ b/.github/actions/egress-audit/action.yml
@@ -1,0 +1,130 @@
+name: egress-audit
+description: Start iron-proxy in warn mode and route the job's traffic through it (audit-only, fail-open)
+inputs:
+  skill:
+    description: Skill name - labels the audit log and selects eyebrowlock hosts
+    required: true
+  mode:
+    description: audit (warn, nothing blocked - default) | enforce (default-deny off-list hosts)
+    required: false
+    default: audit
+runs:
+  using: composite
+  steps:
+    # Cache the pinned binary so audit-on-every-run doesn't re-download ~15MB.
+    # Only reached when the audit step runs (the action is gated), so no cost when off.
+    - name: Cache iron-proxy binary
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      with:
+        path: ~/.cache/iron-proxy
+        key: iron-proxy-0.49.0-${{ runner.os }}-${{ runner.arch }}
+
+    - name: Install iron-proxy (pinned release)
+      shell: bash
+      run: |
+        ver="0.49.0"
+        case "$(uname -m)" in
+          x86_64|amd64) arch=amd64 ;;
+          aarch64|arm64) arch=arm64 ;;
+          *) echo "IRON_AUDIT_UP=0" >> "$GITHUB_ENV"; echo "::warning::unsupported arch $(uname -m) - audit skipped"; exit 0 ;;
+        esac
+        CACHE="$HOME/.cache/iron-proxy"
+        BIN="$RUNNER_TEMP/iron/bin/iron-proxy"
+        mkdir -p "$CACHE" "$RUNNER_TEMP/iron/bin"
+        if [ -x "$CACHE/iron-proxy" ]; then
+          cp "$CACHE/iron-proxy" "$BIN"
+          echo "iron-proxy restored from cache"
+        else
+          url="https://github.com/paradigmxyz/iron-proxy/releases/download/v${ver}/iron-proxy_${ver}_linux_${arch}.tar.gz"
+          if ! curl -fsSL "$url" -o "$RUNNER_TEMP/iron/ip.tgz"; then
+            echo "IRON_AUDIT_UP=0" >> "$GITHUB_ENV"
+            echo "::warning::iron-proxy download failed - audit skipped, run continues"
+            exit 0
+          fi
+          tar -xzf "$RUNNER_TEMP/iron/ip.tgz" -C "$RUNNER_TEMP/iron/bin"
+          DL="$(find "$RUNNER_TEMP/iron/bin" -type f -name 'iron-proxy' | head -1)"
+          if [ -z "$DL" ]; then
+            echo "IRON_AUDIT_UP=0" >> "$GITHUB_ENV"
+            echo "::warning::iron-proxy binary not found in archive - audit skipped"
+            exit 0
+          fi
+          [ "$DL" != "$BIN" ] && cp "$DL" "$BIN"
+          cp "$BIN" "$CACHE/iron-proxy"   # populate for the cache action's post-run save
+          echo "iron-proxy downloaded + cached"
+        fi
+        chmod +x "$BIN"
+        echo "IRON_PROXY_BIN=$BIN" >> "$GITHUB_ENV"
+        "$BIN" --version || true
+
+    - name: Generate CA
+      shell: bash
+      run: |
+        [ "${IRON_AUDIT_UP:-1}" = "0" ] && exit 0
+        mkdir -p "$RUNNER_TEMP/iron/certs"
+        openssl genrsa -out "$RUNNER_TEMP/iron/certs/ca.key" 4096 2>/dev/null
+        openssl req -x509 -new -nodes \
+          -key "$RUNNER_TEMP/iron/certs/ca.key" \
+          -sha256 -days 1 \
+          -subj "/CN=aeon egress audit CA" \
+          -addext "basicConstraints=critical,CA:TRUE" \
+          -addext "keyUsage=critical,keyCertSign" \
+          -out "$RUNNER_TEMP/iron/certs/ca.crt" 2>/dev/null
+
+    - name: Write config
+      shell: bash
+      env:
+        EGRESS_MODE: ${{ inputs.mode }}
+      run: |
+        [ "${IRON_AUDIT_UP:-1}" = "0" ] && exit 0
+        node .github/scripts/iron-config.mjs "${{ inputs.skill }}" > "$RUNNER_TEMP/iron/proxy.yaml"
+        echo "--- iron-proxy config (mode: ${EGRESS_MODE}) ---"
+        cat "$RUNNER_TEMP/iron/proxy.yaml"
+
+    - name: Start proxy (fail-open)
+      shell: bash
+      run: |
+        [ "${IRON_AUDIT_UP:-1}" = "0" ] && exit 0
+        nohup "$IRON_PROXY_BIN" -config "$RUNNER_TEMP/iron/proxy.yaml" \
+          > "$RUNNER_TEMP/iron/audit.jsonl" 2>&1 &
+        PID=$!
+        up=0
+        for i in $(seq 1 20); do
+          kill -0 "$PID" 2>/dev/null || { up=dead; break; }
+          nc -z 127.0.0.1 8080 && { up=1; break; }
+          sleep 0.5
+        done
+        # The proxy can bind the tunnel and then die on a second listener, so a
+        # bare port check is a false positive: confirm it is still alive a moment later.
+        if [ "$up" = "1" ]; then sleep 1; kill -0 "$PID" 2>/dev/null || up=dead; fi
+        if [ "$up" != "1" ]; then
+          echo "IRON_AUDIT_UP=0" >> "$GITHUB_ENV"
+          echo "::warning::iron-proxy not healthy (${up}) - audit skipped, run continues"
+          echo "--- proxy output ---"; cat "$RUNNER_TEMP/iron/audit.jsonl" 2>/dev/null || true
+          exit 0
+        fi
+        echo "iron-proxy up on 127.0.0.1:8080 (warn/audit mode)"
+
+    - name: Export proxy env
+      shell: bash
+      run: |
+        if [ "${IRON_AUDIT_UP:-1}" = "0" ]; then
+          echo "audit not active - proxy env not exported, run proceeds normally"
+          exit 0
+        fi
+        CA="$RUNNER_TEMP/iron/certs/ca.crt"
+        # Sticky for all following steps (incl. the Run step, which reaches the
+        # claude process through bwrap - no --clearenv, so these propagate in).
+        # Actions-internal infra is kept OUT of the proxy so artifact upload and
+        # the runner's own comms are untouched; github.com stays IN so skill
+        # git/gh egress is audited.
+        {
+          echo "HTTP_PROXY=http://127.0.0.1:8080"
+          echo "HTTPS_PROXY=http://127.0.0.1:8080"
+          echo "NO_PROXY=localhost,127.0.0.1,::1,.actions.githubusercontent.com,.blob.core.windows.net"
+          echo "NODE_EXTRA_CA_CERTS=$CA"
+          echo "SSL_CERT_FILE=$CA"
+          echo "REQUESTS_CA_BUNDLE=$CA"
+          echo "CURL_CA_BUNDLE=$CA"
+          echo "GIT_SSL_CAINFO=$CA"
+        } >> "$GITHUB_ENV"
+        echo "proxy env exported (audit active)"

--- a/.github/scripts/iron-config.mjs
+++ b/.github/scripts/iron-config.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+// Generate an iron-proxy config (JSON, a valid YAML subset) for one skill run.
+//
+// Phase 2 = WARN mode: nothing is blocked, every request is logged for audit.
+// The allowlist is sourced from eyebrowlock.json (the CI-maintained per-skill
+// egress-host map) plus a baseline plus every gateway host whose secret is set,
+// so the `warn` annotations in the audit log flag only genuine surprises. In
+// warn mode the domain list is advisory - the audit still logs ALL hosts either
+// way - but priming it now makes the log readable and sets up phase 3 (enforce).
+import { readFileSync } from "node:fs";
+
+const skill = process.argv[2] ?? "unknown";
+const tmp = process.env.RUNNER_TEMP ?? "/tmp";
+
+// audit (default) = warn:true, nothing blocked, everything logged.
+// enforce = warn:false, default-deny anything not on the list below.
+const mode = (process.env.EGRESS_MODE ?? "audit").toLowerCase();
+const warn = mode !== "enforce";
+
+// Always-needed infra: the harness, the model endpoint, package registries.
+// Observed live on every run and NOT declared in any skill's eyebrowlock, so it
+// must be hardcoded here or enforce mode would break the harness itself.
+const baseline = [
+  "api.anthropic.com", "*.anthropic.com",       // model API (from inside bwrap)
+  "github.com", "api.github.com", "*.githubusercontent.com",  // gh / git / raw
+  "registry.npmjs.org",                          // npm (Claude Code install lives outside the run, but stay safe)
+];
+
+// NOTE deliberately absent: http-intake.logs.us5.datadoghq.com. That is Claude
+// Code's OWN usage/error telemetry, not skill egress - no skill needs it, so in
+// enforce mode it is denied on purpose (a real hardening win, and the sandbox has
+// no business phoning home). If a future Claude Code build treats a blocked
+// telemetry POST as fatal, add "*.datadoghq.com" here.
+
+// gateway: auto resolves the model host at run time from any provider secret
+// (claude -> anthropic -> openrouter -> bankr -> ...), and Langfuse tracing is
+// injected on every run. Allowlist all of these UNCONDITIONALLY: the config is
+// generated in a composite step that does NOT carry the secrets, so gating on
+// process.env presence silently drops them (this rejected Langfuse in the first
+// enforce test). Allowing an unused provider host costs ~nothing and covers the
+// whole failover cascade; the credential-blocking job is P5's secrets transform.
+const gatewayHosts = [
+  "openrouter.ai",
+  "llm.bankr.bot",
+  "api.x.ai",
+  "ai-gateway.vercel.sh",
+  "*.cloud.langfuse.com", "cloud.langfuse.com",  // observability, absent from eyebrowlock
+];
+
+// Per-skill declared egress hosts, as extracted by eyebrow and gated in CI.
+let lockHosts = [];
+try {
+  const lock = JSON.parse(readFileSync("eyebrowlock.json", "utf8"));
+  const art = (lock.artifacts ?? []).find((a) => a.name === skill);
+  lockHosts = art?.capabilities?.network ?? [];
+} catch { /* missing/unreadable lock is non-fatal: the audit still logs everything */ }
+
+const domains = [...new Set([...baseline, ...gatewayHosts, ...lockHosts])];
+
+const config = {
+  // Explicit HTTP(S)_PROXY is used, not DNS interception - disable the DNS
+  // server so proxy_ip is not required.
+  dns: { enabled: false },
+  proxy: {
+    // Explicit-proxy (CONNECT/SOCKS5) listener. Clients point HTTPS_PROXY here.
+    tunnel_listen: "127.0.0.1:8080",
+    // The transparent listeners hard-default to :80/:443, which a non-root runner
+    // cannot bind - the resulting fatal kills the proxy right after it binds the
+    // tunnel. Empty string does NOT disable them (it falls back to the default),
+    // so point them at inert high loopback ports instead: they bind harmlessly
+    // and nothing routes there (explicit-proxy traffic uses the tunnel listener).
+    http_listen: "127.0.0.1:8081",
+    https_listen: "127.0.0.1:8082",
+    // The 30s default 502s slow LLM responses; a skill's model call can take
+    // longer to first byte. Give upstream headers room so warn mode never
+    // breaks a real run on a timeout.
+    upstream_response_header_timeout: "5m",
+  },
+  tls: {
+    mode: "mitm",
+    ca_cert: `${tmp}/iron/certs/ca.crt`,
+    ca_key: `${tmp}/iron/certs/ca.key`,
+  },
+  transforms: [
+    { name: "allowlist", config: { warn, domains } },
+  ],
+  log: { level: "info" },
+};
+
+process.stdout.write(JSON.stringify(config, null, 2));

--- a/.github/scripts/iron-report.mjs
+++ b/.github/scripts/iron-report.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+// P4: turn an iron-proxy audit log into a deterministic health signal.
+//
+// Reads audit.jsonl (path in argv[2]) and emits {flag, hosts} JSON on stdout.
+// `egress_blocked` fires when the allowlist REJECTED a host the skill actually
+// tried to reach - an allowlist gap (or an exfil attempt) the §7 repair loop can
+// act on. Rejects occur only in enforce mode; in audit/warn the log is all
+// "allow" and this emits flag:null. Hosts we deny ON PURPOSE are excluded so a
+// by-design block never raises a false signal.
+import { readFileSync } from "node:fs";
+
+const path = process.argv[2];
+
+// Intentional denies (see the baseline note in iron-config.mjs): Claude Code's
+// own telemetry. A reject here is expected, not a misconfiguration.
+const EXPECTED_DENY = [/(^|\.)datadoghq\.com$/];
+
+const stripPort = (h) => (h || "").replace(/:\d+$/, "");
+const isExpected = (h) => EXPECTED_DENY.some((re) => re.test(h));
+
+let text = "";
+try { text = readFileSync(path, "utf8"); } catch { /* no audit log = audit was off */ }
+
+const denied = new Map();
+for (const line of text.split("\n")) {
+  if (!line.startsWith("{")) continue;          // skip non-JSON startup noise
+  let e;
+  try { e = JSON.parse(line); } catch { continue; }
+  if (e.msg !== "request") continue;
+  const a = e.audit || {};
+  const rejected =
+    a.action === "reject" ||
+    Boolean(e.rejected_by) ||
+    (e.request_transforms || []).some((t) => t.action === "reject");
+  if (!rejected) continue;
+  const host = stripPort(a.host);
+  if (!host || isExpected(host)) continue;
+  denied.set(host, (denied.get(host) || 0) + 1);
+}
+
+const hosts = [...denied.entries()].map(([host, count]) => ({ host, count }));
+process.stdout.write(JSON.stringify({
+  flag: hosts.length ? "egress_blocked" : null,
+  hosts,
+}));

--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -176,6 +176,24 @@ jobs:
           git config user.name "aeonframework"
           git config user.email "aeonframework@proton.me"
 
+      # Egress hardening P1: default-deny outbound to link-local + cloud metadata.
+      # No skill has a legitimate reason to reach 169.254.0.0/16. Kills the SSRF /
+      # DNS-rebinding-to-metadata class before any skill runs. REJECT (not DROP) so a
+      # stray probe fails fast. Runs job-wide, covers the Run step.
+      - name: Block link-local and metadata egress
+        if: steps.work.outputs.mode != ''
+        run: |
+          sudo iptables  -A OUTPUT -d 169.254.0.0/16 -j REJECT --reject-with icmp-port-unreachable
+          sudo ip6tables -A OUTPUT -d fd00:ec2::/64  -j REJECT || true
+          sudo ip6tables -A OUTPUT -d fd20:ce::/64   -j REJECT || true
+          if curl -s --max-time 3 -o /dev/null http://169.254.169.254/; then
+            echo "::error::cloud metadata endpoint still reachable - egress block failed"
+            exit 1
+          fi
+          echo "link-local / metadata egress blocked"
+          code=$(curl -s --max-time 10 -o /dev/null -w '%{http_code}' https://api.github.com/zen || echo 000)
+          echo "public egress check (api.github.com/zen): ${code}"
+
       - name: Setup Node.js
         if: steps.work.outputs.mode != ''
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
@@ -545,6 +563,20 @@ jobs:
             echo "hidden=$HIDE" >> "$GITHUB_OUTPUT"
             echo "::notice::single-source: $HARNESS reads $KEPT; hid $HIDE for this run"
           fi
+
+      # Egress hardening P2 (audit). OPT-IN: set repo var EGRESS_AUDIT=1 to enable.
+      # Starts iron-proxy in WARN mode (nothing blocked; EGRESS_MODE=enforce opts into
+      # blocking off-list hosts) and routes this job's egress through it for a per-request
+      # audit log; fail-open, so a proxy that never comes up just skips the audit and the
+      # run proceeds. Env is exported via $GITHUB_ENV and reaches the claude process
+      # inside bwrap (no --clearenv in the sandbox prefix). This is egress control +
+      # audit, NOT credential isolation on a same-box runner; WebFetch/WebSearch bypass it.
+      - name: Egress audit
+        if: steps.work.outputs.mode != '' && vars.EGRESS_AUDIT == '1'
+        uses: ./.github/actions/egress-audit
+        with:
+          skill: ${{ steps.skill.outputs.name }}
+          mode: ${{ vars.EGRESS_MODE || 'audit' }}
 
       - name: Run
         id: run
@@ -1031,6 +1063,16 @@ jobs:
 
           echo "::notice::Token usage — input: $INPUT_TOKENS, output: $OUTPUT_TOKENS, cache_read: $CACHE_READ, cache_creation: $CACHE_CREATION, total: $TOTAL_TOKENS"
 
+      # Egress hardening P2: publish the warn-mode audit log. always() so it lands
+      # even if the run failed; the host list is the allowlist oracle P3 builds from.
+      - name: Upload egress audit log
+        if: always() && vars.EGRESS_AUDIT == '1'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: egress-${{ steps.skill.outputs.name }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/iron/audit.jsonl
+          if-no-files-found: ignore
+
       # Undo "Single-source standing instructions" so the working tree matches HEAD
       # before any capture/guard/commit step runs. always(): the file must come back
       # even if Run failed or timed out. The move is a plain rename back — it touches
@@ -1455,6 +1497,21 @@ jobs:
           ASSESSMENT=$(echo "$PARSED" | jq -r '.assessment // "analysis incomplete"')
           FLAGS=$(echo "$PARSED" | jq -c '.flags // []')
 
+          # P4: fold a deterministic egress_blocked flag into the model's flags.
+          # iron-report reads this run's audit log (present only when EGRESS_AUDIT is
+          # on and enforce rejected something) and reports hosts the allowlist blocked
+          # that the skill needed - an allowlist gap for the §7 repair loop. Intentional
+          # denies (Claude Code telemetry) are excluded, so the by-design block never fires it.
+          EGRESS_DENIED='[]'
+          if [ -f "$RUNNER_TEMP/iron/audit.jsonl" ]; then
+            EGRESS_REPORT=$(node .github/scripts/iron-report.mjs "$RUNNER_TEMP/iron/audit.jsonl" 2>/dev/null || echo '{}')
+            if [ "$(echo "$EGRESS_REPORT" | jq -r '.flag // empty')" = "egress_blocked" ]; then
+              FLAGS=$(echo "$FLAGS" | jq -c '. + ["egress_blocked"] | unique')
+              EGRESS_DENIED=$(echo "$EGRESS_REPORT" | jq -c '.hosts // []')
+              echo "::warning::egress_blocked - allowlist denied needed hosts: $(echo "$EGRESS_DENIED" | jq -c '[.[].host]')"
+            fi
+          fi
+
           # A missing or out-of-range score means the judge malformed its reply, not
           # that the skill scored zero. Treat it as unscored and skip the write, so a
           # judge error can't append a 0 to history and drag avg_score down. (`.score
@@ -1486,8 +1543,8 @@ jobs:
 
           jq -n --arg sk "$SKILL" --arg ts "$NOW_ISO" --argjson sc "$SCORE" \
             --arg as "$ASSESSMENT" --argjson fl "$FLAGS" \
-            --argjson hi "$HISTORY" --argjson avg "$AVG" \
-            '{skill: $sk, last_analyzed: $ts, quality_score: $sc, assessment: $as, flags: $fl, avg_score: $avg, history: $hi}' \
+            --argjson hi "$HISTORY" --argjson avg "$AVG" --argjson ed "$EGRESS_DENIED" \
+            '{skill: $sk, last_analyzed: $ts, quality_score: $sc, assessment: $as, flags: $fl, avg_score: $avg, history: $hi} + (if ($ed | length) > 0 then {egress_denied_hosts: $ed} else {} end)' \
             > "$HEALTH_FILE"
 
           echo "::notice::Skill quality — $SKILL: score=$SCORE, avg=$AVG — $ASSESSMENT"

--- a/scripts/health_triage.py
+++ b/scripts/health_triage.py
@@ -16,9 +16,13 @@ scripts/health_issue.sh; this module is offline and unit-tested.
 import json
 import sys
 
-FAILURE_FLAGS = {"api_error", "empty_output", "rate_limited", "dead_citation", "stale_data"}
+FAILURE_FLAGS = {"api_error", "empty_output", "rate_limited", "dead_citation", "stale_data", "egress_blocked"}
 HIGH_FLAGS = {"api_error", "empty_output"}
-MED_FLAGS = {"dead_citation", "stale_data", "rate_limited"}
+# egress_blocked = the allowlist rejected a host the skill needed (an allowlist gap
+# for the repair loop); medium so a votable §7 Issue opens without out-ranking a
+# hard api_error. Set deterministically from the iron-proxy audit log, not by the
+# Haiku scorer - see .github/scripts/iron-report.mjs.
+MED_FLAGS = {"dead_citation", "stale_data", "rate_limited", "egress_blocked"}
 _SEV_RANK = {"high": 3, "medium": 2, "low": 1, "none": 0}
 
 


### PR DESCRIPTION
Optional per-run egress firewall + audit for skill runs. **Default OFF** - nothing changes unless an operator sets `EGRESS_AUDIT=1` (and `EGRESS_MODE=enforce` to block, not just log).

- **P1** block link-local + cloud-metadata egress (always on) - kills the SSRF / DNS-rebinding-to-metadata class.
- **P2** audit proxy (iron-proxy v0.49.0, cached, fail-open) - warn mode logs every host a run talks to.
- **P3** allowlist (baseline + gateway + Langfuse + eyebrowlock) + `audit|enforce` switch.
- **P4** `egress_blocked` votable §7 health signal (intentional denies excluded).

**Scope, stated plainly:** egress control + audit, **not** credential isolation on a same-box runner - the run's env still holds the secrets. WebFetch/WebSearch bypass the proxy (filter, not boundary).

**Validation:** aeon-data (default-on, curl/gh/git/notify clean), aeon-vuln (vuln-scanner, no MITM breakage, no cert errors). The one untested toolchain is `forge`/`foundry` (deploy-uni-hook, rustls may ignore the CA env) - being validated on aeon-onchain before recommending audit-on for a contract instance. Opt-in default means this is safe to merge regardless.