### PR TITLE
chore: silence two shellcheck false positives (not bugs)

### DIFF
--- a/scripts/audit.sh
+++ b/scripts/audit.sh
@@ -35,6 +35,10 @@ case "$EXITCODE" in ''|*[!0-9]*) EXITCODE=0 ;; esac
 redact() {
   local s="$1" name val enc
   while IFS= read -r name; do
+    # *_API_KEY and *_PRIVATE_KEY are subsumed by *_KEY (identical body: keep and
+    # redact), so they are kept only as explicit documentation of what this list
+    # covers. That is why shellcheck flags the overlap here as intentional.
+    # shellcheck disable=SC2221,SC2222
     case "$name" in
       *_API_KEY|*_KEY|*_TOKEN|*_SECRET|*_PAT|*_WEBHOOK_URL|*_PRIVATE_KEY|*_CHAT_ID|*_CHANNEL_ID) ;;
       *) continue ;;

--- a/scripts/skill-scan.sh
+++ b/scripts/skill-scan.sh
@@ -175,6 +175,9 @@ DEFENSIVE_CONTEXT='never follow|do not follow|do not obey|never obey|ignore (it|
 INJECTION_CITED='["`][^"`]*([Ii]gnore|[Ff]orget|[Dd]isregard|[Oo]verride|[Yy]ou[[:space:]]+are[[:space:]]+now)[^"`]*["`]'
 
 # MEDIUM severity: suspicious patterns that may or may not be intentional
+# shellcheck disable=SC2088  # these are literal grep patterns matched against
+# skill text (looking for references to ~/.ssh, ~/.aws, etc.), not paths to
+# expand. A literal ~ is exactly what we want here.
 MEDIUM_PATTERNS=(
   # Path traversal
   '\.\./\.\.'


### PR DESCRIPTION
Follow-up to #962. Clears the two shellcheck advisory findings it called out, shrinking the shell backlog toward a future warning-severity gate.

**On inspection, neither is a bug** - so both are suppressed with rationale, not "fixed". Zero behavior change (comment/directive only).

| file | code | reality | action |
|------|------|---------|--------|
| `scripts/skill-scan.sh` | SC2088 | `~/.ssh`, `~/.aws`, ... are literal **grep patterns** matched against skill text, not paths to expand. Expanding to `$HOME` would break the scan. | `# shellcheck disable=SC2088` + note |
| `scripts/audit.sh` | SC2221/2222 | `*_API_KEY` / `*_PRIVATE_KEY` are subsumed by `*_KEY`, but every branch shares one body (keep + redact). Overlap is harmless; patterns kept as explicit coverage docs. | `# shellcheck disable=SC2221,SC2222` + note |

Advisory backlog: 39 -> 26. Gate still green.

**Verified:** `test_audit.sh` (11/11) and `test_skill_scan_calibration.sh` (all fixtures) pass; `bash scripts/lint-shell.sh` exit 0; the two codes report 0 findings.
