### PR TITLE
fix(chains): correlate dispatched skill runs uniquely

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -1,5 +1,5 @@
 name: Aeon · Skill Runner
-run-name: "skill: ${{ inputs.skill || 'feature' }}${{ inputs.var && format(' ({0})', inputs.var) || '' }}"
+run-name: "skill: ${{ inputs.skill || 'feature' }}${{ inputs.var && format(' ({0})', inputs.var) || '' }}${{ inputs.dispatch_id && format(' [dispatch: {0}]', inputs.dispatch_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -65,6 +65,10 @@ on:
         description: 'Path to file with prior chain step outputs (set by chain runner)'
         required: false
         type: string
+      dispatch_id:
+        description: 'Correlation ID for chain dispatches'
+        required: false
+        type: string
   workflow_call:
     inputs:
       skill:
@@ -85,6 +89,10 @@ on:
         type: string
       chain_context_file:
         description: 'Chain context file path'
+        required: false
+        type: string
+      dispatch_id:
+        description: 'Correlation ID for chain dispatches'
         required: false
         type: string
   issues:

--- a/.github/workflows/chain-runner.yml
+++ b/.github/workflows/chain-runner.yml
@@ -55,32 +55,45 @@ jobs:
           NOW_ISO=$(date -u +%FT%TZ)
           echo "Running chain: $CHAIN"
 
-          # --- Helper: dispatch a skill and return its run ID ---
+          # --- Helper: dispatch a skill and return its uniquely correlated run ID ---
           dispatch_skill() {
             local skill="$1" var="${2:-}" ctx_file="${3:-}"
             local before_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+            # The ID is bounded and shell-safe so it can be passed as a workflow input
+            # and embedded in the run-name without changing untrusted jq source.
+            local dispatch_id="chain-$(openssl rand -hex 16)"
 
-            local args=(-f skill="$skill")
+            local args=(-f skill="$skill" -f dispatch_id="$dispatch_id")
             [ -n "$var" ] && args+=(-f var="$var")
             [ -n "$ctx_file" ] && args+=(-f chain_context_file="$ctx_file")
+
+            local expected_title="skill: $skill"
+            [ -n "$var" ] && expected_title+=" ($var)"
+            expected_title+=" [dispatch: $dispatch_id]"
 
             echo "  Dispatching: $skill"
             gh workflow run aeon.yml "${args[@]}"
 
-            # Poll for the run to appear (up to 60s)
+            # Poll for the run to appear (up to 60s). Match the exact run-name
+            # containing this dispatch ID; never fall back to a newer skill run.
             local run_id=""
             for i in $(seq 1 12); do
               sleep 5
-              run_id=$(gh run list --workflow=aeon.yml -L 10 \
-                --json databaseId,displayTitle,createdAt \
-                -q "[.[] | select(.displayTitle | test(\"skill: ${skill}( |\$)\"; \"i\")) | select(.createdAt >= \"${before_ts}\")] | .[0].databaseId" \
+              run_id=$(gh run list --workflow=aeon.yml -L 100 \
+                --json databaseId,displayTitle,createdAt |
+                jq -r --arg expected_title "$expected_title" \
+                  --arg dispatch_id "$dispatch_id" --arg before_ts "$before_ts" \
+                  '[.[] | select(.displayTitle == $expected_title and
+                    (.displayTitle | contains($dispatch_id)) and
+                    .createdAt >= $before_ts) | .databaseId] |
+                   if length == 1 then .[0] else empty end' \
                 2>/dev/null || true)
               [ -n "$run_id" ] && [ "$run_id" != "null" ] && break
               run_id=""
             done
 
             if [ -z "$run_id" ]; then
-              echo "::error::Failed to discover run ID for skill: $skill"
+              echo "::error::Failed to discover run ID for skill: $skill (dispatch: $dispatch_id)"
               return 1
             fi
             echo "  Run ID: $run_id"

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -115,6 +115,8 @@ jobs:
         run: bash scripts/tests/test_reactive_when.sh
       - name: chain when-routing tests
         run: bash scripts/tests/test_chain_when.sh
+      - name: chain-runner dispatch correlation tests
+        run: bash scripts/tests/test_chain_runner.sh
       - name: skill-scan calibration (fires on sinks, not benign syntax)
         run: bash scripts/tests/test_skill_scan_calibration.sh
       - name: audit-log redaction tests

--- a/scripts/tests/test_chain_runner.sh
+++ b/scripts/tests/test_chain_runner.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Regression test for chain-runner's run-name correlation.
+# Two same-skill dispatches must resolve their own runs when GitHub lists both.
+set -uo pipefail
+
+WORKFLOW="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/.github/workflows/chain-runner.yml"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/bin"
+
+pass=0
+fail=0
+ok() { pass=$((pass + 1)); }
+no() { fail=$((fail + 1)); printf 'FAIL: %s\n' "$1"; }
+
+# The fake CLI records dispatches and returns both runs in reverse order.
+cat > "$TMP/bin/gh" <<'FAKE_GH'
+#!/usr/bin/env bash
+set -euo pipefail
+STATE=${FAKE_GH_STATE:?}
+
+if [ "${1:-} ${2:-}" = "workflow run" ]; then
+  shift 2
+  skill=''
+  var=''
+  dispatch_id=''
+  while [ "$#" -gt 0 ]; do
+    if [ "$1" = '-f' ]; then
+      key=${2%%=*}
+      value=${2#*=}
+      case "$key" in
+        skill) skill=$value ;;
+        var) var=$value ;;
+        dispatch_id) dispatch_id=$value ;;
+      esac
+      shift 2
+    else
+      shift
+    fi
+  done
+  printf '%s\t%s\t%s\n' "$skill" "$var" "$dispatch_id" >> "$STATE"
+  exit 0
+fi
+
+if [ "${1:-} ${2:-}" = "run list" ]; then
+  # Make each poll observe the two concurrent dispatches, regardless of order.
+  for _ in $(seq 1 100); do
+    [ "$(wc -l < "$STATE" | tr -d ' ')" -ge 2 ] && break
+    sleep 0.01
+  done
+  rows=()
+  while IFS= read -r row; do
+    rows+=("$row")
+  done < "$STATE"
+  entries=()
+  for ((i=${#rows[@]} - 1; i >= 0; i--)); do
+    IFS=$'\t' read -r skill var dispatch_id <<< "${rows[$i]}"
+    case "$skill:$var" in
+      digest:alpha) db_id=1001 ;;
+      digest:beta) db_id=1002 ;;
+      *) db_id=1999 ;;
+    esac
+    entries+=("$(jq -cn --arg id "$db_id" --arg skill "$skill" --arg var "$var" \
+      --arg dispatch_id "$dispatch_id" \
+      '{databaseId:($id|tonumber), displayTitle:("skill: "+$skill+" ("+$var+") [dispatch: "+$dispatch_id+"]"), createdAt:"2099-01-01T00:00:00Z"}')")
+  done
+  printf '%s\n' "${entries[@]}" | jq -s .
+  exit 0
+fi
+
+printf 'unexpected fake gh invocation: %s\n' "$*" >&2
+exit 2
+FAKE_GH
+chmod +x "$TMP/bin/gh"
+
+# Execute the workflow's actual helper rather than a duplicate test implementation.
+sed -n '/^          dispatch_skill() {/,/^          }$/p' "$WORKFLOW" | sed 's/^          //' > "$TMP/dispatch-helper.sh"
+# The helper's polling delay is irrelevant to this deterministic fake.
+sleep() { :; }
+# shellcheck source=/dev/null
+source "$TMP/dispatch-helper.sh"
+
+export PATH="$TMP/bin:$PATH"
+export FAKE_GH_STATE="$TMP/dispatches"
+: > "$FAKE_GH_STATE"
+export GITHUB_RUN_ID=4242
+export GITHUB_RUN_ATTEMPT=1
+
+dispatch_skill digest alpha > "$TMP/alpha.out" &
+alpha_pid=$!
+dispatch_skill digest beta > "$TMP/beta.out" &
+beta_pid=$!
+wait "$alpha_pid" || no 'alpha dispatch failed'
+wait "$beta_pid" || no 'beta dispatch failed'
+
+alpha_id=$(tail -n 1 "$TMP/alpha.out")
+beta_id=$(tail -n 1 "$TMP/beta.out")
+[ "$alpha_id" = 1001 ] && ok || no "alpha resolved wrong run: $alpha_id"
+[ "$beta_id" = 1002 ] && ok || no "beta resolved wrong run: $beta_id"
+
+ids=$(cut -f3 "$FAKE_GH_STATE")
+[ "$(printf '%s\n' "$ids" | sort -u | wc -l | tr -d ' ')" = 2 ] && ok || no 'dispatch IDs were not unique'
+while IFS= read -r id; do
+  [[ "$id" =~ ^chain-[0-9a-f]{32}$ ]] && ok || no "dispatch ID was not shell-safe and bounded: $id"
+done <<< "$ids"
+
+printf '\nchain-runner correlation: %d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## Summary

Correlate chain-dispatched skill workflows with a unique dispatch ID.

## Problem

The chain runner dispatched `aeon.yml` and then identified the resulting run using only the skill name and a timestamp. Concurrent chains could therefore select the wrong run, especially when the same skill ran with different variables. A chain could wait for and consume another chain's output.

## Fix

- Add an optional `dispatch_id` input to `aeon.yml` for both `workflow_dispatch` and `workflow_call`.
- Include the ID in the generated workflow run name when supplied.
- Generate a bounded shell-safe ID for every chain dispatch.
- Poll for the exact expected run name using `jq --arg` values rather than interpolated filter source.
- Require exactly one matching run and remove the newest-run fallback.
- Add a deterministic fake-`gh` concurrent regression test using two same-skill dispatches with distinct variables.

## Testing

- `bash scripts/tests/test_chain_runner.sh`
- `bash -n scripts/tests/test_chain_runner.sh`
- `git diff --check`

Result: 5 correlation assertions passed.