### PR TITLE
fail hermes runs on api errors

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -66,6 +66,8 @@ jobs:
         run: bash scripts/tests/test_run_grok.sh
       - name: harness-adapter grok tests
         run: bash scripts/tests/test_harness_adapter_grok.sh
+      - name: hermes adapter tests
+        run: bash scripts/tests/test_hermes_adapter.sh
       - name: harness capability manifest tests
         run: bash scripts/tests/test_generate_harnesses_json.sh
       - name: harness resolution tests

--- a/harness-adapter/adapters/hermes.sh
+++ b/harness-adapter/adapters/hermes.sh
@@ -19,6 +19,10 @@ PROMPT="$(cat "$RH_PROMPT_FILE")"; PREFIX="${RH_COMPAT_RULES:-}"
 ARGS=(--usage-file "$RH_TMPDIR/hermes-usage.json" -z "$PROMPT"); [ -n "${RH_MODEL:-}" ] && [ "$RH_MODEL" != "default" ] && ARGS+=(--model "$RH_MODEL"); [ "${RH_MODE:-write}" = "read-only" ] && ARGS+=(--safe-mode); [ -z "${HERMES_AUTH:-}" ] && [ -n "${OPENROUTER_API_KEY:-}" ] && ARGS+=(--provider openrouter)
 OUT="$RH_TMPDIR/hermes-out.txt"; hermes "${ARGS[@]}" > "$OUT"; rc=$?
 [ $rc -ne 0 ] && { echo "hermes exited $rc: $(tail -c 4000 "$OUT" | tr '\n' ' ')" >&2; exit $rc; }; RESULT="$(cat "$OUT")"
+if grep -Eq '(^|[[:space:]])HTTP [45][0-9][0-9]:' "$OUT"; then
+  echo "hermes API error: $(tail -c 4000 "$OUT" | tr '\n' ' ')" >&2
+  exit 1
+fi
 TIN=0; TOUT=0; TCR=0; COST=""; SID=""; U="$RH_TMPDIR/hermes-usage.json"
 if [ -f "$U" ] && jq -e . "$U" >/dev/null 2>&1; then TIN=$(jq -r '.input_tokens // 0' "$U"); TOUT=$(jq -r '.output_tokens // 0' "$U"); TCR=$(jq -r '.cache_read_tokens // 0' "$U"); COST=$(jq -r '.estimated_cost_usd // empty' "$U"); SID=$(jq -r '.session_id // ""' "$U"); fi
 if [ -n "${RH_JSON_SCHEMA:-}" ]; then RESULT="$(schema_extract_json "$RESULT")"; schema_validate "$RH_JSON_SCHEMA" "$RESULT" || { echo "structured output failed validation" >&2; exit 3; }; fi

--- a/scripts/tests/test_hermes_adapter.sh
+++ b/scripts/tests/test_hermes_adapter.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/bin"
+printf 'score this output' > "$TMP/prompt"
+
+cat > "$TMP/bin/hermes" <<'SH'
+#!/usr/bin/env bash
+if [ "${HERMES_STUB_MODE:-ok}" = api-error ]; then
+  printf '%s\n' 'HTTP 400: modelCode: does not exist'
+  exit 0
+fi
+printf '%s\n' 'usable hermes result'
+SH
+chmod +x "$TMP/bin/hermes"
+
+run_adapter() {
+  local mode=$1
+  mkdir -p "$TMP/$mode"
+  HERMES_STUB_MODE="$mode" \
+    PATH="$TMP/bin:$PATH" \
+    RH_LIB="$ROOT/harness-adapter/lib" \
+    RH_TMPDIR="$TMP/$mode" \
+    RH_PROMPT_FILE="$TMP/prompt" \
+    RH_MODE=read-only \
+    bash "$ROOT/harness-adapter/adapters/hermes.sh"
+}
+
+normal=$(run_adapter ok)
+[ "$(jq -r '.result' <<<"$normal")" = 'usable hermes result' ] || {
+  echo 'normal hermes output was not preserved' >&2
+  exit 1
+}
+
+set +e
+error=$(run_adapter api-error 2>&1)
+rc=$?
+set -e
+[ "$rc" -eq 1 ] || { echo "hermes HTTP error returned rc=$rc, want 1" >&2; exit 1; }
+grep -Fq 'hermes API error: HTTP 400: modelCode: does not exist' <<<"$error" || {
+  echo "hermes HTTP error diagnostic missing: $error" >&2
+  exit 1
+}
+
+echo 'hermes adapter error tests passed'


### PR DESCRIPTION
## what

make the hermes adapter fail when the cli prints an http 4xx/5xx response while exiting zero. add and register a focused adapter regression test.

## why

fork run 33150824247 looked successful at the workflow level, but the main harness output was only `HTTP 400: modelCode: does not exist`. hermes exited zero, so the adapter wrapped that error text in a success envelope; the scorer then repeated the same error and no health score was recorded.

the exact model source was traced to stale captured config: `model.default: tencent/hy3:free`. the official live nous catalog updated 2026-08-28 contains `tencent/hy3` and no `tencent/hy3:free`. `RH_MODEL_ARG=default` was not passed to hermes because the adapter already suppresses that sentinel.

## fix

- detect hermes stdout containing an http 4xx/5xx response
- emit the real api diagnostic on stderr
- exit nonzero instead of creating a false success envelope
- cover both normal output and the zero-exit api-error case

## verification

mutation with only the detection removed:

```text
rc=1
hermes HTTP error returned rc=0, want 1
```

restored:

```text
hermes adapter error tests passed
```

real fork dispatch 33189422348 now fails at the run step with:

```text
run-harness hermes failed: read-only: workspace write-locked via bwrap hermes API error: HTTP 400: modelCode: does not exist
```

this pr fixes false-green classification. selecting a current nous model and refreshing `HERMES_AUTH` remains an operator credential/configuration action; the adapter does not silently rewrite it.