### PR TITLE
add machine-readable vuln scanner execution evidence

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -1051,6 +1051,17 @@ jobs:
 
       # Egress hardening P2: publish the warn-mode audit log. always() so it lands
       # even if the run failed; the host list is the allowlist oracle P3 builds from.
+      - name: Upload egress audit log
+        if: always() && vars.EGRESS_AUDIT == '1'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: egress-${{ steps.skill.outputs.name }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/iron/audit.jsonl
+          if-no-files-found: ignore
+
+      # Prove the vuln-scanner actually invoked a scanner: the staged wrappers log
+      # each call to executions.log; model prose is not execution evidence. Best-effort,
+      # warnings only, never gates the run.
       - name: Verify vuln-scanner execution evidence
         if: always() && steps.work.outputs.mode != '' && steps.skill.outputs.name == 'vuln-scanner'
         run: |
@@ -1080,14 +1091,6 @@ jobs:
               echo "${tool}=not-observed-or-not-applicable"
             fi
           done
-
-      - name: Upload egress audit log
-        if: always() && vars.EGRESS_AUDIT == '1'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: egress-${{ steps.skill.outputs.name }}-${{ github.run_id }}
-          path: ${{ runner.temp }}/iron/audit.jsonl
-          if-no-files-found: ignore
 
       # Undo "Single-source standing instructions" so the working tree matches HEAD
       # before any capture/guard/commit step runs. always(): the file must come back

--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -1064,6 +1064,22 @@ jobs:
             echo 'executions=none'
             echo '::warning::vuln-scanner produced no machine-readable scanner invocation evidence'
           fi
+          echo '--- per-tool execution status ---'
+          for tool in semgrep trufflehog osv-scanner; do
+            if [ -s /tmp/vuln-scan/executions.log ] && grep -q "^${tool} " /tmp/vuln-scan/executions.log; then
+              echo "${tool}=observed"
+            else
+              echo "${tool}=not-observed"
+              echo "::warning::${tool} was staged but no invocation was recorded"
+            fi
+          done
+          for tool in slither cargo-fuzz; do
+            if [ -s /tmp/vuln-scan/executions.log ] && grep -q "^${tool} " /tmp/vuln-scan/executions.log; then
+              echo "${tool}=observed"
+            else
+              echo "${tool}=not-observed-or-not-applicable"
+            fi
+          done
 
       - name: Upload egress audit log
         if: always() && vars.EGRESS_AUDIT == '1'

--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -1051,6 +1051,20 @@ jobs:
 
       # Egress hardening P2: publish the warn-mode audit log. always() so it lands
       # even if the run failed; the host list is the allowlist oracle P3 builds from.
+      - name: Verify vuln-scanner execution evidence
+        if: always() && steps.work.outputs.mode != '' && steps.skill.outputs.name == 'vuln-scanner'
+        run: |
+          set -u
+          echo '--- staged scanner manifest ---'
+          if [ -f /tmp/vuln-scan/prefetch.txt ]; then cat /tmp/vuln-scan/prefetch.txt; else echo 'manifest=missing'; fi
+          echo '--- actual scanner invocations ---'
+          if [ -s /tmp/vuln-scan/executions.log ]; then
+            cat /tmp/vuln-scan/executions.log
+          else
+            echo 'executions=none'
+            echo '::warning::vuln-scanner produced no machine-readable scanner invocation evidence'
+          fi
+
       - name: Upload egress audit log
         if: always() && vars.EGRESS_AUDIT == '1'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/scripts/stage-vuln-scanner.sh
+++ b/scripts/stage-vuln-scanner.sh
@@ -41,6 +41,23 @@ MANIFEST=/tmp/vuln-scan/prefetch.txt
 log()    { echo "stage-vuln-scanner: $*"; }
 record() { echo "$1=$2" >> "$MANIFEST"; }   # tool=installed|fail|skipped
 
+# Keep machine-readable evidence that the agent actually invoked a scanner. The
+# post-run workflow check reads this file; model prose is not execution evidence.
+EXEC_LOG=/tmp/vuln-scan/executions.log
+: > "$EXEC_LOG"
+
+instrument() { # command name, real executable
+  local name="$1" real="$2" wrapper="$BIN/$1"
+  [ -x "$real" ] || return 0
+  mv "$real" "$BIN/.${name}.real" 2>/dev/null || return 0
+  cat > "$wrapper" <<EOF
+#!/usr/bin/env bash
+printf '%s %s\\n' '$name' "\$*" >> '$EXEC_LOG'
+exec '$BIN/.${name}.real' "\$@"
+EOF
+  chmod +x "$wrapper"
+}
+
 pip_install() { # package
   pip install --quiet "$1" 2>/dev/null \
     || pip3 install --quiet "$1" 2>/dev/null \
@@ -116,6 +133,13 @@ else
   log "cargo-fuzz not installed (optional — only used for repos shipping fuzz/fuzz_targets)"
   record cargo-fuzz skipped
 fi
+
+# Wrap staged binaries after installation so every actual invocation is recorded.
+instrument semgrep "$(command -v semgrep 2>/dev/null || true)"
+instrument trufflehog "$BIN/trufflehog"
+instrument osv-scanner "$BIN/osv-scanner"
+instrument slither "$(command -v slither 2>/dev/null || true)"
+instrument cargo-fuzz "$(command -v cargo-fuzz 2>/dev/null || true)"
 
 log "manifest (/tmp/vuln-scan/prefetch.txt):"
 cat "$MANIFEST"

--- a/scripts/stage-vuln-scanner.sh
+++ b/scripts/stage-vuln-scanner.sh
@@ -50,6 +50,7 @@ instrument() { # command name, real executable
   local name="$1" real="$2" wrapper="$BIN/$1"
   [ -x "$real" ] || return 0
   mv "$real" "$BIN/.${name}.real" 2>/dev/null || return 0
+  rm -f "$wrapper"   # drop any dangling symlink so the heredoc writes a plain file into $BIN
   cat > "$wrapper" <<EOF
 #!/usr/bin/env bash
 printf '%s %s\\n' '$name' "\$*" >> '$EXEC_LOG'


### PR DESCRIPTION
## why

A vuln-scanner run can stage Semgrep, TruffleHog, OSV-Scanner, Slither, and cargo-fuzz successfully while the harness report says they were skipped. Model prose cannot prove whether a scanner actually ran.

## fix

- wrap staged scanner binaries with a tiny execution logger
- add a post-run workflow step that prints the staged manifest and actual invocation log
- warn explicitly when no scanner invocation evidence exists

This keeps the existing best-effort behavior and does not turn an absent optional scanner into a workflow failure.

## verification

- `git diff --check` passed
- shellcheck is not installed in the local environment
- branch diff is limited to `scripts/stage-vuln-scanner.sh` and `.github/workflows/aeon.yml`
- real Cursor run `32931159345` demonstrated the evidence gap: staging succeeded, but the agent report claimed all scanners were skipped
