### PR TITLE
fix(mcp-server): dispatch fx harness

### DIFF
--- a/apps/mcp-server/src/skill-executor.ts
+++ b/apps/mcp-server/src/skill-executor.ts
@@ -52,7 +52,7 @@ export function buildSkillPrompt(slug: string, varValue: string): string {
 }
 
 /** Every harness harness-adapter's run-harness can dispatch to. */
-export const HARNESSES = ["claude", "grok", "codex", "pi", "vibe", "kimi"] as const;
+export const HARNESSES = ["claude", "grok", "codex", "pi", "vibe", "kimi", "fx"] as const;
 export type Harness = (typeof HARNESSES)[number];
 const isHarness = (v: string): v is Harness =>
   (HARNESSES as readonly string[]).includes(v);


### PR DESCRIPTION
## What

`apps/mcp-server/src/skill-executor.ts` `HARNESSES` omitted **fx**, so the local MCP server's `resolveHarness()` rewrote any `fx` skill (or `AEON_HARNESS=fx`) to `claude` — even though the hosted workflows, `scripts/resolve-harness.sh`'s allowlist, and `harness-adapter/adapters/fx.sh` all dispatch fx.

## Fix

One line: add `"fx"` to the `HARNESSES` tuple. The `Harness` type and `isHarness` guard both derive from this const, and `runSkill` forwards the resolved name straight to `harness-adapter/run-harness` (which has the fx adapter), so nothing else needs to change.

Follow-up to #952, which corrected the docs but flagged this as a real code gap (`docs/harnesses.md` per-surface table now says the MCP server resolves "all seven" — this makes that true).
