### PR TITLE
Add Spoolis Outcome Gate skill pack

### DIFF
--- a/catalog/skill-packs.json
+++ b/catalog/skill-packs.json
@@ -261,6 +261,19 @@
       "skills": [
         "cast"
       ]
+    },
+    {
+      "repo": "jsfranklin221/aeon-skill-pack-spoolis",
+      "name": "Spoolis Outcome Gate",
+      "description": "Gate autonomous work on whether it satisfied the agreement: one-call verification against explicit acceptance criteria returns a signed Outcome Receipt with per-unit earned value, plus a chain verdict downstream steps can branch on. Keyless sandbox, zero secrets.",
+      "author": "spoolis",
+      "license": "MIT",
+      "homepage": "https://spoolis.com",
+      "category": "dev",
+      "trust_level": "community",
+      "skills": [
+        "spoolis-outcome-gate"
+      ]
     }
   ]
 }

--- a/docs/community-skill-packs.md
+++ b/docs/community-skill-packs.md
@@ -291,3 +291,4 @@ Community skill packs live in their own repos and install as one bundle. The aut
 | [aeon-skill-pack-skim](https://github.com/JessieJanie/aeon-skill-pack-skim) | 1 | Pay-per-call clean web reads via Skim x402: any URL to markdown ~4x smaller than raw HTML, $0.002 USDC on Base, no API key. |
 | [CultOS Aeon Skills](https://github.com/thesmithdao/cultos-aeon-skills) | 1 | Read-only exact-commit pull-request reviews for CultOS ACP jobs. |
 | [aeon-skill-pack-farcaster](https://github.com/amritmirch/aeon-skill-pack-farcaster) | 1 | Publish to Farcaster via Neynar: drafted for review, posted behind a kill-switch, daily cap, dedup ledger, and a 1024-byte protocol check. |
+| [aeon-skill-pack-spoolis](https://github.com/jsfranklin221/aeon-skill-pack-spoolis) | 1 | Verify delivered work against acceptance criteria: signed Outcome Receipt, per-unit earned value, chain verdict. Keyless sandbox. |


### PR DESCRIPTION
## What

Adds the Spoolis Outcome Gate community skill pack to the catalog, plus its row in the community packs docs table.

## Why

Community skill pack listing: agents gate autonomous work on whether it satisfied the agreed acceptance criteria, with a signed Outcome Receipt and a chain verdict downstream steps can branch on.

## Type of change

- [x] Community skill pack listing

### Community skill pack listing

- Pack repo: https://github.com/jsfranklin221/aeon-skill-pack-spoolis
- One skill: spoolis-outcome-gate
- secrets_required: [] (keyless sandbox; live-tested end to end: gate, verify, receipt, status all pass)
- validate-pack.sh: 0 errors, 0 warnings
- License: MIT