### PR TITLE
fix(scheduler): read per-skill model: from block-style aeon.yml entries

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -725,8 +725,20 @@ jobs:
           TODAY=$(date -u +%Y-%m-%d)
           export SKILL_NAME
           CONFIG_MODEL=$(grep -E '^model:' aeon.yml | sed 's/^model: *//' | tr -d ' ')
-          # Check for per-skill model override in aeon.yml (extract quoted value, ignore comments)
-          SKILL_MODEL=$(grep "^  ${SKILL_NAME}:" aeon.yml | sed -n 's/.*model: *"\([^"]*\)".*/\1/p')
+          # Per-skill model override in aeon.yml. Must handle BOTH entry shapes:
+          #   single-line   name: { enabled: true, model: "x", ... }
+          #   block         name:
+          #                   { enabled: true,
+          #                     model: "x", ... }
+          # The old single-line grep only read the "  name:" header, so a block
+          # entry's model: (on a later line) was missed and the skill silently fell
+          # back to the top-level model. Capture the whole entry (header line to the
+          # block's closing brace), strip comments, then read the quoted model value.
+          SKILL_MODEL=$(awk -v s="$SKILL_NAME" '
+            $0 ~ "^  " s ":" {f=1}
+            f {print}
+            f && /}/ {exit}
+          ' aeon.yml | sed 's/#.*//' | sed -n 's/.*model:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
           if [ -n "$INPUT_MODEL" ] && [ "$INPUT_MODEL" != "(config default)" ]; then
             MODEL="$INPUT_MODEL"
           elif [ -n "$SKILL_MODEL" ]; then


### PR DESCRIPTION
## Bug

The Skill Runner resolved a per-skill `model:` override with a single-line grep:

```sh
SKILL_MODEL=$(grep "^  ${SKILL_NAME}:" aeon.yml | sed -n 's/.*model: *"\([^"]*\)".*/\1/p')
```

That only reads the skill's `  name:` header line. But many entries are **block-style**, with `model:` on its own line inside the `{ }`:

```yaml
  deploy-uni-hook:
    {
      enabled: false,
      model: "claude-opus-4-8",
      var: ""
    }
```

For every block entry the grep returned empty, so the skill silently fell back to the top-level `model:` (e.g. `claude-sonnet-5`) instead of its pin. Confirmed live: an `sc-audit` `workflow_dispatch` (pinned `claude-opus-4-8`) ran on `claude-sonnet-5`. Affects `deploy-uni-hook`, `aeon-update`, and any other block entry with a `model:` pin.

## Fix

Capture the skill's whole entry (header line through the block's closing brace), strip comments, then read the quoted `model:` value. Handles both single-line and block shapes; single-line entries without a pin still return empty and fall back to config default.

Verified against a real aeon.yml: block pins (`sc-audit`, `deploy-uni-hook`, `aeon-update` -> opus; `sc-source` -> sonnet) now resolve; unpinned single-line entries (`pr-triage`, `heartbeat`) return empty as before.
