### PR TITLE
teach deploy-uni-hook the fleet audit rules

### DIFF
--- a/skills/deploy-uni-hook/SKILL.md
+++ b/skills/deploy-uni-hook/SKILL.md
@@ -77,6 +77,31 @@ Uniswap Labs auto-routes a hooked pool unless the address starts with `0x91`, or
 
 Do not generate amount-suffix / block-echo / exact-out-only / direction-gate hooks unless the brief explicitly asks for a revert-gate. Those are not Labs-routable. The miner skips `0x91...` addresses so an otherwise auto-route hook is not accidentally gated.
 
+## Fleet audit rules (from aeon.fun hook audits)
+
+These are standing defects measured on the live fleet. Freeform MUST NOT recreate them. The `skim` template is already patched.
+
+**Fee / `take()`:**
+- Charge the MAGNITUDE of the unspecified delta. Exact-out makes that delta negative. `if (unspecifiedAmount <= 0) return` silently skips the fee on every exact-output swap (shared-base F1).
+- Widen to `int256` before negating. `-type(int128).min` panics and bricks that swap.
+- `poolManager.take(..., feeRecipient, ...)` to an immutable recipient. NEVER `address(this)`. No `withdraw()`. Custody was the CrownClash/LegacyLedger HIGH.
+- An extra skim helper must not copy a `<= 0` early return (second copy of the sign guard).
+
+**Gates** (only if the brief demands a revert-gate):
+- 1a. Value that moves on its own (`block.number`): a `view` helper answered at head N is wrong at execution N+1. Target the execution block.
+- 1b. Value that moves when someone swaps (price low byte): exact match + zero tolerance is a contention DoS. Need a band, or do not gate.
+- 1c. Shared counter an attacker can park, not advanced on failure: griefing primitive.
+- 2. A contract in the `unlock` frame can satisfy the predicate; a signed tx cannot. That binds the wrong party.
+- 5. Never compare raw `amountSpecified` to a token-denominated constant. The caller picks the specified currency via exact-in vs exact-out. Use a dimensionless bound (tick move / liquidity fraction).
+- Never `balanceOf(poolManager)`: that is the v4 singleton's global inventory, not this pool. Use `StateLibrary`.
+- `sender` is the router. Do not treat it as the trader.
+
+**Tests:**
+- A fee hook must assert the take on exact-in AND exact-out.
+- A gate needs a hookless negative control (`hooks = address(0)`).
+- Do not cache `block.number` across `vm.roll` (via-ir folds it). Use `vm.getBlockNumber()`.
+
+
 
 ## Steps
 
@@ -88,7 +113,7 @@ Do not generate amount-suffix / block-echo / exact-out-only / direction-gate hoo
 
 4. **Build the hook (brief-driven).**
    - **Template mode** (`dynamic` / `noop` / `skim`): in `$HOOKBUILD_DIR/src/<Hook>.sol`, edit ONLY the region between `// --- AEON:LOGIC START ---` and `// --- AEON:LOGIC END ---`. Keep the callback signatures and flag set unchanged. If the default already fits the brief, leave it.
-   - **Freeform mode** (anything else): write the whole hook into `$HOOKBUILD_DIR/src/Hook.sol` — replace the `// --- AEON:BODY ... ---` region. Rules: keep the contract name `Hook` and `constructor(IPoolManager)`; implement whichever v4 callbacks the prompt needs, each with the EXACT `IHooks` signature, `onlyPoolManager`, and the right selector return. Do NOT hand-set flags — they are auto-derived from which callbacks you implement. If a callback returns a non-zero delta, set `HOOK_RETURNS_DELTA` in `$HOOKBUILD_DIR/hook.env`; for a fee-override hook set `HOOK_POOL_FEE=dynamic` there. Follow **Labs routing** above: empty `hookData` must succeed; a game must not revert a vanilla exact-in swap; a `take()` must declare `HOOK_RETURNS_DELTA`.
+   - **Freeform mode** (anything else): write the whole hook into `$HOOKBUILD_DIR/src/Hook.sol` — replace the `// --- AEON:BODY ... ---` region. Rules: keep the contract name `Hook` and `constructor(IPoolManager)`; implement whichever v4 callbacks the prompt needs, each with the EXACT `IHooks` signature, `onlyPoolManager`, and the right selector return. Do NOT hand-set flags — they are auto-derived from which callbacks you implement. If a callback returns a non-zero delta, set `HOOK_RETURNS_DELTA` in `$HOOKBUILD_DIR/hook.env`; for a fee-override hook set `HOOK_POOL_FEE=dynamic` there. Follow **Labs routing** and **Fleet audit rules** above: empty `hookData` must succeed; a game must not revert a vanilla exact-in swap; a `take()` must declare `HOOK_RETURNS_DELTA`, charge magnitude (exact-in and exact-out), and never custody.
      - **Also write the behavioral test.** In `$HOOKBUILD_DIR/test/Hook.t.sol`, replace the `// --- AEON:ASSERT ... ---` region with `test_*` functions that assert the hook's SPECIFIC intended behavior — not just "does not revert". For every rule in the brief write at least one positive and one negative case: a swap the hook must REJECT as `_expectSwapRevert(zeroForOne, amount, Hook.SomeError.selector)` (this helper unwraps v4's `WrappedError` for you — do NOT use bare `vm.expectRevert`, it won't match the wrapper); a swap it must ALLOW as a plain `_swap(...)`; any getter/accounting as `assertEq(hook.someGetter(...), expected)`. Do NOT edit `setUp()` or the helpers — only the `AEON:ASSERT` region. If the brief has no rejectable behavior, still assert the observable state the hook changes.
 
 5. **Simulate + audit (always).** Pass mode, kind, and chain (chain omitted = `base-sepolia`):

--- a/skills/deploy-uni-hook/hook-deploy.sh
+++ b/skills/deploy-uni-hook/hook-deploy.sh
@@ -151,9 +151,15 @@ scan_dangerous() {
   local src="$1" bad=0
   grep -qE '\bselfdestruct\b'  "$src" && { echo "  FAIL: selfdestruct present (can brick the hook)"; bad=1; }
   grep -qE '\bdelegatecall\b'  "$src" && { echo "  FAIL: delegatecall present (code-injection risk)"; bad=1; }
-  grep -qE '\btx\.origin\b'    "$src" && echo "  WARN: tx.origin used (auth smell — review)"
+  grep -qE '\btx\.origin\b'    "$src" && echo "  WARN: tx.origin used (auth smell - review)"
   grep -qE '\.call\{[[:space:]]*value' "$src" && echo "  WARN: raw value-bearing call (review)"
   grep -qE '\bassembly\b'      "$src" && echo "  WARN: inline assembly (review)"
+  grep -qE 'poolManager\.take\([^;]*address\(this\)' "$src" \
+    && { echo "  FAIL: take() to address(this) custodies swapper funds"; bad=1; }
+  grep -qE 'unspecifiedAmount[[:space:]]*<=[[:space:]]*0' "$src" \
+    && echo "  WARN: unspecifiedAmount <= 0 skips the fee on exact-output"
+  grep -qE 'balanceOf\([^)]*poolManager' "$src" \
+    && echo "  WARN: balanceOf(poolManager) is singleton inventory, not this pool"
   return $bad
 }
 

--- a/skills/deploy-uni-hook/templates/Hook.sol
+++ b/skills/deploy-uni-hook/templates/Hook.sol
@@ -16,6 +16,10 @@ pragma solidity 0.8.26;
 //   - Labs auto-route forbids 0x91, beforeSwapReturnsDelta, afterSwapReturnsDelta,
 //     and dynamicFees. A take() is allowlist-only. Games must succeed with empty
 //     hookData; do not revert a vanilla exact-in; do not key state off sender.
+//   - Fee take: magnitude of unspecified (exact-in AND exact-out). Widen to int256
+//     before abs. take() to an immutable recipient, never address(this), no withdraw.
+//   - Gates: no exact-match on moving state, no raw amountSpecified cap, no
+//     balanceOf(poolManager). Helpers must match execution-time state.
 //
 // All commonly-needed imports/usings are here so generated bodies compile as-is.
 

--- a/skills/deploy-uni-hook/templates/HookFeeHook.sol
+++ b/skills/deploy-uni-hook/templates/HookFeeHook.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.26;
 
 // TEMPLATE: hook-fee skim (Tier 2, return-delta).
 // Flags required in the address: AFTER_SWAP + AFTER_SWAP_RETURNS_DELTA (0x44).
-// Takes FEE_BPS of the swap's unspecified (usually output) currency for the hook.
-// The owner can withdraw the collected fees.
+// Takes FEE_BPS of the swap's unspecified currency (magnitude: exact-in AND exact-out)
+// and routes it straight to an immutable recipient. The hook never holds funds.
 // Labs routing: allowlist required (afterSwapReturnsDelta). Cannot auto-route.
 //
 // WARNING: a return-delta hook moves the token ledger. A wrong delta or a failed
@@ -13,27 +13,25 @@ pragma solidity 0.8.26;
 import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
 import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
-import {Currency, CurrencyLibrary} from "@uniswap/v4-core/src/types/Currency.sol";
+import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
 import {BalanceDelta, BalanceDeltaLibrary} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
 
 contract HookFeeHook {
-    using CurrencyLibrary for Currency;
     using BalanceDeltaLibrary for BalanceDelta;
 
     IPoolManager public immutable poolManager;
-    address public immutable owner;
+    address public immutable feeRecipient;
 
     // hook fee in basis points of the unspecified amount (100 = 1.00%)
     uint256 public constant FEE_BPS = 100;
 
-    event HookFeeTaken(Currency indexed currency, uint256 amount);
+    event HookFeeTaken(Currency indexed currency, uint256 amount, address indexed recipient);
 
     error NotPoolManager();
-    error NotOwner();
 
     constructor(IPoolManager _pm) {
         poolManager = _pm;
-        owner = msg.sender;
+        feeRecipient = msg.sender;
     }
 
     modifier onlyPoolManager() {
@@ -49,27 +47,23 @@ contract HookFeeHook {
         bytes calldata
     ) external onlyPoolManager returns (bytes4, int128) {
         // --- AEON:LOGIC START ---
-        // pick the unspecified currency + the swapper's delta on it
-        (Currency feeCurrency, int128 unspecifiedAmount) = (params.amountSpecified < 0 == params.zeroForOne)
+        // Unspecified currency: output on exact-in, input on exact-out. Charge both.
+        (Currency feeCurrency, int128 unspecifiedAmount) = ((params.amountSpecified < 0) == params.zeroForOne)
             ? (key.currency1, delta.amount1())
             : (key.currency0, delta.amount0());
 
-        // only skim when the swapper RECEIVES the unspecified currency (positive)
-        if (unspecifiedAmount <= 0) return (IHooks.afterSwap.selector, int128(0));
+        // Widen before negating: -type(int128).min overflows int128 checked arithmetic.
+        int256 wideAmount = int256(unspecifiedAmount);
+        uint256 magnitude = uint256(wideAmount < 0 ? -wideAmount : wideAmount);
+        if (magnitude == 0) return (IHooks.afterSwap.selector, int128(0));
 
-        uint256 feeAmount = (uint256(uint128(unspecifiedAmount)) * FEE_BPS) / 10_000;
+        uint256 feeAmount = (magnitude * FEE_BPS) / 10_000;
         if (feeAmount == 0) return (IHooks.afterSwap.selector, int128(0));
         require(feeAmount <= uint256(uint128(type(int128).max)), "fee overflow");
 
-        poolManager.take(feeCurrency, address(this), feeAmount);
-        emit HookFeeTaken(feeCurrency, feeAmount);
+        poolManager.take(feeCurrency, feeRecipient, feeAmount);
+        emit HookFeeTaken(feeCurrency, feeAmount, feeRecipient);
         return (IHooks.afterSwap.selector, int128(uint128(feeAmount)));
         // --- AEON:LOGIC END ---
-    }
-
-    /// @notice Withdraw collected fees for one currency to a recipient.
-    function withdraw(Currency currency, address to, uint256 amount) external {
-        if (msg.sender != owner) revert NotOwner();
-        currency.transfer(to, amount);
     }
 }


### PR DESCRIPTION
## Why

aeon-vuln `memory/topics/aeon-fun-hooks.md` and aeon-onchain coverage already measured these on the live fleet. Canon `deploy-uni-hook` still shipped them:

- `skim` skipped the fee on exact-output (`unspecifiedAmount <= 0`)
- `skim` `take()`d to `address(this)` and needed `withdraw()` (custody HIGH)
- freeform had no gate checklist, so it would regenerate BlockEcho/TailTwins/CapGate

## What

- `HookFeeHook`: charge magnitude (exact-in and exact-out), widen to int256 before abs, `take()` to immutable `feeRecipient`, no withdraw
- Static audit: FAIL `take(..., address(this), ...)`; WARN exact-out skip and `balanceOf(poolManager)`
- SKILL.md + freeform scaffold: standing fee/gate/test rules from the audits

Follow-up of #991 (Labs routing). Does not change catalogs.

## Test

- `bash -n skills/deploy-uni-hook/hook-deploy.sh`
- Constructor still `constructor(IPoolManager)` so DeployHook.s.sol is unchanged