### PR TITLE
docs: sync PRs #926-#947 to aeon docs

### DIFF
--- a/.claude/skills/aeon/SKILL.md
+++ b/.claude/skills/aeon/SKILL.md
@@ -251,7 +251,7 @@ metadata:
 Today is ${today}. <the prompt — plain instructions, including judgment calls>
 
 ## Steps
-1. <the procedure — 43 of 75 skills lead with this>
+1. <the procedure — 43 of 76 skills lead with this>
 
 ## Network note
 <curl / WebFetch / `./secretcurl` / `gh api` — how this skill fetches>
@@ -311,9 +311,9 @@ Three at a time, not twelve. Every enabled skill is a recurring notification, an
 ./aeon packs ls                  # the six first-party packs
 ```
 
-`ls` footers with `75 skills · 1 enabled` — read it to them before proposing anything. First run installs the CLI runtime (tsx + yaml, ~12MB); the npm noise is one-time and expected. Grep-only equivalents: `references/layout.md`.
+`ls` footers with `76 skills · 1 enabled` — read it to them before proposing anything. First run installs the CLI runtime (tsx + yaml, ~12MB); the npm noise is one-time and expected. Grep-only equivalents: `references/layout.md`.
 
-Packs are a visibility filter, not a runtime switch — revealing one runs nothing. Core (12), Evolution (9) and Basics (17) show by default; Dev (11), Crypto (15) and Productivity (11) are on demand.
+Packs are a visibility filter, not a runtime switch — revealing one runs nothing. Core (12), Evolution (9) and Basics (18) show by default; Dev (11), Crypto (15) and Productivity (11) are on demand.
 
 Reasonable starting sets:
 

--- a/.claude/skills/aeon/references/layout.md
+++ b/.claude/skills/aeon/references/layout.md
@@ -12,7 +12,7 @@ Where everything lives in an Aeon repo, and the fastest way to see what's on.
 ./aeon skills ls --enabled --json # for building the Mode 2 timeline
 ```
 
-`ls` prints `SKILL / ON / SCHEDULE / PACK / DESCRIPTION` and a footer — `75 skills · 1 enabled`. First run installs the CLI runtime (tsx + yaml, ~12MB, one-time); the noise is expected.
+`ls` prints `SKILL / ON / SCHEDULE / PACK / DESCRIPTION` and a footer — `76 skills · 1 enabled`. First run installs the CLI runtime (tsx + yaml, ~12MB, one-time); the noise is expected.
 
 **The `SCHEDULE` column is populated for disabled skills too** — it's their `aeon.yml` entry, not proof anything fires. Only the `●` in `ON` means it runs.
 

--- a/.claude/skills/aeon/references/mcp.md
+++ b/.claude/skills/aeon/references/mcp.md
@@ -7,7 +7,7 @@ Two unrelated things share the name. Get this wrong and nothing works.
 | | |
 |---|---|
 | **`.mcp.json`** — *external MCP servers, called BY Aeon skills* | Wired via the dashboard MCP panel or `./aeon mcp add`. This is what you want when a skill needs a tool. |
-| **`bin/add-mcp`** — *Aeon itself AS an MCP server* | Builds `apps/mcp-server` and registers it with Claude Code / Desktop, so all 75 skills appear as `aeon-*` tools **in your local Claude**. Nothing to do with a skill calling out. |
+| **`bin/add-mcp`** — *Aeon itself AS an MCP server* | Builds `apps/mcp-server` and registers it with Claude Code / Desktop, so all 76 skills appear as `aeon-*` tools **in your local Claude**. Nothing to do with a skill calling out. |
 
 The rest of this doc is the first one. For the second: `bin/add-mcp`, `--desktop` for a Claude Desktop snippet, `--uninstall` to remove, `claude mcp list` to verify.
 

--- a/.claude/skills/aeon/references/skill-anatomy.md
+++ b/.claude/skills/aeon/references/skill-anatomy.md
@@ -1,10 +1,10 @@
 # How Aeon skills are actually written
 
-Surveyed across all 75 skills in `aeonfun/aeon`. Frequencies are real counts — match the dominant convention unless there's a reason not to. Bodies run 133–757 lines (~306 median); a skill is a prompt, not a config file, and reads as prose.
+Surveyed across all 76 skills in `aeonfun/aeon`. Frequencies are real counts — match the dominant convention unless there's a reason not to. Bodies run 133–757 lines (~306 median); a skill is a prompt, not a config file, and reads as prose.
 
 ## Frontmatter
 
-Universal — **all 75 skills** carry these five:
+Universal — **all 76 skills** carry these five:
 
 ```yaml
 name: my-skill       # the slug (matches the skills/<slug>/ directory)
@@ -113,7 +113,7 @@ There is **no network sandbox** — plain `curl` works for unauthenticated GETs.
 
 `memory/` is the durable state that survives between runs. Four conventions, in order of how often skills touch them:
 
-### `memory/logs/${today}.md` — the run log (62 of 75 skills)
+### `memory/logs/${today}.md` — the run log (63 of 76 skills)
 
 Every skill appends what it did, under **one** heading that is exactly its slug:
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="../docs/assets/hero-animated.svg" alt="AEON — the most autonomous agent framework. 60+ skills across 6 harnesses (Claude Code, Grok, Codex, Pi, Vibe, Kimi), running unattended on GitHub Actions: it ships features to your repos, privately discloses real vulnerabilities, deploys live apps, runs deep research, and writes new skills for itself. Keywords: autonomous AI agent, agent framework, GitHub Actions automation, self-improving agent, multi-agent orchestration, LLM skills, cron agent." width="100%" />
+  <img src="../docs/assets/hero-animated.svg" alt="AEON — the most autonomous agent framework. 60+ skills across 7 harnesses (Claude Code, Grok, Codex, Pi, Vibe, Kimi, fx), running unattended on GitHub Actions: it ships features to your repos, privately discloses real vulnerabilities, deploys live apps, runs deep research, and writes new skills for itself. Keywords: autonomous AI agent, agent framework, GitHub Actions automation, self-improving agent, multi-agent orchestration, LLM skills, cron agent." width="100%" />
 </p>
 
 <p align="center">
@@ -46,7 +46,7 @@ git clone https://github.com/<you>/aeon   # skip if you used `gh repo fork --clo
 cd aeon && ./aeon
 ```
 
-Open [localhost:5555](http://localhost:5555) and follow the dashboard: **Authenticate** (any of six [harnesses](../docs/harnesses.md)) → **add a channel** → **pick skills** → **Run**. That's it - Aeon runs unattended. Everything is also an `./aeon` command ([CLI](../apps/cli/README.md)) or a `/aeon` chat command ([setup skill](../docs/aeon-setup.md), installable as a [Claude Code or Codex plugin](../docs/aeon-setup.md#install)).
+Open [localhost:5555](http://localhost:5555) and follow the dashboard: **Authenticate** (any of seven [harnesses](../docs/harnesses.md)) → **add a channel** → **pick skills** → **Run**. That's it - Aeon runs unattended. Everything is also an `./aeon` command ([CLI](../apps/cli/README.md)) or a `/aeon` chat command ([setup skill](../docs/aeon-setup.md), installable as a [Claude Code or Codex plugin](../docs/aeon-setup.md#install)).
 
 <details>
 <summary><strong>No admin rights / can't install <code>gh</code>?</strong></summary>
@@ -87,13 +87,13 @@ The prompt *is* the skill. You schedule it, hand it a `var`, chain it into other
 
 <p align="center"><a href="../docs/community-skill-packs.md#listed-packs"><b>Community skill packs →</b></a></p>
 
-## Support six harnesses: Claude, Grok, Codex, Pi, Vibe, Kimi
+## Support seven harnesses: Claude, Grok, Codex, Pi, Vibe, Kimi, fx
 
 <p align="center">
-  <img src="../docs/assets/harnesses-aeon.jpg" alt="Six engines, one socket - a SKILL.md flows through run-harness into any of six agent CLIs: Claude, Grok, Codex, Pi, Vibe, and Kimi. Every harness honors the same contract: result, usage, session." width="100%" />
+  <img src="../docs/assets/harnesses-aeon.jpg" alt="Seven engines, one socket - a SKILL.md flows through run-harness into any of seven agent CLIs: Claude, Grok, Codex, Pi, Vibe, Kimi, and fx. Every harness honors the same contract: result, usage, session." width="100%" />
 </p>
 
-The same `SKILL.md` runs on any of six agent CLIs - **Claude**, **Grok**, **Codex**, **Pi**, **Vibe**, **Kimi** - behind one `run-harness` contract (same result, usage, and session shape). Swap the harness; nothing else changes. How the contract works: [`docs/harnesses.md`](../docs/harnesses.md).
+The same `SKILL.md` runs on any of seven agent CLIs - **Claude**, **Grok**, **Codex**, **Pi**, **Vibe**, **Kimi**, **fx** - behind one `run-harness` contract (same result, usage, and session shape). Swap the harness; nothing else changes. How the contract works: [`docs/harnesses.md`](../docs/harnesses.md).
 
 ## Why "the most autonomous"
 
@@ -185,7 +185,7 @@ The deep reference lives in [`docs/`](../docs) - jump in:
 
 <p align="center">
   <a href="../docs/CONFIGURATION.md"><img src="../docs/assets/doc-config.svg" alt="Configuration - chaining, triggers, scheduler, capability modes, gateways, Fleet Watcher" height="30" align="absmiddle"></a>&nbsp;
-  <a href="../docs/harnesses.md"><img src="../docs/assets/doc-harnesses.svg" alt="Harnesses - run skills on any of six agent CLIs behind one contract" height="30" align="absmiddle"></a>&nbsp;
+  <a href="../docs/harnesses.md"><img src="../docs/assets/doc-harnesses.svg" alt="Harnesses - run skills on any of seven agent CLIs behind one contract" height="30" align="absmiddle"></a>&nbsp;
   <a href="../docs/skill-packs.md"><img src="../docs/assets/doc-packs.svg" alt="Skill Packs - how packs work and how to build your own" height="30" align="absmiddle"></a>&nbsp;
   <a href="../docs/CORE.md"><img src="../docs/assets/doc-core.svg" alt="Core - the self-healing health and repair loop" height="30" align="absmiddle"></a>
 </p>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Added
 
+- **`fx` (Vercel) added as a 7th run-harness.** Vercel's native Zig coding-agent
+  CLI joins claude/grok/codex/pi/vibe/kimi behind the same `run-harness` contract,
+  verified against a locally-built binary (missing-credential path, `mcpServers` to
+  `mcp.json` translation, second-call usage reporting via `fx session`). It is the
+  one harness with no OpenRouter fallback: it needs a Vercel AI Gateway key
+  (`AI_GATEWAY_API_KEY`) or `VERCEL_OIDC_TOKEN`. See `docs/harnesses.md`. (#941)
+- **New `skill-article` skill (Basics).** Turns any skill in the instance into a
+  publish-ready launch article: proof-stat headline, one contrarian thesis,
+  mechanics, war stories mined from real `memory/logs/` run history, a mental-model
+  reframe, and the full `SKILL.md` embedded verbatim. Optional `--banner` renders a
+  16:9 title card through the Higgsfield MCP. Catalog is now 76 skills. (#945)
+- **Dashboard auto-allowlists MCP secret names into the run workflows.** A connected
+  key-based MCP server's secret is now injected into the generated workflow env, so
+  headless runs can actually see it instead of silently missing the credential.
+  (#931)
+- **Opt-in egress-audit hardening (`iron-proxy`).** A new composite action captures
+  and reports a run's outbound network calls behind an audit proxy, off by default.
+  (#947)
 - **Codex plugin parity + a repo-root `llms.txt`.** The `/aeon` operator skill now
   installs on Codex too (`plugin/.codex-plugin/plugin.json` +
   `.agents/plugins/marketplace.json`: `codex plugin marketplace add aeonfun/aeon`
@@ -230,6 +248,11 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Changed
 
+- **`memory-flush` mechanical bookkeeping moved out of the LLM.** The prep work is
+  now a deterministic, watermark-tracked script (`memory_prep.py` +
+  `memory-flush-state.json`) so the model only does the judgment part. (#938)
+- **README notes the operator console installs as a Codex plugin too.** (#927)
+- **Ecosystem: added AgentOS** to `docs/ECOSYSTEM.md`. (#946)
 - **GitHub token model corrected to a single classic PAT.** `GH_GLOBAL` is now
   documented as one classic PAT with `repo` + `workflow` scopes (was fine-grained
   Contents/PRs/Issues); `GH_READ_PAT` / `GH_SECRETS_PAT` are reframed as legacy and
@@ -327,6 +350,23 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Fixed
 
+- **`fx` now shows up in the dashboard harness picker.** (#943)
+- **Dashboard locks `aeon.yml` read-modify-write.** Concurrent config edits no
+  longer race and clobber each other. (#944)
+- **secretcurl no longer leaks its substituted secret into curl's own argv**, where
+  another process could read it via `ps` or `/proc`. (#935)
+- **Telegram webhook dedupes redelivered updates by `update_id`** before dispatch,
+  so a slow response no longer re-dispatches the same update. (#937)
+- **Racing `state_store` / `health_issue` "ensure" calls converge** instead of
+  creating duplicate GitHub issues for the same title. (#936)
+- **Skill-runner concurrency group scoped by target too**, so dispatching the same
+  skill at two different vars no longer collides. (#934)
+- **`Bash(cd:*)` granted again in skill-mode**, restoring the documented
+  one-cd-per-call workaround for the sandbox's compound-command denial. (#933)
+- **Failed-dispatch diagnostics no longer truncated to the front of the output**, so
+  the actual error fields survive logging. (#932)
+- **Windows Connect/OAuth fix batch:** OAuth truncation, a setup-token timeout,
+  config line-folding, Foundry install, and mainnet-flag masking. (#930)
 - **Reactive `success_rate` conditions now actually fire.** The scheduler's inline
   evaluator only handled `consecutive_failures` and `last_status`; a trigger written
   as `when: "success_rate < 0.5"` matched no branch and was silently dropped.
@@ -652,6 +692,10 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Maintenance
 
+- CI/test/asset noise: HOL AI Plugin Scanner workflow added then dropped same-day
+  (#928, #929); unused `docs/assets` images removed and provider/free-aeon docs
+  images refreshed (#939, #940); state-store/health-issue test hardening (#942);
+  prior in-repo docs-sync of PRs #890-#925 (#926).
 - Dead-code sweep from a `ponytail-audit` pass: verified cuts across the CLI,
   dashboard, mcp-server tracing, and scripts, net -444 lines, no behavior change.
   (#886)

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -94,7 +94,7 @@ mode: write       # default — full Write / Edit / git / gh / python3
 | 2. **OS sandbox** | Write-locks the workspace for the whole run — the repo is mounted read-only, network stays open | `run-harness --mode read-only` → [`harness-adapter/lib/sandbox.sh`](../harness-adapter/lib/sandbox.sh) |
 | 3. Post-run guard | Reverts and cleans anything that still landed under `CODE_PATHS`, preserving the skill's real output (memory, `output/`) and writing its run-log on its behalf | `.github/workflows/aeon.yml` |
 
-**Layer 2 is the guarantee.** Layer 1 is a real narrowing but not a boundary: a shell redirection routes around it, and only the claude and pi adapters consume the allowlist at all. Layer 3 is after-the-fact repair. So the sentence "a read-only skill physically cannot mutate the repo" is true because of the sandbox — `bwrap --ro-bind` on Linux, `sandbox-exec` with a `deny file-write*` profile on macOS — which applies uniformly on **all six harnesses**, claude included.
+**Layer 2 is the guarantee.** Layer 1 is a real narrowing but not a boundary: a shell redirection routes around it, and only the claude and pi adapters consume the allowlist at all. Layer 3 is after-the-fact repair. So the sentence "a read-only skill physically cannot mutate the repo" is true because of the sandbox — `bwrap --ro-bind` on Linux, `sandbox-exec` with a `deny file-write*` profile on macOS — which applies uniformly on **all seven harnesses**, claude included.
 
 ### Why the sandbox is the dispatcher's, not each harness's
 

--- a/docs/assets/hero-animated.svg
+++ b/docs/assets/hero-animated.svg
@@ -75,7 +75,7 @@
     </g>
     <g transform="translate(725,346)">
       <rect x="0" y="0" width="176" height="42" rx="21" fill="#F4EFE1" stroke="#0d0c0a" stroke-width="2"/>
-      <text x="88" y="28" text-anchor="middle">6 harnesses</text>
+      <text x="88" y="28" text-anchor="middle">7 harnesses</text>
     </g>
     <g transform="translate(916,346)">
       <rect x="0" y="0" width="184" height="42" rx="21" fill="#F4EFE1" stroke="#0d0c0a" stroke-width="2"/>

--- a/docs/skill-packs.md
+++ b/docs/skill-packs.md
@@ -73,10 +73,10 @@ Pack key = category. Six packs, no empties; three are shown by default.
 |---|---|---|
 | **Core** (`core`) | Fleet coordination, self-configuration, liveness, memory + reporting. Shown by default; not removable. | 12 |
 | **Evolution** (`evolution`) | The self-improvement loop — authors, evolves, installs, and heals its own skills. Shown by default. | 9 |
-| **Basics** (`basics`) | Simple, immediately-runnable skills — one approachable entry per area. Shown by default. | 17 |
+| **Basics** (`basics`) | Simple, immediately-runnable skills — one approachable entry per area. Shown by default. | 18 |
 | **Dev & Code** (`dev`) | PR/issue triage, review, merges, changelogs, repo monitoring, security scanning, app deploys, cloud-cost analysis. | 11 |
-| **Crypto & Markets** (`crypto`) | Token/DeFi/prediction-market monitoring, narrative tracking, on-chain forensics + automation, Uniswap v4 hook deploys. | 14 |
-| **Productivity** (`productivity`) | Personal + social ops: routines, ideas, retrospectives, mentions, replies, ads, email, competitor watch, media + video generation. | 10 |
+| **Crypto & Markets** (`crypto`) | Token/DeFi/prediction-market monitoring, narrative tracking, on-chain forensics + automation, Uniswap v4 hook deploys. | 15 |
+| **Productivity** (`productivity`) | Personal + social ops: routines, ideas, retrospectives, mentions, replies, ads, email, competitor watch, media + video generation. | 11 |
 
 ### Core + Evolution + Basics — what a fresh fork shows
 

--- a/plugin/skills/aeon/SKILL.md
+++ b/plugin/skills/aeon/SKILL.md
@@ -251,7 +251,7 @@ metadata:
 Today is ${today}. <the prompt — plain instructions, including judgment calls>
 
 ## Steps
-1. <the procedure — 43 of 75 skills lead with this>
+1. <the procedure — 43 of 76 skills lead with this>
 
 ## Network note
 <curl / WebFetch / `./secretcurl` / `gh api` — how this skill fetches>
@@ -311,9 +311,9 @@ Three at a time, not twelve. Every enabled skill is a recurring notification, an
 ./aeon packs ls                  # the six first-party packs
 ```
 
-`ls` footers with `75 skills · 1 enabled` — read it to them before proposing anything. First run installs the CLI runtime (tsx + yaml, ~12MB); the npm noise is one-time and expected. Grep-only equivalents: `references/layout.md`.
+`ls` footers with `76 skills · 1 enabled` — read it to them before proposing anything. First run installs the CLI runtime (tsx + yaml, ~12MB); the npm noise is one-time and expected. Grep-only equivalents: `references/layout.md`.
 
-Packs are a visibility filter, not a runtime switch — revealing one runs nothing. Core (12), Evolution (9) and Basics (17) show by default; Dev (11), Crypto (15) and Productivity (11) are on demand.
+Packs are a visibility filter, not a runtime switch — revealing one runs nothing. Core (12), Evolution (9) and Basics (18) show by default; Dev (11), Crypto (15) and Productivity (11) are on demand.
 
 Reasonable starting sets:
 

--- a/plugin/skills/aeon/references/layout.md
+++ b/plugin/skills/aeon/references/layout.md
@@ -12,7 +12,7 @@ Where everything lives in an Aeon repo, and the fastest way to see what's on.
 ./aeon skills ls --enabled --json # for building the Mode 2 timeline
 ```
 
-`ls` prints `SKILL / ON / SCHEDULE / PACK / DESCRIPTION` and a footer — `75 skills · 1 enabled`. First run installs the CLI runtime (tsx + yaml, ~12MB, one-time); the noise is expected.
+`ls` prints `SKILL / ON / SCHEDULE / PACK / DESCRIPTION` and a footer — `76 skills · 1 enabled`. First run installs the CLI runtime (tsx + yaml, ~12MB, one-time); the noise is expected.
 
 **The `SCHEDULE` column is populated for disabled skills too** — it's their `aeon.yml` entry, not proof anything fires. Only the `●` in `ON` means it runs.
 

--- a/plugin/skills/aeon/references/mcp.md
+++ b/plugin/skills/aeon/references/mcp.md
@@ -7,7 +7,7 @@ Two unrelated things share the name. Get this wrong and nothing works.
 | | |
 |---|---|
 | **`.mcp.json`** — *external MCP servers, called BY Aeon skills* | Wired via the dashboard MCP panel or `./aeon mcp add`. This is what you want when a skill needs a tool. |
-| **`bin/add-mcp`** — *Aeon itself AS an MCP server* | Builds `apps/mcp-server` and registers it with Claude Code / Desktop, so all 75 skills appear as `aeon-*` tools **in your local Claude**. Nothing to do with a skill calling out. |
+| **`bin/add-mcp`** — *Aeon itself AS an MCP server* | Builds `apps/mcp-server` and registers it with Claude Code / Desktop, so all 76 skills appear as `aeon-*` tools **in your local Claude**. Nothing to do with a skill calling out. |
 
 The rest of this doc is the first one. For the second: `bin/add-mcp`, `--desktop` for a Claude Desktop snippet, `--uninstall` to remove, `claude mcp list` to verify.
 

--- a/plugin/skills/aeon/references/skill-anatomy.md
+++ b/plugin/skills/aeon/references/skill-anatomy.md
@@ -1,10 +1,10 @@
 # How Aeon skills are actually written
 
-Surveyed across all 75 skills in `aeonfun/aeon`. Frequencies are real counts — match the dominant convention unless there's a reason not to. Bodies run 133–757 lines (~306 median); a skill is a prompt, not a config file, and reads as prose.
+Surveyed across all 76 skills in `aeonfun/aeon`. Frequencies are real counts — match the dominant convention unless there's a reason not to. Bodies run 133–757 lines (~306 median); a skill is a prompt, not a config file, and reads as prose.
 
 ## Frontmatter
 
-Universal — **all 75 skills** carry these five:
+Universal — **all 76 skills** carry these five:
 
 ```yaml
 name: my-skill       # the slug (matches the skills/<slug>/ directory)
@@ -113,7 +113,7 @@ There is **no network sandbox** — plain `curl` works for unauthenticated GETs.
 
 `memory/` is the durable state that survives between runs. Four conventions, in order of how often skills touch them:
 
-### `memory/logs/${today}.md` — the run log (62 of 75 skills)
+### `memory/logs/${today}.md` — the run log (63 of 76 skills)
 
 Every skill appends what it did, under **one** heading that is exactly its slug:
 


### PR DESCRIPTION
Syncs merged `aeonfun/aeon` PRs **#926-#947** into the in-repo docs, and promotes the harness headline from six to **seven** now that `fx` (#941) is a real run-harness. The website changelog was already independently ahead (covered #926-#942), so this backfills the aeon-repo side for that window and adds the new #943-#947.

## Source PRs synced
- **Signal:** #927 (README Codex-plugin note), #930 (Windows Connect/OAuth fix batch), #931 (dashboard auto-allowlists MCP secret names), #932 (untruncated failed-dispatch diagnostics), #933 (Bash(cd:*) grant), #934 (skill-runner concurrency scoped by target), #935 (secretcurl argv leak), #936 (racing issue-store ensures), #937 (Telegram update_id dedupe), #938 (memory-flush deterministic prep), #941 (**fx = 7th run-harness**), #943 (fx in harness picker), #944 (dashboard aeon.yml race lock), #945 (**new skill-article skill, catalog 75 to 76**), #946 (ecosystem +AgentOS), #947 (egress-audit iron-proxy, opt-in)
- **Noise (one Maintenance line):** #926, #928, #929, #939, #940, #942

## Surfaces changed
- [x] `CHANGELOG.md` [Unreleased] - Added / Changed / Fixed / Maintenance for #926-#947
- [x] Catalog 75 -> 76 (Basics 17 -> 18, skill-article #945): `.claude/skills/aeon/**` + byte-identical `plugin/skills/aeon/**` (footer, all-N, run-log 62 -> 63; Steps 43 stays - skill-article has no `## Steps`)
- [x] `docs/skill-packs.md` summary table - fixed pre-existing drift (Basics 17->18, Crypto 14->15, Productivity 10->11; now sums 76, matching the full-catalog table)
- [x] **Harness headline six -> seven (fx):** README (`## Support seven harnesses`, hero alt-text, "Seven engines" banner alt, the inline "any of seven agent CLIs" line, the doc-nav harness pill), `docs/assets/hero-animated.svg` ("7 harnesses"), `docs/CAPABILITIES.md` ("all seven harnesses" - fx is `read_only: sandbox`, so the sandbox claim holds)

## Notes
- `docs/harnesses.md` + `harness-adapter/harnesses.json` already document fx (from #941). Left **as-is**: line 85 ("verified 2026-07-22") is historical - fx was added later and verified locally; the internal "all six" at lines 295/298/326 live in #941's own file. If fx is now staged by the hosted workflows, 298/326 are worth a follow-up in that file.
- The banner **image** `docs/assets/harnesses-aeon.jpg` still visually shows six engines - @aaronjmars is re-rendering it.
- Marketing/prose total skill counts stay on the `60+` floor (#859 convention).

Watermark advances 925 -> 947.
