### PR TITLE
fix(dashboard): require exact origin host match

### DIFF
--- a/apps/dashboard/lib/security/api-gate.test.ts
+++ b/apps/dashboard/lib/security/api-gate.test.ts
@@ -88,36 +88,83 @@ describe("isSameOriginWrite", () => {
   });
   it("POST with same-origin Origin passes", () => {
     assert.equal(
-      isSameOriginWrite("POST", headers({ origin: "http://localhost:5555" })),
+      isSameOriginWrite(
+        "POST",
+        headers({ host: "localhost:5555", origin: "http://localhost:5555" }),
+      ),
       true,
     );
     assert.equal(
-      isSameOriginWrite("POST", headers({ origin: "http://127.0.0.1:5555" })),
+      isSameOriginWrite(
+        "POST",
+        headers({ host: "127.0.0.1:5555", origin: "http://127.0.0.1:5555" }),
+      ),
       true,
+    );
+  });
+  it("POST with a different loopback alias fails", () => {
+    assert.equal(
+      isSameOriginWrite(
+        "POST",
+        headers({ host: "127.0.0.1:5555", origin: "http://localhost:5555" }),
+      ),
+      false,
     );
   });
   it("POST with cross-origin Origin fails", () => {
     assert.equal(
-      isSameOriginWrite("POST", headers({ origin: "http://attacker.example" })),
+      isSameOriginWrite(
+        "POST",
+        headers({ host: "localhost:5555", origin: "http://attacker.example" }),
+      ),
       false,
     );
   });
   it("POST falls back to Referer when Origin is absent", () => {
     assert.equal(
-      isSameOriginWrite("POST", headers({ referer: "http://localhost:5555/dashboard" })),
+      isSameOriginWrite(
+        "POST",
+        headers({ host: "localhost:5555", referer: "http://localhost:5555/dashboard" }),
+      ),
       true,
     );
     assert.equal(
-      isSameOriginWrite("POST", headers({ referer: "http://attacker.example/p" })),
+      isSameOriginWrite(
+        "POST",
+        headers({ host: "127.0.0.1:5555", referer: "http://localhost:5555/dashboard" }),
+      ),
+      false,
+    );
+    assert.equal(
+      isSameOriginWrite(
+        "POST",
+        headers({ host: "localhost:5555", referer: "http://attacker.example/p" }),
+      ),
       false,
     );
   });
   it("POST with neither Origin nor Referer is rejected", () => {
-    assert.equal(isSameOriginWrite("POST", headers({})), false);
+    assert.equal(isSameOriginWrite("POST", headers({ host: "localhost:5555" })), false);
+  });
+  it("POST with missing or malformed Host is rejected", () => {
+    assert.equal(
+      isSameOriginWrite("POST", headers({ origin: "http://localhost:5555" })),
+      false,
+    );
+    assert.equal(
+      isSameOriginWrite(
+        "POST",
+        headers({ host: "localhost:5555/path", origin: "http://localhost:5555" }),
+      ),
+      false,
+    );
   });
   it("POST with malformed Origin is rejected", () => {
     assert.equal(
-      isSameOriginWrite("POST", headers({ origin: "not-a-url" })),
+      isSameOriginWrite(
+        "POST",
+        headers({ host: "localhost:5555", origin: "not-a-url" }),
+      ),
       false,
     );
   });
@@ -135,6 +182,25 @@ describe("gateRequest (env-driven wrapper)", () => {
       headers: headers({ host: "localhost:5555", origin: "http://localhost:5555" }),
     });
     assert.equal(result, null);
+  });
+
+  it("accepts an exact same-origin POST from 127.0.0.1", () => {
+    const result = gateRequest({
+      method: "POST",
+      headers: headers({ host: "127.0.0.1:5555", origin: "http://127.0.0.1:5555" }),
+    });
+    assert.equal(result, null);
+  });
+
+  it("rejects a POST when loopback Host and Origin aliases differ", async () => {
+    const result = gateRequest({
+      method: "POST",
+      headers: headers({ host: "127.0.0.1:5555", origin: "http://localhost:5555" }),
+    });
+    assert.ok(result instanceof Response, "expected 403 Response");
+    assert.equal(result!.status, 403);
+    const body = await result!.json();
+    assert.equal(body.error, "Cross-origin write rejected");
   });
 
   it("rejects an attacker.example Host (DNS rebinding)", async () => {

--- a/apps/dashboard/lib/security/api-gate.ts
+++ b/apps/dashboard/lib/security/api-gate.ts
@@ -73,6 +73,25 @@ export function stripPort(host: string): string {
   return trimmed;
 }
 
+function normalizeRequestHost(headerHost: string | null): string | null {
+  if (!headerHost) return null;
+  const trimmed = headerHost.trim();
+  if (!trimmed || /[/?#@\\]/.test(trimmed)) return null;
+
+  const authorityPattern = trimmed.startsWith("[")
+    ? /^\[[^\]]+\](?::\d+)?$/
+    : /^[^:]+(?::\d+)?$/;
+  if (!authorityPattern.test(trimmed)) return null;
+
+  try {
+    const url = new URL(`http://${trimmed}`);
+    if (!url.host || url.username || url.password) return null;
+    return url.host.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Parse `AEON_DASHBOARD_ALLOWED_HOSTS` into a normalized set.
  */
@@ -116,8 +135,8 @@ export function isAllowedHost(
 
 /**
  * Returns true iff the `Origin` (or `Referer`) of a state-changing
- * request resolves to a loopback host. GET/HEAD/OPTIONS skip the check
- * because they shouldn't have side effects.
+ * request resolves to the same allowed host as the request Host.
+ * GET/HEAD/OPTIONS skip the check because they shouldn't have side effects.
  *
  * `Origin` is preferred; modern browsers send it on every fetch /
  * XHR / form POST. `Referer` is a fallback for old clients that omit
@@ -134,17 +153,20 @@ export function isSameOriginWrite(
   const safe = method === "GET" || method === "HEAD" || method === "OPTIONS";
   if (safe) return true;
 
+  const requestHost = normalizeRequestHost(headers.get("host"));
+  if (!requestHost || !isAllowedHost(requestHost, opts)) return false;
+
   const originUrl = headers.get("origin") || headers.get("referer");
   if (!originUrl) return false;
 
-  let host: string;
+  let originHost: string;
   try {
-    host = new URL(originUrl).host;
+    originHost = new URL(originUrl).host.toLowerCase();
   } catch {
     return false;
   }
 
-  return isAllowedHost(host, opts);
+  return originHost === requestHost && isAllowedHost(originHost, opts);
 }
 
 /**


### PR DESCRIPTION
## Summary

Require state-changing dashboard requests to use the same host in the Origin/Referer header and the request Host header.

## Problem

The API gate allowed loopback aliases independently. A browser page from `http://localhost:5555` could send a no-CORS POST to `http://127.0.0.1:5555`, and both hosts passed the allowlist even though they are different browser origins.

This exposed privileged routes such as `/api/secrets`, `/api/auth`, and `/api/skills/<name>/run` to cross-origin requests between loopback aliases.

## Fix

- Normalize and validate the request Host header.
- Require the Origin/Referer host to match it exactly, including port.
- Preserve safe-method handling, configured allowed hosts, and `AEON_DASHBOARD_ALLOW_ANY_HOST=1`.
- Add regression coverage for mismatched loopback aliases, exact host matches, malformed hosts, and Referer fallback.

## Testing

- `npm test -- --test-name-pattern='(isSameOriginWrite|gateRequest)'`
- Result: 202 tests passed