### PR TITLE
Add tiered GLM model mapping (GLM_MODEL_SONNET/OPUS/HAIKU)

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -646,6 +646,9 @@ jobs:
           VENICE_CLEANCACHE: ${{ vars.VENICE_CLEANCACHE }}
           SURPLUS_MODEL: ${{ vars.SURPLUS_MODEL }}
           GLM_MODEL: ${{ vars.GLM_MODEL }}
+          GLM_MODEL_SONNET: ${{ vars.GLM_MODEL_SONNET }}
+          GLM_MODEL_OPUS: ${{ vars.GLM_MODEL_OPUS }}
+          GLM_MODEL_HAIKU: ${{ vars.GLM_MODEL_HAIKU }}
           CCR_LOG: ${{ vars.CCR_LOG }}
           # Optional Langfuse observability — set both keys to stream Claude Code's
           # run to Langfuse as a trace (scripts/langfuse-otel.sh; no-op when unset).
@@ -1392,6 +1395,9 @@ jobs:
           VENICE_CLEANCACHE: ${{ vars.VENICE_CLEANCACHE }}
           SURPLUS_MODEL: ${{ vars.SURPLUS_MODEL }}
           GLM_MODEL: ${{ vars.GLM_MODEL }}
+          GLM_MODEL_SONNET: ${{ vars.GLM_MODEL_SONNET }}
+          GLM_MODEL_OPUS: ${{ vars.GLM_MODEL_OPUS }}
+          GLM_MODEL_HAIKU: ${{ vars.GLM_MODEL_HAIKU }}
           CCR_LOG: ${{ vars.CCR_LOG }}
           LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
           LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
@@ -1654,6 +1660,9 @@ jobs:
           VENICE_CLEANCACHE: ${{ vars.VENICE_CLEANCACHE }}
           SURPLUS_MODEL: ${{ vars.SURPLUS_MODEL }}
           GLM_MODEL: ${{ vars.GLM_MODEL }}
+          GLM_MODEL_SONNET: ${{ vars.GLM_MODEL_SONNET }}
+          GLM_MODEL_OPUS: ${{ vars.GLM_MODEL_OPUS }}
+          GLM_MODEL_HAIKU: ${{ vars.GLM_MODEL_HAIKU }}
           GLM_API_KEY: ${{ secrets.GLM_API_KEY }}
           ZAI_API_KEY: ${{ secrets.ZAI_API_KEY }}
           CCR_LOG: ${{ vars.CCR_LOG }}

--- a/scripts/llm-gateway.sh
+++ b/scripts/llm-gateway.sh
@@ -249,7 +249,15 @@ X-Title: ${OPENROUTER_APP_TITLE:-Aeon}"
     export ANTHROPIC_BASE_URL="${ZAI_ANTHROPIC_BASE_URL:-https://api.z.ai/api/anthropic}"
     unset CLAUDE_CODE_OAUTH_TOKEN ANTHROPIC_AUTH_TOKEN
     export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
-    glm_model="${GLM_MODEL:-glm-5.2}"
+    # Tiered mapping: the run's resolved model id picks the GLM id, so sonnet-tier
+    # skills can run the fast flash model while opus-pinned skills get the full one.
+    # Per-tier var wins over GLM_MODEL (same precedence as the OpenRouter arm);
+    # GLM_MODEL still pins every tier when set alone. Fallback stays glm-5.2.
+    case "${MODEL:-}" in
+      *opus*)  glm_model="${GLM_MODEL_OPUS:-${GLM_MODEL:-glm-5.2}}" ;;
+      *haiku*) glm_model="${GLM_MODEL_HAIKU:-${GLM_MODEL:-glm-5.2}}" ;;
+      *)       glm_model="${GLM_MODEL_SONNET:-${GLM_MODEL:-glm-5.2}}" ;;
+    esac
     export ANTHROPIC_DEFAULT_OPUS_MODEL="$glm_model"
     export ANTHROPIC_DEFAULT_SONNET_MODEL="$glm_model"
     export ANTHROPIC_DEFAULT_HAIKU_MODEL="$glm_model"


### PR DESCRIPTION
## What

The glm gateway pins all three Claude model tiers (opus/sonnet/haiku) to one id (`GLM_MODEL`, default `glm-5.2`), which makes the per-skill `model:` tiering in every instance's `aeon.yml` cosmetic. This adds per-tier mapping, mirroring the OpenRouter arm's `OPENROUTER_MODEL_SONNET`/`_HAIKU` pattern:

- `GLM_MODEL_OPUS` - opus-tier ids (`*opus*`)
- `GLM_MODEL_HAIKU` - haiku-tier ids (`*haiku*`)
- `GLM_MODEL_SONNET` - everything else (sonnet + unknown/custom ids)

Precedence: per-tier var > `GLM_MODEL` > `glm-5.2` fallback. Unset configs keep today's single-model behavior exactly.

Also passes the three new vars through in all three `llm-gateway.sh` sourcing steps (skill run, scorer, feed) in `.github/workflows/aeon.yml`.

## Verification

- `bash -n` + `actionlint -shellcheck= -pyflakes=` clean
- Sourced the script with `GATEWAY=glm` and exercised the resolution matrix:

| MODEL | env | resolves to |
|---|---|---|
| claude-opus-4-8 | SONNET=glm-5.3-flash OPUS=glm-5.3 | glm-5.3 |
| claude-sonnet-5 | same | glm-5.3-flash |
| claude-haiku-4-5-20251001 | same | glm-5.2 (haiku unset) |
| claude-sonnet-5 | GLM_MODEL=glm-9.9 | glm-5.3-flash (tier wins) |
| claude-opus-4-8 | GLM_MODEL=glm-9.9 OPUS=glm-5.3 | glm-5.3 (tier wins) |
| (empty) | SONNET=glm-5.3-flash | glm-5.3-flash |

## Fleet rollout

Intended tier mapping to set as repo variables on the 7 live instances: `GLM_MODEL_SONNET=glm-5.3-flash`, `GLM_MODEL_OPUS=glm-5.3`.