### PR TITLE
Add founder credit + link to aaronjmars.com

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -236,3 +236,7 @@ The deep reference lives in [`docs/`](../docs) - jump in:
 ---
 
 <p align="center"><sub>MIT · Support the project: <code>0xbf8e8f0e8866a7052f948c16508644347c57aba3</code> ⭐</sub></p>
+
+---
+
+Built by [Aaron Elijah Mars](https://aaronjmars.com), founder of Aeon and MiroShark · [@aaronjmars](https://github.com/aaronjmars)


### PR DESCRIPTION
Adds a footer credit linking back to the personal hub, so the profile <-> project link is reciprocal (what makes a sameAs edge count).

One line appended to the README; no other change.