### PR TITLE
allow fx workflow dispatches

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -76,7 +76,7 @@ on:
         required: false
         type: string
       harness:
-        description: 'Agent harness override (claude | grok | codex | pi | vibe | kimi | cursor | hermes | glm)'
+        description: 'Agent harness override (claude | grok | codex | pi | vibe | kimi | fx | cursor | hermes | glm)'
         required: false
         type: string
       var:

--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -53,6 +53,7 @@ on:
           - pi
           - vibe
           - kimi
+          - fx
           - cursor
           - hermes
           - glm

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -70,6 +70,8 @@ jobs:
         run: bash scripts/tests/test_generate_harnesses_json.sh
       - name: harness resolution tests
         run: bash scripts/tests/test_resolve_harness.sh
+      - name: workflow harness choice tests
+        run: bash scripts/tests/test_workflow_harness_choices.sh
       - name: harness install/config tests
         run: bash scripts/tests/test_install_harness.sh
       - name: run-harness sandbox-gate tests

--- a/scripts/tests/test_workflow_harness_choices.sh
+++ b/scripts/tests/test_workflow_harness_choices.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+WORKFLOW="$ROOT/.github/workflows/aeon.yml"
+
+choices=$(awk '
+  /^      harness:$/ { in_harness=1; next }
+  in_harness && /^      var:$/ { exit }
+  in_harness && /^          - / { sub(/^          - /, ""); print }
+' "$WORKFLOW")
+
+if ! grep -qx 'fx' <<<"$choices"; then
+  echo 'workflow_dispatch harness choices omit fx' >&2
+  exit 1
+fi
+
+echo 'workflow harness choice tests passed'


### PR DESCRIPTION
## what

add `fx` to the `workflow_dispatch` harness choices and register a focused regression test.

## why

fx is already integrated through the adapter, resolver, installer, dashboard, and standardized harness contract. the manual workflow-dispatch choice list was missed when fx was added, so `gh workflow run aeon.yml -f skill=narrative-tracker -f harness=fx` failed with http 422 before aeon executed any code.

this is not an fx implementation or authentication change. it only makes the existing harness selectable through manual github actions dispatches.

## fix

- add `fx` to `.github/workflows/aeon.yml`
- add `scripts/tests/test_workflow_harness_choices.sh`
- register the regression test in `.github/workflows/ci-tests.yml`

## verification

mutation test with only the `fx` option removed:

```text
rc=1
workflow_dispatch harness choices omit fx
```

after restoring the option:

```text
workflow harness choice tests passed
```

- `node scripts/validate-config.js` — clean
- `node --test scripts/validate-config.test.js` — 14/14 passed
- `bash scripts/tests/test_resolve_harness.sh` — all passed
- `bash scripts/tests/test_generate_harnesses_json.sh` — all passed
- `git diff --check` — clean

real github actions proof on the fork: run 33167164883 was accepted, logged `INPUT_HARNESS: fx`, resolved `Harness: fx`, and installed fx 0.0.6.

the run then stopped at the existing credential gate because the test fork has neither `AI_GATEWAY_API_KEY` nor `VERCEL_OIDC_TOKEN`. this pr does not change credentials, authentication, schedules, models, or the default harness.