### PR TITLE
chore(plugin): prep operator-console plugin for OpenAI submission

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aeon",
   "version": "0.1.0",
-  "description": "Operator console for an Aeon agent instance: enable/schedule/edit skills, wire secrets and channels, debug runs, and mine past Claude Code chats into scheduled skills.",
+  "description": "Operator console for an Aeon agent instance: enable/schedule/edit skills, wire secrets and channels, debug runs, and mine past coding-agent chats into scheduled skills.",
   "author": {
     "name": "Aeon Inc",
     "url": "https://github.com/aeonfun"

--- a/plugin/skills/aeon/SKILL.md
+++ b/plugin/skills/aeon/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aeon
-description: Set up and run an Aeon agent instance — get started from scratch, pick which skills to turn on or install more from packs, reschedule or change what runs, edit what an existing skill does, fix a skill that isn't firing, set the STRATEGY.md north star and soul/ voice, turn a Claude Code chat into a scheduled Aeon skill, and mine past Claude Code conversations for recurring work worth automating as a skill. Use when the user mentions Aeon, aeon.yml, an Aeon skill / instance / routine / pack, asks to schedule, enable, edit, or debug an agent that runs on a cron, or asks what of their repeated/manual work Aeon could take over.
+description: Set up and run an Aeon agent instance — get started from scratch, pick which skills to turn on or install more from packs, reschedule or change what runs, edit what an existing skill does, fix a skill that isn't firing, set the STRATEGY.md north star and soul/ voice, turn a coding-agent chat into a scheduled Aeon skill, and mine past coding-agent conversations for recurring work worth automating as a skill. Use when the user mentions Aeon, aeon.yml, an Aeon skill / instance / routine / pack, asks to schedule, enable, edit, or debug an agent that runs on a cron, or asks what of their repeated/manual work Aeon could take over.
 ---
 
 # Aeon
@@ -18,7 +18,7 @@ Pick the mode they're asking for:
 | **5 · Edit a skill** | Change what an existing skill does |
 | **6 · What to turn on** | Pick skills, browse packs, install more |
 | **7 · Strategy & voice** | `STRATEGY.md` and `soul/` — the north star and the tone |
-| **8 · Mine history → skill** | "What of my repeated work could Aeon do for me?" — surface it from past Claude Code chats |
+| **8 · Mine history → skill** | "What of my repeated work could Aeon do for me?" — surface it from past coding-agent chats |
 
 ## Preflight (every mode)
 
@@ -189,7 +189,7 @@ Note: GitHub only delivers ~10% of `*/5` cron ticks, so the scheduler catches up
 
 ## Mode 4 — Turn this chat into a skill
 
-They just did something in Claude Code and want it to happen on a schedule.
+They just did something in this chat and want it to happen on a schedule.
 
 1. **Write the skill file.** `skills/<name>/SKILL.md` — frontmatter, then the prompt. Derive it from what actually happened in the session:
    - the prompt body = what they asked for, plus the steps that worked
@@ -373,7 +373,7 @@ By default Aeon has no personality. `soul/SOUL.md` (identity, worldview, opinion
 
 ## Mode 8 — Mine history for skills to automate
 
-"What am I doing by hand over and over that Aeon could just do?" Mode 4 turns *this* chat into a skill; Mode 8 mines *past* chats to find which chat is worth turning into one. It reads the operator's local Claude Code transcripts (`~/.claude/projects/*/*.jsonl`), so it only works on their own machine — never inside an Aeon run.
+"What am I doing by hand over and over that Aeon could just do?" Mode 4 turns *this* chat into a skill; Mode 8 mines *past* chats to find which chat is worth turning into one. It reads the operator's local coding-agent transcripts (`~/.claude/projects` or `~/.codex/sessions`), so it only works on their own machine — never inside an Aeon run.
 
 1. **Scan.** Run the miner from the instance repo root:
 

--- a/plugin/skills/aeon/SKILL.md
+++ b/plugin/skills/aeon/SKILL.md
@@ -378,7 +378,7 @@ By default Aeon has no personality. `soul/SOUL.md` (identity, worldview, opinion
 1. **Scan.** Run the miner from the instance repo root:
 
    ```bash
-   node ${CLAUDE_PLUGIN_ROOT}/skills/aeon/scripts/mine-history.mjs --days 45 --top 15
+   node "${PLUGIN_ROOT:-$CLAUDE_PLUGIN_ROOT}/skills/aeon/scripts/mine-history.mjs" --days 45 --top 15
    ```
 
    It parses every top-level session in the window (skips subagent sidechains), normalises shell commands to `binary subcommand`, groups session titles, and prints a digest ranked by **distinct sessions × distinct days** — recurrence and cadence, not raw volume. Flags: `--days N` (window, default 120), `--project SUBSTR` (only sessions whose cwd matches — scope to one repo/topic), `--top N`, `--min-sessions N`, `--json`. It has no dependencies and reverts to a clean error if there's no history. Deeper reading of the tables and the candidate rubric: `references/history-mining.md`.

--- a/plugin/skills/aeon/references/history-mining.md
+++ b/plugin/skills/aeon/references/history-mining.md
@@ -1,6 +1,6 @@
 # History mining — deep reference (Mode 8)
 
-`scripts/mine-history.mjs` reads the operator's local Claude Code transcripts and
+`scripts/mine-history.mjs` reads the operator's local coding-agent transcripts and
 surfaces recurring work that could become a scheduled Aeon skill. This file is the
 detail behind Mode 8: what the tool reads, how it ranks, and how to turn a digest
 row into a real skill without proposing junk.
@@ -8,7 +8,8 @@ row into a real skill without proposing junk.
 ## What it reads
 
 Claude Code writes one JSONL transcript per session under
-`~/.claude/projects/<encoded-cwd>/<session-uuid>.jsonl`. Each line is a record;
+`~/.claude/projects/<encoded-cwd>/<session-uuid>.jsonl`; Codex writes one under
+`~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`. Each line is a record;
 the ones the miner uses:
 
 | record `type` | field | used for |
@@ -104,7 +105,7 @@ Always convert to UTC and confirm the next 3 fire times in their timezone
 ## Privacy
 
 Transcripts are the operator's own and can contain anything they've ever pasted
-into Claude Code. The miner only emits **aggregates** — command patterns, grouped
+into the coding agent. The miner only emits **aggregates** — command patterns, grouped
 titles, counts. Keep it that way: never surface a raw prompt body, and never write
 transcript contents into a committed file or a notification. The counts and titles
 carry all the signal needed to decide what to automate.
@@ -127,10 +128,10 @@ node ${CLAUDE_PLUGIN_ROOT}/skills/aeon/scripts/mine-history.mjs --project my-rep
 node ${CLAUDE_PLUGIN_ROOT}/skills/aeon/scripts/mine-history.mjs --json | jq '.titles'
 ```
 
-Needs only Node (>=16) and a local `~/.claude/projects` — it exits with a clear
+Needs only Node (>=16) and a local `~/.claude/projects` or `~/.codex/sessions` - it exits with a clear
 message anywhere that directory is absent (e.g. a CI checkout), and never writes
 anything. If a busy background app dominates the tables (a tool that itself drives
-Claude Code will pile up near-identical sessions), scope past it with `--project`.
+a coding agent will pile up near-identical sessions), scope past it with `--project`.
 
 ### Flags
 
@@ -145,7 +146,7 @@ Claude Code will pile up near-identical sessions), scope past it with `--project
 ### Sample output (synthetic)
 
 ```
-# Automation candidates — mined from Claude Code history
+# Automation candidates - mined from coding-agent history
 
 Scanned 240 sessions (240 files, last 45 days) across 38 active days.
 

--- a/plugin/skills/aeon/references/history-mining.md
+++ b/plugin/skills/aeon/references/history-mining.md
@@ -116,16 +116,16 @@ From the instance repo root, on the operator's own machine:
 
 ```bash
 # default: last 120 days, markdown digest
-node ${CLAUDE_PLUGIN_ROOT}/skills/aeon/scripts/mine-history.mjs
+node "${PLUGIN_ROOT:-$CLAUDE_PLUGIN_ROOT}/skills/aeon/scripts/mine-history.mjs"
 
 # a tighter recent window, more rows
-node ${CLAUDE_PLUGIN_ROOT}/skills/aeon/scripts/mine-history.mjs --days 45 --top 20
+node "${PLUGIN_ROOT:-$CLAUDE_PLUGIN_ROOT}/skills/aeon/scripts/mine-history.mjs" --days 45 --top 20
 
 # scope to one repo/topic (matches the session's cwd)
-node ${CLAUDE_PLUGIN_ROOT}/skills/aeon/scripts/mine-history.mjs --project my-repo
+node "${PLUGIN_ROOT:-$CLAUDE_PLUGIN_ROOT}/skills/aeon/scripts/mine-history.mjs" --project my-repo
 
 # machine-readable, to post-process
-node ${CLAUDE_PLUGIN_ROOT}/skills/aeon/scripts/mine-history.mjs --json | jq '.titles'
+node "${PLUGIN_ROOT:-$CLAUDE_PLUGIN_ROOT}/skills/aeon/scripts/mine-history.mjs" --json | jq '.titles'
 ```
 
 Needs only Node (>=16) and a local `~/.claude/projects` or `~/.codex/sessions` - it exits with a clear

--- a/plugin/skills/aeon/scripts/mine-history.mjs
+++ b/plugin/skills/aeon/scripts/mine-history.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
-// mine-history.mjs — scan local Claude Code conversation history and surface
+// mine-history.mjs — scan local coding-agent conversation history and surface
 // recurring work worth turning into a scheduled Aeon skill.
 //
-// OPERATOR-SIDE ONLY. Reads ~/.claude/projects/*/*.jsonl (local Claude Code
-// transcripts). Does nothing on GitHub Actions (no history there) — the aeon
+// OPERATOR-SIDE ONLY. Reads local transcripts under ~/.claude/projects (Claude
+// Code) and ~/.codex/sessions (Codex). Does nothing on GitHub Actions (no
+// history there) — the aeon
 // `aeon` skill invokes it during skill authoring (Mode 8), never at run time.
 //
 // It does the mechanical part — parse transcripts, normalise commands, count
@@ -40,9 +41,15 @@ const PROJECT = opt('--project', '');
 const MIN_SESSIONS = parseInt(opt('--min-sessions', '2'), 10);
 const JSON_OUT = flag('--json');
 
-const ROOT = path.join(os.homedir(), '.claude', 'projects');
-if (!fs.existsSync(ROOT)) {
-  console.error(`No Claude history at ${ROOT} — nothing to mine (this is normal off a local machine).`);
+// Coding-agent transcript roots. Claude Code writes
+// ~/.claude/projects/<encoded-cwd>/<session>.jsonl; Codex writes
+// ~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl. Scan whichever exist.
+const ROOTS = [
+  path.join(os.homedir(), '.claude', 'projects'),
+  path.join(os.homedir(), '.codex', 'sessions'),
+].filter((d) => fs.existsSync(d));
+if (!ROOTS.length) {
+  console.error('No coding-agent history found under ~/.claude/projects or ~/.codex/sessions — nothing to mine (this is normal off a local machine).');
   process.exit(2);
 }
 const CUTOFF_MS = Date.now() - DAYS * 86400_000;
@@ -182,6 +189,30 @@ async function scanFile(fp) {
         }
       }
     }
+    // Codex rollout schema (best-effort; refine with real samples). Records are
+    // often wrapped in a `payload`; Claude lines never match these shapes
+    // (`message`/`function_call` + role), so this can't double-count.
+    const px = (d.payload && typeof d.payload === 'object') ? d.payload : d;
+    if (px !== d) {
+      if (px.cwd && !cwd) cwd = px.cwd;
+      if (px.timestamp) { const ts = px.timestamp; if (!minTs || ts < minTs) minTs = ts; if (ts > maxTs) maxTs = ts; }
+    }
+    if (px.type === 'message' && Array.isArray(px.content)) {
+      if (px.role === 'user') {
+        const txt = px.content
+          .map((b) => (b && (b.type === 'input_text' || b.type === 'text')) ? (b.text || '') : '')
+          .join(' ').trim();
+        if (txt.length > 3 && !txt.startsWith('/') && !txt.includes('<system-reminder>')) prompts.push(txt);
+      }
+    } else if (px.type === 'function_call' && /shell/.test(px.name || '')) {
+      let cmd = '';
+      try {
+        const a = JSON.parse(px.arguments || '{}');
+        const cc = a.command;
+        cmd = Array.isArray(cc) ? (cc[cc.length - 1] || cc.join(' ')) : (typeof cc === 'string' ? cc : '');
+      } catch { /* opaque arguments — skip */ }
+      if (cmd) localCmds.push(...normCmd(cmd));
+    }
   }
   if (PROJECT && !cwd.includes(PROJECT)) return false;
   sessionsScanned++;
@@ -227,18 +258,21 @@ async function scanFile(fp) {
 // windowed by mtime for speed.
 function listFiles() {
   const files = [];
-  for (const dir of fs.readdirSync(ROOT)) {
-    const dp = path.join(ROOT, dir);
-    let st; try { st = fs.statSync(dp); } catch { continue; }
-    if (!st.isDirectory()) continue;
-    for (const f of fs.readdirSync(dp)) {
-      if (!f.endsWith('.jsonl')) continue;
-      const fp = path.join(dp, f);
+  // Claude nests one level (projects/<cwd>/*.jsonl); Codex nests by date
+  // (sessions/YYYY/MM/DD/*.jsonl), so walk each root recursively.
+  const walk = (dir) => {
+    let entries;
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+    for (const ent of entries) {
+      const fp = path.join(dir, ent.name);
+      if (ent.isDirectory()) { walk(fp); continue; }
+      if (!ent.name.endsWith('.jsonl')) continue;
       let fst; try { fst = fs.statSync(fp); } catch { continue; }
       if (fst.mtimeMs < CUTOFF_MS) continue;
       files.push(fp);
     }
-  }
+  };
+  for (const root of ROOTS) walk(root);
   return files;
 }
 
@@ -288,7 +322,7 @@ if (JSON_OUT) {
   }, null, 2));
 } else {
   const out = [];
-  out.push(`# Automation candidates — mined from Claude Code history`);
+  out.push(`# Automation candidates — mined from coding-agent history`);
   out.push('');
   out.push(`Scanned **${sessionsScanned}** sessions (${files.length} files, last ${DAYS} days) across **${allDays.size}** active days${PROJECT ? `, project filter \`${PROJECT}\`` : ''}.`);
   out.push('');


### PR DESCRIPTION
Prep the `plugin/` operator-console plugin for submission to the OpenAI plugins directory (skills-only path), per OpenAI's "Submit a Claude Code plugin" guide.

## Why
OpenAI's skills-only conversion rules ask to replace host-product references with neutral language ("the model" / coding agent) and to make bundled scripts work in the Codex environment, not only Claude Code. This plugin ships one skill (`aeon`) with a local history-mining script that was Claude-Code-only.

## Changes
- **Neutralize host-chat / transcript wording** in `SKILL.md`, `references/history-mining.md`, and `.claude-plugin/plugin.json`: "Claude Code chat/conversation/transcript/history" becomes "coding-agent" where it refers to the current chat or the operator's own transcripts. Genuine framework-internal facts (the `claude` harness, `CLAUDE.md` import target, `CLAUDE_CODE_OAUTH_TOKEN`, gateway diagram, the Claude Code install block in the README) are kept - the guide says retain product names when genuinely applicable.
- **`mine-history.mjs`** (Mode 8):
  - Scan both `~/.claude/projects` (Claude Code) and `~/.codex/sessions` (Codex); neutral "no history found" message when neither exists.
  - Walk each root recursively (Codex nests sessions by date), instead of a fixed one-level scan.
  - Add best-effort Codex rollout-schema parsing (payload-wrapped `message`/`function_call` records) so real Codex users get command + prompt signal. Guarded so it can never double-count Claude records.

## Verification
- `node --check` passes; smoke-run against a live `~/.claude/projects` produces the same digest as before (no Claude-side regression).
- No `.mcp.json` / `CLAUDE.md` / `marketplace.json` inside `plugin/`; skills-only, so domain challenge / CSP / MCP tool annotations do not apply.

## Not in this PR (human-only, portal side)
Identity verification (Aeon Inc), Apps Management write role, listing assets (logo, support/privacy/terms URLs), 5 positive + 3 negative test cases, country availability, release notes. Codex `${CLAUDE_PLUGIN_ROOT}` resolution to confirm in the portal test env.
