### PR TITLE
docs: optional runtime hardening for the Aeon MCP server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Added
 
+- **Docs: optional runtime hardening for the installed MCP server.**
+  [`docs/skill-integrity.md`](docs/skill-integrity.md) now describes `eyebrow
+  wrap`, an operator-side complement to the CI gate that routes the registered
+  Aeon MCP server through a local relay for per-tool policy, a redacted audit
+  log, tool-surface capture, and OS-sandbox confinement. Opt-in; no change to the
+  install or CI paths.
 - **Telegram notifications reply to the previous run of the same skill.** Default on. Ledger at `memory/telegram-threads/<skill>.json`. Kill switch: repo variable `TELEGRAM_REPLY_TO_PREVIOUS=0`. (#995)
 - **Three more run-harnesses: Cursor, Hermes, and GLM.** Cursor CLI (`agent -p`,
   `CURSOR_API_KEY`), Hermes via the Nous Portal (`hermes -z`, `HERMES_AUTH`), and

--- a/docs/skill-integrity.md
+++ b/docs/skill-integrity.md
@@ -65,9 +65,40 @@ The diff on `eyebrowlock.json` shows exactly which skill's reach changed,
 reviewed alongside the skill change itself. A skill that adds a new egress host
 with no matching lockfile update is what the gate rejects.
 
+## Runtime hardening (optional, operator-side)
+
+The `ci-skill-integrity` gate protects the skills **in this repo**. It runs at PR
+time and says nothing about the operator's own machine after
+[`bin/add-mcp`](../bin/add-mcp) registers the Aeon MCP server
+(`apps/mcp-server/dist/index.js`) with Claude Code. Once that stdio server is
+live, every Aeon skill is a callable `aeon-*` tool, and a server binary swapped
+outside the build — or a dependency pulled at install — is beyond the reach of a
+repo-side gate.
+
+The same engine covers that surface at call time. For an Aeon server declared in
+a project `.mcp.json`, `eyebrow wrap` routes it through `eyebrow mcp-shim`, a
+local relay that:
+
+- relays JSON-RPC **byte for byte**, so the server behaves identically;
+- enforces a **per-tool policy** you set at the client boundary — a denied tool
+  returns a JSON-RPC error and never reaches the server, above and beyond Claude's
+  own approval prompt;
+- writes an **audit log** of every tool call with argument values redacted
+  (`~/.eyebrow/audit/<date>.jsonl`, queryable with `eyebrow audit`);
+- captures the **exported tool surface** so a server that grows a new tool after
+  approval shows up; and
+- confines the process with the **OS sandbox** (macOS Seatbelt, Linux bwrap; it
+  warns and runs unconfined on Windows).
+
+This is defense-in-depth for the operator, not a repo gate — it complements the
+CI check and Claude's approval flow, and it is entirely opt-in. See
+[eyebrow's `wrap` / `audit` docs](https://github.com/alexverify/eyebrow) for
+setup.
+
 ## Scope
 
 v1 fingerprints the first-party `skills/<slug>/SKILL.md` set: content hash +
 network egress. Exec and filesystem capabilities, lockfile signing, and a
 findings threshold below critical can be layered on later purely in
-`eyebrow.policy.json`, without changing this workflow.
+`eyebrow.policy.json`, without changing this workflow. Runtime confinement of the
+installed MCP server (above) is a separate, operator-side layer.


### PR DESCRIPTION
## What

Adds a "Runtime hardening (optional)" section to `docs/skill-integrity.md`. It documents eyebrow wrap as an operator side complement to the ci-skill-integrity gate, for the Aeon MCP server that `bin/add-mcp` registers with Claude Code.

## Why

The CI gate protects the skills in the repo at PR time. It says nothing about the server once it runs on an operator machine. The new section explains the opt in local relay (per tool policy, redacted audit log, tool surface capture, OS sandbox) that covers that surface. Docs only. No change to install or CI paths, and `eyebrowlock.json` is untouched.

 FYI, separate from this PR: eyebrow v0.4.2 is out and your gate pins v0.4.1. Bump when convenient. I left it as is here to keep this change focused.

## Type of change
- [x] Core fix (dashboard / scripts / workflows / docs)

---
### Core fix (dashboard / scripts / workflows / docs)

- [x] Change is focused — one concern, no unrelated refactor
- [x] Touched code follows the existing pattern in the file
- [x] Relevant CI gates pass locally (e.g. `bash scripts/check-skill-categories.sh`, `bash scripts/check-capabilities-parity.sh`)
- [x] Touched `apps/**`? That app typechecks, tests, and builds (dashboard: `npm run typecheck && npm test && npm run build`)

---

<!-- PRs are squash-merged: the title above becomes the commit subject on main. Branch from main; one change per PR. -->
