### PR TITLE
trust cursor workspaces in headless runs

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -66,6 +66,8 @@ jobs:
         run: bash scripts/tests/test_run_grok.sh
       - name: harness-adapter grok tests
         run: bash scripts/tests/test_harness_adapter_grok.sh
+      - name: cursor adapter tests
+        run: bash scripts/tests/test_cursor_adapter.sh
       - name: harness capability manifest tests
         run: bash scripts/tests/test_generate_harnesses_json.sh
       - name: harness resolution tests

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -59,7 +59,7 @@ login locally, store the session as a repo secret, restore it on the runner):
 | `pi`    | provider API key | `aeon auth --harness pi --key <sk-ant-…\|sk-…>` → the matching `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` (auto-detected) |
 | `vibe`  | Mistral key | `aeon auth --harness vibe --key <key>` → `MISTRAL_API_KEY` (vibe's default provider) |
 | `fx`    | Vercel AI Gateway key (or `VERCEL_OIDC_TOKEN`) | set `AI_GATEWAY_API_KEY` as a repo secret. **No `aeon auth` flow and no OpenRouter fallback** — see below. |
-| `cursor` | Cursor API key | set `CURSOR_API_KEY` as a repo secret; headless entry point is `agent -p`. |
+| `cursor` | Cursor API key | set `CURSOR_API_KEY` as a repo secret; headless entry point is `agent -p --trust` because every CI run starts with a fresh home. `--force` remains write-mode only. |
 | `hermes` | Nous Portal OAuth | `aeon auth --harness hermes` → `HERMES_AUTH`; the adapter restores `~/.hermes/auth.json`. |
 | `glm` | GLM Coding Plan API key | set `GLM_API_KEY` (or `ZAI_API_KEY`); the adapter uses Z.AI's Anthropic endpoint through Claude Code. |
 

--- a/harness-adapter/README.md
+++ b/harness-adapter/README.md
@@ -63,7 +63,7 @@ The three newer adapters are:
 
 | harness | headless entry point | auth | usage |
 |---|---|---|---|
-| cursor | `agent -p --output-format json` | `CURSOR_API_KEY` | provider output only; zero when Cursor omits usage |
+| cursor | `agent -p --trust --output-format json` | `CURSOR_API_KEY` | provider output only; zero when Cursor omits usage |
 | hermes | `hermes -z --usage-file <path>` | `HERMES_AUTH` (Nous Portal OAuth archive) or OpenRouter | usage/session from the usage file |
 | glm | Claude Code `-p` against Z.AI's Anthropic endpoint | `GLM_API_KEY` or `ZAI_API_KEY` | Claude-compatible token usage |
 

--- a/harness-adapter/adapters/cursor.sh
+++ b/harness-adapter/adapters/cursor.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Cursor CLI adapter: documented `agent -p` headless mode.
 # rh-meta-start
-# {"id":"cursor","label":"Cursor CLI","cli":{"install":"curl -fsSL https://cursor.com/install | bash","bin":"agent","min_version":"latest"},"invoke":"agent -p --output-format json","round_trip":true,"token_usage":"none","cost":false,"read_only":"sandbox","structured_output":"shim","mcp":"native","max_turns":"none","claude_md":"native","auth":{"native_oauth":[],"native_key":["CURSOR_API_KEY"],"openrouter":false},"native_control_path":"run-harness"}
+# {"id":"cursor","label":"Cursor CLI","cli":{"install":"curl -fsSL https://cursor.com/install | bash","bin":"agent","min_version":"latest"},"invoke":"agent -p --trust --output-format json","round_trip":true,"token_usage":"none","cost":false,"read_only":"sandbox","structured_output":"shim","mcp":"native","max_turns":"none","claude_md":"native","auth":{"native_oauth":[],"native_key":["CURSOR_API_KEY"],"openrouter":false},"native_control_path":"run-harness"}
 # rh-meta-end
 set -uo pipefail
 . "$RH_LIB/envelope.sh"
@@ -15,6 +15,10 @@ PROMPT="$(cat "$RH_PROMPT_FILE")"; PREFIX="${RH_COMPAT_RULES:-}"
 [ -n "${RH_JSON_SCHEMA:-}" ] && PROMPT="${PROMPT}$(schema_prompt_suffix "$RH_JSON_SCHEMA")"
 ARGS=(-p --output-format json)
 [ -n "${RH_MODEL:-}" ] && [ "$RH_MODEL" != "default" ] && ARGS+=(--model "$RH_MODEL")
+# Headless CI always starts from a fresh HOME, so the workspace has no persisted
+# trust decision. --trust skips only that prompt; unlike --force, it does not
+# grant command execution or file writes.
+ARGS+=(--trust)
 [ "${RH_MODE:-write}" != "read-only" ] && ARGS+=(--force)
 OUT="$RH_TMPDIR/cursor-out.json"; printf '%s' "$PROMPT" | agent "${ARGS[@]}" > "$OUT"; rc=$?
 [ $rc -ne 0 ] && { echo "cursor exited $rc: $(tail -c 4000 "$OUT" | tr '\n' ' ')" >&2; exit $rc; }

--- a/harness-adapter/harnesses.json
+++ b/harness-adapter/harnesses.json
@@ -9,7 +9,7 @@
       "124": "timeout"
     }
   },
-  "generated": "2026-08-25T22:09:20Z",
+  "generated": "2026-08-28T16:08:08Z",
   "count": 10,
   "harnesses": [
     {
@@ -76,7 +76,7 @@
         "bin": "agent",
         "min_version": "latest"
       },
-      "invoke": "agent -p --output-format json",
+      "invoke": "agent -p --trust --output-format json",
       "round_trip": true,
       "token_usage": "none",
       "cost": false,

--- a/scripts/tests/test_cursor_adapter.sh
+++ b/scripts/tests/test_cursor_adapter.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/bin"
+
+cat > "$TMP/bin/agent" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$AGENT_ARGS"
+printf '%s\n' '{"result":"ok","usage":{},"session_id":"cursor-test"}'
+SH
+chmod +x "$TMP/bin/agent"
+printf 'inspect this workspace' > "$TMP/prompt"
+
+run_adapter() {
+  local mode=$1
+  AGENT_ARGS="$TMP/$mode.args" \
+    PATH="$TMP/bin:$PATH" \
+    RH_LIB="$ROOT/harness-adapter/lib" \
+    RH_TMPDIR="$TMP/$mode-tmp" \
+    RH_PROMPT_FILE="$TMP/prompt" \
+    RH_MODE="$mode" \
+    bash "$ROOT/harness-adapter/adapters/cursor.sh" >/dev/null
+}
+
+mkdir -p "$TMP/read-only-tmp" "$TMP/write-tmp"
+run_adapter read-only
+if ! grep -qx -- '--trust' "$TMP/read-only.args"; then
+  echo 'read-only cursor run omitted --trust' >&2
+  exit 1
+fi
+if grep -qx -- '--force' "$TMP/read-only.args"; then
+  echo 'read-only cursor run unexpectedly received --force' >&2
+  exit 1
+fi
+
+run_adapter write
+grep -qx -- '--trust' "$TMP/write.args" || { echo 'write cursor run omitted --trust' >&2; exit 1; }
+grep -qx -- '--force' "$TMP/write.args" || { echo 'write cursor run omitted --force' >&2; exit 1; }
+
+echo 'cursor adapter trust tests passed'


### PR DESCRIPTION
## what

always pass cursor's headless `--trust` flag, while keeping `--force` limited to write-mode runs. add and register a focused adapter regression test, then update the generated capability metadata and harness docs to match the real invocation.

## why

read-only skills never received `--force`, and cursor starts every ci run with a fresh temporary home. the workspace therefore had no saved trust decision, so cursor exited before executing the prompt with `pass --trust, --yolo, or -f if you trust this directory`.

reproduced in fork runs 33149126007 and 33149186413.

## fix

- pass `--trust` for both read-only and write runs
- retain `--force` only outside read-only mode
- test the exact argument split with a stub cursor agent
- register the test in the hand-listed ci workflow
- update the invocation metadata, generated manifest, and both harness docs

## verification

mutation with only `--trust` removed:

```text
rc=1
read-only cursor run omitted --trust
```

restored:

```text
cursor adapter trust tests passed
```

real fork dispatch: run 33187785314

- `harness: cursor | auth: native-key | model: gpt-5.1`
- `capability mode: read-only`
- completed successfully in 4m24s
- captured 4,239 bytes of narrative output
- scorer recorded score 4
- history appended `harness: cursor`, `model: gpt-5.1`
- no `--force` was supplied by the tested adapter path

the skill used its documented internal-log fallback rather than x.ai in this cursor run; that limitation is stated in the captured output and is not hidden as an api-backed result.

local checks:

- cursor adapter regression: passed
- harness manifest tests: passed
- config validation: clean
- `git diff --check`: clean
- local shellcheck unavailable; real ci is the source of truth for that gate.