### PR TITLE
feat(plugin): Agent Plugins plugin.json + privacy/support for Kiro Powers

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -41,6 +41,12 @@ at your instance repo when it asks.
 Everything the skill does is plain `gh` + `./aeon` commands, so nothing about it is
 tied to one coding agent beyond where the skill file is loaded from.
 
+## Privacy and support
+
+- Privacy Policy: https://aeon.fun/privacy
+- Support: email aaron@aeon.fun, or open an issue at https://github.com/aeonfun/aeon/issues
+- Security: see [`SECURITY.md`](./SECURITY.md)
+
 ## License
 
 MIT - see [`LICENSE`](./LICENSE).

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "aeon",
+  "version": "0.1.0",
+  "description": "Operator console for an Aeon agent instance: enable, schedule, and edit skills, wire secrets and channels, debug runs, and mine past coding-agent chats into scheduled skills.",
+  "author": {
+    "name": "Aeon Inc",
+    "url": "https://aeon.fun",
+    "email": "aaron@aeon.fun"
+  },
+  "keywords": ["aeon", "agent", "skills", "automation", "github-actions", "cron", "scheduled-agents"],
+  "license": "MIT",
+  "homepage": "https://aeon.fun",
+  "repository": "https://github.com/aeonfun/aeon"
+}


### PR DESCRIPTION
Adds what the Kiro Powers registry (kiro.dev/powers/submit) requires so the operator-console plugin can be submitted against the existing aeonfun/aeon repo, no separate power repo needed.

- `plugin/plugin.json`: Agent Plugins format (agent-plugins.org schema 1.0.0) with `$schema`, `name`, `version`, `description`, `author` (name + url + email), `keywords`, `license` (MIT), `homepage`, `repository`. Sits alongside the existing `.claude-plugin` / `.codex-plugin` manifests and the skill under `plugin/skills/aeon`.
- `plugin/README.md`: adds Privacy Policy (aeon.fun/privacy), Support (email + issues), and Security links, all required by Kiro's submission checklist.

No MCP server is bundled; the power is the existing operator skill. Purely additive.
