### PR TITLE
fix(deploy-uni-hook): scaffold comment points at _expectSwapRevert not vm.expectRevert

### DIFF
--- a/skills/deploy-uni-hook/templates/Hook.t.sol
+++ b/skills/deploy-uni-hook/templates/Hook.t.sol
@@ -137,7 +137,9 @@ contract HookBehaviorTest is Test {
     // --- AEON:ASSERT START (freeform: replace with behavioral tests for the prompt) ---
     // Default scaffold matches the default Hook body (an afterSwap swap counter).
     // The generator MUST replace this with assertions specific to the generated hook:
-    //   - a swap the hook is meant to REJECT -> vm.expectRevert(...) then _swap(...)
+    //   - a swap the hook is meant to REJECT -> _expectSwapRevert(zeroForOne, amount, Hook.SomeError.selector)
+    //     (use the helper above, NOT bare vm.expectRevert: v4 wraps a hook revert in
+    //      CustomRevert.WrappedError, so vm.expectRevert(selector) never matches)
     //   - a swap the hook is meant to ALLOW  -> _swap(...) with no revert
     //   - any getter / accounting -> assertEq(hook.someGetter(...), expected)
     function test_defaultCounterIncrements() public {


### PR DESCRIPTION
## What

The freeform behavioral-test scaffold (`templates/Hook.t.sol`, AEON:ASSERT block) told the generator to write reject cases with `vm.expectRevert(...)`, which contradicts both `SKILL.md` and the `_expectSwapRevert` helper 30 lines above it.

v4 wraps a hook revert in `CustomRevert.WrappedError`, so a bare `vm.expectRevert(Hook.SomeError.selector)` never matches the top-level revert data. `SKILL.md` step 4 already says exactly this and points at `_expectSwapRevert`, which scans the revert bytes for the selector. Only the scaffold comment was stale.

## Fix

One comment, now points reject cases at `_expectSwapRevert(zeroForOne, amount, Hook.SomeError.selector)` and states why bare `vm.expectRevert` fails. No code change.

## Impact

Opus reads this comment when generating freeform tests; the stale line risked a generated negative test that silently mis-asserts. Templates were byte-identical across instances, so fixing at canon propagates fleet-wide via aeon-update.
