### PR TITLE
feat(notify): reply Telegram to previous skill run

### DIFF
--- a/scripts/notify-deliver.sh
+++ b/scripts/notify-deliver.sh
@@ -23,6 +23,10 @@
 #
 # NOTIFY_DRY_RUN=1 records the Telegram payload to notify-queue/tg-payload.jsonl and
 # the Buzz chunks to buzz-payload.txt instead of sending — no network. Used by tests.
+# Telegram reply-to-previous (default on): a skill's send quotes that skill's last
+# Telegram message via reply_to_message_id + allow_sending_without_reply. Ledger:
+# memory/telegram-threads/<skill>.json ({chat_id, message_id}). Off:
+# TELEGRAM_REPLY_TO_PREVIOUS=0. Dry-run tests set AEON_TG_THREADS_DIR.
 set -euo pipefail
 
 PAYLOAD="${1:-}"
@@ -68,7 +72,77 @@ fi
 
 DELIVERED=false
 
-# --- Telegram — fence-safe chunks (parse_mode HTML, plaintext fallback) ------
+# Per-skill Telegram reply target. Default ON. Dry-run writes a ledger only when
+# AEON_TG_THREADS_DIR is set, so existing tests do not touch memory/.
+TG_DIR=""
+if [ -n "${AEON_TG_THREADS_DIR:-}" ]; then
+  TG_DIR="$AEON_TG_THREADS_DIR"
+elif [ "${NOTIFY_DRY_RUN:-}" != "1" ]; then
+  TG_ROOT="${GITHUB_WORKSPACE:-}"
+  [ -z "$TG_ROOT" ] && TG_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  TG_DIR="$TG_ROOT/memory/telegram-threads"
+fi
+TG_REPLY_ON=1
+case "${TELEGRAM_REPLY_TO_PREVIOUS:-1}" in 0|false|off|no) TG_REPLY_ON=0 ;; esac
+
+_tg_load_mid() {
+  TG_PREV_MID=""
+  [ -n "$TG_DIR" ] && [ -n "$SKILL_NAME" ] || return 0
+  local f="$TG_DIR/${SKILL_NAME}.json"
+  [ -f "$f" ] || return 0
+  local chat mid
+  chat=$(jq -r '.chat_id // empty' "$f" 2>/dev/null || true)
+  mid=$(jq -r '.message_id // empty' "$f" 2>/dev/null || true)
+  [ "$chat" = "$TELEGRAM_CHAT_ID" ] || return 0
+  [[ "$mid" =~ ^[0-9]+$ ]] || return 0
+  TG_PREV_MID="$mid"
+}
+_tg_save_mid() {
+  local mid="$1"
+  [ -n "$TG_DIR" ] && [ -n "$SKILL_NAME" ] && [ -n "$mid" ] || return 0
+  [[ "$SKILL_NAME" =~ ^[a-z0-9_-]+$ ]] || return 0
+  [[ "$mid" =~ ^[0-9]+$ ]] || return 0
+  mkdir -p "$TG_DIR" || return 0
+  local f="$TG_DIR/${SKILL_NAME}.json" tmp
+  tmp=$(mktemp) || return 0
+  if jq -n --arg c "$TELEGRAM_CHAT_ID" --argjson m "$mid" \
+      '{chat_id:$c, message_id:$m}' > "$tmp"
+  then
+    mv "$tmp" "$f"
+  else
+    rm -f "$tmp"
+  fi
+}
+_tg_next_dry_mid() {
+  mkdir -p "$TG_DIR" || return 0
+  local seqf="$TG_DIR/.seq" n=0
+  [ -f "$seqf" ] && n=$(cat "$seqf" 2>/dev/null || echo 0)
+  n=$((n + 1))
+  printf '%s\n' "$n" > "$seqf"
+  printf '%s\n' "$n"
+}
+_tg_payload() {
+  local text="$1" mode="$2" rm="$3" reply="$4"
+  if [ -n "$reply" ]; then
+    if [ -n "$mode" ]; then
+      jq -n --arg chat "$TELEGRAM_CHAT_ID" --arg text "$text" --argjson rm "$rm" --argjson reply "$reply" \
+        '{chat_id:$chat, text:$text, parse_mode:"HTML", reply_to_message_id:$reply, allow_sending_without_reply:true} + (if $rm then {reply_markup:$rm} else {} end)'
+    else
+      jq -n --arg chat "$TELEGRAM_CHAT_ID" --arg text "$text" --argjson rm "$rm" --argjson reply "$reply" \
+        '{chat_id:$chat, text:$text, reply_to_message_id:$reply, allow_sending_without_reply:true} + (if $rm then {reply_markup:$rm} else {} end)'
+    fi
+  else
+    if [ -n "$mode" ]; then
+      jq -n --arg chat "$TELEGRAM_CHAT_ID" --arg text "$text" --argjson rm "$rm" \
+        '{chat_id:$chat, text:$text, parse_mode:"HTML"} + (if $rm then {reply_markup:$rm} else {} end)'
+    else
+      jq -n --arg chat "$TELEGRAM_CHAT_ID" --arg text "$text" --argjson rm "$rm" \
+        '{chat_id:$chat, text:$text} + (if $rm then {reply_markup:$rm} else {} end)'
+    fi
+  fi
+}
+
+# --- Telegram - fence-safe chunks (parse_mode HTML, plaintext fallback) ------
 if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ]; then
   TG_CHUNKS_B64=$(printf '%s' "$MSG" | python3 "$FMT" telegram --title "$TITLE" --severity "$SEVERITY" || true)
   TG_CHUNKS=()
@@ -77,6 +151,10 @@ if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ]; then
     TG_CHUNKS+=("$TG_CHUNK_B64")
   done <<< "$TG_CHUNKS_B64"
   TG_LAST=$(( ${#TG_CHUNKS[@]} - 1 ))
+  TG_PREV_MID=""
+  TG_RUN_ROOT=""
+  TG_LAST_MID=""
+  [ "$TG_REPLY_ON" = "1" ] && _tg_load_mid
   for TG_I in "${!TG_CHUNKS[@]}"; do
     TG_MSG=$(printf '%s' "${TG_CHUNKS[$TG_I]}" | base64 -d)
     # reply_markup rides only on the last chunk.
@@ -85,35 +163,59 @@ if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ]; then
     else
       TG_RM="null"
     fi
-    TG_PAYLOAD=$(jq -n --arg chat "$TELEGRAM_CHAT_ID" --arg text "$TG_MSG" --argjson rm "$TG_RM" \
-      '{chat_id:$chat, text:$text, parse_mode:"HTML"} + (if $rm then {reply_markup:$rm} else {} end)')
+    TG_REPLY_TO=""
+    if [ "$TG_REPLY_ON" = "1" ]; then
+      if [ -n "$TG_RUN_ROOT" ]; then
+        TG_REPLY_TO="$TG_RUN_ROOT"
+      elif [ -n "$TG_PREV_MID" ]; then
+        TG_REPLY_TO="$TG_PREV_MID"
+      fi
+    fi
+    TG_PAYLOAD=$(_tg_payload "$TG_MSG" HTML "$TG_RM" "$TG_REPLY_TO")
 
+    TG_MID=""
     # Dry-run (tests): record the payload instead of sending. No network.
     if [ "${NOTIFY_DRY_RUN:-}" = "1" ]; then
       mkdir -p "$QUEUE_DIR"
       printf '%s\n' "$TG_PAYLOAD" >> "$QUEUE_DIR/tg-payload.jsonl"
       DELIVERED=true
-      continue
-    fi
-
-    TG_RESULT=$(curl -s -w "\n%{http_code}" -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
-      -H "Content-Type: application/json" -d "$TG_PAYLOAD" 2>/dev/null) || true
-    TG_HTTP=$(echo "$TG_RESULT" | tail -1)
-    TG_OK=$(echo "$TG_RESULT" | sed '$d' | jq -r '.ok // false' 2>/dev/null || echo "false")
-    if [ "$TG_HTTP" = "200" ] && [ "$TG_OK" = "true" ]; then
-      DELIVERED=true
+      if [ -n "$TG_DIR" ] && [ -n "$SKILL_NAME" ]; then
+        TG_MID=$(_tg_next_dry_mid)
+      fi
     else
-      # Fallback without parse_mode. Strip tags + unescape so it degrades to clean
-      # plaintext, not visible <b>…</b> markup. Keep the reply_markup.
-      TG_PLAIN=$(printf '%s' "$TG_MSG" | sed -E 's/<[^>]+>//g' \
-        | sed -E 's/&lt;/</g; s/&gt;/>/g; s/&amp;/\&/g')
-      TG_FALLBACK=$(jq -n --arg chat "$TELEGRAM_CHAT_ID" --arg text "$TG_PLAIN" --argjson rm "$TG_RM" \
-        '{chat_id:$chat, text:$text} + (if $rm then {reply_markup:$rm} else {} end)')
-      curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
-        -H "Content-Type: application/json" -d "$TG_FALLBACK" > /dev/null 2>&1 && DELIVERED=true || true
+      TG_RESULT=$(curl -s -w "\n%{http_code}" -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+        -H "Content-Type: application/json" -d "$TG_PAYLOAD" 2>/dev/null) || true
+      TG_HTTP=$(echo "$TG_RESULT" | tail -1)
+      TG_BODY=$(echo "$TG_RESULT" | sed '$d')
+      TG_OK=$(printf '%s' "$TG_BODY" | jq -r '.ok // false' 2>/dev/null || echo "false")
+      if [ "$TG_HTTP" = "200" ] && [ "$TG_OK" = "true" ]; then
+        DELIVERED=true
+        TG_MID=$(printf '%s' "$TG_BODY" | jq -r '.result.message_id // empty' 2>/dev/null || true)
+      else
+        # Fallback without parse_mode. Strip tags + unescape so it degrades to clean
+        # plaintext, not visible <b>...</b> markup. Keep the reply_markup.
+        TG_PLAIN=$(printf '%s' "$TG_MSG" | sed -E 's/<[^>]+>//g' \
+          | sed -E 's/&lt;/</g; s/&gt;/>/g; s/&amp;/\&/g')
+        TG_FALLBACK=$(_tg_payload "$TG_PLAIN" "" "$TG_RM" "$TG_REPLY_TO")
+        TG_RESULT=$(curl -s -w "\n%{http_code}" -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+          -H "Content-Type: application/json" -d "$TG_FALLBACK" 2>/dev/null) || true
+        TG_HTTP=$(echo "$TG_RESULT" | tail -1)
+        TG_BODY=$(echo "$TG_RESULT" | sed '$d')
+        TG_OK=$(printf '%s' "$TG_BODY" | jq -r '.ok // false' 2>/dev/null || echo "false")
+        if [ "$TG_HTTP" = "200" ] && [ "$TG_OK" = "true" ]; then
+          DELIVERED=true
+          TG_MID=$(printf '%s' "$TG_BODY" | jq -r '.result.message_id // empty' 2>/dev/null || true)
+        fi
+      fi
+      sleep 0.3
     fi
-    sleep 0.3
+    if [[ "$TG_MID" =~ ^[0-9]+$ ]]; then
+      echo "notify-deliver: telegram skill=${SKILL_NAME:-?} mid=$TG_MID reply_to=${TG_REPLY_TO:-none}" >&2
+      [ -z "$TG_RUN_ROOT" ] && TG_RUN_ROOT="$TG_MID"
+      TG_LAST_MID="$TG_MID"
+    fi
   done
+  [ -n "$TG_LAST_MID" ] && _tg_save_mid "$TG_LAST_MID"
 fi
 
 # --- Discord — rich embeds, one POST per embed ------------------------------

--- a/scripts/tests/test_notify.sh
+++ b/scripts/tests/test_notify.sh
@@ -269,6 +269,89 @@ TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 NOTIFY_DRY_RUN=1 bash "$DELIVER" "$p" 
 n=$(jq -s 'length' "$WORK/tg-payload.jsonl" 2>/dev/null)
 [ "$n" = "1" ] && pass "deliver: idempotent re-delivery sends once ($n)" || bad "deliver: idempotent re-delivery sends once (got $n)"
 
+# 22-27. reply-to-previous (default on). Isolated ledger dir so memory/ is never touched.
+TDIR=$(mktemp -d)
+
+# 22. first send for a skill has no reply_to; ledger stores a dry-run mid
+reset
+TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 SKILL_NAME=digest \
+  bash "$NOTIFY" "First digest body long enough to clear the probe filter aaa" >/dev/null 2>&1
+p="$(payload)"
+AEON_TG_THREADS_DIR="$TDIR" TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 NOTIFY_DRY_RUN=1 \
+  bash "$DELIVER" "$p" >/dev/null 2>&1
+{ [ -f "$WORK/tg-payload.jsonl" ] \
+  && jq -e 'has("reply_to_message_id")|not' "$WORK/tg-payload.jsonl" >/dev/null 2>&1 \
+  && jq -e '.chat_id=="123" and .message_id==1' "$TDIR/digest.json" >/dev/null 2>&1; } \
+  && pass "deliver: first send has no reply_to and writes ledger" \
+  || bad "deliver: first send has no reply_to and writes ledger"
+
+# 23. second send for the same skill quotes the stored mid
+reset
+TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 SKILL_NAME=digest \
+  bash "$NOTIFY" "Second digest body long enough to clear the probe filter bbb" >/dev/null 2>&1
+p="$(payload)"
+AEON_TG_THREADS_DIR="$TDIR" TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 NOTIFY_DRY_RUN=1 \
+  bash "$DELIVER" "$p" >/dev/null 2>&1
+{ jq -e '.reply_to_message_id==1 and .allow_sending_without_reply==true' "$WORK/tg-payload.jsonl" >/dev/null 2>&1 \
+  && jq -e '.message_id==2' "$TDIR/digest.json" >/dev/null 2>&1; } \
+  && pass "deliver: second send replies to previous mid" \
+  || bad "deliver: second send replies to previous mid"
+
+# 24. a different skill does not inherit the other skill's mid
+reset
+TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 SKILL_NAME=heartbeat \
+  bash "$NOTIFY" "Heartbeat body long enough to clear the probe filter ccc" >/dev/null 2>&1
+p="$(payload)"
+AEON_TG_THREADS_DIR="$TDIR" TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 NOTIFY_DRY_RUN=1 \
+  bash "$DELIVER" "$p" >/dev/null 2>&1
+{ jq -e 'has("reply_to_message_id")|not' "$WORK/tg-payload.jsonl" >/dev/null 2>&1 \
+  && jq -e '.message_id==3' "$TDIR/heartbeat.json" >/dev/null 2>&1; } \
+  && pass "deliver: other skill does not inherit reply_to" \
+  || bad "deliver: other skill does not inherit reply_to"
+
+# 25. TELEGRAM_REPLY_TO_PREVIOUS=0 skips reply_to even with a ledger
+reset
+TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 SKILL_NAME=digest \
+  bash "$NOTIFY" "Killswitch digest body long enough to clear the probe filter ddd" >/dev/null 2>&1
+p="$(payload)"
+AEON_TG_THREADS_DIR="$TDIR" TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 TELEGRAM_REPLY_TO_PREVIOUS=0 NOTIFY_DRY_RUN=1 \
+  bash "$DELIVER" "$p" >/dev/null 2>&1
+jq -e 'has("reply_to_message_id")|not' "$WORK/tg-payload.jsonl" >/dev/null 2>&1 \
+  && pass "deliver: TELEGRAM_REPLY_TO_PREVIOUS=0 skips reply_to" \
+  || bad "deliver: TELEGRAM_REPLY_TO_PREVIOUS=0 skips reply_to"
+
+# 26. chat_id mismatch skips reply_to
+TDIR2=$(mktemp -d)
+printf '%s\n' '{"chat_id":"999","message_id":42}' > "$TDIR2/digest.json"
+reset
+TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 SKILL_NAME=digest \
+  bash "$NOTIFY" "Chat mismatch body long enough to clear the probe filter eee" >/dev/null 2>&1
+p="$(payload)"
+AEON_TG_THREADS_DIR="$TDIR2" TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 NOTIFY_DRY_RUN=1 \
+  bash "$DELIVER" "$p" >/dev/null 2>&1
+jq -e 'has("reply_to_message_id")|not' "$WORK/tg-payload.jsonl" >/dev/null 2>&1 \
+  && pass "deliver: chat_id mismatch skips reply_to" \
+  || bad "deliver: chat_id mismatch skips reply_to"
+
+# 27. multi-chunk: first chunk replies to previous run; later chunks reply to chunk 1
+TDIR3=$(mktemp -d)
+printf '%s\n' '{"chat_id":"123","message_id":7}' > "$TDIR3/digest.json"
+LONG=$(python3 -c 'print("word " * 2500)')
+reset
+TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 SKILL_NAME=digest \
+  bash "$NOTIFY" --title "Long" "$LONG" >/dev/null 2>&1
+p="$(payload)"
+AEON_TG_THREADS_DIR="$TDIR3" TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 NOTIFY_DRY_RUN=1 \
+  bash "$DELIVER" "$p" >/dev/null 2>&1
+n=$(jq -s 'length' "$WORK/tg-payload.jsonl" 2>/dev/null)
+r1=$(jq -s '.[0].reply_to_message_id' "$WORK/tg-payload.jsonl" 2>/dev/null)
+r2=$(jq -s '.[1].reply_to_message_id' "$WORK/tg-payload.jsonl" 2>/dev/null)
+{ [ "$n" -gt 1 ] && [ "$r1" = "7" ] && [ "$r2" = "1" ]; } \
+  && pass "deliver: multi-chunk replies to prev then to chunk 1 ($n chunks)" \
+  || bad "deliver: multi-chunk replies to prev then to chunk 1 (n=$n r1=$r1 r2=$r2)"
+
+rm -rf "$TDIR" "$TDIR2" "$TDIR3"
+
 echo "---"
 [ "$fail" = "0" ] && echo "ALL PASS" || echo "SOME FAILED"
 exit "$fail"


### PR DESCRIPTION
## What
Each skill's Telegram notification now quotes that skill's previous message (`reply_to_message_id` + `allow_sending_without_reply`). Default on.

## Why
The chat is a firehose of sibling messages. Replying to the last run of the same skill groups today's digest under yesterday's without forum topics or a DM-breaking migration.

## How
- `scripts/notify-deliver.sh` keeps `result.message_id` and writes `memory/telegram-threads/<skill>.json`
- Next send of that skill sets `reply_to_message_id`; same-run chunks 2..N reply to chunk 1
- Deleted parent fails open (Telegram still delivers)
- `TELEGRAM_REPLY_TO_PREVIOUS=0` disables
- Dry-run tests 22-27 cover first send, second send, other skill, kill switch, chat_id mismatch, multi-chunk

## Live proof
Shipped first on `aaronjmars/aeon-data` (#44). Two live heartbeat sends:
1. `mid=15 reply_to=none`
2. `mid=16 reply_to=15`