### PR TITLE
fix(notify): report per-channel delivery status and fail on total delivery failure

### DIFF
--- a/scripts/notify-deliver.sh
+++ b/scripts/notify-deliver.sh
@@ -71,6 +71,8 @@ if [ -n "$HASH" ] && grep -qxF "$HASH" "$DELIVERED_HASHES" 2>/dev/null; then
 fi
 
 DELIVERED=false
+TG_STATUS="not-configured"
+EMAIL_STATUS="not-configured"
 
 # Per-skill Telegram reply target. Default ON. Dry-run writes a ledger only when
 # AEON_TG_THREADS_DIR is set, so existing tests do not touch memory/.
@@ -144,6 +146,7 @@ _tg_payload() {
 
 # --- Telegram - fence-safe chunks (parse_mode HTML, plaintext fallback) ------
 if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ]; then
+  TG_STATUS="failed"
   TG_CHUNKS_B64=$(printf '%s' "$MSG" | python3 "$FMT" telegram --title "$TITLE" --severity "$SEVERITY" || true)
   TG_CHUNKS=()
   while IFS= read -r TG_CHUNK_B64; do
@@ -179,6 +182,7 @@ if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ]; then
       mkdir -p "$QUEUE_DIR"
       printf '%s\n' "$TG_PAYLOAD" >> "$QUEUE_DIR/tg-payload.jsonl"
       DELIVERED=true
+      TG_STATUS="delivered"
       if [ -n "$TG_DIR" ] && [ -n "$SKILL_NAME" ]; then
         TG_MID=$(_tg_next_dry_mid)
       fi
@@ -190,6 +194,7 @@ if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ]; then
       TG_OK=$(printf '%s' "$TG_BODY" | jq -r '.ok // false' 2>/dev/null || echo "false")
       if [ "$TG_HTTP" = "200" ] && [ "$TG_OK" = "true" ]; then
         DELIVERED=true
+        TG_STATUS="delivered"
         TG_MID=$(printf '%s' "$TG_BODY" | jq -r '.result.message_id // empty' 2>/dev/null || true)
       else
         # Fallback without parse_mode. Strip tags + unescape so it degrades to clean
@@ -204,7 +209,11 @@ if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ]; then
         TG_OK=$(printf '%s' "$TG_BODY" | jq -r '.ok // false' 2>/dev/null || echo "false")
         if [ "$TG_HTTP" = "200" ] && [ "$TG_OK" = "true" ]; then
           DELIVERED=true
+          TG_STATUS="delivered"
           TG_MID=$(printf '%s' "$TG_BODY" | jq -r '.result.message_id // empty' 2>/dev/null || true)
+        else
+          TG_REASON=$(printf '%s' "$TG_BODY" | jq -r '.description // "unknown telegram api error"' 2>/dev/null || echo "invalid telegram response")
+          echo "notify-deliver: telegram failed http=${TG_HTTP:-000} reason=$TG_REASON" >&2
         fi
       fi
       sleep 0.3
@@ -259,6 +268,7 @@ fi
 
 # --- Email via Resend (operator-notify channel) -----------------------------
 if [ -n "${RESEND_API_KEY:-}" ] && [ -n "${NOTIFY_EMAIL_TO:-}" ]; then
+  EMAIL_STATUS="failed"
   FROM="${NOTIFY_EMAIL_FROM:-aeon@notifications.aeon.bot}"
   PREFIX="${NOTIFY_EMAIL_SUBJECT_PREFIX:-[Aeon]}"
   SUBJECT="$PREFIX ${TITLE:-${SKILL_NAME:-notification}}"
@@ -268,13 +278,26 @@ if [ -n "${RESEND_API_KEY:-}" ] && [ -n "${NOTIFY_EMAIL_TO:-}" ]; then
     mkdir -p "$QUEUE_DIR"
     printf '%s\n' "$SUBJECT" >> "$QUEUE_DIR/email-payload.txt"
     DELIVERED=true
+    EMAIL_STATUS="delivered"
   else
-    curl -sf -X POST "https://api.resend.com/emails" \
+    EMAIL_RESULT=$(curl -s -w "\n%{http_code}" -X POST "https://api.resend.com/emails" \
       -H "Authorization: Bearer ${RESEND_API_KEY}" \
       -H "Content-Type: application/json" \
       -d "$(jq -n --arg from "$FROM" --arg to "$NOTIFY_EMAIL_TO" --arg subject "$SUBJECT" \
             --arg html "$HTML_BODY" --arg text "$PLAIN" \
-            '{from:$from, to:[$to], subject:$subject, html:$html, text:$text}')" > /dev/null 2>&1 && DELIVERED=true || true
+            '{from:$from, to:[$to], subject:$subject, html:$html, text:$text}')" 2>/dev/null) || true
+    EMAIL_HTTP=$(echo "$EMAIL_RESULT" | tail -1)
+    EMAIL_BODY=$(echo "$EMAIL_RESULT" | sed '$d')
+    case "$EMAIL_HTTP" in
+      2??)
+        DELIVERED=true
+        EMAIL_STATUS="delivered"
+        ;;
+      *)
+        EMAIL_REASON=$(printf '%s' "$EMAIL_BODY" | jq -r '.message // .name // "unknown resend api error"' 2>/dev/null || echo "invalid resend response")
+        echo "notify-deliver: email failed http=${EMAIL_HTTP:-000} reason=$EMAIL_REASON" >&2
+        ;;
+    esac
   fi
 fi
 
@@ -300,8 +323,8 @@ if [ -n "${AEON_AUDIT_LOG:-}" ]; then
     if [ -n "${BUZZ_PRIVATE_KEY:-}" ] && [ -n "${BUZZ_CHANNEL_ID:-}" ]; then _CHANS="${_CHANS}buzz,"; _SECS="${_SECS}BUZZ_PRIVATE_KEY,"; fi
     if [ -n "${RESEND_API_KEY:-}" ] && [ -n "${NOTIFY_EMAIL_TO:-}" ]; then _CHANS="${_CHANS}email,"; _SECS="${_SECS}RESEND_API_KEY,"; fi
     if [ "$DELIVERED" = "true" ]; then _RC=0; else _RC=1; fi
-    bash "$_AUDIT" "notify" "channels=${_CHANS%,} delivered=${DELIVERED}" "$_RC" "${_SECS%,}" || true
+    bash "$_AUDIT" "notify" "channels=${_CHANS%,} delivered=${DELIVERED} telegram=${TG_STATUS} email=${EMAIL_STATUS}" "$_RC" "${_SECS%,}" || true
   fi
 fi
 
-[ "$DELIVERED" = "true" ] && exit 0 || exit 0
+[ "$DELIVERED" = "true" ] && exit 0 || exit 1

--- a/scripts/tests/test_notify.sh
+++ b/scripts/tests/test_notify.sh
@@ -269,6 +269,48 @@ TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 NOTIFY_DRY_RUN=1 bash "$DELIVER" "$p" 
 n=$(jq -s 'length' "$WORK/tg-payload.jsonl" 2>/dev/null)
 [ "$n" = "1" ] && pass "deliver: idempotent re-delivery sends once ($n)" || bad "deliver: idempotent re-delivery sends once (got $n)"
 
+# 21b. Telegram HTTP/API failure stays failed even when curl itself exits zero.
+reset
+SKILL_NAME=vuln-scanner AEON_MESSAGES_WF_STATE=disabled_manually \
+  bash "$NOTIFY" "Telegram failure body long enough to clear the probe filter" >/dev/null 2>&1
+p="$(payload)"
+FAKE_BIN=$(mktemp -d)
+cat > "$FAKE_BIN/curl" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n%s\n' '{"ok":false,"error_code":400,"description":"Bad Request: chat not found"}' '400'
+SH
+chmod +x "$FAKE_BIN/curl"
+tg_rc=0
+AEON_AUDIT_LOG="$WORK/audit.jsonl" TELEGRAM_BOT_TOKEN=x TELEGRAM_CHAT_ID=123 \
+  PATH="$FAKE_BIN:$PATH" bash "$DELIVER" "$p" >/dev/null 2>"$WORK/tg-error.log" || tg_rc=$?
+{ grep -q 'telegram failed http=400 reason=Bad Request: chat not found' "$WORK/tg-error.log" \
+  && jq -e '.target|contains("telegram=failed")' "$WORK/audit.jsonl" >/dev/null 2>&1 \
+  && [ "$tg_rc" = "1" ]; } \
+  && pass "deliver: Telegram API failure is diagnosed and audited as failed" \
+  || bad "deliver: Telegram API failure was hidden"
+rm -rf "$FAKE_BIN"
+
+# 21c. Resend failure exposes its HTTP/API reason and cannot count as delivery.
+reset
+SKILL_NAME=vuln-scanner AEON_MESSAGES_WF_STATE=disabled_manually \
+  bash "$NOTIFY" "Email failure body long enough to clear the probe filter" >/dev/null 2>&1
+p="$(payload)"
+FAKE_BIN=$(mktemp -d)
+cat > "$FAKE_BIN/curl" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n%s\n' '{"name":"validation_error","message":"The example.com domain is not verified"}' '403'
+SH
+chmod +x "$FAKE_BIN/curl"
+email_rc=0
+AEON_AUDIT_LOG="$WORK/audit.jsonl" RESEND_API_KEY=x NOTIFY_EMAIL_TO=a@b.com \
+  PATH="$FAKE_BIN:$PATH" bash "$DELIVER" "$p" >/dev/null 2>"$WORK/email-error.log" || email_rc=$?
+{ grep -q 'email failed http=403 reason=The example.com domain is not verified' "$WORK/email-error.log" \
+  && jq -e '.target|contains("email=failed")' "$WORK/audit.jsonl" >/dev/null 2>&1 \
+  && [ "$email_rc" = "1" ]; } \
+  && pass "deliver: Resend API failure is diagnosed and audited as failed" \
+  || bad "deliver: Resend API failure was hidden"
+rm -rf "$FAKE_BIN"
+
 # 22-27. reply-to-previous (default on). Isolated ledger dir so memory/ is never touched.
 TDIR=$(mktemp -d)
 


### PR DESCRIPTION
## what looked broken

`notify-deliver.sh` had two silent-failure bugs, both unrelated to the reply-threading feature already on `main`:

1. the script always exited 0: `[ "$DELIVERED" = "true" ] && exit 0 || exit 0`. a notification that reached **zero** configured channels still told the calling workflow it succeeded — no caller could ever detect total delivery failure.

2. both channels swallowed their real API errors. telegram's HTML send falls back to a plaintext retry, but if *that* also failed there was no error captured at all — just `|| true`. resend was worse: `curl -sf ... > /dev/null 2>&1 && DELIVERED=true || true` discarded the HTTP status and response body unconditionally, so a 403 (unverified sending domain, expired key, anything) looked identical to a network hiccup: silent, unlogged, unaudited.

## fix

each channel now tracks its own status (`TG_STATUS`/`EMAIL_STATUS`: `not-configured` | `failed` | `delivered`), captures the real HTTP code + API error reason on failure and logs it (`notify-deliver: telegram failed http=400 reason=...`), threads both statuses into the audit record alongside `delivered=`, and exits 1 when nothing actually delivered.

## tests

two new cases in `scripts/tests/test_notify.sh`, both stubbing `curl` to return a realistic API failure body:
- Telegram: `400 Bad Request: chat not found` → asserts the reason is logged, `telegram=failed` lands in the audit target, and the script exits 1
- Resend: `403` domain-not-verified → same shape

verified by mutation: reverted just the `notify-deliver.sh` side (kept the tests) and both new cases failed for exactly the predicted reason (`"was hidden"`); restored, full 28-case suite green.

https://claude.ai/code/session_01SbipDt7VmuDvosRPS8AfEx
