### PR TITLE
fix macos cron date portability

### DIFF
--- a/scripts/cron-due.sh
+++ b/scripts/cron-due.sh
@@ -24,8 +24,8 @@
 # Exit 0 (DUE)  → prints the matched slot time (ISO 8601) to stdout.
 # Exit 1 (skip) → no output.
 #
-# Env: AEON_DATE overrides the `date` binary (set AEON_DATE=gdate to test on
-#      macOS/BSD; the workflow runner is GNU coreutils and needs no override).
+# Env: AEON_DATE overrides the `date` binary. When unset, GNU and BSD/macOS
+#      date are detected automatically.
 set -euo pipefail
 
 SCHED="${1:?schedule required (5 cron fields)}"
@@ -33,6 +33,21 @@ NOW_EPOCH="${2:?now epoch required}"
 LAST_EPOCH="${3:-0}"
 CATCHUP_HOURS="${4:-6}"
 DATE="${AEON_DATE:-date}"
+
+if "$DATE" --version >/dev/null 2>&1; then
+  DATE_FLAVOR=gnu
+else
+  DATE_FLAVOR=bsd
+fi
+
+format_epoch() {
+  local epoch="$1" format="$2"
+  if [ "$DATE_FLAVOR" = gnu ]; then
+    "$DATE" -u -d "@$epoch" "$format"
+  else
+    "$DATE" -u -r "$epoch" "$format"
+  fi
+}
 
 IFS=' ' read -r C_MIN C_HOUR C_DOM C_MONTH C_DOW <<< "$SCHED"
 # Malformed / non-time schedule (e.g. "workflow_dispatch", "reactive", empty) → never due.
@@ -82,7 +97,7 @@ HOUR_TOP=$(( NOW_EPOCH - (NOW_EPOCH % 3600) ))
 DUE_SLOT=-1
 for (( h=0; h<=CATCHUP_HOURS; h++ )); do
   BUCKET_TOP=$(( HOUR_TOP - h * 3600 ))
-  read -r B_HOUR B_DOM B_MON B_DOW <<< "$("$DATE" -u -d "@$BUCKET_TOP" +'%-H %-d %-m %w')"
+  read -r B_HOUR B_DOM B_MON B_DOW <<< "$(format_epoch "$BUCKET_TOP" +'%-H %-d %-m %w')"
   cron_match "$C_HOUR"  "$B_HOUR" || continue
   cron_match "$C_MONTH" "$B_MON"  || continue
   # Standard cron day rule: when BOTH day-of-month and day-of-week are restricted
@@ -107,7 +122,7 @@ done
 
 # Due iff we haven't dispatched since that slot's scheduled time.
 if [ "$DUE_SLOT" -ge 0 ] && [ "$LAST_EPOCH" -lt "$DUE_SLOT" ]; then
-  "$DATE" -u -d "@$DUE_SLOT" +%FT%TZ
+  format_epoch "$DUE_SLOT" +%FT%TZ
   exit 0
 fi
 exit 1

--- a/scripts/tests/test_cron_due.sh
+++ b/scripts/tests/test_cron_due.sh
@@ -1,20 +1,34 @@
 #!/usr/bin/env bash
 # Tests for scripts/cron-due.sh — the exact-slot "debt" scheduler decision.
 # Run:  bash scripts/tests/test_cron_due.sh
-# On macOS/BSD:  AEON_DATE=gdate bash scripts/tests/test_cron_due.sh
 set -uo pipefail
 
 SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/cron-due.sh"
 DATE="${AEON_DATE:-date}"
 [ -n "${AEON_DATE:-}" ] && export AEON_DATE
 
+if "$DATE" --version >/dev/null 2>&1; then
+  DATE_FLAVOR=gnu
+else
+  DATE_FLAVOR=bsd
+fi
+
+parse_iso() {
+  local value="$1"
+  if [ "$DATE_FLAVOR" = gnu ]; then
+    "$DATE" -u -d "$value" +%s
+  else
+    "$DATE" -j -u -f '%Y-%m-%dT%H:%M:%SZ' "$value" +%s
+  fi
+}
+
 pass=0; fail=0
 # check <desc> <schedule> <now-iso> <last-iso|never> <catchup_hours> <expect: due|skip>
 check() {
   local desc="$1" sched="$2" now="$3" last="$4" catch="$5" expect="$6"
   local now_e last_e out rc
-  now_e=$("$DATE" -u -d "$now" +%s)
-  if [ "$last" = "never" ]; then last_e=0; else last_e=$("$DATE" -u -d "$last" +%s); fi
+  now_e=$(parse_iso "$now")
+  if [ "$last" = "never" ]; then last_e=0; else last_e=$(parse_iso "$last"); fi
   if out=$(bash "$SCRIPT" "$sched" "$now_e" "$last_e" "$catch" 2>/dev/null); then rc=due; else rc=skip; fi
   if [ "$rc" = "$expect" ]; then
     pass=$((pass+1))


### PR DESCRIPTION
## why

`scripts/cron-due.sh` and its test use GNU `date -d`, so the cron test fails on a stock macOS checkout before it can exercise the scheduler. The existing `AEON_DATE=gdate` escape hatch works only after installing GNU coreutils.

This is a local-development portability issue, not evidence that the Linux production scheduler is broken.

## fix

Detect the available `date` implementation and use its native syntax:

- GNU: `date -d`
- BSD/macOS: `date -r` for epoch formatting and `date -j -f` for ISO parsing

`AEON_DATE` remains available for explicit binary overrides.

## verification

- `bash scripts/tests/test_cron_due.sh` — 38 passed, 0 failed with stock macOS `date`
- `AEON_DATE=date bash scripts/tests/test_cron_due.sh` — 38 passed, 0 failed
- `AEON_DATE=gdate bash scripts/tests/test_cron_due.sh` — 38 passed, 0 failed with GNU date
- `bash -n scripts/cron-due.sh scripts/tests/test_cron_due.sh` — passed
- `git diff --check` — passed
