### PR TITLE
docs: fix stale harness/MCP catalog counts (six->seven, four->every, +higgsfield)

### DIFF
--- a/.claude/skills/aeon/references/mcp.md
+++ b/.claude/skills/aeon/references/mcp.md
@@ -119,7 +119,7 @@ If a provider rotates the refresh token on each use, the old one dies immediatel
 
 Writing a secret needs a secrets-write credential, and **the default `GITHUB_TOKEN` cannot do it.** Add a fine-grained PAT with **Secrets: read/write** as **`GH_SECRETS_PAT`** (or repo-wide `GH_GLOBAL`).
 
-**All four catalog providers rotate — treat the PAT as required, not optional.**
+**Every catalog provider rotates - treat the PAT as required, not optional.**
 
 After adding the PAT, **re-connect the affected server once**. A refresh token already consumed by an earlier run can't be revived by the PAT alone.
 

--- a/docs/mcp-oauth.md
+++ b/docs/mcp-oauth.md
@@ -50,6 +50,7 @@ discovery notes) and their companion skills:
 | Executor (`executor`) | `executor.sh/mcp` | `openid offline_access` | yes — **verified live 2026-07-16** | `executor-mcp` |
 | Finance District Agent Wallet (`finance-district`) | `wallet-mcp.fd.xyz` | `openid offline_access api://fd-agent-wallet-mcp/mcp:tools` (resource scope gates tool access) | yes | `finance-district-mcp` |
 | PostHog (`posthog`) | `mcp.posthog.com/mcp` | `openid user:read organization:read project:read error_tracking:read` (read scopes only; `user:read` is required or the session 403s on init) | unverified — assume yes (no `offline_access`; refresh via the `refresh_token` grant) | `posthog-errors` |
+| Higgsfield (`higgsfield`) | `mcp.higgsfield.ai/mcp` | `openid email offline_access` | yes | `higgsfield` |
 
 The glim and Executor loops were verified end-to-end on a live instance
 (Connect → per-run refresh → PAT-persisted rotation → refresh off the persisted

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Aeon
 
-> Aeon is an autonomous agent framework. It runs your own skills on a schedule in GitHub Actions, keeps state in git-committed memory, and dispatches every run through one harness adapter that works across six coding-agent CLIs (Claude Code, Codex, Grok, Kimi, Pi, Vibe). Skills are Markdown with a spec-form frontmatter; a least-privilege `requires:` -> dashboard vault contract wires secrets. Fork the repo, turn skills on, and it runs itself.
+> Aeon is an autonomous agent framework. It runs your own skills on a schedule in GitHub Actions, keeps state in git-committed memory, and dispatches every run through one harness adapter that works across seven coding-agent CLIs (Claude Code, Codex, Grok, Kimi, Pi, Vibe, fx). Skills are Markdown with a spec-form frontmatter; a least-privilege `requires:` -> dashboard vault contract wires secrets. Fork the repo, turn skills on, and it runs itself.
 
 Repo: https://github.com/aeonfun/aeon
 Site: https://aeon.fun
@@ -28,7 +28,7 @@ Site: https://aeon.fun
 
 ## Harnesses and integrations
 
-- [docs/harnesses.md](https://raw.githubusercontent.com/aeonfun/aeon/main/docs/harnesses.md): Advanced harness behavior across the six supported coding-agent CLIs.
+- [docs/harnesses.md](https://raw.githubusercontent.com/aeonfun/aeon/main/docs/harnesses.md): Advanced harness behavior across the seven supported coding-agent CLIs.
 - [harness-adapter/README.md](https://raw.githubusercontent.com/aeonfun/aeon/main/harness-adapter/README.md): The single dispatch path that translates one tool grammar to every harness.
 - [docs/mcp-oauth.md](https://raw.githubusercontent.com/aeonfun/aeon/main/docs/mcp-oauth.md): Durable dashboard OAuth for OAuth-gated MCP servers.
 - [docs/telegram-commands.md](https://raw.githubusercontent.com/aeonfun/aeon/main/docs/telegram-commands.md): The inbound Telegram command surface.

--- a/plugin/skills/aeon/references/mcp.md
+++ b/plugin/skills/aeon/references/mcp.md
@@ -119,7 +119,7 @@ If a provider rotates the refresh token on each use, the old one dies immediatel
 
 Writing a secret needs a secrets-write credential, and **the default `GITHUB_TOKEN` cannot do it.** Add a fine-grained PAT with **Secrets: read/write** as **`GH_SECRETS_PAT`** (or repo-wide `GH_GLOBAL`).
 
-**All four catalog providers rotate — treat the PAT as required, not optional.**
+**Every catalog provider rotates - treat the PAT as required, not optional.**
 
 After adding the PAT, **re-connect the affected server once**. A refresh token already consumed by an earlier run can't be revived by the PAT alone.
 


### PR DESCRIPTION
Fixes stale harness/MCP counts found in a factual audit of both repos. All are current-state literal surfaces (not historical records).

## Harness count
- **`llms.txt`** — the agent-discovery doc map still said **six** coding-agent CLIs. Now **seven**:
  - line 3 summary: "works across six coding-agent CLIs (Claude Code, Codex, Grok, Kimi, Pi, Vibe)" -> seven, **+fx**.
  - line 31 harnesses.md pointer: "six supported coding-agent CLIs" -> seven.

## MCP OAuth catalog
- **`docs/mcp-oauth.md`** "Current catalog" table listed **6** OAuth servers but the real catalog has **7** (`oauth: true` in `apps/dashboard/lib/mcp-catalog.ts`). Added the missing **Higgsfield** row (`mcp.higgsfield.ai/mcp`, `openid email offline_access`, rotates, skill `higgsfield`).
- **Setup-skill `references/mcp.md`** (`.claude/skills/aeon/` + the byte-identical `plugin/skills/aeon/` copy) said **"All four catalog providers rotate"** — stale digit (real = 7). Changed to the durable phrasing **"Every catalog provider rotates"** (matches `docs/mcp-oauth.md`), and normalized the pre-existing em dash on that line to a hyphen (house style). The hosted website mirror is fixed in a companion PR on aeon-website.

## Not touched (deliberate, verified accurate)
- `harness-adapter/README.md` "## The six harnesses" heading + `docs/harnesses.md` "verified 2026-07-22 / all six" — these describe the **6-harness live-tested matrix**; the same files state seven and document fx as the 7th adapter "mechanically verified, not yet in the live matrix." Accurate nuance, left as-is.
- Non-user-facing code comments with old literals (`scripts/skill-scan.sh` "67 skills", website CSS "102 SKILLS") — invisible, out of scope.
- All "seven harnesses" and "76 skills" current-state spots verified correct.
