### PR TITLE
docs: normalize harness count to seven, drop fx singling-out

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -283,7 +283,7 @@ jobs:
       # grok by name — so those two had no sandbox available even when asked for
       # one, and run-harness would have degraded to "read-only is advisory" with
       # only a stderr notice. Now every harness gets it, so --mode read-only means
-      # the same thing on all six.
+      # the same thing on all seven.
       - name: Install bubblewrap (read-only sandbox)
         if: steps.work.outputs.mode != ''
         # Bound this step. apt can block on the runner's unattended-upgrades dpkg
@@ -911,13 +911,13 @@ jobs:
           # (harness-adapter/run-harness), which speaks one Claude-Code-shaped
           # contract — prompt on stdin, a normalized {result,usage{...},session_id}
           # envelope on stdout, diagnostics on stderr — so everything downstream
-          # (.result/.usage jq, scoring, token accounting) is identical for all six.
+          # (.result/.usage jq, scoring, token accounting) is identical for all seven.
           # There is no longer a native `claude -p` or `run-grok.sh` run path; the
           # two features those paths carried are preserved AROUND the adapter call:
           #   * claude  — wrapped in the multi-provider gateway cascade below, so it
           #               keeps 8-provider failover + Langfuse tracing.
           #   * grok    — GROK_* run-knobs from frontmatter (adapters/grok.sh maps them).
-          # ALL six now run read-only under the wrapper OS sandbox (bwrap). claude and
+          # ALL seven now run read-only under the wrapper OS sandbox (bwrap). claude and
           # grok used to pass --no-sandbox because ./notify needed to write its queue
           # inside the workspace; that queue moved to $AEON_PENDING_DIR, so the reason
           # is gone. It mattered most on grok, whose adapter runs

--- a/.github/workflows/ci-harnesses-json.yml
+++ b/.github/workflows/ci-harnesses-json.yml
@@ -1,6 +1,6 @@
 name: ci-harnesses-json
 
-# harness-adapter/harnesses.json is the capability manifest for the six adapters -
+# harness-adapter/harnesses.json is the capability manifest for the seven adapters -
 # the local analog of a UHP GET /v1/harnesses discovery response. It is generated
 # from each adapters/<h>.sh rh-meta block by
 # harness-adapter/bin/generate-harnesses-json. This workflow fails any PR that

--- a/.github/workflows/messages.yml
+++ b/.github/workflows/messages.yml
@@ -443,8 +443,8 @@ jobs:
         run: bash scripts/resolve-harness.sh >> "$GITHUB_OUTPUT"
 
       # Stage the resolved harness's CLI + provider auth. This step is why
-      # messages.yml now supports all six: it previously had none, so a repo on
-      # codex/pi/vibe/kimi had its messages answered on claude with a warning.
+      # messages.yml now supports all seven: it previously had none, so a repo on
+      # codex/pi/vibe/kimi/fx had its messages answered on claude with a warning.
       # The `env:` block is duplicated from aeon.yml by necessity (`secrets.*`
       # resolves per workflow); the recipes it feeds are shared.
       - name: Install harness CLI
@@ -584,8 +584,8 @@ jobs:
 
           # HARNESS / AUTH_MODE / MODEL_ARG come from the "Resolve harness" step
           # (scripts/resolve-harness.sh), and the CLI was staged by "Install harness
-          # CLI" — so all six answer messages now. This used to be an inline
-          # claude-or-grok resolution here that downgraded the other four to claude
+          # CLI" — so all seven answer messages now. This used to be an inline
+          # claude-or-grok resolution here that downgraded the other five to claude
           # with a ::warning::, because nothing on this workflow could install them.
           # On grok a claude-* model id is meaningless — fall back to grok's default.
           if [ "$HARNESS" = "grok" ]; then

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -292,10 +292,10 @@ one path, an adapter-level fix reaches every surface by construction.
 claude/grok/codex, prompt-shim on pi/vibe/kimi). Callers that don't pass it get
 plain text. (A grok-only `GROK_JSON_SCHEMA` env var existed on the old script
 path until it was removed: nothing in the repo ever set it, and the scorer it was
-reserved for goes schema-less on purpose so a single parse path covers all six
+reserved for goes schema-less on purpose so a single parse path covers all seven
 harnesses.)
 
-**Both hosted surfaces stage all six.** `aeon.yml` (skill runs) and
+**Both hosted surfaces stage all seven.** `aeon.yml` (skill runs) and
 `messages.yml` (inbound messages) share the same two scripts, so a repo answers
 messages on the harness it runs skills on:
 
@@ -322,7 +322,7 @@ behaves identically everywhere. All of them dispatch through `run-harness`:
 |---------|---------------------|-------|
 | Scheduled / manual skill run (`aeon.yml`) | dispatch **Harness** input → per-skill `harness:` → global `harness:` → `claude` | full flags + MCP + scorer |
 | Skill chains (`chain-runner.yml`) | inherits — each step dispatches `aeon.yml`, which resolves per-skill/global | |
-| Inbound messages (`messages.yml`, Telegram/Discord/Slack) | global `harness:` in `aeon.yml` | conversational reply in write mode; only `claude`/`grok` have a CLI staged here — the other four warn and answer on claude |
+| Inbound messages (`messages.yml`, Telegram/Discord/Slack) | global `harness:` in `aeon.yml` | conversational reply in write mode; the resolved harness's CLI is staged here (all seven), same as skill runs |
 | Local MCP server (`apps/mcp-server`) | `AEON_HARNESS` env → global `harness:` | `resolveHarness()` in `skill-executor.ts`; resolves all six, expects the CLI installed locally |
 | Webhook (`apps/webhook`) | relay only → dispatches `messages.yml` | harness-agnostic |
 | Post-run quality scorer (`aeon.yml`) | scores through the same harness the skill ran on | |

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -1,6 +1,6 @@
 ---
 title: Harnesses — advanced behavior
-description: Deep reference for Aeon's harness axis (Claude Code, Grok Build, and the four run-harness harnesses) — token accounting, capability-mode mapping, MCP and grok's folder-trust gate, per-skill grok knobs, and per-surface harness selection.
+description: Deep reference for Aeon's harness axis (the seven agent CLIs behind one run-harness contract) — token accounting, capability-mode mapping, MCP and grok's folder-trust gate, per-skill grok knobs, and per-surface harness selection.
 ---
 
 # Harnesses — advanced behavior
@@ -23,13 +23,13 @@ the same Claude-Code-shaped `{result, usage, session_id}` contract that
 `scripts/run-grok.sh` provides, so everything downstream (scoring, token
 accounting, memory, notifications) is unchanged.
 
-**fx is the odd one out on auth** — see the table below, but the short version
-is it has no OpenRouter fallback at all, unlike the other four. Skip it unless
-you have a Vercel AI Gateway key or are already inside Vercel's own CI.
+**fx** differs on auth — see the table below: it has no OpenRouter fallback, so
+it runs on a Vercel AI Gateway key (or `VERCEL_OIDC_TOKEN` inside Vercel's own
+CI) rather than the shared `OPENROUTER_API_KEY`.
 
 Each one runs on its own provider login (see **Native auth** below); a single
-shared **`OPENROUTER_API_KEY`** is the zero-setup alternative that makes all four
-work at once. Their model picker offers OpenRouter ids rather than the
+shared **`OPENROUTER_API_KEY`** is the zero-setup alternative for codex, pi,
+vibe, and kimi at once. Their model picker offers OpenRouter ids rather than the
 `claude-*`/`grok-*` ids, and the model you pick is what actually runs. Each of
 these harnesses carries its own curated list (`CODEX_MODELS` /
 `VIBE_MODELS` / `PI_MODELS` / `KIMI_MODELS`): **codex**

--- a/harness-adapter/README.md
+++ b/harness-adapter/README.md
@@ -1,9 +1,9 @@
 # harness-adapter
 
-**One Claude Code-shaped contract, six coding-agent harnesses.**
+**One Claude Code-shaped contract, seven coding-agent harnesses.**
 
 This directory is exactly what the workflow runs: the `run-harness` dispatcher and
-the six adapters aeon can dispatch to — **claude, grok, codex, pi, vibe, kimi**.
+the seven adapters aeon can dispatch to — **claude, grok, codex, pi, vibe, kimi, fx**.
 It is self-contained, so fixes land here directly. Three further harnesses
 (`opencode`, `copilot`, `agy`) were evaluated and deliberately left out; the
 per-harness reasons are recorded in the allowlist comment in
@@ -53,6 +53,11 @@ All six round-trip the contract on real CLIs (claude ≥2.1, grok 0.2.101,
 codex-cli 0.144.6, pi 0.80.9, vibe 2.20.0, kimi 0.28.0). aeon reaches claude and
 grok through its own native paths (the AI gateway / `run-grok.sh`); codex, pi, vibe
 and kimi run only through this adapter.
+
+**fx** is the seventh adapter (`adapters/fx.sh`) - verified mechanically
+end-to-end (envelope, MCP-config translation, model/step env, and the
+success/failure paths against a real fx 0.0.5 binary), but not yet
+live-dispatched on GitHub Actions, so it is absent from the tested matrix above.
 
 ¹ grok reports usage **only** on `--output-format streaming-json`, whose terminal
 `{"type":"end"}` event carries usage, `total_cost_usd` and `sessionId`; the adapter
@@ -114,8 +119,8 @@ bind-mounts) kimi still reads the literal `${VAR}`s.
 
 **Read-only enforcement is hoisted into the dispatcher.** Only codex has a native
 kernel sandbox that actually holds; every other harness — claude, grok, pi, vibe,
-kimi — runs read-only under `sandbox-exec` (macOS) or `bwrap` (Linux) with the
-workspace mounted read-only, so `--mode read-only` means the same thing on all six:
+kimi, fx — runs read-only under `sandbox-exec` (macOS) or `bwrap` (Linux) with the
+workspace mounted read-only, so `--mode read-only` means the same thing on all seven:
 *the repo physically cannot be mutated*, regardless of the model or its permission
 config. (vibe and kimi lean on this entirely — their `-p` modes have no
 permission-layer gate of their own.)
@@ -171,7 +176,7 @@ step and the native-auth secrets (`CODEX_AUTH`, `KIMI_AUTH`, `MISTRAL_API_KEY`,
 ## Capability manifest
 
 [`harnesses.json`](harnesses.json) is the machine-readable capability manifest for
-the six adapters - the local analog of a UHP [`GET /v1/harnesses`](https://unifiedharnessprotocol.org)
+the seven adapters - the local analog of a UHP [`GET /v1/harnesses`](https://unifiedharnessprotocol.org)
 discovery response. One queryable file answers *does this harness report token
 cost? enforce read-only natively or via the wrapper sandbox? support MCP, and
 how? what auth does it take?* - instead of that knowledge living only in the
@@ -196,7 +201,7 @@ staleness-fails this gate.
 
 ```
 run-harness            dispatcher: args → RH_* env → sandbox/timeout → adapter → validate
-adapters/<h>.sh        one per harness: invoke, translate, normalize (claude grok codex pi vibe kimi)
+adapters/<h>.sh        one per harness: invoke, translate, normalize (claude grok codex pi vibe kimi fx)
 harnesses.json         generated capability manifest (UHP GET /v1/harnesses analog)
 bin/generate-harnesses-json  aggregate adapters' rh-meta blocks → harnesses.json
 lib/envelope.sh        emit/validate the contract envelope

--- a/harness-adapter/docs/aeon-integration.md
+++ b/harness-adapter/docs/aeon-integration.md
@@ -1,7 +1,7 @@
 # Wiring the harness swap into an aeon instance
 
 A deployment runbook for putting `run-harness` into [aeonfun/aeon](https://github.com/aeonfun/aeon)
-so a skill can run on **codex, pi, vibe, kimi, or fx** instead of only claude/grok.
+so a skill can run on **codex, pi, vibe, or kimi** instead of only claude/grok.
 
 Every change below was applied to a full aeon fork and verified on a real GitHub
 runner (6-harness × 3-scenario matrix, Tier 4). This document is how to reproduce

--- a/harness-adapter/docs/aeon-integration.md
+++ b/harness-adapter/docs/aeon-integration.md
@@ -1,7 +1,7 @@
 # Wiring the harness swap into an aeon instance
 
 A deployment runbook for putting `run-harness` into [aeonfun/aeon](https://github.com/aeonfun/aeon)
-so a skill can run on **codex, pi, vibe, or kimi** instead of only claude/grok.
+so a skill can run on **codex, pi, vibe, kimi, or fx** instead of only claude/grok.
 
 Every change below was applied to a full aeon fork and verified on a real GitHub
 runner (6-harness × 3-scenario matrix, Tier 4). This document is how to reproduce

--- a/harness-adapter/lib/otel-span.sh
+++ b/harness-adapter/lib/otel-span.sh
@@ -6,7 +6,7 @@
 #   • OTEL_EXPORTER_OTLP_ENDPOINT is set (the same env the shim exports)
 #   • the harness is NOT claude — Claude Code emits its own OTEL spans natively,
 #     so tracing it here would double-count; this fills the gap for the other
-#     five harnesses (grok/codex/pi/vibe/kimi), which emit nothing on their own
+#     six harnesses (grok/codex/pi/vibe/kimi/fx), which emit nothing on their own
 #   • `otel-cli` is on PATH (the shell OTLP emitter; staged by
 #     scripts/install-otel-cli.sh in CI) and `jq` is available to read usage
 #

--- a/harness-adapter/lib/sandbox.sh
+++ b/harness-adapter/lib/sandbox.sh
@@ -9,7 +9,7 @@
 # usable (harnesses need to write their own state under $HOME and $TMPDIR, and
 # the network stays open — read-only is about the repo, not egress).
 # This mirrors aeon's semantic: "a read-only skill physically cannot mutate the
-# repo" — and makes it mean the same thing on all six harnesses.
+# repo" — and makes it mean the same thing on all seven harnesses.
 
 sandbox_prefix() {
   # sandbox_prefix TMPDIR [EXPANDED_MCP] -> prints prefix argv tokens (one per

--- a/scripts/resolve-harness.sh
+++ b/scripts/resolve-harness.sh
@@ -5,7 +5,7 @@
 # an agent resolves identically. It is the companion of scripts/install-harness.sh
 # (which stages the CLI these outputs describe) and of harness-adapter/run-harness
 # (which consumes MODEL_ARG). Splitting the decision from the workflow is what lets
-# messages.yml support all six harnesses instead of only claude/grok — a gap that
+# messages.yml support all seven harnesses instead of only claude/grok — a gap that
 # existed purely because this ~100 lines lived inside one workflow step.
 #
 # Usage:
@@ -57,7 +57,7 @@ else
 fi
 
 # Allowlist. Upstream had a claude/grok binary, so ANY other value was silently
-# rewritten to claude. These six are the ones measured end to end on a real runner.
+# rewritten to claude. These seven are the ones wired end to end on a real runner.
 # Deliberately NOT here, each for a measured reason:
 #   opencode — its .result carried the agent's narration instead of the
 #              deliverable (fixed in the adapter, but it still loops to the

--- a/scripts/run-grok.sh
+++ b/scripts/run-grok.sh
@@ -39,7 +39,7 @@
 # The run-shaping knobs (GROK_MAX_TURNS / GROK_EFFORT / GROK_BEST_OF_N /
 # GROK_CHECK / GROK_COMPAT_RULES) moved with the run path: aeon.yml maps a
 # skill's frontmatter to them and harness-adapter/adapters/grok.sh reads them.
-# Structured output is `run-harness --json-schema`, uniform across all six
+# Structured output is `run-harness --json-schema`, uniform across all seven
 # harnesses; a grok-only env var here would recreate the divergence the adapter
 # exists to remove.
 #

--- a/scripts/skill_mode.sh
+++ b/scripts/skill_mode.sh
@@ -120,7 +120,7 @@ write_tools() { echo "$BASE_TOOLS,$WRITE_TOOLS"; }
 #   * grok's own `--sandbox read-only` is silently ignored on grok 0.2.101 (writes
 #     still land) and nest-conflicts with the wrapper sandbox.
 #
-# So read-only on grok — as on all six harnesses — is enforced by the dispatcher's
+# So read-only on grok — as on all seven harnesses — is enforced by the dispatcher's
 # OS sandbox (harness-adapter/lib/sandbox.sh: bwrap / sandbox-exec write-locks the
 # workspace) plus the workflow's post-run revert. Nothing about that is expressible
 # in this file, which is why the mapping is gone instead of rewritten.


### PR DESCRIPTION
## What

fx (Vercel's fx) is Aeon's 7th harness — `harness-adapter/adapters/fx.sh` exists and `harnesses.json` carries **7 ids** — but many docs/comments still said **six / five / four** and framed fx as "the odd one out ... skip it." This normalizes every **capability / inventory count** to **seven** and presents the seven evenly. Full local sweep of the repo (`*.md`, `*.sh`, `*.yml`), two passes.

## Changed (all capability / inventory, fx genuinely participates)

**`harness-adapter/README.md`** — tagline "six coding-agent harnesses" → seven; intro "the six adapters ... claude,grok,codex,pi,vibe,kimi" → seven +fx; read-only guarantee "same thing on all six" (+fx in the harness list) → seven; capability-manifest "the six adapters" → seven; `adapters/<h>.sh` inventory +fx; **added a note** that fx is the 7th adapter, mechanically verified but not yet in the live tested matrix.
**`docs/harnesses.md`** — frontmatter "four run-harness harnesses" → "seven agent CLIs behind one run-harness contract"; dropped "fx is the odd one out ... skip it" (now neutral Vercel AI Gateway auth); "all four work at once" → names codex/pi/vibe/kimi; parse-path + hosted-staging "all six" → seven; **fixed the stale per-surface row** that still claimed messages.yml stages only claude/grok (it stages the resolved harness now — all seven).
**`.github/workflows/aeon.yml`** — sandbox + downstream-contract + read-only comments "all six" → seven.
**`.github/workflows/messages.yml`** — staging + "answer messages" comments "all six" → seven; downgrade list +fx; "other four" → "other five".
**`.github/workflows/ci-harnesses-json.yml`** — manifest covers seven adapters.
**`scripts/{resolve-harness,skill_mode,run-grok}.sh`, `harness-adapter/lib/{sandbox,otel-span}.sh`** — count comments → seven (otel: the six non-claude harnesses now incl fx).

## Left as-is on purpose

- **`apps/mcp-server`** `HARNESSES` const genuinely lacks fx (`docs/harnesses.md:326` "resolves all six" is *accurate*). This is a **real code gap**, not doc drift — see below.
- **Verification records:** the 2026-07-22 six-harness sweep table, `harness-adapter/README.md` `## The six harnesses` 6-column tested matrix + tested versions. fx isn't live-dispatched (no hosted `AI_GATEWAY_API_KEY`), so faking a 7th column would be false — the doc explicitly says fx was added later.
- **OpenRouter "all four"** (`aeon.yml`, `install-harness.sh`, `aeon-integration.md`, `secrets-catalog.ts`) — factual subset; fx has no OpenRouter fallback.
- **`aeon-integration.md`** historical 4-harness runbook (reverted the round-1 intro edit to keep it internally consistent).
- **`CHANGELOG.md`** history.

## Follow-up (separate, code — not in this PR)

`apps/mcp-server/src/skill-executor.ts:55` `HARNESSES = [claude,grok,codex,pi,vibe,kimi]` — missing `fx`. The local MCP server can't dispatch fx even though the workflows + adapter can. Worth a one-line add (+ any downstream typing), tested, in its own PR.
