### PR TITLE
fix(workflow): preserve expression headroom

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -608,6 +608,14 @@ jobs:
           skill: ${{ steps.skill.outputs.name }}
           mode: ${{ vars.EGRESS_MODE || 'audit' }}
 
+      # The Run script must stay well below GitHub's 21,000-character expression
+      # ceiling after interpolation. Keep explanatory prose at YAML level rather
+      # than inside the run scalar; scripts/tests/test_workflow_harness_choices.sh
+      # enforces headroom for input expansion.
+      #
+      # Chain context is env-bound and restricted to output/.chains/ so an input
+      # cannot splice an arbitrary runner file into the prompt. Every harness then
+      # uses the adapter's normalized result/usage/session_id envelope.
       - name: Run
         id: run
         if: steps.work.outputs.mode != ''
@@ -895,12 +903,7 @@ jobs:
             fi
           fi
 
-          # Per-skill least-privilege secrets: inject ONLY the keys this skill
-          # declares in its `requires:` frontmatter (both required and `?` works-better
-          # tiers). Same resolve-from-ALL_SECRETS shape as the MCP loop above. A skill
-          # sees nothing else from the secret store — so an injected read skill has
-          # only its own (capped) keys to leak. Optional key with no secret set → not
-          # exported, skill degrades to its public path (unchanged behaviour).
+          # Inject only secrets declared by this skill's requires: frontmatter.
           SECRETS_JSON="${ALL_SECRETS:-}"; [ -z "$SECRETS_JSON" ] && SECRETS_JSON='{}'
           INJECTED=""
           while IFS= read -r key; do
@@ -916,12 +919,7 @@ jobs:
           SKILL_NAME="${{ steps.skill.outputs.name }}"
           VAR="$SKILL_VAR"
 
-          # Build prompt — inject chain context if running as part of a chain.
-          # env-bound (passed via env:, not expanded into this run: block) +
-          # path-contained: the context file
-          # must be a chain-runner artifact under output/.chains/, never an
-          # arbitrary path — otherwise cat would read any file on the runner (e.g.
-          # /proc/self/environ, secrets) into the prompt/logs. (GHSA-cqvj-gr78-24mc)
+          # Inject path-contained chain context when present. (GHSA-cqvj-gr78-24mc)
           CHAIN_CTX="$INPUT_CHAIN_CTX"
           if [ -n "$CHAIN_CTX" ]; then
             case "$CHAIN_CTX" in
@@ -958,13 +956,7 @@ jobs:
           elif [ -n "$AEON_DISPATCH_ID" ]; then
             echo "::warning::ignoring malformed dispatch correlation ID"
           fi
-          # Unified execution: EVERY harness runs through the harness-adapter
-          # (harness-adapter/run-harness), which speaks one Claude-Code-shaped
-          # contract — prompt on stdin, a normalized {result,usage{...},session_id}
-          # envelope on stdout, diagnostics on stderr — so everything downstream
-          # (.result/.usage jq, scoring, token accounting) is identical for all seven.
-          # There is no longer a native `claude -p` or `run-grok.sh` run path; the
-          # two features those paths carried are preserved AROUND the adapter call:
+          # Unified execution through harness-adapter; harness-specific behavior:
           #   * claude  — wrapped in the multi-provider gateway cascade below, so it
           #               keeps 9-provider failover + Langfuse tracing.
           #   * grok    — GROK_* run-knobs from frontmatter (adapters/grok.sh maps them).

--- a/scripts/tests/test_workflow_harness_choices.sh
+++ b/scripts/tests/test_workflow_harness_choices.sh
@@ -15,4 +15,21 @@ if ! grep -qx 'fx' <<<"$choices"; then
   exit 1
 fi
 
+python3 - "$WORKFLOW" <<'PY'
+import sys
+
+import yaml
+
+workflow = yaml.safe_load(open(sys.argv[1], encoding="utf-8"))
+for job_name, job in workflow.get("jobs", {}).items():
+    for step in job.get("steps", []):
+        run = step.get("run") if isinstance(step, dict) else None
+        if isinstance(run, str) and len(run) > 20_500:
+            name = step.get("name", "unnamed")
+            raise SystemExit(
+                f"workflow run expression too large: {job_name}/{name} "
+                f"is {len(run)} characters (limit 21000, guard 20500)"
+            )
+PY
+
 echo 'workflow harness choice tests passed'


### PR DESCRIPTION
## what

keep the main skill runner comfortably below github actions' 21,000-character expression limit and add a regression guard at 20,500 characters.

## why

github expands expressions before executing a `run:` block. the runner script was already 20,729 characters on current upstream main, leaving too little room for interpolation. on a real fork with a slightly larger copy, github rejected every dispatch before execution with:

```
failed to parse workflow: (Line: 763, Col: 14): Exceeded max expression length 21000
```

## fix

move explanatory prose outside the shell scalar, retain short operational comments beside the commands, and make the existing workflow harness test enforce 500 characters of headroom. behavior is unchanged.

## verification

- upstream pre-fix mutation: `workflow run expression too large: run/Run is 20729 characters (limit 21000, guard 20500)`
- fixed run scalar: 19,611 characters
- `bash scripts/tests/test_workflow_harness_choices.sh` — passed
- `node scripts/validate-config.js` — clean
- `git diff --check` — clean
- fork proof: chain run 33866530845 completed successfully after the same fix merged; it created `Svector-anu/skopos#110`, verified head `e1b3da417fc736f428ed4ebb42a50146d73e1064`, verified its checks/status, and accepted an `approve-ready` review receipt bound to that exact sha

a separate post-review `jq` warning observed in that dogfood run is not changed or hidden here.