### PR TITLE
feat(notify): post-run delivery dispatcher, drop channel tokens from skill env (#912 Phase 2)

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -596,7 +596,7 @@ jobs:
           # dashboard).
           # Consumed by the MCP/requires loops below, then unset before Claude runs.
           ALL_SECRETS: >-
-            {"ADMANAGE_API_KEY":${{ toJSON(secrets.ADMANAGE_API_KEY) }},"AI_GATEWAY_API_KEY":${{ toJSON(secrets.AI_GATEWAY_API_KEY) }},"ALCHEMY_API_KEY":${{ toJSON(secrets.ALCHEMY_API_KEY) }},"ANTHROPIC_API_KEY":${{ toJSON(secrets.ANTHROPIC_API_KEY) }},"ANTHROPIC_OAUTH_TOKEN":${{ toJSON(secrets.ANTHROPIC_OAUTH_TOKEN) }},"BANKR_API_KEY":${{ toJSON(secrets.BANKR_API_KEY) }},"BANKR_LLM_KEY":${{ toJSON(secrets.BANKR_LLM_KEY) }},"BASESCAN_API_KEY":${{ toJSON(secrets.BASESCAN_API_KEY) }},"BASE_RPC_URL":${{ toJSON(secrets.BASE_RPC_URL) }},"CLAUDE_CODE_OAUTH_TOKEN":${{ toJSON(secrets.CLAUDE_CODE_OAUTH_TOKEN) }},"CODEX_AUTH":${{ toJSON(secrets.CODEX_AUTH) }},"COINGECKO_API_KEY":${{ toJSON(secrets.COINGECKO_API_KEY) }},"DISCORD_WEBHOOK_URL":${{ toJSON(secrets.DISCORD_WEBHOOK_URL) }},"ETHERSCAN_API_KEY":${{ toJSON(secrets.ETHERSCAN_API_KEY) }},"FLEET_ENDPOINT":${{ toJSON(secrets.FLEET_ENDPOINT) }},"FLEET_TOKEN":${{ toJSON(secrets.FLEET_TOKEN) }},"GH_GLOBAL":${{ toJSON(secrets.GH_GLOBAL) }},"GH_READ_PAT":${{ toJSON(secrets.GH_READ_PAT) }},"GH_SECRETS_PAT":${{ toJSON(secrets.GH_SECRETS_PAT) }},"GITHUB_TOKEN":${{ toJSON(secrets.GITHUB_TOKEN) }},"GROK_CREDENTIALS":${{ toJSON(secrets.GROK_CREDENTIALS) }},"HOOK_DEPLOYER_PRIVATE_KEY":${{ toJSON(secrets.HOOK_DEPLOYER_PRIVATE_KEY) }},"KIMI_AUTH":${{ toJSON(secrets.KIMI_AUTH) }},"LANGFUSE_PUBLIC_KEY":${{ toJSON(secrets.LANGFUSE_PUBLIC_KEY) }},"LANGFUSE_SECRET_KEY":${{ toJSON(secrets.LANGFUSE_SECRET_KEY) }},"MISTRAL_API_KEY":${{ toJSON(secrets.MISTRAL_API_KEY) }},"MOONSHOT_API_KEY":${{ toJSON(secrets.MOONSHOT_API_KEY) }},"NOTIFY_EMAIL_TO":${{ toJSON(secrets.NOTIFY_EMAIL_TO) }},"OPENAI_API_KEY":${{ toJSON(secrets.OPENAI_API_KEY) }},"OPENROUTER_API_KEY":${{ toJSON(secrets.OPENROUTER_API_KEY) }},"PAGESPEED_API_KEY":${{ toJSON(secrets.PAGESPEED_API_KEY) }},"REPLICATE_API_TOKEN":${{ toJSON(secrets.REPLICATE_API_TOKEN) }},"RESEND_API_KEY":${{ toJSON(secrets.RESEND_API_KEY) }},"RESEND_FROM":${{ toJSON(secrets.RESEND_FROM) }},"RESEND_REPLY_TO":${{ toJSON(secrets.RESEND_REPLY_TO) }},"SLACK_WEBHOOK_URL":${{ toJSON(secrets.SLACK_WEBHOOK_URL) }},"SURPLUS_API_KEY":${{ toJSON(secrets.SURPLUS_API_KEY) }},"TELEGRAM_BOT_TOKEN":${{ toJSON(secrets.TELEGRAM_BOT_TOKEN) }},"TELEGRAM_CHAT_ID":${{ toJSON(secrets.TELEGRAM_CHAT_ID) }},"USEPOD_TOKEN":${{ toJSON(secrets.USEPOD_TOKEN) }},"VENICE_API_KEY":${{ toJSON(secrets.VENICE_API_KEY) }},"VERCEL_OIDC_TOKEN":${{ toJSON(secrets.VERCEL_OIDC_TOKEN) }},"VERCEL_TOKEN":${{ toJSON(secrets.VERCEL_TOKEN) }},"XAI_API_KEY":${{ toJSON(secrets.XAI_API_KEY) }},"YDC_API_KEY":${{ toJSON(secrets.YDC_API_KEY) }}}
+            {"ADMANAGE_API_KEY":${{ toJSON(secrets.ADMANAGE_API_KEY) }},"AI_GATEWAY_API_KEY":${{ toJSON(secrets.AI_GATEWAY_API_KEY) }},"ALCHEMY_API_KEY":${{ toJSON(secrets.ALCHEMY_API_KEY) }},"ANTHROPIC_API_KEY":${{ toJSON(secrets.ANTHROPIC_API_KEY) }},"ANTHROPIC_OAUTH_TOKEN":${{ toJSON(secrets.ANTHROPIC_OAUTH_TOKEN) }},"BANKR_API_KEY":${{ toJSON(secrets.BANKR_API_KEY) }},"BANKR_LLM_KEY":${{ toJSON(secrets.BANKR_LLM_KEY) }},"BASESCAN_API_KEY":${{ toJSON(secrets.BASESCAN_API_KEY) }},"BASE_RPC_URL":${{ toJSON(secrets.BASE_RPC_URL) }},"CLAUDE_CODE_OAUTH_TOKEN":${{ toJSON(secrets.CLAUDE_CODE_OAUTH_TOKEN) }},"CODEX_AUTH":${{ toJSON(secrets.CODEX_AUTH) }},"COINGECKO_API_KEY":${{ toJSON(secrets.COINGECKO_API_KEY) }},"ETHERSCAN_API_KEY":${{ toJSON(secrets.ETHERSCAN_API_KEY) }},"FLEET_ENDPOINT":${{ toJSON(secrets.FLEET_ENDPOINT) }},"FLEET_TOKEN":${{ toJSON(secrets.FLEET_TOKEN) }},"GH_GLOBAL":${{ toJSON(secrets.GH_GLOBAL) }},"GH_READ_PAT":${{ toJSON(secrets.GH_READ_PAT) }},"GH_SECRETS_PAT":${{ toJSON(secrets.GH_SECRETS_PAT) }},"GITHUB_TOKEN":${{ toJSON(secrets.GITHUB_TOKEN) }},"GROK_CREDENTIALS":${{ toJSON(secrets.GROK_CREDENTIALS) }},"HOOK_DEPLOYER_PRIVATE_KEY":${{ toJSON(secrets.HOOK_DEPLOYER_PRIVATE_KEY) }},"KIMI_AUTH":${{ toJSON(secrets.KIMI_AUTH) }},"LANGFUSE_PUBLIC_KEY":${{ toJSON(secrets.LANGFUSE_PUBLIC_KEY) }},"LANGFUSE_SECRET_KEY":${{ toJSON(secrets.LANGFUSE_SECRET_KEY) }},"MISTRAL_API_KEY":${{ toJSON(secrets.MISTRAL_API_KEY) }},"MOONSHOT_API_KEY":${{ toJSON(secrets.MOONSHOT_API_KEY) }},"OPENAI_API_KEY":${{ toJSON(secrets.OPENAI_API_KEY) }},"OPENROUTER_API_KEY":${{ toJSON(secrets.OPENROUTER_API_KEY) }},"PAGESPEED_API_KEY":${{ toJSON(secrets.PAGESPEED_API_KEY) }},"REPLICATE_API_TOKEN":${{ toJSON(secrets.REPLICATE_API_TOKEN) }},"RESEND_API_KEY":${{ toJSON(secrets.RESEND_API_KEY) }},"RESEND_FROM":${{ toJSON(secrets.RESEND_FROM) }},"RESEND_REPLY_TO":${{ toJSON(secrets.RESEND_REPLY_TO) }},"SURPLUS_API_KEY":${{ toJSON(secrets.SURPLUS_API_KEY) }},"USEPOD_TOKEN":${{ toJSON(secrets.USEPOD_TOKEN) }},"VENICE_API_KEY":${{ toJSON(secrets.VENICE_API_KEY) }},"VERCEL_OIDC_TOKEN":${{ toJSON(secrets.VERCEL_OIDC_TOKEN) }},"VERCEL_TOKEN":${{ toJSON(secrets.VERCEL_TOKEN) }},"XAI_API_KEY":${{ toJSON(secrets.XAI_API_KEY) }},"YDC_API_KEY":${{ toJSON(secrets.YDC_API_KEY) }}}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
@@ -641,21 +641,12 @@ jobs:
           OTEL_SERVICE_NAME: ${{ vars.OTEL_SERVICE_NAME }}
           GITHUB_TOKEN: ${{ secrets.GH_GLOBAL || secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GH_GLOBAL || secrets.GITHUB_TOKEN }}
-          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
-          # Discord + Slack deliver via WEBHOOK only (see scripts/notify.sh); the
-          # BOT_TOKEN / CHANNEL_ID pairs had no in-run consumer, so they are not bound.
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          # Buzz channel (Block's Nostr-relay workspace). ./notify signs + publishes
-          # via the buzz CLI staged by "Stage Buzz CLI"; the channel no-ops without
-          # BUZZ_PRIVATE_KEY. BUZZ_RELAY_URL is a var (defaults to localhost in the CLI).
-          BUZZ_PRIVATE_KEY: ${{ secrets.BUZZ_PRIVATE_KEY }}
-          BUZZ_CHANNEL_ID: ${{ secrets.BUZZ_CHANNEL_ID }}
-          BUZZ_RELAY_URL: ${{ vars.BUZZ_RELAY_URL }}
-          NOTIFY_EMAIL_TO: ${{ secrets.NOTIFY_EMAIL_TO }}
-          NOTIFY_EMAIL_FROM: ${{ vars.NOTIFY_EMAIL_FROM || 'aeon@notifications.aeon.bot' }}
-          NOTIFY_EMAIL_SUBJECT_PREFIX: ${{ vars.NOTIFY_EMAIL_SUBJECT_PREFIX || '[Aeon]' }}
+          # #912 Phase 2: the notify channel tokens (TELEGRAM_*/DISCORD_WEBHOOK_URL/
+          # SLACK_WEBHOOK_URL/BUZZ_*/NOTIFY_EMAIL_TO) are NO LONGER bound in the skill
+          # run env. ./notify is a queue-writer; the post-run "Send pending
+          # notifications" step owns these and delivers via scripts/notify-deliver.sh,
+          # so a skill can ask for a message but cannot read the credential that sends
+          # it. GITHUB_TOKEN/GH_GLOBAL stay in-run (deferred, broad gh surface).
           GROK_CREDENTIALS: ${{ secrets.GROK_CREDENTIALS }}
           # Send caps + audit CC for the IN-RUN email senders (send-email + vuln-scanner
           # Arm C). RESEND_API_KEY / RESEND_FROM / RESEND_REPLY_TO are per-skill secrets
@@ -1633,88 +1624,55 @@ jobs:
           if [ "$found" -eq 0 ]; then echo "No claude-code-router logs found (gateway was not a sidecar provider, or it never started)."; fi
 
       - name: Send pending notifications
-        if: steps.work.outputs.mode != '' && steps.run.outcome == 'success'
+        # !cancelled() (NOT a bare `mode != ''`, which GitHub implies success() onto
+        # and would skip on a failed skill): a FAILED skill still delivers what it
+        # queued (#912 R1). Cancellation is excluded so a killed job doesn't half-send.
+        if: ${{ !cancelled() && steps.work.outputs.mode != '' }}
         env:
+          # #912 Phase 2: THIS step owns the channel tokens. ./notify (the queue-writer)
+          # no longer reads them in the skill run env; notify-deliver.sh consumes them
+          # here, post-run, where a per-step env is a real process boundary.
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          BUZZ_PRIVATE_KEY: ${{ secrets.BUZZ_PRIVATE_KEY }}
+          BUZZ_CHANNEL_ID: ${{ secrets.BUZZ_CHANNEL_ID }}
+          BUZZ_RELAY_URL: ${{ vars.BUZZ_RELAY_URL }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           NOTIFY_EMAIL_TO: ${{ secrets.NOTIFY_EMAIL_TO }}
           NOTIFY_EMAIL_FROM: ${{ vars.NOTIFY_EMAIL_FROM || 'aeon@notifications.aeon.bot' }}
           NOTIFY_EMAIL_SUBJECT_PREFIX: ${{ vars.NOTIFY_EMAIL_SUBJECT_PREFIX || '[Aeon]' }}
+          # Trusted post-run credential (reply_markup is precomputed by notify.sh; this
+          # is here for a future re-probe path). NOT a skill-facing token.
+          GITHUB_TOKEN: ${{ secrets.GH_GLOBAL || secrets.GITHUB_TOKEN }}
           SKILL_NAME: ${{ steps.skill.outputs.name }}
         run: |
-          # Re-deliver any queued messages that failed to send during the run.
+          # Deliver the structured payloads ./notify queued during the run. Rich render
+          # (Telegram HTML + reply_markup, Discord embeds, Slack Block Kit, Buzz) + a
+          # per-send audit record, all in scripts/notify-deliver.sh - the ONLY place a
+          # channel token is read. No -e: one payload/channel failing must not drop the
+          # rest (#912 R6).
+          set -uo pipefail
           Q="${AEON_PENDING_DIR:-${RUNNER_TEMP:-/tmp}/aeon-pending}/notify-queue"
-          # Skip messages whose hash was already sent by ./notify inline,
-          # and skip short test/trace probes that shouldn't reach channels.
-          if [ ! -d "$Q" ] || [ -z "$(ls -A "$Q"/*.md 2>/dev/null)" ]; then
+          shopt -s nullglob
+          payloads=("$Q"/*.json)
+          if [ ${#payloads[@]} -eq 0 ]; then
             echo "No pending notifications"
             exit 0
           fi
-          HASH_FILE="${AEON_PENDING_DIR:-${RUNNER_TEMP:-/tmp}/aeon-pending}/notify-sent-hashes"
-          touch "$HASH_FILE"
-          for pending in "$Q"/*.md; do
-            [ -f "$pending" ] || continue
-            MSG=$(cat "$pending")
-
-            # Suppress trivial probes
-            MSG_LEN=${#MSG}
-            if [ "$MSG_LEN" -lt 120 ]; then
-              MSG_LOWER=$(printf '%s' "$MSG" | tr '[:upper:]' '[:lower:]')
-              case "$MSG_LOWER" in
-                *test*|*trace*|*ping*|*debug*|hello|hi)
-                  echo "Skipping pending trace/test message: $MSG"
-                  continue
-                  ;;
-              esac
-            fi
-
-            # Dedup against messages already sent by ./notify inline
-            HASH=$(printf '%s' "$MSG" | sha256sum | awk '{print $1}')
-            if grep -qxF "$HASH" "$HASH_FILE" 2>/dev/null; then
-              echo "Skipping pending duplicate (${HASH:0:8}): $(basename "$pending")"
-              continue
-            fi
-            printf '%s\n' "$HASH" >> "$HASH_FILE"
-
-            echo "Delivering pending notification: $(basename "$pending")"
-            # Telegram
-            if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ]; then
-              TG_MSG="$MSG"
-              [ ${#TG_MSG} -gt 4000 ] && TG_MSG="${TG_MSG:0:3990}...(truncated)"
-              curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
-                -H "Content-Type: application/json" \
-                -d "$(jq -n --arg chat "$TELEGRAM_CHAT_ID" --arg text "$TG_MSG" '{chat_id: $chat, text: $text}')" > /dev/null 2>&1 || true
-            fi
-            # Discord
-            if [ -n "${DISCORD_WEBHOOK_URL:-}" ]; then
-              curl -sf -X POST "$DISCORD_WEBHOOK_URL" \
-                -H "Content-Type: application/json" \
-                -d "$(jq -n --arg text "$MSG" '{content: $text}')" > /dev/null 2>&1 || true
-            fi
-            # Slack
-            if [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
-              curl -sf -X POST "$SLACK_WEBHOOK_URL" \
-                -H "Content-Type: application/json" \
-                -d "$(jq -n --arg text "$MSG" '{text: $text}')" > /dev/null 2>&1 || true
-            fi
-            # Email (Resend) — same key as the vuln-disclosure sender
-            if [ -n "${RESEND_API_KEY:-}" ] && [ -n "${NOTIFY_EMAIL_TO:-}" ]; then
-              EMAIL_FROM="${NOTIFY_EMAIL_FROM:-aeon@notifications.aeon.bot}"
-              EMAIL_SUBJECT="${NOTIFY_EMAIL_SUBJECT_PREFIX:-[Aeon]} ${SKILL_NAME:-notification}"
-              EMAIL_HTML=$(printf '%s' "$MSG" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g')
-              EMAIL_HTML="<html><body><pre style=\"font-family:monospace;white-space:pre-wrap;\">${EMAIL_HTML}</pre></body></html>"
-              curl -sf -X POST "https://api.resend.com/emails" \
-                -H "Authorization: Bearer ${RESEND_API_KEY}" \
-                -H "Content-Type: application/json" \
-                -d "$(jq -n --arg from "$EMAIL_FROM" --arg to "$NOTIFY_EMAIL_TO" --arg subject "$EMAIL_SUBJECT" \
-                      --arg html "$EMAIL_HTML" --arg text "$MSG" \
-                      '{from:$from, to:[$to], subject:$subject, html:$html, text:$text}')" > /dev/null 2>&1 || true
-            fi
+          # Audit each send to a file we print for verification (audit.sh no-ops if unset).
+          export AEON_AUDIT_LOG="${AEON_AUDIT_LOG:-${AEON_PENDING_DIR:-${RUNNER_TEMP:-/tmp}/aeon-pending}/audit.jsonl}"
+          ok=0
+          for p in "${payloads[@]}"; do
+            echo "Delivering: $(basename "$p")"
+            if bash scripts/notify-deliver.sh "$p"; then ok=$((ok+1)); else echo "notify-deliver failed for $(basename "$p")"; fi
           done
-          rm -rf "$Q"
+          echo "Delivered $ok/${#payloads[@]} pending payload(s) via notify-deliver.sh"
+          if [ -f "$AEON_AUDIT_LOG" ]; then
+            echo "--- notify audit records ---"; cat "$AEON_AUDIT_LOG"
+          fi
+          rm -f "$Q"/*.json
 
       - name: Read-only capability guard
         if: steps.work.outputs.mode != '' && env.SKILL_MODE == 'read-only'

--- a/scripts/notify-deliver.sh
+++ b/scripts/notify-deliver.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# notify-deliver.sh — Phase 2 (#912) delivery half of ./notify.
+#
+# Reads ONE structured queue payload (written by scripts/notify.sh, the queue-writer)
+# and delivers it to every configured channel. THIS is the only place channel tokens
+# are consumed: it runs in the post-run "Send pending notifications" workflow step,
+# whose per-step env binds TELEGRAM_*/DISCORD_*/SLACK_*/BUZZ_*/RESEND_*/NOTIFY_EMAIL_*.
+# The skill's own Run-step env no longer carries them (see aeon.yml), so a skill can
+# only ask for a message — never read the credential that sends it.
+#
+#   scripts/notify-deliver.sh <payload.json>
+#
+# Payload fields (see notify.sh): title, severity, body, plain, link, skill_name,
+# hash, reply_markup (JSON: null or a Telegram reply_markup object).
+#
+# Per-channel delivery is INDEPENDENT: one channel failing never aborts the rest
+# (each block is guarded + `|| true`, DELIVERED is a logical OR). This is the fix for
+# the old inline all-or-nothing quirk (#912 R6): a Telegram failure no longer drops
+# the email. Rendering reuses scripts/notify_format.py exactly as the old inline path.
+#
+# Idempotency: a payload whose hash is already in notify-delivered-hashes is skipped,
+# so re-running the step (or a retried job) never double-sends.
+#
+# NOTIFY_DRY_RUN=1 records the Telegram payload to notify-queue/tg-payload.jsonl and
+# the Buzz chunks to buzz-payload.txt instead of sending — no network. Used by tests.
+set -euo pipefail
+
+PAYLOAD="${1:-}"
+if [ -z "$PAYLOAD" ] || [ ! -f "$PAYLOAD" ]; then
+  echo "notify-deliver: usage: notify-deliver.sh <payload.json>" >&2
+  exit 2
+fi
+
+# Resolve the formatter whether run from repo root or scripts/.
+_HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FMT=""
+for _cand in "scripts/notify_format.py" "$_HERE/notify_format.py" "$_HERE/scripts/notify_format.py"; do
+  [ -f "$_cand" ] && FMT="$_cand" && break
+done
+if [ -z "$FMT" ]; then echo "notify-deliver: notify_format.py not found" >&2; exit 3; fi
+
+PENDING_DIR="${AEON_PENDING_DIR:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}/aeon-pending}"
+QUEUE_DIR="$PENDING_DIR/notify-queue"
+
+# --- read the structured payload --------------------------------------------
+TITLE=$(jq -r '.title // ""' "$PAYLOAD")
+SEVERITY=$(jq -r '.severity // "info"' "$PAYLOAD")
+MSG=$(jq -r '.body // ""' "$PAYLOAD")
+PLAIN=$(jq -r '.plain // .body // ""' "$PAYLOAD")
+SKILL_FROM_JSON=$(jq -r '.skill_name // ""' "$PAYLOAD")
+HASH=$(jq -r '.hash // ""' "$PAYLOAD")
+# reply_markup is stored as embedded JSON (null or an object). Keep it as a compact
+# JSON string so the Telegram block can splice it verbatim.
+REPLY_MARKUP=$(jq -c '.reply_markup // null' "$PAYLOAD")
+[ -z "$REPLY_MARKUP" ] && REPLY_MARKUP="null"
+
+SKILL_NAME="${SKILL_FROM_JSON:-${SKILL_NAME:-}}"
+# audit.sh attributes the record to $AEON_SKILL/$SKILL — carry the skill through.
+[ -n "$SKILL_NAME" ] && export AEON_SKILL="$SKILL_NAME"
+
+# --- idempotency: skip a payload already delivered --------------------------
+DELIVERED_HASHES="$PENDING_DIR/notify-delivered-hashes"
+touch "$DELIVERED_HASHES" 2>/dev/null || true
+if [ -n "$HASH" ] && grep -qxF "$HASH" "$DELIVERED_HASHES" 2>/dev/null; then
+  echo "notify-deliver: already delivered (${HASH:0:8}) — skipping $(basename "$PAYLOAD")" >&2
+  exit 0
+fi
+
+DELIVERED=false
+
+# --- Telegram — fence-safe chunks (parse_mode HTML, plaintext fallback) ------
+if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ]; then
+  TG_CHUNKS_B64=$(printf '%s' "$MSG" | python3 "$FMT" telegram --title "$TITLE" --severity "$SEVERITY" || true)
+  TG_CHUNKS=()
+  while IFS= read -r TG_CHUNK_B64; do
+    [ -z "$TG_CHUNK_B64" ] && continue
+    TG_CHUNKS+=("$TG_CHUNK_B64")
+  done <<< "$TG_CHUNKS_B64"
+  TG_LAST=$(( ${#TG_CHUNKS[@]} - 1 ))
+  for TG_I in "${!TG_CHUNKS[@]}"; do
+    TG_MSG=$(printf '%s' "${TG_CHUNKS[$TG_I]}" | base64 -d)
+    # reply_markup rides only on the last chunk.
+    if [ "$TG_I" -eq "$TG_LAST" ] && [ "$REPLY_MARKUP" != "null" ]; then
+      TG_RM="$REPLY_MARKUP"
+    else
+      TG_RM="null"
+    fi
+    TG_PAYLOAD=$(jq -n --arg chat "$TELEGRAM_CHAT_ID" --arg text "$TG_MSG" --argjson rm "$TG_RM" \
+      '{chat_id:$chat, text:$text, parse_mode:"HTML"} + (if $rm then {reply_markup:$rm} else {} end)')
+
+    # Dry-run (tests): record the payload instead of sending. No network.
+    if [ "${NOTIFY_DRY_RUN:-}" = "1" ]; then
+      mkdir -p "$QUEUE_DIR"
+      printf '%s\n' "$TG_PAYLOAD" >> "$QUEUE_DIR/tg-payload.jsonl"
+      DELIVERED=true
+      continue
+    fi
+
+    TG_RESULT=$(curl -s -w "\n%{http_code}" -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+      -H "Content-Type: application/json" -d "$TG_PAYLOAD" 2>/dev/null) || true
+    TG_HTTP=$(echo "$TG_RESULT" | tail -1)
+    TG_OK=$(echo "$TG_RESULT" | sed '$d' | jq -r '.ok // false' 2>/dev/null || echo "false")
+    if [ "$TG_HTTP" = "200" ] && [ "$TG_OK" = "true" ]; then
+      DELIVERED=true
+    else
+      # Fallback without parse_mode. Strip tags + unescape so it degrades to clean
+      # plaintext, not visible <b>…</b> markup. Keep the reply_markup.
+      TG_PLAIN=$(printf '%s' "$TG_MSG" | sed -E 's/<[^>]+>//g' \
+        | sed -E 's/&lt;/</g; s/&gt;/>/g; s/&amp;/\&/g')
+      TG_FALLBACK=$(jq -n --arg chat "$TELEGRAM_CHAT_ID" --arg text "$TG_PLAIN" --argjson rm "$TG_RM" \
+        '{chat_id:$chat, text:$text} + (if $rm then {reply_markup:$rm} else {} end)')
+      curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+        -H "Content-Type: application/json" -d "$TG_FALLBACK" > /dev/null 2>&1 && DELIVERED=true || true
+    fi
+    sleep 0.3
+  done
+fi
+
+# --- Discord — rich embeds, one POST per embed ------------------------------
+if [ -n "${DISCORD_WEBHOOK_URL:-}" ]; then
+  DISCORD_PAYLOADS=$(printf '%s' "$MSG" | python3 "$FMT" discord --title "$TITLE" --severity "$SEVERITY" || true)
+  while IFS= read -r DC_PAYLOAD; do
+    [ -z "$DC_PAYLOAD" ] && continue
+    curl -sf -X POST "$DISCORD_WEBHOOK_URL" -H "Content-Type: application/json" \
+      -d "$DC_PAYLOAD" > /dev/null 2>&1 && DELIVERED=true || true
+    sleep 0.3
+  done <<< "$DISCORD_PAYLOADS"
+fi
+
+# --- Slack — Block Kit ------------------------------------------------------
+if [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
+  SLACK_PAYLOAD=$(printf '%s' "$MSG" | python3 "$FMT" slack --title "$TITLE" --severity "$SEVERITY" || true)
+  if [ -n "$SLACK_PAYLOAD" ]; then
+    curl -sf -X POST "$SLACK_WEBHOOK_URL" -H "Content-Type: application/json" \
+      -d "$SLACK_PAYLOAD" > /dev/null 2>&1 && DELIVERED=true || true
+  fi
+fi
+
+# --- Buzz — signed Nostr publish via the buzz CLI (skips cleanly if absent) --
+if { command -v buzz >/dev/null 2>&1 || [ "${NOTIFY_DRY_RUN:-}" = "1" ]; } \
+   && [ -n "${BUZZ_PRIVATE_KEY:-}" ] && [ -n "${BUZZ_CHANNEL_ID:-}" ]; then
+  BUZZ_CHUNKS_B64=$(printf '%s' "$MSG" | python3 "$FMT" buzz --title "$TITLE" --severity "$SEVERITY" || true)
+  while IFS= read -r BZ_B64; do
+    [ -z "$BZ_B64" ] && continue
+    BZ_MSG=$(printf '%s' "$BZ_B64" | base64 -d)
+    if [ "${NOTIFY_DRY_RUN:-}" = "1" ]; then
+      mkdir -p "$QUEUE_DIR"
+      printf '%s\n---\n' "$BZ_MSG" >> "$QUEUE_DIR/buzz-payload.txt"
+      DELIVERED=true
+      continue
+    fi
+    printf '%s' "$BZ_MSG" | buzz messages send --channel "$BUZZ_CHANNEL_ID" --content - >/dev/null 2>&1 \
+      && DELIVERED=true || true
+    sleep 0.3
+  done <<< "$BUZZ_CHUNKS_B64"
+fi
+
+# --- Email via Resend (operator-notify channel) -----------------------------
+if [ -n "${RESEND_API_KEY:-}" ] && [ -n "${NOTIFY_EMAIL_TO:-}" ]; then
+  FROM="${NOTIFY_EMAIL_FROM:-aeon@notifications.aeon.bot}"
+  PREFIX="${NOTIFY_EMAIL_SUBJECT_PREFIX:-[Aeon]}"
+  SUBJECT="$PREFIX ${TITLE:-${SKILL_NAME:-notification}}"
+  HTML_BODY=$(printf '%s' "$PLAIN" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g')
+  HTML_BODY="<html><body><pre style=\"font-family:monospace;white-space:pre-wrap;\">${HTML_BODY}</pre></body></html>"
+  if [ "${NOTIFY_DRY_RUN:-}" = "1" ]; then
+    mkdir -p "$QUEUE_DIR"
+    printf '%s\n' "$SUBJECT" >> "$QUEUE_DIR/email-payload.txt"
+    DELIVERED=true
+  else
+    curl -sf -X POST "https://api.resend.com/emails" \
+      -H "Authorization: Bearer ${RESEND_API_KEY}" \
+      -H "Content-Type: application/json" \
+      -d "$(jq -n --arg from "$FROM" --arg to "$NOTIFY_EMAIL_TO" --arg subject "$SUBJECT" \
+            --arg html "$HTML_BODY" --arg text "$PLAIN" \
+            '{from:$from, to:[$to], subject:$subject, html:$html, text:$text}')" > /dev/null 2>&1 && DELIVERED=true || true
+  fi
+fi
+
+# --- record delivery + audit ------------------------------------------------
+if [ "$DELIVERED" = "true" ] && [ -n "$HASH" ]; then
+  printf '%s\n' "$HASH" >> "$DELIVERED_HASHES" 2>/dev/null || true
+fi
+
+# Audit trail (no-op unless AEON_AUDIT_LOG is set; see scripts/audit.sh). One record
+# per delivered payload listing which channels were configured + whether any send
+# succeeded. Channel token VALUES never reach the record — audit.sh redacts, and we
+# pass NAMES only.
+if [ -n "${AEON_AUDIT_LOG:-}" ]; then
+  _AUDIT=""
+  for _c in "scripts/audit.sh" "$_HERE/audit.sh" "$_HERE/scripts/audit.sh"; do
+    if [ -f "$_c" ]; then _AUDIT="$_c"; break; fi
+  done
+  if [ -n "$_AUDIT" ]; then
+    _CHANS=""; _SECS=""
+    if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ]; then _CHANS="${_CHANS}telegram,"; _SECS="${_SECS}TELEGRAM_BOT_TOKEN,"; fi
+    if [ -n "${DISCORD_WEBHOOK_URL:-}" ]; then _CHANS="${_CHANS}discord,"; _SECS="${_SECS}DISCORD_WEBHOOK_URL,"; fi
+    if [ -n "${SLACK_WEBHOOK_URL:-}" ]; then _CHANS="${_CHANS}slack,"; _SECS="${_SECS}SLACK_WEBHOOK_URL,"; fi
+    if [ -n "${BUZZ_PRIVATE_KEY:-}" ] && [ -n "${BUZZ_CHANNEL_ID:-}" ]; then _CHANS="${_CHANS}buzz,"; _SECS="${_SECS}BUZZ_PRIVATE_KEY,"; fi
+    if [ -n "${RESEND_API_KEY:-}" ] && [ -n "${NOTIFY_EMAIL_TO:-}" ]; then _CHANS="${_CHANS}email,"; _SECS="${_SECS}RESEND_API_KEY,"; fi
+    if [ "$DELIVERED" = "true" ]; then _RC=0; else _RC=1; fi
+    bash "$_AUDIT" "notify" "channels=${_CHANS%,} delivered=${DELIVERED}" "$_RC" "${_SECS%,}" || true
+  fi
+fi
+
+[ "$DELIVERED" = "true" ] && exit 0 || exit 0

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 # Aeon notify — committed source of truth for the ./notify command.
 # The workflow copies this to ./notify before each run (was a heredoc inline).
-# Keeping it a real file makes it version-controlled, lintable, and testable:
-#   python3 scripts/tests/test_notify_format.py
+#
+# Phase 2 (#912): this is now a QUEUE-WRITER ONLY. It never reads a channel token
+# and never touches the wire. A skill call writes ONE structured payload to
+# $AEON_PENDING_DIR/notify-queue/<TS>.json; the post-run "Send pending notifications"
+# workflow step owns the tokens and does the actual send via scripts/notify-deliver.sh.
+# Moving delivery post-run keeps TELEGRAM_*/DISCORD_*/SLACK_*/BUZZ_*/NOTIFY_EMAIL_*
+# out of the process env the skill runs in — a skill can ask for a message but can
+# never read the credential that sends it.
 #
 # Usage (backward compatible):
 #   ./notify "message"                         — inline arg (short, multi-line OK)
@@ -11,20 +17,11 @@
 #   ./notify --title "Token Report" --severity warn -f body.md --link https://...
 #   severity ∈ {info(default), success, warn, critical}; gated by NOTIFY_MIN_SEVERITY.
 #
-# Per-channel rendering (via scripts/notify_format.py): Telegram = Markdown
-# normalized to HTML (parse_mode=HTML, fence-safe chunks, 3900), Discord embeds
-# (color by severity), Slack Block Kit, Buzz = raw Markdown via the buzz-cli. Falls
-# back to $AEON_PENDING_DIR/notify-queue for post-run delivery when the sandbox blocks
-# outbound curl.
+# What still lives here (unchanged): arg parse, severity gate, mute/snooze, probe
+# suppression, per-run dedup, and the Telegram reply_markup / messages.yml-state
+# logic (it needs GITHUB_TOKEN, which stays in-run). Per-channel RENDERING and the
+# curl sends moved to scripts/notify-deliver.sh.
 set -euo pipefail
-
-# Resolve the formatter whether run as ./notify (repo root) or scripts/notify.sh
-_HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-FMT=""
-for _cand in "scripts/notify_format.py" "$_HERE/notify_format.py" "$_HERE/scripts/notify_format.py"; do
-  [ -f "$_cand" ] && FMT="$_cand" && break
-done
-if [ -z "$FMT" ]; then echo "notify: notify_format.py not found" >&2; exit 3; fi
 
 TITLE=""
 SEVERITY="info"
@@ -127,22 +124,15 @@ if [ -n "$LINK" ]; then
   MSG=$(printf '%s\n\n🔗 %s' "$MSG" "$LINK")
 fi
 
-# --- staging area for notify's queues ---------------------------------------
-# These MUST live outside the workspace. Two reasons, both measured:
-#   1. A read-only skill runs under an OS sandbox that mounts the repo read-only,
-#      so a queue inside the workspace simply cannot be written — the run then
-#      loses its dedup state, its re-delivery queue and its feed entry.
-#   2. `.gitignore` ignores `.pending-*/` (directories), not `.pending-*.md`, so
-#      the json-render staging FILE was getting COMMITTED. A later sandboxed run
-#      that couldn't overwrite it left the previous run's copy in place, and the
-#      "Capture skill output" step happily published that stale digest as the new
-#      run's output — a green run reporting someone else's work.
-# The workflow exports AEON_PENDING_DIR; the fallbacks keep local runs and other
-# entry points working.
+# --- staging area for notify's queue ----------------------------------------
+# MUST live outside the workspace. A read-only skill runs under an OS sandbox that
+# mounts the repo read-only, so a queue inside the workspace cannot be written. The
+# workflow exports AEON_PENDING_DIR; the fallbacks keep local runs + other entry
+# points working.
 PENDING_DIR="${AEON_PENDING_DIR:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}/aeon-pending}"
 mkdir -p "$PENDING_DIR" 2>/dev/null || true
 
-# Dedup within this run — same rendered message never sent twice
+# Dedup within this run — same rendered message never queued twice
 _sha() { if command -v sha256sum >/dev/null 2>&1; then sha256sum; else shasum -a 256; fi; }
 HASH=$(printf '%s' "$TITLE|$SEVERITY|$MSG" | _sha | awk '{print $1}')
 HASH_FILE="$PENDING_DIR/notify-sent-hashes"
@@ -153,7 +143,7 @@ if grep -qxF "$HASH" "$HASH_FILE" 2>/dev/null; then
 fi
 printf '%s\n' "$HASH" >> "$HASH_FILE" 2>/dev/null || true
 
-# Plain-text header for the pending/fallback path (live channels render their own)
+# Plain-text header for the email/fallback render (live channels render their own)
 case "$SEVERITY" in
   critical) EMOJI='🚨' ;;
   warn)     EMOJI='⚠️' ;;
@@ -166,51 +156,26 @@ else
   PLAIN="$MSG"
 fi
 
-# Try to save to $PENDING_DIR/notify-queue for post-run re-delivery. This queue is the
-# fallback for the INVERSE sandbox — network blocked, FS writable (the old claude
-# wrapper case): notify can't reach the wire inline, so the workflow's "Send
-# pending notifications" step re-delivers post-run from here.
-#
-# Non-fatal by design: codex's native read-only sandbox is the MIRROR case — the
-# FS is blocked but the network is open — so this write fails while inline delivery
-# below works fine. A failed fallback write must NOT abort the primary path (this
-# script runs `set -e`, so an unguarded failure here would kill the whole notify
-# before a single channel is tried).
-TS=$(date -u +%s)
-if ! { mkdir -p "$PENDING_DIR/notify-queue" && printf '%s' "$PLAIN" > "$PENDING_DIR/notify-queue/${TS}.md"; } 2>/dev/null; then
-  echo "notify: notify-queue unwritable — delivering inline only" >&2
-fi
-
-DELIVERED=false
-
-# Build reply_markup once (Telegram-only). Attached to the LAST chunk so it renders
-# under the full (possibly chunked) text.
-#
+# --- Telegram reply_markup (computed in-run; needs the messages.yml state probe) ---
 # GLOBAL quick-action buttons: every skill notification gets a "Run again" +
-# "Schedule weekly" row, keyed to $SKILL_NAME (the running skill) so a tap re-runs
-# it (callback run:<skill>) or schedules it weekly (callback schedule:<skill>:weekly,
-# handled in scripts/telegram-route.sh). This is a global notify feature — skills do
-# NOT wire it per-skill. The row is appended beneath any skill-supplied --buttons.
-# Skipped when there's no skill context ($SKILL_NAME unset), when the skill name is
-# too long to fit callback_data's 64-byte budget, or on a force_reply prompt (Telegram
+# "Schedule weekly" row, keyed to $SKILL_NAME so a tap re-runs it (callback
+# run:<skill>) or schedules it weekly (schedule:<skill>:weekly, handled in
+# scripts/telegram-route.sh). Skipped when there's no skill context, when the name is
+# too long for callback_data's 64-byte budget, or on a force_reply prompt (Telegram
 # forbids inline buttons + force_reply on one message — the deliberate ask wins).
-# Interactive controls — inline callback buttons AND force_reply prompts — only do
-# anything if the inbound Messages workflow is running to receive the tap/reply:
-# .github/workflows/messages.yml. If the operator DISABLED that workflow, every tap is
-# dead and every force_reply answer routes nowhere, so notify must not attach them —
-# a "Run again" button that silently does nothing (or, in a shared chat, invites a
-# stranger to tap it) is worse than no button. The message body still sends.
 #
-# We resolve the workflow's state (best-effort, cached once per run) and drop
-# interactive markup only when it is DEFINITIVELY disabled:
+# Interactive controls only do anything if the inbound Messages workflow
+# (.github/workflows/messages.yml) is running to receive the tap/reply. If the
+# operator DISABLED it, every tap is dead, so we must not attach controls — a button
+# that silently does nothing (or, in a shared chat, invites a stranger to tap it) is
+# worse than none. We resolve the workflow state (best-effort, cached once per run)
+# and drop interactive markup only when it is DEFINITIVELY disabled:
 #   • active                                  -> attach (inbound is live)
 #   • disabled_manually / disabled_inactivity -> suppress (operator turned it off)
-#   • unknown / unreachable                   -> attach (fail open: never silently
-#                                                drop controls when we can't prove off)
+#   • unknown / unreachable                   -> attach (fail open)
 # Overrides: TELEGRAM_FORCE_BUTTONS=1 forces attach; AEON_MESSAGES_WF_STATE=<state>
-# skips the API call (operator override + test hook). The owner-user gate in
-# messages.yml still governs WHO may act on a tap when the workflow IS enabled — that
-# is a separate defence and stays in force regardless of this.
+# skips the API call (operator override + test hook). The reply_markup is written into
+# the queue payload; notify-deliver.sh attaches it to the last Telegram chunk.
 INBOUND_OK=true
 if [ "${TELEGRAM_FORCE_BUTTONS:-}" != "1" ]; then
   MSG_WF_STATE="${AEON_MESSAGES_WF_STATE:-}"
@@ -270,153 +235,36 @@ elif [ -n "$BUTTONS_JSON" ]; then
   echo "notify: inbound Messages workflow disabled — suppressing inline buttons (set TELEGRAM_FORCE_BUTTONS=1 to keep them)" >&2
 fi
 
-# Telegram — fence-safe chunks (parse_mode Markdown, fallback to none)
-if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ]; then
-  TG_CHUNKS_B64=$(printf '%s' "$MSG" | python3 "$FMT" telegram --title "$TITLE" --severity "$SEVERITY" || true)
-  # Materialize chunks so we know which one is last (gets the reply_markup).
-  TG_CHUNKS=()
-  while IFS= read -r TG_CHUNK_B64; do
-    [ -z "$TG_CHUNK_B64" ] && continue
-    TG_CHUNKS+=("$TG_CHUNK_B64")
-  done <<< "$TG_CHUNKS_B64"
-  TG_LAST=$(( ${#TG_CHUNKS[@]} - 1 ))
-  for TG_I in "${!TG_CHUNKS[@]}"; do
-    TG_MSG=$(printf '%s' "${TG_CHUNKS[$TG_I]}" | base64 -d)
-    # reply_markup rides only on the last chunk.
-    if [ "$TG_I" -eq "$TG_LAST" ] && [ "$REPLY_MARKUP" != "null" ]; then
-      TG_RM="$REPLY_MARKUP"
-    else
-      TG_RM="null"
-    fi
-    # notify_format.py already normalized Markdown -> Telegram HTML for this path.
-    TG_PAYLOAD=$(jq -n --arg chat "$TELEGRAM_CHAT_ID" --arg text "$TG_MSG" --argjson rm "$TG_RM" \
-      '{chat_id:$chat, text:$text, parse_mode:"HTML"} + (if $rm then {reply_markup:$rm} else {} end)')
-
-    # Dry-run (tests): record the payload instead of sending. No network.
-    if [ "${NOTIFY_DRY_RUN:-}" = "1" ]; then
-      mkdir -p "$PENDING_DIR/notify-queue"
-      printf '%s\n' "$TG_PAYLOAD" >> "$PENDING_DIR/notify-queue/tg-payload.jsonl"
-      DELIVERED=true
-      continue
-    fi
-
-    TG_RESULT=$(curl -s -w "\n%{http_code}" -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
-      -H "Content-Type: application/json" -d "$TG_PAYLOAD" 2>/dev/null) || true
-    TG_HTTP=$(echo "$TG_RESULT" | tail -1)
-    TG_OK=$(echo "$TG_RESULT" | sed '$d' | jq -r '.ok // false' 2>/dev/null || echo "false")
-    if [ "$TG_HTTP" = "200" ] && [ "$TG_OK" = "true" ]; then
-      DELIVERED=true
-    else
-      # Fallback without parse_mode (should be near-zero — our HTML is deterministic).
-      # Strip tags and unescape entities so it degrades to clean plaintext, not
-      # visible <b>…</b> markup. Keep the reply_markup.
-      TG_PLAIN=$(printf '%s' "$TG_MSG" | sed -E 's/<[^>]+>//g' \
-        | sed -E 's/&lt;/</g; s/&gt;/>/g; s/&amp;/\&/g')
-      TG_FALLBACK=$(jq -n --arg chat "$TELEGRAM_CHAT_ID" --arg text "$TG_PLAIN" --argjson rm "$TG_RM" \
-        '{chat_id:$chat, text:$text} + (if $rm then {reply_markup:$rm} else {} end)')
-      curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
-        -H "Content-Type: application/json" -d "$TG_FALLBACK" > /dev/null 2>&1 && DELIVERED=true || true
-    fi
-    sleep 0.3
-  done
-fi
-
-# Discord — rich embeds, one POST per embed
-if [ -n "${DISCORD_WEBHOOK_URL:-}" ]; then
-  DISCORD_PAYLOADS=$(printf '%s' "$MSG" | python3 "$FMT" discord --title "$TITLE" --severity "$SEVERITY" || true)
-  while IFS= read -r DC_PAYLOAD; do
-    [ -z "$DC_PAYLOAD" ] && continue
-    curl -sf -X POST "$DISCORD_WEBHOOK_URL" -H "Content-Type: application/json" \
-      -d "$DC_PAYLOAD" > /dev/null 2>&1 && DELIVERED=true || true
-    sleep 0.3
-  done <<< "$DISCORD_PAYLOADS"
-fi
-
-# Slack — Block Kit
-if [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
-  SLACK_PAYLOAD=$(printf '%s' "$MSG" | python3 "$FMT" slack --title "$TITLE" --severity "$SEVERITY" || true)
-  if [ -n "$SLACK_PAYLOAD" ]; then
-    curl -sf -X POST "$SLACK_WEBHOOK_URL" -H "Content-Type: application/json" \
-      -d "$SLACK_PAYLOAD" > /dev/null 2>&1 && DELIVERED=true || true
+# --- write ONE structured payload to the queue ------------------------------
+# This is the whole job of notify.sh now: no channel curl, no token read. The
+# post-run step's notify-deliver.sh renders + delivers this per channel. Non-fatal
+# if the queue is unwritable (read-only-FS harness with no post-run delivery path):
+# match the prior degrade rather than aborting the skill on `set -e`.
+QUEUE_DIR="$PENDING_DIR/notify-queue"
+if ! mkdir -p "$QUEUE_DIR" 2>/dev/null; then
+  echo "notify: notify-queue unwritable (read-only FS) — message not queued" >&2
+else
+  TS=$(date -u +%s)
+  QUEUE_FILE="$QUEUE_DIR/${TS}-$$-${RANDOM}.json"
+  if jq -n \
+      --arg title "$TITLE" --arg severity "$SEVERITY" --arg body "$MSG" \
+      --arg plain "$PLAIN" --arg link "$LINK" --arg skill "${SKILL_NAME:-}" \
+      --arg hash "$HASH" --argjson reply_markup "$REPLY_MARKUP" \
+      '{title:$title, severity:$severity, body:$body, plain:$plain, link:$link,
+        skill_name:$skill, hash:$hash, reply_markup:$reply_markup}' \
+      > "$QUEUE_FILE" 2>/dev/null; then
+    echo "notify: queued ${HASH:0:8} -> $(basename "$QUEUE_FILE")" >&2
+  else
+    echo "notify: failed to write queue payload" >&2
+    rm -f "$QUEUE_FILE" 2>/dev/null || true
   fi
 fi
 
-# Buzz — Block's Nostr-relay workspace (buzz.xyz / github.com/block/buzz). Aeon posts
-# as itself: BUZZ_PRIVATE_KEY is a Schnorr keypair (nsec) and the buzz-cli signs each
-# message + publishes it over the relay at BUZZ_RELAY_URL into channel BUZZ_CHANNEL_ID.
-# Unlike the webhook channels above there is no bearer-URL to POST to, so delivery needs
-# the `buzz` binary staged in the run (see install-harness); we gate on its presence and
-# skip cleanly when it is absent — same graceful degrade as a missing webhook. Content is
-# Markdown, which Buzz renders natively (no HTML/Block-Kit transform). One send per chunk.
-if { command -v buzz >/dev/null 2>&1 || [ "${NOTIFY_DRY_RUN:-}" = "1" ]; } \
-   && [ -n "${BUZZ_PRIVATE_KEY:-}" ] && [ -n "${BUZZ_CHANNEL_ID:-}" ]; then
-  BUZZ_CHUNKS_B64=$(printf '%s' "$MSG" | python3 "$FMT" buzz --title "$TITLE" --severity "$SEVERITY" || true)
-  while IFS= read -r BZ_B64; do
-    [ -z "$BZ_B64" ] && continue
-    BZ_MSG=$(printf '%s' "$BZ_B64" | base64 -d)
-    # Dry-run (tests): record the decoded Markdown instead of sending. No binary, no network.
-    if [ "${NOTIFY_DRY_RUN:-}" = "1" ]; then
-      mkdir -p "$PENDING_DIR/notify-queue"
-      printf '%s\n---\n' "$BZ_MSG" >> "$PENDING_DIR/notify-queue/buzz-payload.txt"
-      DELIVERED=true
-      continue
-    fi
-    printf '%s' "$BZ_MSG" | buzz messages send --channel "$BUZZ_CHANNEL_ID" --content - >/dev/null 2>&1 \
-      && DELIVERED=true || true
-    sleep 0.3
-  done <<< "$BUZZ_CHUNKS_B64"
-fi
-
-# Email via Resend (operator-notify channel — same provider/key as the in-run
-# disclosure/outreach senders in send-email + vuln-scanner Arm C, one Resend
-# account for all outbound mail). Best-effort inline; the workflow's "Send pending
-# notifications" step re-delivers via Resend if this is blocked in the sandbox.
-if [ -n "${RESEND_API_KEY:-}" ] && [ -n "${NOTIFY_EMAIL_TO:-}" ]; then
-  FROM="${NOTIFY_EMAIL_FROM:-aeon@notifications.aeon.bot}"
-  PREFIX="${NOTIFY_EMAIL_SUBJECT_PREFIX:-[Aeon]}"
-  SUBJECT="$PREFIX ${TITLE:-${SKILL_NAME:-notification}}"
-  HTML_BODY=$(printf '%s' "$PLAIN" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g')
-  HTML_BODY="<html><body><pre style=\"font-family:monospace;white-space:pre-wrap;\">${HTML_BODY}</pre></body></html>"
-  curl -sf -X POST "https://api.resend.com/emails" \
-    -H "Authorization: Bearer ${RESEND_API_KEY}" \
-    -H "Content-Type: application/json" \
-    -d "$(jq -n --arg from "$FROM" --arg to "$NOTIFY_EMAIL_TO" --arg subject "$SUBJECT" \
-          --arg html "$HTML_BODY" --arg text "$PLAIN" \
-          '{from:$from, to:[$to], subject:$subject, html:$html, text:$text}')" > /dev/null 2>&1 && DELIVERED=true || true
-fi
-
-# json-render channel — save raw message for post-run conversion. Non-fatal for
-# the same reason as the notify-queue above: on a read-only-FS harness
-# (codex) this write can't land, and it must not abort a run whose channel
-# delivery already succeeded inline. The feed entry is simply skipped.
+# json-render channel — save raw message for post-run feed conversion. Non-fatal:
+# on a read-only-FS harness this write can't land and must not abort the run. This
+# is the public status-feed digest, separate from the delivery queue above.
 if [ "${JSONRENDER_ENABLED:-false}" = "true" ] && [ -n "${SKILL_NAME:-}" ]; then
   if ! printf '%s' "$PLAIN" > "$PENDING_DIR/.pending-${SKILL_NAME}.md" 2>/dev/null; then
     echo "notify: json-render queue unwritable (read-only FS) — feed entry skipped" >&2
-  fi
-fi
-
-# Remove pending file if immediate delivery succeeded (prevents double-send)
-if [ "$DELIVERED" = "true" ]; then
-  rm -f "$PENDING_DIR/notify-queue/${TS}.md"
-fi
-
-# Audit trail (no-op unless AEON_AUDIT_LOG is set; see scripts/audit.sh). One record
-# per notify call listing which channels were configured and whether any delivery
-# succeeded. Channel token VALUES never reach the record -- audit.sh redacts, and we
-# pass NAMES only. if-blocks keep this set -e safe.
-if [ -n "${AEON_AUDIT_LOG:-}" ]; then
-  _AUDIT=""
-  for _c in "scripts/audit.sh" "$_HERE/audit.sh" "$_HERE/scripts/audit.sh"; do
-    if [ -f "$_c" ]; then _AUDIT="$_c"; break; fi
-  done
-  if [ -n "$_AUDIT" ]; then
-    _CHANS=""; _SECS=""
-    if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ]; then _CHANS="${_CHANS}telegram,"; _SECS="${_SECS}TELEGRAM_BOT_TOKEN,"; fi
-    if [ -n "${DISCORD_WEBHOOK_URL:-}" ]; then _CHANS="${_CHANS}discord,"; _SECS="${_SECS}DISCORD_WEBHOOK_URL,"; fi
-    if [ -n "${SLACK_WEBHOOK_URL:-}" ]; then _CHANS="${_CHANS}slack,"; _SECS="${_SECS}SLACK_WEBHOOK_URL,"; fi
-    if [ -n "${BUZZ_PRIVATE_KEY:-}" ] && [ -n "${BUZZ_CHANNEL_ID:-}" ]; then _CHANS="${_CHANS}buzz,"; _SECS="${_SECS}BUZZ_PRIVATE_KEY,"; fi
-    if [ -n "${RESEND_API_KEY:-}" ] && [ -n "${NOTIFY_EMAIL_TO:-}" ]; then _CHANS="${_CHANS}email,"; _SECS="${_SECS}RESEND_API_KEY,"; fi
-    if [ "$DELIVERED" = "true" ]; then _RC=0; else _RC=1; fi
-    bash "$_AUDIT" "notify" "channels=${_CHANS%,} delivered=${DELIVERED}" "$_RC" "${_SECS%,}" || true
   fi
 fi

--- a/scripts/tests/test_notify.sh
+++ b/scripts/tests/test_notify.sh
@@ -1,316 +1,274 @@
 #!/usr/bin/env bash
-# Integration test for scripts/notify.sh — exercises arg parsing, probe suppression,
-# dedup, severity gate, and the notify-queue fallback with all channels unset.
-# The queues live under $AEON_PENDING_DIR (outside the workspace), so the test
-# points that at a temp dir instead of writing into the repo.
-# No network, no secrets. Run: bash scripts/tests/test_notify.sh
+# Integration test for the ./notify writer/deliver split (#912 Phase 2).
+#   scripts/notify.sh          - queue-writer: writes ONE structured .json payload,
+#                                never reads a channel token, never hits the wire.
+#   scripts/notify-deliver.sh  - delivery half: renders + sends a queued payload,
+#                                the only place a channel token is consumed.
+# WRITER tests assert the .json payload (incl. the reply_markup notify.sh computes).
+# DELIVER tests queue a payload then run notify-deliver.sh with NOTIFY_DRY_RUN=1, which
+# records the per-channel payloads instead of sending. No network, no secrets.
+#   Run: bash scripts/tests/test_notify.sh
 set -uo pipefail
 cd "$(dirname "$0")/../.." || exit 1
 NOTIFY="scripts/notify.sh"
+DELIVER="scripts/notify-deliver.sh"
 
 # Queues live outside the repo now; isolate them per-run.
 AEON_PENDING_DIR="$(mktemp -d)"; export AEON_PENDING_DIR
 trap 'rm -rf "$AEON_PENDING_DIR"' EXIT
 
-# Channels unset → everything falls back to .pending-notify
 unset TELEGRAM_BOT_TOKEN TELEGRAM_CHAT_ID DISCORD_WEBHOOK_URL SLACK_WEBHOOK_URL \
-      RESEND_API_KEY NOTIFY_EMAIL_TO JSONRENDER_ENABLED NOTIFY_MIN_SEVERITY 2>/dev/null
+      BUZZ_PRIVATE_KEY BUZZ_CHANNEL_ID RESEND_API_KEY NOTIFY_EMAIL_TO \
+      JSONRENDER_ENABLED NOTIFY_MIN_SEVERITY NOTIFY_DRY_RUN 2>/dev/null
 
 WORK="$AEON_PENDING_DIR/notify-queue"
 fail=0
 pass() { echo "ok   - $1"; }
 bad()  { echo "FAIL - $1"; fail=1; }
-reset() { rm -rf "$WORK" "$AEON_PENDING_DIR/notify-sent-hashes"; }
+reset() { rm -rf "$WORK" "$AEON_PENDING_DIR/notify-sent-hashes" "$AEON_PENDING_DIR/notify-delivered-hashes"; }
+payload() { ls -t "$WORK"/*.json 2>/dev/null | head -1; }
+# Queue via notify.sh then render the newest payload with notify-deliver.sh (dry-run).
+deliver() { local p; p="$(payload)"; [ -n "$p" ] && NOTIFY_DRY_RUN=1 bash "$DELIVER" "$p" >/dev/null 2>&1; }
 
-# 1. structured message lands in pending with title header
+# ============================ WRITER TESTS (.json) ==========================
+
+# 1. structured message lands in the queue as .json with title + body
 reset
 bash "$NOTIFY" --title "Token Report" --severity warn "Prices down 3.3 percent today" >/dev/null 2>&1
-f=$(ls "$WORK"/*.md 2>/dev/null | head -1)
-if [ -n "$f" ] && grep -q "Token Report" "$f" && grep -q "Prices down" "$f"; then
-  pass "structured message saved with title header"
+p="$(payload)"
+if [ -n "$p" ] && jq -e '.title=="Token Report" and (.body|contains("Prices down")) and .severity=="warn"' "$p" >/dev/null 2>&1; then
+  pass "structured message queued as .json with title + severity"
 else
-  bad "structured message saved with title header"
+  bad "structured message queued as .json with title + severity"
 fi
 
-# 2. probe/test message is suppressed (no pending file)
+# 2. probe/test message is suppressed (no payload)
 reset
 bash "$NOTIFY" "quick test ping" >/dev/null 2>&1
-if [ -z "$(ls "$WORK"/*.md 2>/dev/null)" ]; then
-  pass "probe message suppressed"
-else
-  bad "probe message suppressed"
-fi
+[ -z "$(payload)" ] && pass "probe message suppressed" || bad "probe message suppressed"
 
-# 3. dedup — identical message twice produces a single pending file
+# 3. dedup - identical message twice produces a single payload
 reset
 bash "$NOTIFY" "Deployment finished successfully on prod cluster" >/dev/null 2>&1
 bash "$NOTIFY" "Deployment finished successfully on prod cluster" >/dev/null 2>&1
-count=$(ls "$WORK"/*.md 2>/dev/null | wc -l | tr -d ' ')
-if [ "$count" = "1" ]; then
-  pass "duplicate message deduped ($count file)"
-else
-  bad "duplicate message deduped (got $count files)"
-fi
+count=$(ls "$WORK"/*.json 2>/dev/null | wc -l | tr -d ' ')
+[ "$count" = "1" ] && pass "duplicate message deduped ($count file)" || bad "duplicate message deduped (got $count files)"
 
-# 4. severity gate — warn below critical floor is skipped
+# 4. severity gate - warn below critical floor is skipped
 reset
 NOTIFY_MIN_SEVERITY=critical bash "$NOTIFY" --severity warn "Heads up, minor wobble in metrics" >/dev/null 2>&1
-if [ -z "$(ls "$WORK"/*.md 2>/dev/null)" ]; then
-  pass "below-floor severity skipped"
-else
-  bad "below-floor severity skipped"
-fi
+[ -z "$(payload)" ] && pass "below-floor severity skipped" || bad "below-floor severity skipped"
 
-# 5. severity gate — critical passes the floor
+# 5. severity gate - critical passes the floor
 reset
 NOTIFY_MIN_SEVERITY=warn bash "$NOTIFY" --severity critical "Database is down, paging now" >/dev/null 2>&1
-if [ -n "$(ls "$WORK"/*.md 2>/dev/null)" ]; then
-  pass "at/above-floor severity delivered"
-else
-  bad "at/above-floor severity delivered"
-fi
+[ -n "$(payload)" ] && pass "at/above-floor severity delivered" || bad "at/above-floor severity delivered"
 
 # 6. -f file body still works (backward compat)
 reset
 tmp=$(mktemp); printf 'Line one\n\nLine two with detail' > "$tmp"
 bash "$NOTIFY" -f "$tmp" >/dev/null 2>&1
-f=$(ls "$WORK"/*.md 2>/dev/null | head -1)
-if [ -n "$f" ] && grep -q "Line two" "$f"; then
-  pass "-f file body delivered"
-else
-  bad "-f file body delivered"
-fi
+p="$(payload)"
+{ [ -n "$p" ] && jq -e '.body|contains("Line two")' "$p" >/dev/null 2>&1; } \
+  && pass "-f file body queued" || bad "-f file body queued"
 rm -f "$tmp"
 
-# --- interactive flags (Telegram dry-run; NOTIFY_DRY_RUN records the payload
-#     instead of sending, so these assert reply_markup with no network) ---
-ROOT="$(pwd)"
-ABS_NOTIFY="$ROOT/scripts/notify.sh"
+# --- reply_markup is computed by notify.sh and stored in the payload ---
+ROOT="$(pwd)"; ABS_NOTIFY="$ROOT/scripts/notify.sh"
 
-# 7. --buttons attaches an inline_keyboard to the Telegram payload
+# 7. --buttons attaches an inline_keyboard to the payload's reply_markup
 reset
-TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 AEON_MESSAGES_WF_STATE=active NOTIFY_DRY_RUN=1 \
+TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 AEON_MESSAGES_WF_STATE=active \
   bash "$NOTIFY" "Alert body long enough to clear the probe filter here" \
   --buttons '[[{"text":"Snooze","callback_data":"snooze:x:y:60"}]]' >/dev/null 2>&1
-if [ -f "$WORK/tg-payload.jsonl" ] && \
-   jq -e '.reply_markup.inline_keyboard[0][0].callback_data=="snooze:x:y:60"' "$WORK/tg-payload.jsonl" >/dev/null 2>&1; then
-  pass "--buttons attaches inline_keyboard"
-else
-  bad "--buttons attaches inline_keyboard"
-fi
+p="$(payload)"
+{ [ -n "$p" ] && jq -e '.reply_markup.inline_keyboard[0][0].callback_data=="snooze:x:y:60"' "$p" >/dev/null 2>&1; } \
+  && pass "--buttons attaches inline_keyboard" || bad "--buttons attaches inline_keyboard"
 
-# 8. --force-reply + --context set force_reply and prefix the [skill::intent] marker
+# 8. --force-reply + --context set force_reply and prefix the [skill::intent] marker in body
 reset
-TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 AEON_MESSAGES_WF_STATE=active NOTIFY_DRY_RUN=1 \
+TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 AEON_MESSAGES_WF_STATE=active \
   bash "$NOTIFY" "Which repository should I track for you" \
   --force-reply --placeholder "owner/repo" --context "github-monitor::add-repo" >/dev/null 2>&1
-if [ -f "$WORK/tg-payload.jsonl" ] && \
-   jq -e '.reply_markup.force_reply==true' "$WORK/tg-payload.jsonl" >/dev/null 2>&1 && \
-   jq -e '.text|startswith("[github-monitor::add-repo]")' "$WORK/tg-payload.jsonl" >/dev/null 2>&1; then
-  pass "--force-reply + --context set marker and force_reply"
-else
-  bad "--force-reply + --context set marker and force_reply"
-fi
+p="$(payload)"
+{ [ -n "$p" ] && jq -e '.reply_markup.force_reply==true' "$p" >/dev/null 2>&1 \
+  && jq -e '.body|startswith("[github-monitor::add-repo]")' "$p" >/dev/null 2>&1; } \
+  && pass "--force-reply + --context set marker and force_reply" || bad "--force-reply + --context set marker and force_reply"
 
 # 9-11. --mute-key gate. Isolated cwd so the repo's memory/ is never touched.
 MK="$(mktemp -d)"; mkdir -p "$MK/memory"; cd "$MK" || exit 1
 
 # 9. muted key suppresses the send
-rm -rf "$WORK" "$AEON_PENDING_DIR/notify-sent-hashes"; echo "token-movers:BTC" > memory/mutes.log; : > memory/snoozes.log
-TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 NOTIFY_DRY_RUN=1 \
-  bash "$ABS_NOTIFY" "BTC alert that should be muted away entirely" --mute-key "token-movers:BTC" >/dev/null 2>&1
-[ ! -f "$WORK/tg-payload.jsonl" ] && pass "--mute-key muted suppresses" || bad "--mute-key muted suppresses"
+reset; echo "token-movers:BTC" > memory/mutes.log; : > memory/snoozes.log
+bash "$ABS_NOTIFY" "BTC alert that should be muted away entirely" --mute-key "token-movers:BTC" >/dev/null 2>&1
+[ -z "$(payload)" ] && pass "--mute-key muted suppresses" || bad "--mute-key muted suppresses"
 
 # 10. future snooze suppresses
-rm -rf "$WORK" "$AEON_PENDING_DIR/notify-sent-hashes"; : > memory/mutes.log
+reset; : > memory/mutes.log
 printf 'token-movers:ETH:%s\n' "$(( $(date -u +%s) + 3600 ))" > memory/snoozes.log
-TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 NOTIFY_DRY_RUN=1 \
-  bash "$ABS_NOTIFY" "ETH alert snoozed for an hour from now" --mute-key "token-movers:ETH" >/dev/null 2>&1
-[ ! -f "$WORK/tg-payload.jsonl" ] && pass "--mute-key future snooze suppresses" || bad "--mute-key future snooze suppresses"
+bash "$ABS_NOTIFY" "ETH alert snoozed for an hour from now" --mute-key "token-movers:ETH" >/dev/null 2>&1
+[ -z "$(payload)" ] && pass "--mute-key future snooze suppresses" || bad "--mute-key future snooze suppresses"
 
 # 11. expired snooze delivers
-rm -rf "$WORK" "$AEON_PENDING_DIR/notify-sent-hashes"
+reset
 printf 'token-movers:SOL:%s\n' "$(( $(date -u +%s) - 10 ))" > memory/snoozes.log
-TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 NOTIFY_DRY_RUN=1 \
-  bash "$ABS_NOTIFY" "SOL alert should deliver since snooze expired" --mute-key "token-movers:SOL" >/dev/null 2>&1
-[ -f "$WORK/tg-payload.jsonl" ] && pass "--mute-key expired snooze delivers" || bad "--mute-key expired snooze delivers"
+bash "$ABS_NOTIFY" "SOL alert should deliver since snooze expired" --mute-key "token-movers:SOL" >/dev/null 2>&1
+[ -n "$(payload)" ] && pass "--mute-key expired snooze delivers" || bad "--mute-key expired snooze delivers"
 
-cd "$ROOT" || exit 1
-rm -rf "$MK"
-
-# --- global quick-action buttons (Run again + Schedule weekly), keyed to SKILL_NAME ---
+cd "$ROOT" || exit 1; rm -rf "$MK"
 
 # 12. a normal skill notification gets the global Run again + Schedule weekly row
 reset
-TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 AEON_MESSAGES_WF_STATE=active NOTIFY_DRY_RUN=1 SKILL_NAME=token-movers \
+TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 AEON_MESSAGES_WF_STATE=active SKILL_NAME=token-movers \
   bash "$NOTIFY" "A normal skill digest long enough to clear the probe filter here" >/dev/null 2>&1
-if [ -f "$WORK/tg-payload.jsonl" ] && \
-   jq -e '.reply_markup.inline_keyboard[-1][0].callback_data=="run:token-movers"' "$WORK/tg-payload.jsonl" >/dev/null 2>&1 && \
-   jq -e '.reply_markup.inline_keyboard[-1][1].callback_data=="schedule:token-movers:weekly"' "$WORK/tg-payload.jsonl" >/dev/null 2>&1; then
-  pass "global Run again + Schedule weekly buttons attached"
-else
-  bad "global Run again + Schedule weekly buttons attached"
-fi
+p="$(payload)"
+{ [ -n "$p" ] && jq -e '.reply_markup.inline_keyboard[-1][0].callback_data=="run:token-movers"' "$p" >/dev/null 2>&1 \
+  && jq -e '.reply_markup.inline_keyboard[-1][1].callback_data=="schedule:token-movers:weekly"' "$p" >/dev/null 2>&1; } \
+  && pass "global Run again + Schedule weekly buttons attached" || bad "global Run again + Schedule weekly buttons attached"
 
-# 13. skill --buttons rows are kept, with the global quick-action row appended beneath
+# 13. skill --buttons rows are kept, with the global row appended beneath
 reset
-TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 AEON_MESSAGES_WF_STATE=active NOTIFY_DRY_RUN=1 SKILL_NAME=pr-review \
+TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 AEON_MESSAGES_WF_STATE=active SKILL_NAME=pr-review \
   bash "$NOTIFY" "Digest body long enough to clear the probe filter comfortably" \
   --buttons '[[{"text":"Open","url":"https://example.com"}]]' >/dev/null 2>&1
-if [ -f "$WORK/tg-payload.jsonl" ] && \
-   jq -e '.reply_markup.inline_keyboard[0][0].url=="https://example.com"' "$WORK/tg-payload.jsonl" >/dev/null 2>&1 && \
-   jq -e '.reply_markup.inline_keyboard[-1][0].callback_data=="run:pr-review"' "$WORK/tg-payload.jsonl" >/dev/null 2>&1; then
-  pass "custom --buttons kept + global row appended"
-else
-  bad "custom --buttons kept + global row appended"
-fi
+p="$(payload)"
+{ [ -n "$p" ] && jq -e '.reply_markup.inline_keyboard[0][0].url=="https://example.com"' "$p" >/dev/null 2>&1 \
+  && jq -e '.reply_markup.inline_keyboard[-1][0].callback_data=="run:pr-review"' "$p" >/dev/null 2>&1; } \
+  && pass "custom --buttons kept + global row appended" || bad "custom --buttons kept + global row appended"
 
-# 14. a force_reply prompt never carries inline buttons (mutual exclusivity), even with SKILL_NAME set
+# 14. a force_reply prompt never carries inline buttons (mutual exclusivity)
 reset
-TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 AEON_MESSAGES_WF_STATE=active NOTIFY_DRY_RUN=1 SKILL_NAME=github-monitor \
+TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 AEON_MESSAGES_WF_STATE=active SKILL_NAME=github-monitor \
   bash "$NOTIFY" "Which repository should I track for you now" \
   --force-reply --placeholder "owner/repo" --context "github-monitor::add-repo" >/dev/null 2>&1
-if [ -f "$WORK/tg-payload.jsonl" ] && \
-   jq -e '.reply_markup.force_reply==true' "$WORK/tg-payload.jsonl" >/dev/null 2>&1 && \
-   jq -e '.reply_markup|has("inline_keyboard")|not' "$WORK/tg-payload.jsonl" >/dev/null 2>&1; then
-  pass "force_reply prompt carries no inline buttons"
-else
-  bad "force_reply prompt carries no inline buttons"
-fi
+p="$(payload)"
+{ [ -n "$p" ] && jq -e '.reply_markup.force_reply==true' "$p" >/dev/null 2>&1 \
+  && jq -e '.reply_markup|has("inline_keyboard")|not' "$p" >/dev/null 2>&1; } \
+  && pass "force_reply prompt carries no inline buttons" || bad "force_reply prompt carries no inline buttons"
 
-# 15. no SKILL_NAME context -> no global buttons (bare notify stays button-free)
+# 15. no SKILL_NAME context -> reply_markup null (bare notify stays button-free)
 reset
-TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 NOTIFY_DRY_RUN=1 \
+TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 \
   bash "$NOTIFY" "A contextless notification with no skill name set at all here" >/dev/null 2>&1
-if [ -f "$WORK/tg-payload.jsonl" ] && \
-   jq -e '.|has("reply_markup")|not' "$WORK/tg-payload.jsonl" >/dev/null 2>&1; then
-  pass "no SKILL_NAME -> no global buttons"
-else
-  bad "no SKILL_NAME -> no global buttons"
-fi
+p="$(payload)"
+{ [ -n "$p" ] && jq -e '.reply_markup==null' "$p" >/dev/null 2>&1; } \
+  && pass "no SKILL_NAME -> reply_markup null" || bad "no SKILL_NAME -> reply_markup null"
 
-# 15b. inbound Messages workflow disabled -> interactive buttons auto-suppressed, but
-#      the message still delivers. Neither the global row nor custom --buttons attach.
-#      (AEON_MESSAGES_WF_STATE short-circuits the GitHub API lookup.)
+# 15b. inbound Messages workflow disabled -> interactive markup suppressed (still queued)
 reset
-TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 AEON_MESSAGES_WF_STATE=disabled_manually NOTIFY_DRY_RUN=1 SKILL_NAME=token-movers \
+TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 AEON_MESSAGES_WF_STATE=disabled_manually SKILL_NAME=token-movers \
   bash "$NOTIFY" "A broadcast body long enough to clear the probe filter here now" \
   --buttons '[[{"text":"Snooze","callback_data":"snooze:token-movers:BTC:60"}]]' >/dev/null 2>&1
-if [ -f "$WORK/tg-payload.jsonl" ] && \
-   jq -e '.|has("reply_markup")|not' "$WORK/tg-payload.jsonl" >/dev/null 2>&1; then
-  pass "messages.yml disabled -> interactive buttons suppressed (message still sent)"
-else
-  bad "messages.yml disabled -> interactive buttons suppressed (message still sent)"
-fi
+p="$(payload)"
+{ [ -n "$p" ] && jq -e '.reply_markup==null' "$p" >/dev/null 2>&1; } \
+  && pass "messages.yml disabled -> markup suppressed (still queued)" || bad "messages.yml disabled -> markup suppressed (still queued)"
 
-# 15c. force_reply is also suppressed when inbound is disabled (its answer can't route)
+# 15c. force_reply also suppressed when inbound disabled; body still carries the marker
 reset
-TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 AEON_MESSAGES_WF_STATE=disabled_manually NOTIFY_DRY_RUN=1 SKILL_NAME=github-monitor \
+TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 AEON_MESSAGES_WF_STATE=disabled_manually SKILL_NAME=github-monitor \
   bash "$NOTIFY" "Which repository should I track for you now" \
   --force-reply --placeholder "owner/repo" --context "github-monitor::add-repo" >/dev/null 2>&1
-if [ -f "$WORK/tg-payload.jsonl" ] && \
-   jq -e '.|has("reply_markup")|not' "$WORK/tg-payload.jsonl" >/dev/null 2>&1 && \
-   jq -e '.text|startswith("[github-monitor::add-repo]")' "$WORK/tg-payload.jsonl" >/dev/null 2>&1; then
-  pass "messages.yml disabled -> force_reply sent as plain text (no reply markup)"
-else
-  bad "messages.yml disabled -> force_reply sent as plain text (no reply markup)"
-fi
+p="$(payload)"
+{ [ -n "$p" ] && jq -e '.reply_markup==null' "$p" >/dev/null 2>&1 \
+  && jq -e '.body|startswith("[github-monitor::add-repo]")' "$p" >/dev/null 2>&1; } \
+  && pass "messages.yml disabled -> force_reply plain (no markup)" || bad "messages.yml disabled -> force_reply plain (no markup)"
 
 # 15d. workflow active -> buttons attach as normal
 reset
-TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 AEON_MESSAGES_WF_STATE=active NOTIFY_DRY_RUN=1 SKILL_NAME=token-movers \
+TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 AEON_MESSAGES_WF_STATE=active SKILL_NAME=token-movers \
   bash "$NOTIFY" "A broadcast body long enough to clear the probe filter here now" >/dev/null 2>&1
-if [ -f "$WORK/tg-payload.jsonl" ] && \
-   jq -e '.reply_markup.inline_keyboard[-1][0].callback_data=="run:token-movers"' "$WORK/tg-payload.jsonl" >/dev/null 2>&1; then
-  pass "messages.yml active -> buttons attached"
-else
-  bad "messages.yml active -> buttons attached"
-fi
+p="$(payload)"
+{ [ -n "$p" ] && jq -e '.reply_markup.inline_keyboard[-1][0].callback_data=="run:token-movers"' "$p" >/dev/null 2>&1; } \
+  && pass "messages.yml active -> buttons attached" || bad "messages.yml active -> buttons attached"
 
 # 15e. disabled workflow + TELEGRAM_FORCE_BUTTONS=1 override -> buttons come back
 reset
-TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 AEON_MESSAGES_WF_STATE=disabled_manually TELEGRAM_FORCE_BUTTONS=1 NOTIFY_DRY_RUN=1 SKILL_NAME=token-movers \
+TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 AEON_MESSAGES_WF_STATE=disabled_manually TELEGRAM_FORCE_BUTTONS=1 SKILL_NAME=token-movers \
   bash "$NOTIFY" "A broadcast body long enough to clear the probe filter here now" >/dev/null 2>&1
-if [ -f "$WORK/tg-payload.jsonl" ] && \
-   jq -e '.reply_markup.inline_keyboard[-1][0].callback_data=="run:token-movers"' "$WORK/tg-payload.jsonl" >/dev/null 2>&1; then
-  pass "TELEGRAM_FORCE_BUTTONS=1 overrides disabled workflow"
-else
-  bad "TELEGRAM_FORCE_BUTTONS=1 overrides disabled workflow"
-fi
+p="$(payload)"
+{ [ -n "$p" ] && jq -e '.reply_markup.inline_keyboard[-1][0].callback_data=="run:token-movers"' "$p" >/dev/null 2>&1; } \
+  && pass "TELEGRAM_FORCE_BUTTONS=1 overrides disabled workflow" || bad "TELEGRAM_FORCE_BUTTONS=1 overrides disabled workflow"
 
-reset
-
-# 16. read-only cwd (a read-only skill under the OS sandbox): the queue lives
-#     OUTSIDE the workspace now, so notify must still succeed AND still queue —
-#     that is what lets the capture/feed steps see this run's output instead of
-#     republishing the previous run's file. Regression guard for the stale-digest
-#     bug and for the set -e abort that once dropped codex notifications entirely.
+# 16. read-only cwd (a read-only skill under the OS sandbox): the queue lives OUTSIDE
+#     the workspace, so notify must still succeed AND still queue.
 reset
 NOTIFY_ABS="$PWD/scripts/notify.sh"
-RO="$(mktemp -d)"
-chmod 555 "$RO"
+RO="$(mktemp -d)"; chmod 555 "$RO"
 if ( cd "$RO" && : > .wtest ) 2>/dev/null; then
   rm -f "$RO/.wtest"; chmod 755 "$RO"; rm -rf "$RO"
-  pass "read-only cwd queues outside the workspace (skipped: cwd still writable, likely root)"
+  pass "read-only cwd queues outside the workspace (skipped: cwd writable, likely root)"
 else
   ( cd "$RO" && bash "$NOTIFY_ABS" --severity critical \
       "A real notification long enough to clear the probe and severity floors here" ) \
       >/dev/null 2>"${RO}.err"
-  ec=$?
-  chmod 755 "$RO"; rm -rf "$RO"
-  if [ "$ec" -eq 0 ] && [ -n "$(ls -A "$WORK"/*.md 2>/dev/null)" ]; then
-    pass "read-only cwd still queues (queue is outside the workspace)"
-  else
-    bad "read-only cwd queue (exit=$ec; queued=$(ls -A "$WORK" 2>/dev/null | tr '\n' ' '); err=$(tr '\n' '|' <"${RO}.err"))"
-  fi
+  ec=$?; chmod 755 "$RO"; rm -rf "$RO"
+  { [ "$ec" -eq 0 ] && [ -n "$(payload)" ]; } \
+    && pass "read-only cwd still queues (queue is outside the workspace)" \
+    || bad "read-only cwd queue (exit=$ec; err=$(tr '\n' '|' <"${RO}.err"))"
   rm -f "${RO}.err"
 fi
 
-# 17. …and if the QUEUE ITSELF is unwritable, notify must fall through to inline
-#     delivery rather than abort under set -e (the original codex regression).
+# 17. queue itself unwritable: notify must exit 0 (no set -e abort), warning to stderr.
 reset
 UNWRITABLE="$(mktemp -d)"; chmod 555 "$UNWRITABLE"
 if ( : > "$UNWRITABLE/.wtest" ) 2>/dev/null; then
   rm -f "$UNWRITABLE/.wtest"; chmod 755 "$UNWRITABLE"; rm -rf "$UNWRITABLE"
-  pass "unwritable queue -> inline fallthrough (skipped: dir still writable, likely root)"
+  pass "unwritable queue -> exit 0 (skipped: dir writable, likely root)"
 else
   AEON_PENDING_DIR="$UNWRITABLE/nope" bash "$NOTIFY_ABS" --severity critical \
     "Another real notification long enough to clear the probe and severity floors" \
     >/dev/null 2>"${UNWRITABLE}.err"
-  ec=$?
-  chmod 755 "$UNWRITABLE"; rm -rf "$UNWRITABLE"
-  if [ "$ec" -eq 0 ] && grep -q "unwritable" "${UNWRITABLE}.err"; then
-    pass "unwritable queue -> inline fallthrough (exit 0, no set -e abort)"
-  else
-    bad "unwritable queue fallthrough (exit=$ec; err=$(tr '\n' '|' <"${UNWRITABLE}.err"))"
-  fi
+  ec=$?; chmod 755 "$UNWRITABLE"; rm -rf "$UNWRITABLE"
+  { [ "$ec" -eq 0 ] && grep -q "unwritable" "${UNWRITABLE}.err"; } \
+    && pass "unwritable queue -> exit 0, no set -e abort" \
+    || bad "unwritable queue (exit=$ec; err=$(tr '\n' '|' <"${UNWRITABLE}.err"))"
   rm -f "${UNWRITABLE}.err"
 fi
 
-# 18. Buzz channel — dry-run records the decoded Markdown (no `buzz` binary, no network).
-#     Gated on BUZZ_PRIVATE_KEY + BUZZ_CHANNEL_ID; NOTIFY_DRY_RUN bypasses `command -v buzz`.
-reset
-BUZZ_PRIVATE_KEY=nsec1x BUZZ_CHANNEL_ID=chan-uuid NOTIFY_DRY_RUN=1 \
-  bash "$NOTIFY" --title "Scan Report" --severity warn "Found 3 movers worth a look today" >/dev/null 2>&1
-BZ="$WORK/buzz-payload.txt"
-if [ -f "$BZ" ] && grep -q "Scan Report" "$BZ" && grep -q "Found 3 movers" "$BZ"; then
-  pass "buzz dry-run records decoded markdown payload"
-else
-  bad "buzz dry-run records decoded markdown payload"
-fi
+# ========================== DELIVER TESTS (dry-run) =========================
 
-# 18b. Buzz gate — with the binary absent and NOT in dry-run, the channel is skipped
-#      (falls back to the pending queue like any unconfigured channel).
+# 18. Telegram render: notify-deliver.sh emits an HTML payload with parse_mode + text.
+reset
+TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 AEON_MESSAGES_WF_STATE=active SKILL_NAME=token-movers \
+  bash "$NOTIFY" --title "Scan Report" --severity warn "Found 3 movers worth a look today" >/dev/null 2>&1
+p="$(payload)"
+TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 NOTIFY_DRY_RUN=1 bash "$DELIVER" "$p" >/dev/null 2>&1
+TG="$WORK/tg-payload.jsonl"
+{ [ -f "$TG" ] && jq -e '.parse_mode=="HTML"' "$TG" >/dev/null 2>&1 \
+  && jq -e '.text|contains("Scan Report")' "$TG" >/dev/null 2>&1 \
+  && jq -e '.reply_markup.inline_keyboard[-1][0].callback_data=="run:token-movers"' "$TG" >/dev/null 2>&1; } \
+  && pass "deliver: Telegram HTML payload + reply_markup" || bad "deliver: Telegram HTML payload + reply_markup"
+
+# 19. Buzz render: dry-run records the decoded Markdown (no `buzz` binary, no network).
 reset
 BUZZ_PRIVATE_KEY=nsec1x BUZZ_CHANNEL_ID=chan-uuid \
-  bash "$NOTIFY" --severity critical "A real critical notification long enough to clear the floors" >/dev/null 2>&1
-if [ ! -f "$WORK/buzz-payload.txt" ] && [ -n "$(ls "$WORK"/*.md 2>/dev/null)" ]; then
-  pass "buzz skipped when binary absent -> pending-queue fallback"
-else
-  bad "buzz skipped when binary absent -> pending-queue fallback"
-fi
+  bash "$NOTIFY" --title "Scan Report" --severity warn "Found 3 movers worth a look today" >/dev/null 2>&1
+p="$(payload)"
+BUZZ_PRIVATE_KEY=nsec1x BUZZ_CHANNEL_ID=chan-uuid NOTIFY_DRY_RUN=1 bash "$DELIVER" "$p" >/dev/null 2>&1
+BZ="$WORK/buzz-payload.txt"
+{ [ -f "$BZ" ] && grep -q "Scan Report" "$BZ" && grep -q "Found 3 movers" "$BZ"; } \
+  && pass "deliver: buzz dry-run records decoded markdown" || bad "deliver: buzz dry-run records decoded markdown"
 
+# 20. R6 multi-channel: Telegram + email BOTH fire from one deliver call, independently.
 reset
+SKILL_NAME=vuln-scanner AEON_MESSAGES_WF_STATE=disabled_manually \
+  bash "$NOTIFY" --title "Multi" --severity critical "R6 body long enough to clear floors" >/dev/null 2>&1
+p="$(payload)"
+TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=1 RESEND_API_KEY=re_x NOTIFY_EMAIL_TO=a@b.com NOTIFY_DRY_RUN=1 \
+  bash "$DELIVER" "$p" >/dev/null 2>&1
+{ [ -f "$WORK/tg-payload.jsonl" ] && [ -f "$WORK/email-payload.txt" ]; } \
+  && pass "deliver: R6 telegram + email both fire from one call" || bad "deliver: R6 telegram + email both fire from one call"
+
+# 21. idempotency: delivering the same payload twice sends once (delivered-hash guard).
+reset
+TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 \
+  bash "$NOTIFY" "An idempotency probe body long enough to clear the probe filter" >/dev/null 2>&1
+p="$(payload)"
+TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 NOTIFY_DRY_RUN=1 bash "$DELIVER" "$p" >/dev/null 2>&1
+TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 NOTIFY_DRY_RUN=1 bash "$DELIVER" "$p" >/dev/null 2>&1
+n=$(jq -s 'length' "$WORK/tg-payload.jsonl" 2>/dev/null)
+[ "$n" = "1" ] && pass "deliver: idempotent re-delivery sends once ($n)" || bad "deliver: idempotent re-delivery sends once (got $n)"
+
 echo "---"
 [ "$fail" = "0" ] && echo "ALL PASS" || echo "SOME FAILED"
 exit "$fail"


### PR DESCRIPTION
Closes the Phase 2 half of #912: move `./notify` behind a credential-owning post-run dispatcher so infra channel tokens stop being bound into every skill's run env. (Phase 1 = #951, merged.)

## What changes
- **`scripts/notify.sh` -> queue-writer.** A skill call writes ONE structured JSON payload to `$AEON_PENDING_DIR/notify-queue/<TS>.json`. It never reads a channel token and never hits the wire. All the arg-parse / severity gate / mute-snooze / probe suppression / dedup / Telegram reply_markup + messages.yml-state logic stays here (reply_markup needs `GITHUB_TOKEN`, which stays in-run).
- **`scripts/notify-deliver.sh` (new) -> the send half.** Reads a queued payload, renders per channel via `scripts/notify_format.py` (Telegram HTML + reply_markup, Discord embeds, Slack Block Kit, Buzz), delivers, and writes a per-send audit line. This is the ONLY place a channel token is consumed. It runs in the post-run "Send pending notifications" step.
- **`aeon.yml` Run-step env + `ALL_SECRETS`:** remove `TELEGRAM_BOT_TOKEN`/`TELEGRAM_CHAT_ID`, `DISCORD_WEBHOOK_URL`, `SLACK_WEBHOOK_URL`, `BUZZ_PRIVATE_KEY`/`BUZZ_CHANNEL_ID`/`BUZZ_RELAY_URL`, `NOTIFY_EMAIL_TO`. Kept: `RESEND_*` (per-skill `requires:` for send-email / vuln-scanner), `GITHUB_TOKEN`/`GH_GLOBAL` (deferred - broad `gh` surface).
- **Post-run step** iterates the structured queue and calls `notify-deliver.sh`. Gained `BUZZ_*` + `GITHUB_TOKEN` in its step env.

Net: a skill can ask for a message but cannot read the credential that sends it. GitHub Actions per-step `env:` is a real process boundary - a secret bound only on the post-run step is never in the env the skill runs in.

## Two things worth a look
1. **`if:` is `!cancelled() && mode != ''`, not a bare `mode != ''`.** GitHub auto-prepends `success()` to any `if:` without a status function, so a bare `mode != ''` would SKIP the delivery step on a failed skill. `!cancelled()` keeps R1 (a failed skill still delivers what it queued) while excluding cancellation.
2. **Delivery dedups against a separate `notify-delivered-hashes`,** not `notify-sent-hashes` (which notify.sh marks at queue time - reusing it would make the post-run step skip every send).

## Proven live
Ran the full two-commit staged rollout on **aeon-vuln** (private) before this PR: delivery via the post-run path with tokens still in the run env, then with tokens removed - both delivered (Telegram 200/ok), and the Run step showed 0 channel-token env lines after removal. `messages.yml` is untouched (it writes its own inline `./notify`, not `scripts/notify.sh`). Per-send audit records land in the same `AEON_AUDIT_LOG` the run uploads as `audit-log-<run_id>` - no #908 regression.

## Tests
`test_notify.sh` rewritten for the writer/deliver split (25 pass), `test_notify_format.py` 25 pass, `actionlint` clean, `ALL_SECRETS` still valid JSON.

## Fleet rollout note
After this lands, the fleet picks it up via `aeon-update` (3-way merge), not hand-editing. Re-check each instance's Run-step env + `ALL_SECRETS` after the sync - a canon rebase can re-seed the channel tokens (same class as the messages.yml `ALL_SECRETS` re-seed gotcha).

## Not in this PR (deferred)
- `messages.yml`'s inbound reply agent still gets `TELEGRAM_BOT_TOKEN` in its env - a separate surface Phase 2 didn't target.
- `GITHUB_TOKEN`/`GH_GLOBAL` stay in-run.
