### PR TITLE
Bump eyebrow skill-integrity gate to v0.4.2

### DIFF
--- a/.github/workflows/ci-skill-integrity.yml
+++ b/.github/workflows/ci-skill-integrity.yml
@@ -79,8 +79,8 @@ jobs:
           done
           exit "$missing"
       - name: eyebrow verify (drift / rug-pull gate)
-        uses: alexverify/eyebrow/action@9592921a04a41fc0aae5439406511ed70a15f03a # v0.4.1
+        uses: alexverify/eyebrow/action@b2cebcb8bdd555b5f64ba9bf43a4c7bbb59b112b # v0.4.2
         with:
-          version: v0.4.1
+          version: v0.4.2
           path: .
           lockfile: eyebrowlock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ from or pin to; the template keeps serving the latest `main` to new forks.
 
 ### Changed
 
+- **`ci-skill-integrity` pins eyebrow v0.4.2.** The drift / rug-pull gate now
+  installs `alexverify/eyebrow/action@v0.4.2` (still pinned by commit SHA). No
+  policy change: `eyebrow.policy.json` still gates on egress expansion and
+  critical findings only, and `allowContentDrift` stays true. Verified against
+  the current lock — clean, no new gate failures.
 - **GLM Coding Plan is a Claude AI Gateway hop, not a harness.** `GLM_API_KEY` (alias `ZAI_API_KEY`) now routes `claude -p` at `api.z.ai/api/anthropic` through `scripts/llm-gateway.sh`, last in the auto cascade (override with `gateway.provider: glm` or `GLM_MODEL`). `harness: glm` is a dead name and falls back to `claude`. The `glm` adapter is gone.
 
 ### Added


### PR DESCRIPTION
## What

Bumps the pinned eyebrow action in ci-skill-integrity from v0.4.1 to v0.4.2, still pinned by commit SHA.

## Why

Keeps the drift gate on the current release. I built v0.4.2 and ran your gate locally against the committed `eyebrowlock.json` and eyebrow.policy.json: it exits 0. The content drifts it reports are pre existing on main and stay advisory under `allowContentDrift`, so no gate outcome changes. No policy change.

## Type of change

- [ ] New skill
- [ ] New LLM gateway
- [ ] Community skill pack listing
- [x] Core fix (dashboard / scripts / workflows / docs)

---

### Core fix (dashboard / scripts / workflows / docs)

- [x] Focused: one line pin bump plus its changelog entry
- [x] Verified locally: v0.4.2 gate exits 0 against the committed lock and policy
- [x] No apps/ changes

