### PR TITLE
docs: list Farcaster Pack in the community skill-pack registry

### DIFF
--- a/catalog/skill-packs.json
+++ b/catalog/skill-packs.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "updated": "2026-08-04",
+  "updated": "2026-08-27",
   "description": "Machine-readable registry of community skill packs installable via bin/install-skill-pack. Mirrors the human-readable table in README.md.",
   "packs": [
     {
@@ -247,6 +247,19 @@
       "capabilities": [
         "read_only",
         "external_api"
+      ]
+    },
+    {
+      "repo": "amritmirch/aeon-skill-pack-farcaster",
+      "name": "Farcaster Pack",
+      "description": "Publish to Farcaster from Aeon via Neynar. Drafting and publishing are separate branches; the default never posts. Publishing is fail-closed behind a kill-switch, daily cap, dedup ledger, 1024-byte protocol check, and a secret tripwire.",
+      "author": "amritmirch",
+      "license": "MIT",
+      "homepage": "https://github.com/amritmirch/aeon-skill-pack-farcaster",
+      "category": "social",
+      "trust_level": "community",
+      "skills": [
+        "cast"
       ]
     }
   ]

--- a/docs/community-skill-packs.md
+++ b/docs/community-skill-packs.md
@@ -290,3 +290,4 @@ Community skill packs live in their own repos and install as one bundle. The aut
 | [AI2Human Create Task](https://github.com/richard7463/ai2human-aeon-skill-pack) | 1 | Route a blocked human step to AI2Human: dispatch human execution, then follow the proof, verify, settle loop before USDC payout. |
 | [aeon-skill-pack-skim](https://github.com/JessieJanie/aeon-skill-pack-skim) | 1 | Pay-per-call clean web reads via Skim x402: any URL to markdown ~4x smaller than raw HTML, $0.002 USDC on Base, no API key. |
 | [CultOS Aeon Skills](https://github.com/thesmithdao/cultos-aeon-skills) | 1 | Read-only exact-commit pull-request reviews for CultOS ACP jobs. |
+| [aeon-skill-pack-farcaster](https://github.com/amritmirch/aeon-skill-pack-farcaster) | 1 | Publish to Farcaster via Neynar: drafted for review, posted behind a kill-switch, daily cap, dedup ledger, and a 1024-byte protocol check. |


### PR DESCRIPTION
## What

Lists a new community skill pack, [amritmirch/aeon-skill-pack-farcaster](https://github.com/amritmirch/aeon-skill-pack-farcaster), in `catalog/skill-packs.json` and the Listed packs table in `docs/community-skill-packs.md`.

One skill in it so far: **`cast`** — publish a Farcaster cast through Neynar.

## Why

Aeon ships `write-tweet`, `fetch-tweets`, `mention-radar` and `reply-maker` for X, and nothing for Farcaster. `cast` closes the publish half of that gap.

Three things it gets right that are easy to get wrong, in case they are useful reference for other packs:

- **Bytes, not characters.** The protocol caps cast text at 1024 **bytes**, and UTF-8 emoji and CJK cost 2 to 4 bytes each, so a 1024-character cast with emoji is over the limit. The skill measures bytes and blocks rather than letting the API truncate.
- **Drafting and publishing are separate branches**, and the default never posts. Nothing auto-publishes generated text on a schedule. Publishing runs the `send-email` fail-closed shape: kill-switch, config presence, daily cap, dedup ledger, byte check, secret tripwire. The cast text's hash is both the local dedup key and Neynar's `idem` key, so a retried run cannot double-post.
- **Both credentials stay off the command line.** The API key goes through `./secretcurl` as a `{NEYNAR_API_KEY}` placeholder. The signer UUID is a posting credential too, but `secretcurl`'s substitution allowlist is `*_API_KEY|*_KEY|*_TOKEN|*_SECRET|*_PAT|*_WEBHOOK_URL`, which does not cover `*_UUID` — so the request body is built by `python3` reading it from `os.environ`, the pattern `send-email` uses for `RESEND_FROM`.

Verified against a mock Neynar endpoint: happy path, duplicate, kill-switch, unconfigured, daily cap, corrupt ledger, 1200-byte emoji cast, secrets in text, empty draft, HTTP 400, and connection failure each produce the right terminal code, and no failed publish ever reaches the ledger.

## Type of change

- [x] Community skill pack listing

### Community skill pack listing

- [x] Pack repo is public with a clear license (MIT)
- [x] Pack has a `skills-pack.json` manifest at its root and a `SKILL.md` per skill
- [x] Write / onchain / bet skills are `default_enabled: false`
- [x] This PR adds **both** a table row and a matching `skill-packs.json` entry
- [x] `node scripts/validate-skill-packs.mjs` passes
- [x] No monkey-patching of Aeon internals; no private or auth-walled endpoints required to run

`./scripts/validate-pack.sh` on the pack repo: valid, 0 warnings.

Note: the validator's default `--readme` path is `.github/README.md`, which no longer carries the packs table — it lives in `docs/community-skill-packs.md#listed-packs`, where this row was added. The resulting `README has no table — parity unchecked` warning is pre-existing and applies to all 14 entries, not this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)