### PR TITLE
style(dashboard): shorten harness picker labels

### DIFF
--- a/apps/dashboard/components/AuthModal.tsx
+++ b/apps/dashboard/components/AuthModal.tsx
@@ -35,7 +35,7 @@ export function AuthModal({ loading, onClose, onAuth }: AuthModalProps) {
     <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/30 backdrop-blur-sm">
       <div className="bg-aeon-panel border border-[rgba(250,250,250,0.10)] w-full max-w-sm mx-4 p-[var(--space-lg)] shadow-2xl">
         <div className="flex items-center justify-between mb-[var(--space-sm)]">
-          <h2 className="font-display text-xl">Anthropic</h2>
+          <h2 className="font-display text-xl">Claude</h2>
           <button onClick={onClose} className="text-primary-35 hover:text-primary-100 text-lg">&times;</button>
         </div>
         <p className="text-xs text-primary-50 font-mono mb-[var(--space-md)]">Connect a Claude subscription token, or pick your key&apos;s provider and paste it below. Routing is automatic - at run time Aeon uses whichever provider keys are set, in priority order.</p>

--- a/apps/dashboard/components/GrokAuthModal.tsx
+++ b/apps/dashboard/components/GrokAuthModal.tsx
@@ -28,7 +28,7 @@ export function GrokAuthModal({ loading, onClose, onGrokAuth, patSet, onGoToSecr
     <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/30 backdrop-blur-sm">
       <div className="bg-aeon-panel border border-[rgba(250,250,250,0.10)] w-full max-w-sm mx-4 p-[var(--space-lg)] shadow-2xl">
         <div className="flex items-center justify-between mb-[var(--space-sm)]">
-          <h2 className="font-display text-xl">xAI</h2>
+          <h2 className="font-display text-xl">Grok</h2>
           <button onClick={onClose} className="text-primary-35 hover:text-primary-100 text-lg">&times;</button>
         </div>
         <p className="text-xs text-primary-50 font-mono mb-[var(--space-md)]">Run skills with the grok CLI on your X account. Click below: a browser tab opens to approve on <code className="text-primary-70">accounts.x.ai</code>, and the session is stored for CI. Needs SuperGrok / X Premium+ and the <code className="text-primary-70">grok</code> CLI installed.</p>

--- a/apps/dashboard/components/HarnessAuthModal.tsx
+++ b/apps/dashboard/components/HarnessAuthModal.tsx
@@ -14,8 +14,8 @@ const TITLES: Record<string, string> = {
   codex: 'Codex',
   kimi: 'Kimi',
   pi: 'Pi',
-  vibe: 'Vibe',
-  cursor: 'Cursor CLI',
+  vibe: 'Mistral',
+  cursor: 'Cursor',
   hermes: 'Hermes',
 }
 const OAUTH_BLURB: Record<string, string> = {

--- a/apps/dashboard/lib/constants.ts
+++ b/apps/dashboard/lib/constants.ts
@@ -99,15 +99,15 @@ export const HERMES_MODELS = [
 // select options while making a typo'd or dropped harness a compile error
 // against the Harness union in ./types.
 export const HARNESSES = [
-  { id: 'claude', label: 'Anthropic' },
-  { id: 'grok', label: 'xAI' },
+  { id: 'claude', label: 'Claude' },
+  { id: 'grok', label: 'Grok' },
   { id: 'codex', label: 'Codex' },
-  { id: 'fx', label: 'fx (Vercel)' },
+  { id: 'fx', label: 'fx' },
   { id: 'pi', label: 'Pi' },
-  { id: 'vibe', label: 'Vibe' },
+  { id: 'vibe', label: 'Mistral' },
   { id: 'kimi', label: 'Kimi' },
-  { id: 'cursor', label: 'Cursor CLI' },
-  { id: 'hermes', label: 'Hermes (Nous Portal)' },
+  { id: 'cursor', label: 'Cursor' },
+  { id: 'hermes', label: 'Hermes' },
 ] as const satisfies readonly { id: Harness; label: string }[]
 
 // fx has no model picker: unlike codex/pi/vibe/kimi's OpenRouter path, fx's


### PR DESCRIPTION
Dashboard harness dropdown labels:

- Anthropic -> Claude
- xAI -> Grok
- fx (Vercel) -> fx
- Vibe -> Mistral
- Cursor CLI -> Cursor
- Hermes (Nous Portal) -> Hermes

Ids unchanged. Kimi stays Kimi.
