### PR TITLE
fix(chain-runner): stop a rejected dispatch from poisoning the reliability signal

### DIFF
--- a/.github/workflows/chain-runner.yml
+++ b/.github/workflows/chain-runner.yml
@@ -66,6 +66,11 @@ jobs:
           if [ "$CHAIN" = "dev-loop" ]; then
             if ! bash scripts/dev-loop-pr.sh validate-target "$CHAIN_TARGET" >/dev/null; then
               echo "::error::dev-loop requires target=external:owner/repo or external:owner/repo#issue"
+              # A caller error caught before any skill ran, not evidence the loop
+              # itself is unreliable. Mark it distinctly so "Update cron state"
+              # (which runs `if: always()`) skips the write instead of recording a
+              # "failed" outcome indistinguishable from a real mid-run failure.
+              echo "CHAIN_STATUS=invalid-dispatch" >> "$GITHUB_ENV"
               exit 1
             fi
           fi
@@ -272,6 +277,10 @@ jobs:
               # chain reusing this var can't fall back to feature's broad selector.
               if ! bash scripts/dev-loop-pr.sh validate-target "$CHAIN_TARGET" >/dev/null; then
                 echo "::error::\$chain_target requires target=external:owner/repo or external:owner/repo#issue"
+                # Same caller-error case as the top-level dev-loop guard above —
+                # see that comment. Don't let a rejected dispatch masquerade as a
+                # real chain failure in cron-state.
+                echo "CHAIN_STATUS=invalid-dispatch" >> "$GITHUB_ENV"
                 exit 1
               fi
               VAR="$CHAIN_TARGET"
@@ -444,6 +453,17 @@ jobs:
           fi
           NOW_ISO=$(date -u +%FT%TZ)
           STATUS="${CHAIN_STATUS:-failed}"
+
+          # A rejected malformed dispatch (see the target guards above) never
+          # started a real run — recording it would corrupt the chain's lifetime
+          # success-rate signal skill-health reads. The job itself still fails (this
+          # step running under `if: always()` doesn't change that); only the
+          # reliability bookkeeping is skipped.
+          if [ "$STATUS" = "invalid-dispatch" ]; then
+            echo "Chain '$CHAIN' was rejected before any skill ran (missing/invalid target) — not recording as a functional failure"
+            exit 0
+          fi
+
           STATE_FILE="memory/cron-state.json"
 
           # Issues backend (hardening §3) — STATE_BACKEND tri-state, matching aeon.yml:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -119,6 +119,8 @@ jobs:
         run: bash scripts/tests/test_chain_when.sh
       - name: chain-runner dispatch correlation tests
         run: bash scripts/tests/test_chain_runner.sh
+      - name: chain-runner invalid-dispatch cron-state tests
+        run: bash scripts/tests/test_chain_runner_invalid_dispatch.sh
       - name: dev-loop deterministic handoff tests
         run: bash scripts/tests/test_dev_loop_handoff.sh
       - name: skill-scan calibration (fires on sinks, not benign syntax)

--- a/scripts/tests/test_chain_runner_invalid_dispatch.sh
+++ b/scripts/tests/test_chain_runner_invalid_dispatch.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Regression test for chain-runner's "Update cron state" step: a chain rejected
+# before any skill ran (CHAIN_STATUS=invalid-dispatch, set by the dev-loop target
+# guard) must skip cron-state bookkeeping entirely, while a real failure/success
+# must still fall through to it unchanged.
+set -uo pipefail
+
+WORKFLOW="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/.github/workflows/chain-runner.yml"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Extract the guard verbatim from the "Update cron state" step: from the env-bound
+# chain-name re-derivation up to (excluding) the real cron-state.json write. Real
+# git/state-file work is intentionally out of scope here — see test_chain_runner.sh
+# for the sibling dispatch_skill() extraction using the same anchored-sed pattern.
+awk '
+  /^          # env-bound \+ allowlisted, same as the Run chain step\./ { on=1 }
+  on && /^          STATE_FILE="memory\/cron-state\.json"$/ { exit }
+  on { print }
+' "$WORKFLOW" | sed 's/^          //' > "$TMP/guard.sh"
+# Sanity: the extraction must have found both the chain-name guard and the
+# invalid-dispatch guard — a rename/reflow of the source step would otherwise
+# silently extract nothing (or half) and the test would pass on a stub script.
+grep -q "Invalid chain name" "$TMP/guard.sh" && grep -q 'CHAIN_STATUS' "$TMP/guard.sh" \
+  || { echo "FAIL: extraction anchor drifted — expected content missing from extracted guard" >&2; cat "$TMP/guard.sh" >&2; exit 1; }
+printf 'echo REACHED_STATE_WRITE\n' >> "$TMP/guard.sh"
+
+run_guard() {
+  ( _INPUT_CHAIN="dev-loop" CHAIN_STATUS="${1:-}" bash "$TMP/guard.sh" )
+}
+
+fail=0
+pass() { echo "ok   - $1"; }
+bad() { echo "FAIL - $1"; fail=1; }
+
+# CHAIN_STATUS=invalid-dispatch → skip the write, exit 0, no sentinel reached.
+out=$(run_guard invalid-dispatch); rc=$?
+[ "$rc" -eq 0 ] && pass "invalid-dispatch exits 0" || bad "invalid-dispatch should exit 0 (got $rc)"
+echo "$out" | grep -q "REACHED_STATE_WRITE" && bad "invalid-dispatch must not reach the state write" || pass "invalid-dispatch skips the cron-state write"
+echo "$out" | grep -q "rejected before any skill ran" && pass "invalid-dispatch logs why it's skipping" || bad "missing explanatory log line"
+
+# CHAIN_STATUS unset (the CHAIN_STATUS:-failed default, a genuine failure) → falls
+# through to the write path unchanged.
+out=$(run_guard ""); rc=$?
+[ "$rc" -eq 0 ] && echo "$out" | grep -q "REACHED_STATE_WRITE" \
+  && pass "a real failure (CHAIN_STATUS unset) still reaches the state write" \
+  || bad "a real failure must still reach the state write (rc=$rc)"
+
+# CHAIN_STATUS=success (the normal happy path) → also falls through unchanged.
+out=$(run_guard success); rc=$?
+[ "$rc" -eq 0 ] && echo "$out" | grep -q "REACHED_STATE_WRITE" \
+  && pass "a real success still reaches the state write" \
+  || bad "a real success must still reach the state write (rc=$rc)"
+
+echo "---"
+[ "$fail" -eq 0 ] && echo "ALL PASS" || echo "SOME FAILED"
+exit "$fail"


### PR DESCRIPTION
## what looked broken

after wiring a cross-model dev-loop chain on my fork, `chain:dev-loop` got flagged repeatedly by skill-health — six manual dispatches over two days, all recorded as failures, dragging the chain's lifetime success rate down and firing false P0s.

## what's actually happening

not a defect in the loop. every one of those failures happened at the exact same point, before any skill ran:

```
##[error]dev-loop requires target=external:owner/repo or external:owner/repo#issue
```

both target guards (the top-level `dev-loop` check and the generalized `$chain_target` check any future chain can reuse) are working exactly as designed — rejecting a dispatch with no `target` input rather than silently falling back to `feature`'s broad `watched` selector. `target` can't be made conditionally-required in the native `workflow_dispatch` schema, so it's easy to dispatch this chain manually (CLI or the Actions UI) and forget it. that part of the design is correct and untouched by this PR.

## the actual bug

`Update cron state` runs `if: always()` and defaults `STATUS="${CHAIN_STATUS:-failed}"` for any early exit — so the correctly-rejected malformed dispatch gets written into `memory/cron-state.json` identical in shape to a genuine mid-run failure. that's the signal skill-health reads for lifetime reliability, so non-runs were making a working chain look broken.

confirmed both `snapshot` and `feature dispatch has no correlation ID` failure paths are unaffected and out of scope — they already correctly set `CHAIN_FAILED=true; break`, funneling through the proper final-status logic. only the two pre-flight guards bypass it entirely.

## fix

mark the pre-flight rejection distinctly (`CHAIN_STATUS=invalid-dispatch`) at both guard sites, and skip the cron-state write for that case only. the job still fails loud — red x, `::error::` unchanged — for whoever ran the malformed dispatch; only the fleet-wide bookkeeping stops being polluted. a real failure or success still writes exactly as before.

## tests

- `scripts/tests/test_chain_runner.sh` — unchanged, still passes
- `scripts/tests/test_chain_runner_invalid_dispatch.sh` (new) — extracts the guard verbatim from the workflow (same anchored-sed pattern the sibling test already uses for `dispatch_skill()`) and asserts: `invalid-dispatch` exits 0 without reaching the state write and logs why; a real failure (`CHAIN_STATUS` unset) and a real success both still reach the write unchanged

