### PR TITLE
fix(skill-health): detect critical-incident recovery without waiting on lifetime success_rate

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -99,6 +99,8 @@ jobs:
         run: bash scripts/tests/test_state_store.sh
       - name: health triage tests
         run: python3 scripts/tests/test_health_triage.py
+      - name: skill-health recovery tests
+        run: python3 scripts/tests/test_skill_health_recovery.py
       - name: health-issue ensure-race tests
         run: bash scripts/tests/test_health_issue.sh
       - name: skill-health harness routing tests

--- a/scripts/skill_health_recovery.py
+++ b/scripts/skill_health_recovery.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Decide whether a critical skill-health incident has recovered."""
+
+import json
+import sys
+from datetime import datetime
+
+
+def _timestamp(value):
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo is not None else None
+
+
+def critical_incident_recovered(state, detected_at):
+    """Return true after a successful run newer than a critical incident."""
+    if not isinstance(state, dict):
+        return False
+    last_success = _timestamp(state.get("last_success"))
+    detected = _timestamp(detected_at)
+    return (
+        state.get("last_status") == "success"
+        and state.get("consecutive_failures") == 0
+        and last_success is not None
+        and detected is not None
+        and last_success > detected
+    )
+
+
+def main():
+    detected_at = sys.argv[1] if len(sys.argv) == 2 else None
+    try:
+        state = json.load(sys.stdin)
+    except (json.JSONDecodeError, OSError):
+        state = None
+    print("recovered" if critical_incident_recovered(state, detected_at) else "active")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_skill_health_recovery.py
+++ b/scripts/tests/test_skill_health_recovery.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Unit tests for skill_health_recovery. Run: python3 scripts/tests/test_skill_health_recovery.py"""
+import json
+import os
+import subprocess
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import skill_health_recovery as shr  # noqa: E402
+
+
+class TestCriticalIncidentRecovery(unittest.TestCase):
+    def test_recovery_does_not_wait_for_lifetime_success_rate(self):
+        state = {
+            "last_status": "success",
+            "consecutive_failures": 0,
+            "last_success": "2026-08-25T19:42:58Z",
+            "success_rate": 0.33,
+        }
+        self.assertTrue(
+            shr.critical_incident_recovered(state, "2026-08-25T19:42:49Z")
+        )
+
+    def test_success_before_incident_does_not_resolve_it(self):
+        state = {
+            "last_status": "failed",
+            "consecutive_failures": 3,
+            "last_success": "2026-08-24T19:42:58Z",
+            "success_rate": 0.75,
+        }
+        self.assertFalse(
+            shr.critical_incident_recovered(state, "2026-08-25T19:42:49Z")
+        )
+
+    def test_dispatch_after_success_waits_for_run_outcome(self):
+        state = {
+            "last_status": "dispatched",
+            "consecutive_failures": 0,
+            "last_success": "2026-08-25T19:42:58Z",
+            "success_rate": 0.33,
+        }
+        self.assertFalse(
+            shr.critical_incident_recovered(state, "2026-08-25T19:42:49Z")
+        )
+
+    def test_invalid_or_missing_timestamps_fail_closed(self):
+        state = {
+            "last_status": "success",
+            "consecutive_failures": 0,
+            "last_success": "not-a-time",
+        }
+        self.assertFalse(shr.critical_incident_recovered(state, "2026-08-25T19:42:49Z"))
+        self.assertFalse(shr.critical_incident_recovered(state, None))
+        state["last_success"] = "2026-08-25T19:42:58"
+        self.assertFalse(shr.critical_incident_recovered(state, "2026-08-25T19:42:49Z"))
+
+    def test_cli_reports_recovery(self):
+        result = subprocess.run(
+            [sys.executable, "scripts/skill_health_recovery.py", "2026-08-25T19:42:49Z"],
+            input=json.dumps({
+                "last_status": "success",
+                "consecutive_failures": 0,
+                "last_success": "2026-08-25T19:42:58Z",
+                "success_rate": 0.33,
+            }),
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        self.assertEqual(result.stdout.strip(), "recovered")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/skills/skill-health/SKILL.md
+++ b/skills/skill-health/SKILL.md
@@ -123,7 +123,7 @@ For each skill in a `status: open` **critical** issue that is still DEGRADED or 
    severity: critical | high | medium | low   # critical=CRITICAL status, high=FLAPPING, medium=DEGRADED
    category: rate-limit | timeout | missing-secret | config | api-change | sandbox-limitation | unknown
    detected_by: skill-health
-   detected_at: <ISO timestamp>
+   detected_at: <ISO-8601 UTC, e.g. 2026-09-03T12:00:00Z>   # must carry Z or a +00:00 offset; a naive stamp fails closed to active
    affected_skills: [<skill>, ...]    # may grow later
    root_cause: <error signature, 1 line>
    fix_pr: null

--- a/skills/skill-health/SKILL.md
+++ b/skills/skill-health/SKILL.md
@@ -110,6 +110,8 @@ For each skill now HEALTHY whose name appears in any `status: open` issue's `aff
 - Skip `status: fix-pending` issues. Those wait for the reconcile step above; a lucky HEALTHY classification must not close a repair that has not merged.
 - Remove the skill from that issue's `affected_skills`. If the list becomes empty, set `status: resolved`, set `resolved_at: <now ISO>`, and move the row from Open to Resolved in INDEX.md.
 
+For each skill in a `status: open` **critical** issue that is still DEGRADED or WARNING only because of historical metrics, pipe its cron-state JSON object to `python3 scripts/skill_health_recovery.py '<detected_at>'`. If it prints `recovered`, remove the skill from `affected_skills` and resolve an empty issue exactly as above. A successful run after detection proves that specific failure incident recovered even when lifetime `success_rate` remains low. Do not apply this shortcut to FLAPPING/high issues (one successful run does not prove flapping stopped) or to `status: fix-pending` issues (those wait for the reconcile step above). Invalid or missing state/timestamps print `active` and fail closed.
+
 **Filing a new issue:**
 1. Find next ID: scan `memory/issues/ISS-*.md`, take max `NNN`, add 1. Format as zero-padded 3 digits (`ISS-042`).
 2. Write `memory/issues/ISS-NNN.md` with YAML frontmatter:


### PR DESCRIPTION
## what

a critical skill-health issue only auto-resolves once the skill's classification clears CRITICAL/DEGRADED/WARNING — which is gated on lifetime `success_rate`. so a skill that recovers cleanly (several straight successful runs) can still sit "unhealthy" and its issue can stay open for a long stretch of history to age out of the average, even though the specific incident is long over.

## fix

`scripts/skill_health_recovery.py`: a small, independently-tested, fail-closed check. a run newer than the issue's `detected_at`, with `last_status=success` and `consecutive_failures=0`, proves that specific incident recovered — regardless of what the lifetime average still says.

wired into skill-health's issue-resolution step, deliberately scoped narrow:
- only `status: open` **critical** issues
- not FLAPPING/high issues — one successful run doesn't prove flapping stopped
- not `status: fix-pending` issues — those already have their own reconcile step (the fix-pending → merged/reopened logic from #997)

invalid or missing state/timestamps fail closed (`active`, never a false recovery).

## tests

`scripts/tests/test_skill_health_recovery.py` — 5 cases: recovery ignores lifetime success_rate, a success *before* the incident's `detected_at` doesn't resolve it, an in-flight `dispatched` status waits for the actual outcome, invalid/missing timestamps fail closed, and the CLI's stdin→stdout contract. wired into `ci-tests.yml` alongside the other health-suite steps.

https://claude.ai/code/session_01SbipDt7VmuDvosRPS8AfEx
