### PR TITLE
fix(mcp-server): run skills async with a single-flight queue

### DIFF
--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -116,7 +116,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools }));
 
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const toolName = request.params.name;
-  return tracer.startActiveSpan(`mcp.call_tool ${toolName}`, (span) => {
+  return tracer.startActiveSpan(`mcp.call_tool ${toolName}`, async (span) => {
     const slug = toolNameToSlug(toolName);
     const skill = skills.find((s) => s.slug === slug);
     span.setAttribute("aeon.mcp.tool", toolName);
@@ -140,7 +140,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     try {
       const varArg = request.params.arguments?.var;
       const varValue = typeof varArg === "string" ? varArg : "";
-      const output = runSkill(REPO_ROOT, slug, varValue, LOG_PREFIX);
+      const output = await runSkill(REPO_ROOT, slug, varValue, LOG_PREFIX);
       span.setAttribute("aeon.output_bytes", output.length);
       return {
         content: [{ type: "text" as const, text: output }],

--- a/apps/mcp-server/src/skill-executor.ts
+++ b/apps/mcp-server/src/skill-executor.ts
@@ -10,7 +10,7 @@
 
 import { readFileSync, existsSync } from "fs";
 import { join } from "path";
-import { spawnSync } from "child_process";
+import { spawn, spawnSync } from "child_process";
 
 export interface Skill {
   slug: string;
@@ -127,19 +127,134 @@ function resolveMode(repoRoot: string, slug: string): { mode: string; allowedToo
   return { mode, allowedTools };
 }
 
+// Single-flight queue. spawnSync used to serialize runs by freezing the event
+// loop; moving to async spawn removes that accidental lock, so runs must be
+// serialized explicitly. Every run shares `cwd: repoRoot`, so two concurrent
+// write-mode skills would race the same working tree: `.git/index.lock`
+// collisions on commit, plus interleaved writes to memory/, output/ and
+// cron-state.json. This keeps one skill running at a time; a second tools/call
+// waits its turn instead of corrupting the tree.
+let runQueue: Promise<unknown> = Promise.resolve();
+function enqueue<T>(task: () => Promise<T>): Promise<T> {
+  const result = runQueue.then(task, task);
+  // Keep the chain alive regardless of this run's outcome so one failure does
+  // not wedge every later run.
+  runQueue = result.then(
+    () => undefined,
+    () => undefined
+  );
+  return result;
+}
+
+interface HarnessResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  error?: NodeJS.ErrnoException;
+}
+
 /**
- * Run a skill synchronously and return its text output. Dispatches through
+ * Async replacement for spawnSync with the same result shape
+ * (status/stdout/stderr/error) so the parsing below is unchanged, but it awaits
+ * `close` instead of blocking the Node event loop for the whole 10-minute run.
+ * Enforces the same timeout and combined output cap, surfacing each as `error`
+ * the way spawnSync did (ETIMEDOUT / ENOBUFS).
+ */
+function spawnHarness(
+  args: string[],
+  opts: {
+    input: string;
+    cwd: string;
+    env: NodeJS.ProcessEnv;
+    timeout: number;
+    maxBuffer: number;
+  }
+): Promise<HarnessResult> {
+  return new Promise((resolve) => {
+    const child = spawn("bash", args, { cwd: opts.cwd, env: opts.env });
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let killReason: "timeout" | "buffer" | null = null;
+
+    const timer = setTimeout(() => {
+      killReason = "timeout";
+      child.kill("SIGKILL");
+    }, opts.timeout);
+
+    const capture = (chunk: Buffer, sink: "out" | "err") => {
+      if (sink === "out") stdout += chunk.toString("utf-8");
+      else stderr += chunk.toString("utf-8");
+      if (stdout.length + stderr.length > opts.maxBuffer) {
+        killReason = "buffer";
+        child.kill("SIGKILL");
+      }
+    };
+    child.stdout.on("data", (c: Buffer) => capture(c, "out"));
+    child.stderr.on("data", (c: Buffer) => capture(c, "err"));
+
+    const finish = (r: HarnessResult) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(r);
+    };
+
+    child.on("error", (err) =>
+      finish({ status: null, stdout, stderr, error: err as NodeJS.ErrnoException })
+    );
+    child.on("close", (code) => {
+      let error: NodeJS.ErrnoException | undefined;
+      if (killReason === "timeout") {
+        error = Object.assign(
+          new Error(`run-harness timed out after ${opts.timeout} ms`),
+          { code: "ETIMEDOUT" }
+        );
+      } else if (killReason === "buffer") {
+        error = Object.assign(
+          new Error(`run-harness output exceeded ${opts.maxBuffer} bytes`),
+          { code: "ENOBUFS" }
+        );
+      }
+      finish({ status: code, stdout, stderr, error });
+    });
+
+    // Feed the prompt on stdin, matching spawnSync's `input`. Ignore EPIPE if the
+    // child exits before the write finishes.
+    child.stdin.on("error", () => {});
+    child.stdin.write(opts.input);
+    child.stdin.end();
+  });
+}
+
+/**
+ * Run a skill and return its text output. Serialized through `enqueue` (one skill
+ * at a time, since they share the repo working tree) and dispatched through
  * harness-adapter's `run-harness`, which emits one `{ result, usage }` envelope
  * for every harness, so parsing is shared. Failure modes (missing skill, missing
  * CLI, non-zero exit, empty output) are returned as human-readable strings rather
  * than thrown, so callers can surface them without special-casing.
+ *
+ * Async so a running skill no longer freezes the whole stdio MCP server: the old
+ * spawnSync parked the Node event loop for up to 10 minutes per call, blocking
+ * every other request (tools/list, pings, a second tool call). This awaits the
+ * child instead.
  */
 export function runSkill(
   repoRoot: string,
   slug: string,
   varValue: string,
   logPrefix = "[aeon]"
-): string {
+): Promise<string> {
+  return enqueue(() => runSkillInner(repoRoot, slug, varValue, logPrefix));
+}
+
+async function runSkillInner(
+  repoRoot: string,
+  slug: string,
+  varValue: string,
+  logPrefix: string
+): Promise<string> {
   const skillFile = join(repoRoot, "skills", slug, "SKILL.md");
   if (!existsSync(skillFile)) {
     return [
@@ -185,17 +300,16 @@ export function runSkill(
     args.push("--mcp-config", join(repoRoot, ".mcp.json"));
   }
 
-  const result = spawnSync("bash", args, {
+  const result = await spawnHarness(args, {
     input: prompt,
     cwd: repoRoot,
     env: process.env,
-    timeout: 600_000, // 10 minutes — same as the GitHub Actions timeout
+    timeout: 600_000, // 10 minutes - same as the GitHub Actions timeout
     maxBuffer: 10 * 1024 * 1024, // 10 MB
-    encoding: "utf-8",
   });
 
   if (result.error) {
-    const enoent = (result.error as NodeJS.ErrnoException).code === "ENOENT";
+    const enoent = result.error.code === "ENOENT";
     const msg = enoent
       ? `'bash' or harness-adapter/run-harness not found — run from inside an Aeon repo clone.`
       : `Failed to spawn run-harness: ${result.error.message}`;


### PR DESCRIPTION
## Problem

`apps/mcp-server` ran each skill via `spawnSync` with a 600s timeout. `spawnSync` blocks the whole Node event loop, so a single `tools/call` froze the entire stdio MCP server for up to 10 minutes: no `tools/list`, ping, or second tool call could be answered while a skill ran.

## Fix

- Replace `spawnSync` with an async `spawn` (new `spawnHarness` helper) that awaits `close`. Same result shape (`status`/`stdout`/`stderr`/`error`), same 600s timeout and 10MB output cap (enforced via SIGKILL, surfaced as `ETIMEDOUT`/`ENOBUFS`).
- `spawnSync` was also serializing runs by accident. With it gone, concurrent calls would race the shared working tree (`cwd = repoRoot`): `.git/index.lock` on commit, plus interleaved `memory/`, `output/`, `cron-state.json` writes. Add an in-process single-flight queue so one skill runs at a time; a second call waits.
- `index.ts` awaits the now-async `runSkill`; the tracing span callback is async so the span still closes after completion.

No protocol/SDK change - works on the pinned `@modelcontextprotocol/sdk@^1.0.0`. No `gh`/Actions/auth dependency; the local-spawn path is unchanged in behavior.

## Verification

- `npm run typecheck` and `npm run build` clean; server boots and lists skills.
- Fake-harness test, two skills fired concurrently: event loop ticked 21x during the run (0 before - frozen), and the two runs serialized cleanly (`START alpha -> END alpha -> START beta -> END beta`, wall ~2x single-run).
