### PR TITLE
don't mark an issue resolved when the repair PR is only opened

### DIFF
--- a/skills/skill-health/SKILL.md
+++ b/skills/skill-health/SKILL.md
@@ -101,6 +101,14 @@ For each CRITICAL or FLAPPING skill, check if an open issue already exists with 
 For each skill now HEALTHY whose name appears in any open issue's `affected_skills`:
 - Remove it from that issue's `affected_skills`. If the list becomes empty, set `status: resolved`, set `resolved_at: <now ISO>`, and move the row from Open to Resolved in INDEX.md.
 
+**Reconcile `fix-pending` issues.** `skill-repair` sets `status: fix-pending` with a `fix_pr` when it opens a repair PR — it cannot know whether that PR merges, so it deliberately does not claim `resolved`. This step closes that loop. For each issue with `status: fix-pending` and a non-null `fix_pr`, check the PR's real state (`gh pr view <fix_pr> --json state,mergedAt`) and reconcile:
+
+- **Merged** (`mergedAt` non-null) → the fix shipped. Set `status: resolved`, `resolved_at: <mergedAt>`, move the row from Open to Resolved in INDEX.md.
+- **Closed without merging** (`state: CLOSED`, `mergedAt: null`) → the fix did **not** ship. Set `status: open`, set `fix_pr: null`, and append `Update <YYYY-MM-DD>: fix PR <url> was closed unmerged; issue reopened.` to the body. The skill is still broken; leaving it `fix-pending` would hide that.
+- **Still open** → leave untouched. The repair is in flight.
+
+If `gh` is unavailable or the lookup errors, leave the issue untouched and log it — never resolve on an unverified assumption.
+
 **Filing a new issue:**
 1. Find next ID: scan `memory/issues/ISS-*.md`, take max `NNN`, add 1. Format as zero-padded 3 digits (`ISS-042`).
 2. Write `memory/issues/ISS-NNN.md` with YAML frontmatter:
@@ -108,7 +116,7 @@ For each skill now HEALTHY whose name appears in any open issue's `affected_skil
    ---
    id: ISS-NNN
    title: <skill> <concise failure>
-   status: open
+   status: open   # open | fix-pending | resolved — fix-pending means a repair PR is open but unmerged; only a merged PR becomes resolved
    severity: critical | high | medium | low   # critical=CRITICAL status, high=FLAPPING, medium=DEGRADED
    category: rate-limit | timeout | missing-secret | config | api-change | sandbox-limitation | unknown
    detected_by: skill-health

--- a/skills/skill-health/SKILL.md
+++ b/skills/skill-health/SKILL.md
@@ -92,22 +92,23 @@ Group non-HEALTHY skills by shared `api_host` OR shared `last_error` signature. 
 
 **Precondition guard:** only perform issue filing/resolution if `memory/issues/INDEX.md` already exists. If it is missing, the operator has not opted into the issue-tracker contract yet — log `SKILL_HEALTH_ISSUE_TRACKER_MISSING` to `memory/logs/${today}.md`, skip this entire step (and the reconciliation side of step 5), and continue with classification + notification only. Do **not** auto-create `INDEX.md`.
 
-For each CRITICAL or FLAPPING skill, check if an open issue already exists with this skill in `affected_skills` AND a matching `root_cause` signature:
+For each CRITICAL or FLAPPING skill, check if an issue with `status: open` or `status: fix-pending` already has this skill in `affected_skills` AND a matching `root_cause` signature:
 
-- **Open issue exists, same root cause** → do nothing (no new file, no notification for this skill).
-- **Open issue exists, different root cause** → append a note to the existing ISS file's body: `Update YYYY-MM-DD: new signature: <error>`. Do not file a new issue.
-- **No open issue** → file a new one (see below).
+- **Matching issue exists, same root cause** → do nothing (no new file, no notification for this skill).
+- **Matching issue exists, different root cause** → append a note to the existing ISS file's body: `Update YYYY-MM-DD: new signature: <error>`. Do not file a new issue.
+- **No matching issue** → file a new one (see below).
 
-For each skill now HEALTHY whose name appears in any open issue's `affected_skills`:
-- Remove it from that issue's `affected_skills`. If the list becomes empty, set `status: resolved`, set `resolved_at: <now ISO>`, and move the row from Open to Resolved in INDEX.md.
-
-**Reconcile `fix-pending` issues.** `skill-repair` sets `status: fix-pending` with a `fix_pr` when it opens a repair PR — it cannot know whether that PR merges, so it deliberately does not claim `resolved`. This step closes that loop. For each issue with `status: fix-pending` and a non-null `fix_pr`, check the PR's real state (`gh pr view <fix_pr> --json state,mergedAt`) and reconcile:
+**Reconcile `fix-pending` issues first.** `skill-repair` sets `status: fix-pending` with a `fix_pr` when it opens a repair PR - it cannot know whether that PR merges, so it deliberately does not claim `resolved`. This step closes that loop. For each issue with `status: fix-pending` and a non-null `fix_pr`, check the PR's real state (`gh pr view <fix_pr> --json state,mergedAt`) and reconcile:
 
 - **Merged** (`mergedAt` non-null) → the fix shipped. Set `status: resolved`, `resolved_at: <mergedAt>`, move the row from Open to Resolved in INDEX.md.
-- **Closed without merging** (`state: CLOSED`, `mergedAt: null`) → the fix did **not** ship. Set `status: open`, set `fix_pr: null`, and append `Update <YYYY-MM-DD>: fix PR <url> was closed unmerged; issue reopened.` to the body. The skill is still broken; leaving it `fix-pending` would hide that.
+- **Closed without merging** (`state: CLOSED`, `mergedAt: null`) → the fix did not ship. Set `status: open`, set `fix_pr: null`, and append `Update <YYYY-MM-DD>: fix PR <url> was closed unmerged; issue reopened.` to the body. The skill is still broken; leaving it `fix-pending` would hide that.
 - **Still open** → leave untouched. The repair is in flight.
 
-If `gh` is unavailable or the lookup errors, leave the issue untouched and log it — never resolve on an unverified assumption.
+If `gh` is unavailable or the lookup errors, leave the issue untouched and log it - never resolve on an unverified assumption.
+
+For each skill now HEALTHY whose name appears in any `status: open` issue's `affected_skills`:
+- Skip `status: fix-pending` issues. Those wait for the reconcile step above; a lucky HEALTHY classification must not close a repair that has not merged.
+- Remove the skill from that issue's `affected_skills`. If the list becomes empty, set `status: resolved`, set `resolved_at: <now ISO>`, and move the row from Open to Resolved in INDEX.md.
 
 **Filing a new issue:**
 1. Find next ID: scan `memory/issues/ISS-*.md`, take max `NNN`, add 1. Format as zero-padded 3 digits (`ISS-042`).
@@ -116,7 +117,7 @@ If `gh` is unavailable or the lookup errors, leave the issue untouched and log i
    ---
    id: ISS-NNN
    title: <skill> <concise failure>
-   status: open   # open | fix-pending | resolved — fix-pending means a repair PR is open but unmerged; only a merged PR becomes resolved
+   status: open   # open | fix-pending | resolved. fix-pending = repair PR open, unmerged. Health resolves fix-pending only after merge (or reopens if closed unmerged). HEALTHY recovery still resolves status: open issues with no pending PR.
    severity: critical | high | medium | low   # critical=CRITICAL status, high=FLAPPING, medium=DEGRADED
    category: rate-limit | timeout | missing-secret | config | api-change | sandbox-limitation | unknown
    detected_by: skill-health

--- a/skills/skill-repair/SKILL.md
+++ b/skills/skill-repair/SKILL.md
@@ -196,10 +196,12 @@ If risk is HIGH, also: `gh pr edit "$PR_URL" --add-label manual-review`.
 
 ## 7. Update issue tracker (`memory/issues/`)
 
+**An open PR is not a fix.** This step runs immediately after §6 opened the PR, and nothing here can know whether that PR will ever merge. Do **not** write `status: resolved` — that records a repair that has not shipped, and if the PR is later closed unmerged the issue stays permanently marked fixed while the failure is still live. `skill-health` reconciles the real outcome once the PR's fate is known (see its "Reconcile `fix-pending` issues" step).
+
 - If an open issue for this skill exists:
-  - Fix applied → set `status: resolved`, `resolved_at: ${today}`, `fix_pr: <url>`. Move row from Open → Resolved in `INDEX.md`.
+  - PR opened → set `status: fix-pending`, `fix_pr: <url>`, and append `## Repair Attempt — ${today}` with the dossier. **Leave the row under Open in `INDEX.md`** — it is not resolved yet.
   - No fix possible → append `## Repair Attempt — ${today}` with the dossier and reason.
-- If no issue exists but a real problem was found and fixed → create `memory/issues/ISS-{NNN}.md` with status already `resolved` (NNN = next free number from INDEX.md).
+- If no issue exists but a real problem was found and a PR was opened for it → create `memory/issues/ISS-{NNN}.md` with `status: fix-pending` and `fix_pr: <url>` (NNN = next free number from INDEX.md), filed under **Open**.
 - If systemic clustering fired in step 2 → ensure `affected_skills:` lists every skill matched by the signature.
 
 ## 8. Persist cooldown

--- a/skills/skill-repair/SKILL.md
+++ b/skills/skill-repair/SKILL.md
@@ -198,7 +198,7 @@ If risk is HIGH, also: `gh pr edit "$PR_URL" --add-label manual-review`.
 
 **An open PR is not a fix.** This step runs immediately after §6 opened the PR, and nothing here can know whether that PR will ever merge. Do **not** write `status: resolved` — that records a repair that has not shipped, and if the PR is later closed unmerged the issue stays permanently marked fixed while the failure is still live. `skill-health` reconciles the real outcome once the PR's fate is known (see its "Reconcile `fix-pending` issues" step).
 
-- If an open issue for this skill exists:
+- If an issue with `status: open` or `status: fix-pending` for this skill exists:
   - PR opened → set `status: fix-pending`, `fix_pr: <url>`, and append `## Repair Attempt — ${today}` with the dossier. **Leave the row under Open in `INDEX.md`** — it is not resolved yet.
   - No fix possible → append `## Repair Attempt — ${today}` with the dossier and reason.
 - If no issue exists but a real problem was found and a PR was opened for it → create `memory/issues/ISS-{NNN}.md` with `status: fix-pending` and `fix_pr: <url>` (NNN = next free number from INDEX.md), filed under **Open**.


### PR DESCRIPTION
## the bug

`skill-repair` marks an issue `status: resolved` at PR-**creation** time, not at merge time. An open PR isn't a fix — if it never merges, the issue is permanently recorded as resolved, pointing at code that isn't on `main`, while the failure it described is still live and no longer tracked as open.

Proof, all from `skills/skill-repair/SKILL.md` on current `main`:

- `## 6. Branch, commit, PR` — line 160. Its last action is creating the PR.
- `## 7. Update issue tracker` — line 197, immediately after.
- Line 200, verbatim: *"Fix applied → set `status: resolved`, `resolved_at: ${today}`, `fix_pr: <url>`. Move row from Open → Resolved in `INDEX.md`."*
- Declared phase order, line 23: `PREFLIGHT → TRIAGE → DIAGNOSE → REPAIR → VERIFY → LOG` — there is no merge-wait phase.
- `grep -ic "merged" skills/skill-repair/SKILL.md` → **0**. The word never appears; there is no merge check anywhere, by construction.

## it fired in production, and here is the commit

On my instance, ISS-001 — critical, a fleet-wide zero-token outage (Claude 429 weekly-limit + Bankr 402 no-credits, so inference never started).

The automated run wrote this, 61 seconds after opening its own PR:

```
commit a67874696a7015e12a53b36b0b01dad772a17893
author:  aeonframework <aeonframework@proton.me>
date:    2026-08-25 01:12:08 +0000
subject: chore(skill-repair): auto-commit 2026-08-25

--- a/memory/issues/ISS-001.md
-status: open
+status: resolved
-fix_pr: null
+resolved_at: 2026-08-25
+fix_pr: https://github.com/Svector-anu/svectors-lab/pull/31
```

Timeline:

| time (UTC) | event |
|---|---|
| 01:10:48 | `fix(skill-repair): close systemic zero-token outage` — branch commit |
| 01:11:07 | PR #31 created |
| 01:11:36 | `docs(skill-repair): link repair PR` |
| 01:12:08 | bot auto-commit flips ISS-001 `open` → `resolved`, citing that PR |

PR #31 has `mergedAt: null`, `mergeCommit: null` — **it was never merged.** It also contained only memory/log bookkeeping, not the fix; the actual fix had shipped the day before in a separate commit that switched the harness.

So a critical issue sat marked "resolved" for six days, crediting a PR that never landed, while nothing tracked the underlying failure as open.

## the fix

Two files, 13 lines, no behaviour invented — it splits one status into two and gives the verification to the skill that already does reconciliation.

- **`skill-repair`** writes `status: fix-pending` with `fix_pr: <url>` and leaves the row under **Open**. It genuinely cannot know the PR's fate at that point in the run, so it no longer claims to.
- **`skill-health`** — which owns the issue schema (per `CLAUDE.md`), already runs on a schedule, and already has a reconciliation step — checks the PR's real state and either resolves it (merged, using the real `mergedAt` as `resolved_at`) or reopens it and clears `fix_pr` (closed unmerged, with a note in the body).
- If `gh` is unavailable or the lookup errors, the issue is left untouched and logged — it never resolves on an unverified assumption.

`fix-pending` is added to the status vocabulary in the schema template.

No new skill, no new state file, no scheduling change. The existing preflight cooldown ("an open PR already exists matching `fix/skill-repair-{name}-*`") already prevents re-attempts while a repair PR is in flight, so `fix-pending` issues don't cause repeat work.