### PR TITLE
fix(scorer): grade the sent notify card, not the harness .result summary

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -1378,19 +1378,34 @@ jobs:
             AEON_OTEL_COMPONENT=scorer source "${GITHUB_WORKSPACE}/scripts/langfuse-otel.sh"
           fi
 
-          # Read skill output for analysis. Sample head + tail so the judge sees the
-          # conclusion of long outputs, not just the intro - a flat 3KB head-truncate
-          # graded only the opening and biased the score against skills that build to
-          # their payoff (articles, digests, research compendia routinely exceed a few
-          # KB). `iconv -c` drops any partial UTF-8 char left at a byte cut.
+          # Grade the artifact the skill actually SENT, not its closing summary.
+          # For a notify-first skill the deliverable is the ./notify card, captured
+          # to output/.chains/<skill>.md (from .pending-<skill>.md) by the "Capture
+          # skill output" step above. The harness's final .result message is often
+          # just a terse "sent the card, 13 PRs, 769 runs" recap - which strips every
+          # figure of its labeled source and reliably draws an unverifiable_claim cap
+          # (kpi-daily, github-trending). Prefer the captured card; fall back to
+          # .result. Non-notify skills are unaffected: their chain file is a copy of
+          # /tmp/skill-result.txt (see the capture step's elif), so SRC is identical.
+          SRC=/tmp/skill-result.txt
+          CHAIN="output/.chains/${SKILL}.md"
+          if [ -f "$CHAIN" ] && [ -s "$CHAIN" ] && [ "$(head -n1 "$CHAIN")" != "_No output captured._" ]; then
+            SRC="$CHAIN"
+          fi
+
+          # Sample head + tail so the judge sees the conclusion of long outputs, not
+          # just the intro - a flat 3KB head-truncate graded only the opening and
+          # biased the score against skills that build to their payoff (articles,
+          # digests, research compendia routinely exceed a few KB). `iconv -c` drops
+          # any partial UTF-8 char left at a byte cut.
           OUTPUT=""
-          if [ -f /tmp/skill-result.txt ] && [ -s /tmp/skill-result.txt ]; then
-            BYTES=$(wc -c < /tmp/skill-result.txt)
+          if [ -f "$SRC" ] && [ -s "$SRC" ]; then
+            BYTES=$(wc -c < "$SRC")
             if [ "$BYTES" -le 14000 ]; then
-              OUTPUT=$(iconv -f UTF-8 -t UTF-8 -c < /tmp/skill-result.txt)
+              OUTPUT=$(iconv -f UTF-8 -t UTF-8 -c < "$SRC")
             else
-              OHEAD=$(head -c 10000 /tmp/skill-result.txt | iconv -f UTF-8 -t UTF-8 -c)
-              OTAIL=$(tail -c 4000 /tmp/skill-result.txt | iconv -f UTF-8 -t UTF-8 -c)
+              OHEAD=$(head -c 10000 "$SRC" | iconv -f UTF-8 -t UTF-8 -c)
+              OTAIL=$(tail -c 4000 "$SRC" | iconv -f UTF-8 -t UTF-8 -c)
               OUTPUT=$(printf '%s\n\n[... middle truncated ...]\n\n%s' "$OHEAD" "$OTAIL")
             fi
           fi


### PR DESCRIPTION
## Problem

The post-run scorer grades **only `/tmp/skill-result.txt`** — the harness's final `.result` message (`aeon.yml` "Analyze skill output" step). For a **notify-first skill** the real deliverable is the `./notify` card, but the agent's closing message is often a terse recap like *"sent the daily KPI card — 13 PRs, 769 runs, $106.19"*. That summary strips every figure of its labeled source, so the rubric caps it at **2 with `unverifiable_claim`** even though the numbers are real and were sent verifiably in the card.

The card is **already captured** to `output/.chains/<skill>.md` (from `.pending-<skill>.md`, written by `notify.sh:393`) in the **Capture skill output** step that runs just before the scorer — the scorer just wasn't reading it.

## Fix

The scorer now prefers the captured chain artifact (the sent card) and falls back to `.result`:

```sh
SRC=/tmp/skill-result.txt
CHAIN="output/.chains/${SKILL}.md"
if [ -f "$CHAIN" ] && [ -s "$CHAIN" ] && [ "$(head -n1 "$CHAIN")" != "_No output captured._" ]; then
  SRC="$CHAIN"
fi
```

The existing head/tail sampling then reads `$SRC`.

**Non-notify skills are unaffected** — their chain file is a byte copy of `/tmp/skill-result.txt` (the capture step's `elif`), so the graded text is identical. Both steps share the same `steps.run.outcome == 'success'` gate and `SKILL` name, and capture runs first in the job, so the artifact always exists when the scorer runs.

## Evidence

Recurring score-2 `unverifiable_claim` on genuinely-measured output:
- **kpi-daily** — aeon-data #14 (2026-08-21, 2026-08-24)
- **github-trending** — aeon-vuln #193 (had a separate real fabrication bug too, fixed skill-side)

Instance-side skill fixes are already up (aeon-data#22, aeon-vuln#198); this is the durable systemic fix. Instances inherit it on their next `aeon-update` rebase.

## Verification

`actionlint -shellcheck= -pyflakes=` exits 0; YAML parses; no new `${{ }}` added to the `run:` block.
