### PR TITLE
fix(fleet-scorecard): stop non-skill runs from leaking into the per-skill reliability table

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -54,6 +54,8 @@ jobs:
         run: bash scripts/tests/test_skill_requires.sh
       - name: run actions summary tests
         run: bash scripts/tests/test_run_actions_summary.sh
+      - name: fleet scorecard classification tests
+        run: node --test scripts/tests/test_fleet_scorecard.mjs
       - name: skill-pack manifest validation tests
         run: bash scripts/tests/test_validate_pack.sh
       - name: community pack registry validation tests

--- a/scripts/fleet-scorecard.mjs
+++ b/scripts/fleet-scorecard.mjs
@@ -109,6 +109,7 @@ const commafy = (x) => Math.trunc(x).toLocaleString('en-US');
 const hum = (n) => n >= 1e9 ? `${(n / 1e9).toFixed(2)}B` : n >= 1e6 ? `${(n / 1e6).toFixed(1)}M` : n >= 1e3 ? `${(n / 1e3).toFixed(1)}K` : `${Math.trunc(n)}`;
 const basename = (p) => String(p).replace(/.*\//, '');
 const baseName = (name) => String(name || '(none)').replace(/ \(.*$/, ''); // strip " (…)" suffix
+const skillName = (name) => /^skill: /.test(name || '') ? baseName(String(name).replace(/^skill: /, '')) : null;
 const num = (x) => Number(x) || 0;
 
 // ---- run-level aggregates --------------------------------------------------
@@ -123,7 +124,8 @@ for (const r of runs) {
   const s = (runStat[r.repo] ||= { tot: 0, succ: 0, skills: new Set() });
   s.tot++;
   if (r.conclusion === 'success') s.succ++;
-  if (/^skill:/.test(r.name || '')) s.skills.add(baseName(String(r.name).replace(/^skill: /, '')));
+  const skill = skillName(r.name);
+  if (skill) s.skills.add(skill);
 }
 
 // ---- token aggregates (fleet, per-repo, per-skill) -------------------------
@@ -193,7 +195,8 @@ for (const r of runs) {
   if (r.head_branch !== 'main') continue;
   const t = Date.parse(r.created_at || '');
   if (!(t >= cutoff)) continue;
-  const skill = baseName(r.name);
+  const skill = skillName(r.name);
+  if (!skill) continue;
   const key = `${r.repo}|${skill}`;
   const g = (grp[key] ||= { repo: r.repo, skill, total: 0, fail: 0 });
   g.total++;

--- a/scripts/tests/test_fleet_scorecard.mjs
+++ b/scripts/tests/test_fleet_scorecard.mjs
@@ -1,0 +1,44 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+test('least-reliable table contains skills only and uses their slug', async () => {
+  const originalFetch = globalThis.fetch
+  const originalRepo = process.env.GITHUB_REPOSITORY
+  const createdAt = new Date().toISOString()
+  const run = (name) => ({ name, conclusion: 'failure', created_at: createdAt, head_branch: 'main' })
+  const workflowRuns = [
+    run('ci-tests'), run('ci-tests'), run('ci-tests'),
+    run('skill: digest'), run('skill: digest'), run('skill: digest'),
+  ]
+
+  process.env.GITHUB_REPOSITORY = 'operator/aeon'
+  globalThis.fetch = async (input) => {
+    const url = String(input)
+    if (url.includes('/actions/runs?')) {
+      return new Response(JSON.stringify({ workflow_runs: workflowRuns }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }
+    if (url.endsWith('/contents/skills')) {
+      return new Response(JSON.stringify([{ type: 'dir' }]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }
+    return new Response('', { status: 404 })
+  }
+
+  try {
+    await import(new URL(`../fleet-scorecard.mjs?test=${Date.now()}`, import.meta.url))
+    const body = readFileSync('/tmp/fleet-scorecard/scorecard-body.md', 'utf8')
+    assert.doesNotMatch(body, /\| ci-tests \|/, 'non-skill workflow leaked into the skill table')
+    assert.match(body, /\| digest \|/, 'skill slug missing from the skill table')
+    assert.doesNotMatch(body, /\| skill: digest \|/, 'workflow prefix leaked into the skill name')
+  } finally {
+    globalThis.fetch = originalFetch
+    if (originalRepo === undefined) delete process.env.GITHUB_REPOSITORY
+    else process.env.GITHUB_REPOSITORY = originalRepo
+  }
+})


### PR DESCRIPTION
## what

`fleet-scorecard.mjs`'s "Least reliable skills" table filtered nothing: every row's key came from `baseName(r.name)` unconditionally. `baseName` only strips a trailing `" (...)"` suffix — it never checks the run is actually a skill dispatch and never strips a `"skill: "` prefix. Two consequences, both live:

1. any non-skill workflow run (`ci-tests`, a chain run like `"chain: dev-loop"`, any other job) gets counted as if it were a skill's own failure rate
2. even genuine skill runs keep their raw `"skill: "` prefix in this specific table, so a real skill's row reads `"skill: digest"` instead of `"digest"` — inconsistent with every other table in the same report, which already uses the correctly-prefix-stripped name

with chains now a real, running part of the fleet, `"chain: X"` runs actively pollute this table with phantom 100%-failure "skills" that were never skills.

## fix

one shared `skillName(name)` helper (`/^skill: /` match required, `null` otherwise) used by both aggregation loops. both loops now skip/ignore non-matches instead of coercing them into a fake skill key.

## verification

mutation-checked, not just diffed clean: reverted the fix and re-ran the test — it fails for exactly the predicted reason, reproducing both bugs at once (`ci-tests` shows up as a 100%-failure "skill"; `skill: digest`'s prefix survives unstripped). restored the fix, green again.

## tests

`scripts/tests/test_fleet_scorecard.mjs` (new) — mocks `fetch` with a synthetic run set (3× a non-skill `ci-tests` run, 3× `skill: digest`), imports the real script end-to-end, and asserts on its actual markdown output: no non-skill leak, the skill slug present cleanly, no raw prefix leak. wired into `ci-tests.yml`.

https://claude.ai/code/session_01SbipDt7VmuDvosRPS8AfEx
