### PR TITLE
docs: sync PRs #957-#979 to aeon docs

### DIFF
--- a/.claude/skills/aeon/SKILL.md
+++ b/.claude/skills/aeon/SKILL.md
@@ -251,7 +251,7 @@ metadata:
 Today is ${today}. <the prompt — plain instructions, including judgment calls>
 
 ## Steps
-1. <the procedure — 43 of 76 skills lead with this>
+1. <the procedure — 43 of 77 skills lead with this>
 
 ## Network note
 <curl / WebFetch / `./secretcurl` / `gh api` — how this skill fetches>
@@ -311,9 +311,9 @@ Three at a time, not twelve. Every enabled skill is a recurring notification, an
 ./aeon packs ls                  # the six first-party packs
 ```
 
-`ls` footers with `76 skills · 1 enabled` — read it to them before proposing anything. First run installs the CLI runtime (tsx + yaml, ~12MB); the npm noise is one-time and expected. Grep-only equivalents: `references/layout.md`.
+`ls` footers with `77 skills · 1 enabled` — read it to them before proposing anything. First run installs the CLI runtime (tsx + yaml, ~12MB); the npm noise is one-time and expected. Grep-only equivalents: `references/layout.md`.
 
-Packs are a visibility filter, not a runtime switch — revealing one runs nothing. Core (12), Evolution (9) and Basics (18) show by default; Dev (11), Crypto (15) and Productivity (11) are on demand.
+Packs are a visibility filter, not a runtime switch — revealing one runs nothing. Core (12), Evolution (9) and Basics (18) show by default; Dev (12), Crypto (15) and Productivity (11) are on demand.
 
 Reasonable starting sets:
 

--- a/.claude/skills/aeon/references/layout.md
+++ b/.claude/skills/aeon/references/layout.md
@@ -12,7 +12,7 @@ Where everything lives in an Aeon repo, and the fastest way to see what's on.
 ./aeon skills ls --enabled --json # for building the Mode 2 timeline
 ```
 
-`ls` prints `SKILL / ON / SCHEDULE / PACK / DESCRIPTION` and a footer — `76 skills · 1 enabled`. First run installs the CLI runtime (tsx + yaml, ~12MB, one-time); the noise is expected.
+`ls` prints `SKILL / ON / SCHEDULE / PACK / DESCRIPTION` and a footer — `77 skills · 1 enabled`. First run installs the CLI runtime (tsx + yaml, ~12MB, one-time); the noise is expected.
 
 **The `SCHEDULE` column is populated for disabled skills too** — it's their `aeon.yml` entry, not proof anything fires. Only the `●` in `ON` means it runs.
 

--- a/.claude/skills/aeon/references/mcp.md
+++ b/.claude/skills/aeon/references/mcp.md
@@ -7,7 +7,7 @@ Two unrelated things share the name. Get this wrong and nothing works.
 | | |
 |---|---|
 | **`.mcp.json`** — *external MCP servers, called BY Aeon skills* | Wired via the dashboard MCP panel or `./aeon mcp add`. This is what you want when a skill needs a tool. |
-| **`bin/add-mcp`** — *Aeon itself AS an MCP server* | Builds `apps/mcp-server` and registers it with Claude Code / Desktop, so all 76 skills appear as `aeon-*` tools **in your local Claude**. Nothing to do with a skill calling out. |
+| **`bin/add-mcp`** — *Aeon itself AS an MCP server* | Builds `apps/mcp-server` and registers it with Claude Code / Desktop, so all 77 skills appear as `aeon-*` tools **in your local Claude**. Nothing to do with a skill calling out. |
 
 The rest of this doc is the first one. For the second: `bin/add-mcp`, `--desktop` for a Claude Desktop snippet, `--uninstall` to remove, `claude mcp list` to verify.
 

--- a/.claude/skills/aeon/references/skill-anatomy.md
+++ b/.claude/skills/aeon/references/skill-anatomy.md
@@ -1,10 +1,10 @@
 # How Aeon skills are actually written
 
-Surveyed across all 76 skills in `aeonfun/aeon`. Frequencies are real counts — match the dominant convention unless there's a reason not to. Bodies run 133–757 lines (~306 median); a skill is a prompt, not a config file, and reads as prose.
+Surveyed across all 77 skills in `aeonfun/aeon`. Frequencies are real counts — match the dominant convention unless there's a reason not to. Bodies run 133–757 lines (~306 median); a skill is a prompt, not a config file, and reads as prose.
 
 ## Frontmatter
 
-Universal — **all 76 skills** carry these five:
+Universal — **all 77 skills** carry these five:
 
 ```yaml
 name: my-skill       # the slug (matches the skills/<slug>/ directory)
@@ -113,7 +113,7 @@ There is **no network sandbox** — plain `curl` works for unauthenticated GETs.
 
 `memory/` is the durable state that survives between runs. Four conventions, in order of how often skills touch them:
 
-### `memory/logs/${today}.md` — the run log (63 of 76 skills)
+### `memory/logs/${today}.md` — the run log (63 of 77 skills)
 
 Every skill appends what it did, under **one** heading that is exactly its slug:
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="../docs/assets/hero-animated.svg" alt="AEON — the most autonomous agent framework. 60+ skills across 7 harnesses (Claude Code, Grok, Codex, Pi, Vibe, Kimi, fx), running unattended on GitHub Actions: it ships features to your repos, privately discloses real vulnerabilities, deploys live apps, runs deep research, and writes new skills for itself. Keywords: autonomous AI agent, agent framework, GitHub Actions automation, self-improving agent, multi-agent orchestration, LLM skills, cron agent." width="100%" />
+  <img src="../docs/assets/hero-animated.svg" alt="AEON — the most autonomous agent framework. 60+ skills across 10 harnesses (Claude Code, Grok, Codex, Pi, Vibe, Kimi, fx, Cursor, Hermes, GLM), running unattended on GitHub Actions: it ships features to your repos, privately discloses real vulnerabilities, deploys live apps, runs deep research, and writes new skills for itself. Keywords: autonomous AI agent, agent framework, GitHub Actions automation, self-improving agent, multi-agent orchestration, LLM skills, cron agent." width="100%" />
 </p>
 
 <p align="center">
@@ -46,7 +46,7 @@ git clone https://github.com/<you>/aeon   # skip if you used `gh repo fork --clo
 cd aeon && ./aeon
 ```
 
-Open [localhost:5555](http://localhost:5555) and follow the dashboard: **Authenticate** (any of seven [harnesses](../docs/harnesses.md)) → **add a channel** → **pick skills** → **Run**. That's it - Aeon runs unattended. Everything is also an `./aeon` command ([CLI](../apps/cli/README.md)) or a `/aeon` chat command ([setup skill](../docs/aeon-setup.md), installable as a [Claude Code or Codex plugin](../docs/aeon-setup.md#install)).
+Open [localhost:5555](http://localhost:5555) and follow the dashboard: **Authenticate** (any of ten [harnesses](../docs/harnesses.md)) → **add a channel** → **pick skills** → **Run**. That's it - Aeon runs unattended. Everything is also an `./aeon` command ([CLI](../apps/cli/README.md)) or a `/aeon` chat command ([setup skill](../docs/aeon-setup.md), installable as a [Claude Code or Codex plugin](../docs/aeon-setup.md#install)).
 
 <details>
 <summary><strong>No admin rights / can't install <code>gh</code>?</strong></summary>
@@ -87,13 +87,13 @@ The prompt *is* the skill. You schedule it, hand it a `var`, chain it into other
 
 <p align="center"><a href="../docs/community-skill-packs.md#listed-packs"><b>Community skill packs →</b></a></p>
 
-## Support seven harnesses: Claude, Grok, Codex, Pi, Vibe, Kimi, fx
+## Support ten harnesses: Claude, Grok, Codex, Pi, Vibe, Kimi, fx, Cursor, Hermes, GLM
 
 <p align="center">
-  <img src="../docs/assets/harnesses-aeon.jpg" alt="Seven engines, one socket - a SKILL.md flows through run-harness into any of seven agent CLIs: Claude, Grok, Codex, Pi, Vibe, Kimi, and fx. Every harness honors the same contract: result, usage, session." width="100%" />
+  <img src="../docs/assets/harnesses-aeon.jpg" alt="Ten engines, one socket - a SKILL.md flows through run-harness into any of ten agent CLIs: Claude, Grok, Codex, Pi, Vibe, Kimi, fx, Cursor, Hermes, and GLM. Every harness honors the same contract: result, usage, session." width="100%" />
 </p>
 
-The same `SKILL.md` runs on any of seven agent CLIs - **Claude**, **Grok**, **Codex**, **Pi**, **Vibe**, **Kimi**, **fx** - behind one `run-harness` contract (same result, usage, and session shape). Swap the harness; nothing else changes. How the contract works: [`docs/harnesses.md`](../docs/harnesses.md).
+The same `SKILL.md` runs on any of ten agent CLIs - **Claude**, **Grok**, **Codex**, **Pi**, **Vibe**, **Kimi**, **fx**, **Cursor**, **Hermes**, **GLM** - behind one `run-harness` contract (same result, usage, and session shape). Swap the harness; nothing else changes. How the contract works: [`docs/harnesses.md`](../docs/harnesses.md).
 
 ## Why "the most autonomous"
 
@@ -185,7 +185,7 @@ The deep reference lives in [`docs/`](../docs) - jump in:
 
 <p align="center">
   <a href="../docs/CONFIGURATION.md"><img src="../docs/assets/doc-config.svg" alt="Configuration - chaining, triggers, scheduler, capability modes, gateways, Fleet Watcher" height="30" align="absmiddle"></a>&nbsp;
-  <a href="../docs/harnesses.md"><img src="../docs/assets/doc-harnesses.svg" alt="Harnesses - run skills on any of seven agent CLIs behind one contract" height="30" align="absmiddle"></a>&nbsp;
+  <a href="../docs/harnesses.md"><img src="../docs/assets/doc-harnesses.svg" alt="Harnesses - run skills on any of ten agent CLIs behind one contract" height="30" align="absmiddle"></a>&nbsp;
   <a href="../docs/skill-packs.md"><img src="../docs/assets/doc-packs.svg" alt="Skill Packs - how packs work and how to build your own" height="30" align="absmiddle"></a>&nbsp;
   <a href="../docs/CORE.md"><img src="../docs/assets/doc-core.svg" alt="Core - the self-healing health and repair loop" height="30" align="absmiddle"></a>
 </p>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,37 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Added
 
+- **Three more run-harnesses: Cursor, Hermes, and GLM.** Cursor CLI (`agent -p`,
+  `CURSOR_API_KEY`), Hermes via the Nous Portal (`hermes -z`, `HERMES_AUTH`), and
+  the GLM Coding Plan on Z.AI's Anthropic endpoint (`GLM_API_KEY` / `ZAI_API_KEY`)
+  join the `run-harness` contract, wired through the resolver, installer, both
+  workflows, the local MCP dispatch path, the capability manifest, and regression
+  tests. Aeon now dispatches to ten coding-agent CLIs. Their credentials are
+  permanent first-class rows in the dashboard Access Keys panel, with Hermes on the
+  captured-login Connect/Reconnect flow. (#967, #975)
+- **New `rightstack` skill (Dev & Code).** A read-only Web3 stack advisor
+  (recommend / workflow / compare / explain / migrate) that maps a build goal to a
+  coherent stack before implementation; disabled and manual-only, it cannot install
+  packages, edit an app, or touch a wallet or contract. Catalog is now 77 skills.
+  (#961)
+- **Read-only harness comparison (`scripts/skill-health-routing.mjs`).** Phase 2 of
+  measured harness routing: it groups harness-tagged skill-health scores (five
+  required per harness) and joins per-run token / cache usage, so an operator can
+  weigh quality against cost before changing `aeon.yml`. It never writes repo
+  state. (#969)
+- **Machine-readable vuln-scanner execution evidence.** Staged scanner binaries
+  (Semgrep, TruffleHog, OSV-Scanner, Slither, cargo-fuzz) are wrapped with an
+  invocation logger, and a post-run step prints the staged manifest plus the actual
+  invocation log, so a report can no longer claim a scan that never ran. An absent
+  optional scanner still does not fail the run. (#968)
+- **Three community skill packs listed:** CultOS exact-commit PR review (#974), the
+  Farcaster pack with a Neynar-backed `cast` publish skill (#977), and the Spoolis
+  Outcome Gate acceptance-criteria gate (#978).
+- **Operator-console plugin prepped for more marketplaces.** The `plugin/` operator
+  skill gained manifests and privacy / support metadata for OpenAI's plugin
+  directory (host-neutral wording, a Codex-runnable history-mining script), the
+  Kiro Powers registry, and MiniMax. (#959, #964, #965)
+
 - **`./notify` moves behind a post-run delivery dispatcher (#912 Phase 2).** A
   skill call now writes one structured JSON payload to the notify queue instead of
   ever touching the wire; a new post-run `scripts/notify-deliver.sh` is the only
@@ -257,6 +288,13 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Changed
 
+- **Stale harness and MCP catalog counts corrected.** `llms.txt` moved from six to
+  seven coding-agent CLIs (the harness work above then takes the count to ten), and
+  the MCP OAuth catalog in `docs/mcp-oauth.md` gained the missing Higgsfield row
+  (`mcp.higgsfield.ai/mcp`), so "every catalog provider rotates" replaces "all
+  four". (#960)
+- **Ecosystem list churn:** added Eyebrow (#976) and removed Amper (#979).
+
 - **Harness inventory counts normalized to seven.** With fx as the 7th adapter,
   `docs/harnesses.md`, `harness-adapter/README.md`, and the workflow comments now
   say seven (not six / five / four) and present the harnesses evenly, and the
@@ -362,6 +400,25 @@ from or pin to; the template keeps serving the latest `main` to new forks.
   should re-add the PAT as `GH_SECRETS_PAT`; `GH_GLOBAL` users are unaffected.
 
 ### Fixed
+
+- **Local MCP server runs skills without blocking.** `apps/mcp-server` replaced the
+  event-loop-freezing `spawnSync` with an async `spawn`, so a long `tools/call` no
+  longer stalls `tools/list`, ping, or a second call; a new in-process single-flight
+  queue serializes runs to protect the shared working tree from `.git/index.lock`
+  and interleaved `memory/` writes. Same 600s timeout and 10MB output cap. (#973)
+- **Telegram notification chunks stay under the size limit.** Markdown is now
+  rendered to HTML before the final size split, and active tags are closed and
+  reopened at chunk boundaries, so a skill with many links can no longer produce an
+  unsendable oversized payload. (#970)
+- **`bin/add-skill` records the real source commit in `skills.lock`.** The
+  provenance lookup passed a `gh api` field that forced a `POST` to the GET-only
+  commits collection, 404ed, and fell back to `commit_sha: "unknown"`; it now reads
+  the commit correctly. (#972)
+- **macOS portability:** the cron scheduler test detects GNU vs BSD `date` and uses
+  native syntax (#957), and the issue-backed cron-state / health helpers no longer
+  abort under Bash 3.2 `set -u` on an empty `REPO_ARGS` in their default
+  current-repo mode (#971). Both were local-dev-only; Linux Actions scheduling was
+  never affected.
 
 - **Post-run scorer grades the sent notify card, not the harness `.result`
   recap.** For a notify-first skill the scorer now reads the captured chain
@@ -726,6 +783,11 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 - Bumped the dashboard `postcss` override past `GHSA-r28c-9q8g-f849`. (#783)
 
 ### Maintenance
+
+- First repo lint gates: eslint (per app) and shellcheck (whole shell surface),
+  both green on the current tree, with two shellcheck false positives suppressed
+  with rationale (#962, #963); plus a 400x400 MCP logo for the Cline marketplace
+  (#966).
 
 - CI/test/asset noise: HOL AI Plugin Scanner workflow added then dropped same-day
   (#928, #929); unused `docs/assets` images removed and provider/free-aeon docs

--- a/apps/dashboard/lib/skill-icons.data.ts
+++ b/apps/dashboard/lib/skill-icons.data.ts
@@ -55,6 +55,7 @@ export const SKILL_ICONS: Record<string, string> = {
   "price-alert": "<path d='M10.3 21a2 2 0 0 0 3.4 0'/><path d='M22 8c0-2.3-.8-4.3-2-6'/><path d='M3.3 15.3A1 1 0 0 0 4 17h16a1 1 0 0 0 .7-1.7C19.4 14 18 12.5 18 8A6 6 0 0 0 6 8c0 4.5-1.4 6-2.7 7.3'/><path d='M4 2C2.8 3.7 2 5.7 2 8'/>",
   "remotion": "<rect x='2' y='3' width='20' height='18' rx='2'/><path d='M7 3v18M17 3v18'/><path d='M2 9h5M2 15h5M17 9h5M17 15h5'/><path d='M11 9.5l3 2.5-3 2.5z' fill='currentColor' stroke='none'/>",
   "reply-maker": "<path d='M9 17l-5-5 5-5'/><path d='M20 18v-2a4 4 0 0 0-4-4H4'/>",
+  "rightstack": "<path d='M12 3l8 4.5-8 4.5-8-4.5z'/><path d='M4 12l8 4.5 8-4.5'/><path d='M4 16.5l8 4.5 8-4.5'/>",
   "robinhood-mcp": "<path d='M12.7 19a2 2 0 0 0 1.4-.6l6.2-6.2a6 6 0 0 0-8.5-8.5L5.6 9.9A2 2 0 0 0 5 11.3V18a1 1 0 0 0 1 1z'/><path d='M16 8 2 22'/><path d='M17.5 15H9'/>",
   "schedule-ads": "<path d='M3 11l18-5v12L3 14z'/><path d='M11.6 16.8a3 3 0 1 1-5.8-1.6'/>",
   "search-skill": "<circle cx='11' cy='11' r='8'/><path d='M21 21l-4.3-4.3'/>",

--- a/catalog/skill-icons.json
+++ b/catalog/skill-icons.json
@@ -73,6 +73,7 @@
     "schedule-ads": "<path d='M3 11l18-5v12L3 14z'/><path d='M11.6 16.8a3 3 0 1 1-5.8-1.6'/>",
     "send-email": "<rect x='2' y='4' width='20' height='16' rx='2'/><path d='M22 7l-9 5.7a1.9 1.9 0 0 1-2 0L2 7'/>",
     "spend-watch": "<path d='M4 4v16h16'/><path d='M20 8l-6 7-4-3-5 5'/><path d='M20 12V8h-4'/>",
+    "rightstack": "<path d='M12 3l8 4.5-8 4.5-8-4.5z'/><path d='M4 12l8 4.5 8-4.5'/><path d='M4 16.5l8 4.5 8-4.5'/>",
     "competitor-monitor": "<path d='M5 3v3M9 3v3'/><rect x='3' y='6' width='6' height='13' rx='3'/><rect x='15' y='6' width='6' height='13' rx='3'/><path d='M9 12h6'/>",
     "higgsfield": "<rect x='3' y='4' width='18' height='16' rx='2'/><circle cx='8.5' cy='9.5' r='1.5'/><path d='M3 16l5-4 4 3 3-2 6 4'/><path d='M18 3v3M16.5 4.5h3'/>",
     "hunter-22": "<circle cx='12' cy='12' r='10'/><circle cx='12' cy='12' r='6'/><circle cx='12' cy='12' r='2'/>",

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -94,7 +94,7 @@ mode: write       # default — full Write / Edit / git / gh / python3
 | 2. **OS sandbox** | Write-locks the workspace for the whole run — the repo is mounted read-only, network stays open | `run-harness --mode read-only` → [`harness-adapter/lib/sandbox.sh`](../harness-adapter/lib/sandbox.sh) |
 | 3. Post-run guard | Reverts and cleans anything that still landed under `CODE_PATHS`, preserving the skill's real output (memory, `output/`) and writing its run-log on its behalf | `.github/workflows/aeon.yml` |
 
-**Layer 2 is the guarantee.** Layer 1 is a real narrowing but not a boundary: a shell redirection routes around it, and only the claude and pi adapters consume the allowlist at all. Layer 3 is after-the-fact repair. So the sentence "a read-only skill physically cannot mutate the repo" is true because of the sandbox — `bwrap --ro-bind` on Linux, `sandbox-exec` with a `deny file-write*` profile on macOS — which applies uniformly on **all seven harnesses**, claude included.
+**Layer 2 is the guarantee.** Layer 1 is a real narrowing but not a boundary: a shell redirection routes around it, and only the claude and pi adapters consume the allowlist at all. Layer 3 is after-the-fact repair. So the sentence "a read-only skill physically cannot mutate the repo" is true because of the sandbox — `bwrap --ro-bind` on Linux, `sandbox-exec` with a `deny file-write*` profile on macOS — which applies uniformly on **all ten harnesses**, claude included.
 
 ### Why the sandbox is the dispatcher's, not each harness's
 

--- a/docs/assets/hero-animated.svg
+++ b/docs/assets/hero-animated.svg
@@ -75,7 +75,7 @@
     </g>
     <g transform="translate(725,346)">
       <rect x="0" y="0" width="176" height="42" rx="21" fill="#F4EFE1" stroke="#0d0c0a" stroke-width="2"/>
-      <text x="88" y="28" text-anchor="middle">7 harnesses</text>
+      <text x="88" y="28" text-anchor="middle">10 harnesses</text>
     </g>
     <g transform="translate(916,346)">
       <rect x="0" y="0" width="184" height="42" rx="21" fill="#F4EFE1" stroke="#0d0c0a" stroke-width="2"/>

--- a/docs/assets/skill-icons/rightstack.svg
+++ b/docs/assets/skill-icons/rightstack.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24' fill='none' stroke='#3B82F6' color='#3B82F6' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'><path d='M12 3l8 4.5-8 4.5-8-4.5z'/><path d='M4 12l8 4.5 8-4.5'/><path d='M4 16.5l8 4.5 8-4.5'/></svg>

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -252,7 +252,7 @@ the harness is already executing as the agent's workspace.
 
 **Other harnesses.** MCP is not grok-only: `claude`, `codex`, `vibe` and `kimi`
 all call live MCP tools too (codex and kimi needed their own dispatcher fixes —
-see the [harness-adapter README](../harness-adapter/README.md#the-six-harnesses)).
+see the [harness-adapter README](../harness-adapter/README.md#the-ten-harnesses)).
 `pi` is the one harness that cannot: it rejects MCP by design, so its adapter
 warns and skips every configured server, and the dashboard's MCP panel disables
 itself when `pi` is the selected harness.
@@ -295,10 +295,10 @@ one path, an adapter-level fix reaches every surface by construction.
 claude/grok/codex, prompt-shim on pi/vibe/kimi). Callers that don't pass it get
 plain text. (A grok-only `GROK_JSON_SCHEMA` env var existed on the old script
 path until it was removed: nothing in the repo ever set it, and the scorer it was
-reserved for goes schema-less on purpose so a single parse path covers all seven
+reserved for goes schema-less on purpose so a single parse path covers all ten
 harnesses.)
 
-**Both hosted surfaces stage all seven.** `aeon.yml` (skill runs) and
+**Both hosted surfaces stage all ten.** `aeon.yml` (skill runs) and
 `messages.yml` (inbound messages) share the same two scripts, so a repo answers
 messages on the harness it runs skills on:
 
@@ -312,8 +312,7 @@ Each workflow still declares its own `env:` block, because `secrets.*` only
 resolves inside a workflow — but the logic is shared, which is the half that
 drifted before. `messages.yml` used to carry a second, weaker copy that knew only
 claude and grok, so a repo on codex/pi/vibe/kimi had its messages answered on
-claude with a `::warning::`. The local MCP server (`apps/mcp-server`) resolves all
-six but expects the CLI to already be installed on your machine.
+claude with a `::warning::`. The local MCP server (`apps/mcp-server`) resolves all ten but expects the CLI to already be installed on your machine.
 
 ## Every entry point runs on either harness
 
@@ -325,8 +324,8 @@ behaves identically everywhere. All of them dispatch through `run-harness`:
 |---------|---------------------|-------|
 | Scheduled / manual skill run (`aeon.yml`) | dispatch **Harness** input → per-skill `harness:` → global `harness:` → `claude` | full flags + MCP + scorer |
 | Skill chains (`chain-runner.yml`) | inherits — each step dispatches `aeon.yml`, which resolves per-skill/global | |
-| Inbound messages (`messages.yml`, Telegram/Discord/Slack) | global `harness:` in `aeon.yml` | conversational reply in write mode; the resolved harness's CLI is staged here (all seven), same as skill runs |
-| Local MCP server (`apps/mcp-server`) | `AEON_HARNESS` env → global `harness:` | `resolveHarness()` in `skill-executor.ts`; resolves all six, expects the CLI installed locally |
+| Inbound messages (`messages.yml`, Telegram/Discord/Slack) | global `harness:` in `aeon.yml` | conversational reply in write mode; the resolved harness's CLI is staged here (all ten), same as skill runs |
+| Local MCP server (`apps/mcp-server`) | `AEON_HARNESS` env → global `harness:` | `resolveHarness()` in `skill-executor.ts`; resolves all ten, expects the CLI installed locally |
 | Webhook (`apps/webhook`) | relay only → dispatches `messages.yml` | harness-agnostic |
 | Post-run quality scorer (`aeon.yml`) | scores through the same harness the skill ran on | |
 

--- a/harness-adapter/README.md
+++ b/harness-adapter/README.md
@@ -128,7 +128,7 @@ bind-mounts) kimi still reads the literal `${VAR}`s.
 **Read-only enforcement is hoisted into the dispatcher.** Only codex has a native
 kernel sandbox that actually holds; every other harness — claude, grok, pi, vibe,
 kimi, fx — runs read-only under `sandbox-exec` (macOS) or `bwrap` (Linux) with the
-workspace mounted read-only, so `--mode read-only` means the same thing on all seven:
+workspace mounted read-only, so `--mode read-only` means the same thing on all ten:
 *the repo physically cannot be mutated*, regardless of the model or its permission
 config. (vibe and kimi lean on this entirely — their `-p` modes have no
 permission-layer gate of their own.)
@@ -187,7 +187,7 @@ step and the native-auth secrets (`CODEX_AUTH`, `KIMI_AUTH`, `MISTRAL_API_KEY`,
 ## Capability manifest
 
 [`harnesses.json`](harnesses.json) is the machine-readable capability manifest for
-the seven adapters - the local analog of a UHP [`GET /v1/harnesses`](https://unifiedharnessprotocol.org)
+the ten adapters - the local analog of a UHP [`GET /v1/harnesses`](https://unifiedharnessprotocol.org)
 discovery response. One queryable file answers *does this harness report token
 cost? enforce read-only natively or via the wrapper sandbox? support MCP, and
 how? what auth does it take?* - instead of that knowledge living only in the

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Aeon
 
-> Aeon is an autonomous agent framework. It runs your own skills on a schedule in GitHub Actions, keeps state in git-committed memory, and dispatches every run through one harness adapter that works across seven coding-agent CLIs (Claude Code, Codex, Grok, Kimi, Pi, Vibe, fx). Skills are Markdown with a spec-form frontmatter; a least-privilege `requires:` -> dashboard vault contract wires secrets. Fork the repo, turn skills on, and it runs itself.
+> Aeon is an autonomous agent framework. It runs your own skills on a schedule in GitHub Actions, keeps state in git-committed memory, and dispatches every run through one harness adapter that works across ten coding-agent CLIs (Claude Code, Codex, Grok, Kimi, Pi, Vibe, fx, Cursor, Hermes, GLM). Skills are Markdown with a spec-form frontmatter; a least-privilege `requires:` -> dashboard vault contract wires secrets. Fork the repo, turn skills on, and it runs itself.
 
 Repo: https://github.com/aeonfun/aeon
 Site: https://aeon.fun
@@ -28,7 +28,7 @@ Site: https://aeon.fun
 
 ## Harnesses and integrations
 
-- [docs/harnesses.md](https://raw.githubusercontent.com/aeonfun/aeon/main/docs/harnesses.md): Advanced harness behavior across the seven supported coding-agent CLIs.
+- [docs/harnesses.md](https://raw.githubusercontent.com/aeonfun/aeon/main/docs/harnesses.md): Advanced harness behavior across the ten supported coding-agent CLIs.
 - [harness-adapter/README.md](https://raw.githubusercontent.com/aeonfun/aeon/main/harness-adapter/README.md): The single dispatch path that translates one tool grammar to every harness.
 - [docs/mcp-oauth.md](https://raw.githubusercontent.com/aeonfun/aeon/main/docs/mcp-oauth.md): Durable dashboard OAuth for OAuth-gated MCP servers.
 - [docs/telegram-commands.md](https://raw.githubusercontent.com/aeonfun/aeon/main/docs/telegram-commands.md): The inbound Telegram command surface.

--- a/plugin/skills/aeon/SKILL.md
+++ b/plugin/skills/aeon/SKILL.md
@@ -251,7 +251,7 @@ metadata:
 Today is ${today}. <the prompt — plain instructions, including judgment calls>
 
 ## Steps
-1. <the procedure — 43 of 76 skills lead with this>
+1. <the procedure — 43 of 77 skills lead with this>
 
 ## Network note
 <curl / WebFetch / `./secretcurl` / `gh api` — how this skill fetches>
@@ -311,9 +311,9 @@ Three at a time, not twelve. Every enabled skill is a recurring notification, an
 ./aeon packs ls                  # the six first-party packs
 ```
 
-`ls` footers with `76 skills · 1 enabled` — read it to them before proposing anything. First run installs the CLI runtime (tsx + yaml, ~12MB); the npm noise is one-time and expected. Grep-only equivalents: `references/layout.md`.
+`ls` footers with `77 skills · 1 enabled` — read it to them before proposing anything. First run installs the CLI runtime (tsx + yaml, ~12MB); the npm noise is one-time and expected. Grep-only equivalents: `references/layout.md`.
 
-Packs are a visibility filter, not a runtime switch — revealing one runs nothing. Core (12), Evolution (9) and Basics (18) show by default; Dev (11), Crypto (15) and Productivity (11) are on demand.
+Packs are a visibility filter, not a runtime switch — revealing one runs nothing. Core (12), Evolution (9) and Basics (18) show by default; Dev (12), Crypto (15) and Productivity (11) are on demand.
 
 Reasonable starting sets:
 

--- a/plugin/skills/aeon/references/layout.md
+++ b/plugin/skills/aeon/references/layout.md
@@ -12,7 +12,7 @@ Where everything lives in an Aeon repo, and the fastest way to see what's on.
 ./aeon skills ls --enabled --json # for building the Mode 2 timeline
 ```
 
-`ls` prints `SKILL / ON / SCHEDULE / PACK / DESCRIPTION` and a footer — `76 skills · 1 enabled`. First run installs the CLI runtime (tsx + yaml, ~12MB, one-time); the noise is expected.
+`ls` prints `SKILL / ON / SCHEDULE / PACK / DESCRIPTION` and a footer — `77 skills · 1 enabled`. First run installs the CLI runtime (tsx + yaml, ~12MB, one-time); the noise is expected.
 
 **The `SCHEDULE` column is populated for disabled skills too** — it's their `aeon.yml` entry, not proof anything fires. Only the `●` in `ON` means it runs.
 

--- a/plugin/skills/aeon/references/mcp.md
+++ b/plugin/skills/aeon/references/mcp.md
@@ -7,7 +7,7 @@ Two unrelated things share the name. Get this wrong and nothing works.
 | | |
 |---|---|
 | **`.mcp.json`** — *external MCP servers, called BY Aeon skills* | Wired via the dashboard MCP panel or `./aeon mcp add`. This is what you want when a skill needs a tool. |
-| **`bin/add-mcp`** — *Aeon itself AS an MCP server* | Builds `apps/mcp-server` and registers it with Claude Code / Desktop, so all 76 skills appear as `aeon-*` tools **in your local Claude**. Nothing to do with a skill calling out. |
+| **`bin/add-mcp`** — *Aeon itself AS an MCP server* | Builds `apps/mcp-server` and registers it with Claude Code / Desktop, so all 77 skills appear as `aeon-*` tools **in your local Claude**. Nothing to do with a skill calling out. |
 
 The rest of this doc is the first one. For the second: `bin/add-mcp`, `--desktop` for a Claude Desktop snippet, `--uninstall` to remove, `claude mcp list` to verify.
 

--- a/plugin/skills/aeon/references/skill-anatomy.md
+++ b/plugin/skills/aeon/references/skill-anatomy.md
@@ -1,10 +1,10 @@
 # How Aeon skills are actually written
 
-Surveyed across all 76 skills in `aeonfun/aeon`. Frequencies are real counts — match the dominant convention unless there's a reason not to. Bodies run 133–757 lines (~306 median); a skill is a prompt, not a config file, and reads as prose.
+Surveyed across all 77 skills in `aeonfun/aeon`. Frequencies are real counts — match the dominant convention unless there's a reason not to. Bodies run 133–757 lines (~306 median); a skill is a prompt, not a config file, and reads as prose.
 
 ## Frontmatter
 
-Universal — **all 76 skills** carry these five:
+Universal — **all 77 skills** carry these five:
 
 ```yaml
 name: my-skill       # the slug (matches the skills/<slug>/ directory)
@@ -113,7 +113,7 @@ There is **no network sandbox** — plain `curl` works for unauthenticated GETs.
 
 `memory/` is the durable state that survives between runs. Four conventions, in order of how often skills touch them:
 
-### `memory/logs/${today}.md` — the run log (63 of 76 skills)
+### `memory/logs/${today}.md` — the run log (63 of 77 skills)
 
 Every skill appends what it did, under **one** heading that is exactly its slug:
 


### PR DESCRIPTION
Syncs merged PRs **#957-#979** (watermark 956) into the aeon-repo docs. Source of truth = merged PRs on `aeonfun/aeon`. #958 skipped (prior run's own aeon-side sync).

## Headline: seven -> ten harnesses (#967)

Cursor, Hermes, and GLM shipped as run-harnesses (#967) + dashboard auth rows (#975), taking Aeon to **ten** coding-agent CLIs. #967 updated the mechanism (`harnesses.json`, adapters, `docs/harnesses.md`, `harness-adapter/README.md` headline) but deliberately left the brand/headline surfaces at seven, the same pattern fx used. Promoted them to ten here.

> **Heads-up (binary asset):** `docs/assets/harnesses-aeon.jpg` is a committed image still showing the old engine graphic. Its alt-text now reads ten, but the picture needs a manual re-render (same as the fx banner).

## Surfaces changed

- [x] `.github/README.md` - harness headline + hero/banner/doc-nav alt-text + inline list: seven -> ten, added Cursor/Hermes/GLM (skill total left at the `60+` floor)
- [x] `docs/assets/hero-animated.svg` - "7 harnesses" -> "10 harnesses"
- [x] `docs/CAPABILITIES.md` - "all seven harnesses" -> "all ten"
- [x] `llms.txt` - six -> seven -> ten CLIs (line 3 + harnesses.md pointer), +Cursor/Hermes/GLM (#960 had taken it to seven)
- [x] `docs/harnesses.md` - fixed the broken `#the-six-harnesses` anchor (heading is now "The ten harnesses") + current-state staging/resolve counts to ten; dated "verified 2026-07-22" lines left untouched
- [x] `harness-adapter/README.md` - sandbox-applies + adapter-count to ten; the verification list + "fx is the seventh adapter" left as #967's own follow-up
- [x] Setup skill `.claude/skills/aeon/**` + plugin copy `plugin/skills/aeon/**` - catalog literal 76 -> 77 (SKILL.md footer + Steps stat, layout.md footer, mcp.md, skill-anatomy.md survey), Dev pack (11) -> (12). rightstack leads with `## Integration boundary` and is read-only (no run log), so the lead-with-Steps and run-log numerators are unchanged - only the denominators moved. #961 never touched the setup skill, so this was drift.
- [x] `catalog/skill-icons.json` + regenerated `docs/assets/skill-icons/rightstack.svg` + `apps/dashboard/lib/skill-icons.data.ts` - rightstack had no glyph (#961 skipped `bin/generate-skill-icons`, like taskmarket-delegate did). `--check` now passes 77/77.
- [x] `CHANGELOG.md` - `[Unreleased]` Added/Changed/Fixed/Maintenance for the batch

## Already at HEAD (no edit needed)

- `.github/README.md` full-catalog caption/anchor + `docs/skill-packs.md` Dev (12) / 77 - done by #961
- `docs/mcp-oauth.md` Higgsfield OAuth row + the "every catalog provider rotates" wording - done by #960

## Noise (bundled as one Maintenance line)

- #962 (eslint + shellcheck lint gates), #963 (silence two shellcheck false positives), #966 (Cline marketplace logo, asset only)
