### PR TITLE
retry transient xai search failures

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -123,3 +123,5 @@ jobs:
         run: bash scripts/tests/test_dry_run.sh
       - name: secretcurl argv-exposure tests
         run: bash scripts/tests/test_secretcurl.sh
+      - name: secretcurl xai retry tests
+        run: bash scripts/tests/test_secretcurl_xai_retry.sh

--- a/scripts/secretcurl.sh
+++ b/scripts/secretcurl.sh
@@ -89,6 +89,80 @@ build_config() {
 
 CONFIG="$(build_config "${args[@]}")" || exit 1
 
+# x_search is a live, variable-latency request.  Every skill uses this helper,
+# so retry only the X.AI Responses endpoint here instead of duplicating subtly
+# different retry loops in eleven SKILL.md files.  Other authenticated requests
+# remain a transparent curl passthrough.
+is_xai_search() {
+  local a
+  for a in "$@"; do
+    case "$a" in
+      https://api.x.ai/v1/responses) return 0 ;;
+    esac
+  done
+  return 1
+}
+
+run_xai_search() {
+  local -a a=("$@")
+  local out_file="" i tok next
+  for ((i=0; i<${#a[@]}; i++)); do
+    tok="${a[$i]}"
+    if [ "$tok" = "-o" ] || [ "$tok" = "--output" ]; then
+      next=$((i + 1)); out_file="${a[$next]-}"; i=$next
+    fi
+  done
+  local attempt=1 max_attempts=3 delay=2 rc http bytes reason stdout_file has_write=0
+  for tok in "${a[@]}"; do
+    [ "$tok" = "-w" ] || [ "$tok" = "--write-out" ] && has_write=1
+  done
+  while [ "$attempt" -le "$max_attempts" ]; do
+    stdout_file="$(mktemp)"
+    set +e
+    printf '%s' "$CONFIG" | curl -K - >"$stdout_file"
+    rc=$?
+    set -e
+    http=""
+    if [ "$has_write" -eq 1 ] && [ -s "$stdout_file" ]; then
+      http="$(tail -c 4 "$stdout_file" | tr -cd '0-9' || true)"
+      [ "${#http}" -eq 3 ] || http=""
+    fi
+    bytes=0
+    [ -n "$out_file" ] && [ -f "$out_file" ] && bytes="$(wc -c <"$out_file" | tr -d ' ')"
+    if [ "$rc" -eq 28 ]; then
+      reason=timeout
+    elif [ "$rc" -ne 0 ]; then
+      reason="curl-$rc"
+    elif [ -n "$http" ] && { [ "$http" -lt 200 ] || [ "$http" -ge 300 ]; }; then
+      reason="http-$http"
+    elif [ "$bytes" -eq 0 ] && [ -n "$out_file" ]; then
+      reason=empty
+    elif [ -n "$out_file" ] && [ "$http" = 200 ] && jq -e -r '
+        [ .output[]? | select(.type == "message") | .content[]?
+          | select(.type == "output_text") | .text // empty
+          | select(length > 0) ] | length > 0
+      ' "$out_file" >/dev/null 2>&1; then
+      reason=ok
+    elif [ -n "$out_file" ] && [ "$http" = 200 ]; then
+      reason=empty
+    elif [ -z "$out_file" ] && [ ! -s "$stdout_file" ]; then
+      reason=empty
+    else
+      reason=ok
+    fi
+    printf 'secretcurl xai attempt=%s/%s http=%s bytes=%s reason=%s\n' \
+      "$attempt" "$max_attempts" "${http:-000}" "$bytes" "$reason" >&2
+    if [ "$reason" = ok ] || [ "$attempt" -eq "$max_attempts" ]; then
+      cat "$stdout_file"
+      rm -f "$stdout_file"
+      return "$([ "$reason" = ok ] && echo 0 || echo "$rc")"
+    fi
+    rm -f "$stdout_file"
+    sleep "$delay"
+    delay=$((delay * 2)); attempt=$((attempt + 1))
+  done
+}
+
 # When auditing is off (AEON_AUDIT_LOG unset), stay a transparent passthrough --
 # byte-identical output/exit behaviour to a plain curl call. When on, run curl in
 # the foreground (stdout/stderr/exit all pass through unchanged) so we can record
@@ -105,7 +179,11 @@ if [ -n "${AEON_AUDIT_LOG:-}" ]; then
   _URL=""
   for a in "$@"; do case "$a" in http://*|https://*) _URL="$a"; break ;; esac; done
   set +e
-  printf '%s' "$CONFIG" | curl -K -
+  if is_xai_search "${args[@]}"; then
+    run_xai_search "${args[@]}"
+  else
+    printf '%s' "$CONFIG" | curl -K -
+  fi
   _RC=$?
   set -e
   _HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -113,5 +191,9 @@ if [ -n "${AEON_AUDIT_LOG:-}" ]; then
     if [ -f "$_c" ]; then bash "$_c" "secretcurl" "${_URL%%\?*}" "$_RC" "${_SECS%,}" || true; break; fi
   done
   exit "$_RC"
+fi
+if is_xai_search "${args[@]}"; then
+  run_xai_search "${args[@]}"
+  exit $?
 fi
 printf '%s' "$CONFIG" | curl -K -

--- a/scripts/secretcurl.sh
+++ b/scripts/secretcurl.sh
@@ -152,7 +152,13 @@ run_xai_search() {
     fi
     printf 'secretcurl xai attempt=%s/%s http=%s bytes=%s reason=%s\n' \
       "$attempt" "$max_attempts" "${http:-000}" "$bytes" "$reason" >&2
-    if [ "$reason" = ok ] || [ "$attempt" -eq "$max_attempts" ]; then
+    retryable=1
+    case "$reason" in
+      ok) retryable=0 ;;
+      http-429|http-5??) retryable=1 ;;
+      http-*) retryable=0 ;;
+    esac
+    if [ "$reason" = ok ] || [ "$attempt" -eq "$max_attempts" ] || [ "$retryable" -eq 0 ]; then
       cat "$stdout_file"
       rm -f "$stdout_file"
       return "$([ "$reason" = ok ] && echo 0 || echo "$rc")"

--- a/scripts/tests/fixtures/curl
+++ b/scripts/tests/fixtures/curl
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cfg=$(cat)
+state=${FAKE_CURL_STATE:?FAKE_CURL_STATE is required}
+attempt=0
+[ -f "$state" ] && attempt=$(cat "$state")
+next=$((attempt + 1))
+echo "$next" > "$state"
+out=$(printf '%s\n' "$cfg" | sed -n 's/^-o "\(.*\)"$/\1/p' | head -1)
+if [ "$attempt" -eq 0 ]; then
+  [ -z "$out" ] || printf '%s' '{"error":"transient"}' > "$out"
+  printf '503'
+else
+  [ -z "$out" ] || printf '%s' '{"output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}]}' > "$out"
+  printf '200'
+fi

--- a/scripts/tests/fixtures/curl
+++ b/scripts/tests/fixtures/curl
@@ -7,6 +7,11 @@ attempt=0
 next=$((attempt + 1))
 echo "$next" > "$state"
 out=$(printf '%s\n' "$cfg" | sed -n 's/^-o "\(.*\)"$/\1/p' | head -1)
+if [ -n "${FAKE_CURL_HTTP:-}" ]; then
+  [ -z "$out" ] || printf '%s' '{"error":"client"}' > "$out"
+  printf '%s' "$FAKE_CURL_HTTP"
+  exit 0
+fi
 if [ "$attempt" -eq 0 ]; then
   [ -z "$out" ] || printf '%s' '{"error":"transient"}' > "$out"
   printf '503'

--- a/scripts/tests/test_secretcurl_xai_retry.sh
+++ b/scripts/tests/test_secretcurl_xai_retry.sh
@@ -19,4 +19,20 @@ FAKE_CURL_STATE="$state" \
 grep -q '"text":"ok"' "$response" || { echo "FAIL - final response was not retained"; exit 1; }
 grep -q 'attempt=1/3 http=503 .*reason=http-503' "$tmp/diag" || { echo "FAIL - missing first-attempt diagnostic"; exit 1; }
 grep -q 'attempt=2/3 http=200 .*reason=ok' "$tmp/diag" || { echo "FAIL - missing success diagnostic"; exit 1; }
-echo 'ALL PASS - xai retries transient HTTP failures with diagnostics'
+echo 'PASS - xai retries transient HTTP 503'
+
+state401="$tmp/state401"
+response401="$tmp/response401.json"
+PATH="$PWD/scripts/tests/fixtures:$PATH" \
+FAKE_CURL_STATE="$state401" \
+FAKE_CURL_HTTP=401 \
+  ./scripts/secretcurl.sh -s -o "$response401" -w '%{http_code}' \
+    --max-time 1 -X POST "https://api.x.ai/v1/responses" \
+    -H 'Authorization: Bearer {XAI_API_KEY}' -d @/dev/null \
+    >"$tmp/http401" 2>"$tmp/diag401"
+
+[ "$(cat "$state401")" = 1 ] || { echo "FAIL - 401 should not retry"; exit 1; }
+[ "$(cat "$tmp/http401")" = 401 ] || { echo "FAIL - expected HTTP 401"; exit 1; }
+grep -q 'attempt=1/3 http=401 .*reason=http-401' "$tmp/diag401" || { echo "FAIL - missing 401 diagnostic"; exit 1; }
+if grep -q 'attempt=2/' "$tmp/diag401"; then echo "FAIL - 401 retried"; exit 1; fi
+echo 'ALL PASS - xai retries 5xx, not 4xx'

--- a/scripts/tests/test_secretcurl_xai_retry.sh
+++ b/scripts/tests/test_secretcurl_xai_retry.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+state="$tmp/state"
+response="$tmp/response.json"
+
+PATH="$PWD/scripts/tests/fixtures:$PATH" \
+FAKE_CURL_STATE="$state" \
+  ./scripts/secretcurl.sh -s -o "$response" -w '%{http_code}' \
+    --max-time 1 -X POST "https://api.x.ai/v1/responses" \
+    -H 'Authorization: Bearer {XAI_API_KEY}' -d @/dev/null \
+    >"$tmp/http" 2>"$tmp/diag"
+
+[ "$(cat "$state")" = 2 ] || { echo "FAIL - expected two attempts"; exit 1; }
+[ "$(cat "$tmp/http")" = 200 ] || { echo "FAIL - expected final HTTP 200"; exit 1; }
+grep -q '"text":"ok"' "$response" || { echo "FAIL - final response was not retained"; exit 1; }
+grep -q 'attempt=1/3 http=503 .*reason=http-503' "$tmp/diag" || { echo "FAIL - missing first-attempt diagnostic"; exit 1; }
+grep -q 'attempt=2/3 http=200 .*reason=ok' "$tmp/diag" || { echo "FAIL - missing success diagnostic"; exit 1; }
+echo 'ALL PASS - xai retries transient HTTP failures with diagnostics'


### PR DESCRIPTION
ports Svector-anu/svectors-lab#37 upstream — that fix has been running on my fork since 2026-08-27, this brings it to main so every operator using x_search-dependent skills benefits, not just my fork.

## what
x_search calls to api.x.ai are live, variable-latency requests. a single transient failure (timeout, 5xx, an empty 200) was previously permanent — no retry, immediate fallback to a lower-quality path. this centralizes a 3-attempt retry/backoff with per-attempt diagnostics inside `secretcurl` itself, so every skill that calls x_search through it benefits without individual changes.

## why here, not per-skill
11 skills declare `XAI_API_KEY` and share this exact fragile single-shot pattern. fixing it once in `secretcurl` (the shared call path) avoids 11 near-identical retry loops.

## verification
- existing `scripts/tests/test_secretcurl.sh` suite: unchanged, passes
- new `scripts/tests/test_secretcurl_xai_retry.sh`: passes
- mutation-tested: forced `max_attempts=1`, confirmed the test fails for the predicted reason ("expected two attempts"), restored, confirmed green again
- real-world validation: this exact fix has been live on my fork since 2026-08-27 (Svector-anu/svectors-lab#37), including a live proof-of-concept against the real X.AI API (real x_search content returned on attempt 1)