### PR TITLE
fix(dry-run): support explicit claude and codex model selection

### DIFF
--- a/docs/dry-run-harness-selection.md
+++ b/docs/dry-run-harness-selection.md
@@ -41,7 +41,7 @@ elapsed time, result character count and reason. Stdout/stderr are captured in t
 private temporary directory printed at startup. Treat those files as private: inspect
 locally when diagnosing a failure, never commit them or publish them without review.
 
-## verification — 2026-09-05
+## verification - 2026-09-05
 
 The existing CI step invokes `scripts/tests/test_dry_run.sh`; that test now invokes
 `test_dry_run_dispatch.sh` too. Offline tests use the real dry-run and mode/requires

--- a/docs/dry-run-harness-selection.md
+++ b/docs/dry-run-harness-selection.md
@@ -1,0 +1,84 @@
+# local skill dry runs
+
+The local dry-run gate now uses `harness-adapter/run-harness`. Choose the CLI
+separately from its native model identifier:
+
+```bash
+bash scripts/dry-run.sh run <skill> '<input>' --harness codex --model gpt-6-astra
+bash scripts/dry-run.sh run <skill> '<input>' --harness claude --model sonnet
+```
+
+Only Claude and Codex are supported by this local gate. With no options it retains
+Claude as the default; no model argument means the selected CLI's own default.
+`DRYRUN_HARNESS` and `DRYRUN_MODEL` also work; explicit flags take precedence.
+This does not change `aeon.yml`, Actions model choices, dashboard settings, or login
+state. The selected CLI must already be installed and authenticated. An unavailable
+model fails through that CLI; there is no retry on a different harness. Receipt
+`requested_model` records the request, not independent server-side model attestation.
+
+## scope and safety
+
+- Use a disposable, clean checkout and a reviewed skill. Existing uncommitted paths
+  are included in the structural write check; this is not a per-run filesystem audit.
+- Declared task credentials and default GitHub/Telegram tokens are synthetic;
+  notifications use the existing capture mode. Model authentication remains real.
+- This is **not** a complete security sandbox: undeclared environment credentials,
+  SSH/git helpers, local CLI profiles and MCP connections are not isolated by fake
+  tokens. Do not use it to execute an untrusted skill on a credentialed workstation.
+- Capability mode and tool permissions come from `skill_mode.sh` (including nested
+  `metadata.mode`). Read-only requires the dispatcher's OS sandbox; missing support
+  fails closed. A parent sandbox can reject nested `sandbox-exec`; do not disable
+  the read-only wrapper to make a test pass.
+- `DRYRUN_TIMEOUT` defaults to 300 seconds and requires `timeout` or `gtimeout`.
+- Exit zero alone is insufficient: the result must be non-empty, the envelope must
+  be valid, and raw-output wrapper fallbacks are rejected. Structural checks still
+  do not establish semantic task completion or prove absence of secret access.
+- The existing explicit `SKILL_DRYRUN=0` bypass remains; its receipt says `skipped`.
+
+The JSON receipt is at `output/.dry-run/<skill>.json` (or `DRYRUN_VERDICT`, relative
+to the checkout unless absolute). It includes harness, requested model, exit code,
+elapsed time, result character count and reason. Stdout/stderr are captured in the
+private temporary directory printed at startup. Treat those files as private: inspect
+locally when diagnosing a failure, never commit them or publish them without review.
+
+## verification — 2026-09-05
+
+The existing CI step invokes `scripts/tests/test_dry_run.sh`; that test now invokes
+`test_dry_run_dispatch.sh` too. Offline tests use the real dry-run and mode/requires
+helpers with a deliberately stubbed dispatcher: they do not spend model credits.
+
+Local checks: 19 primitive assertions and 35 dispatch assertions pass. `bash -n`
+and `git diff --check` pass. ShellCheck is not installed in the test environment;
+no ShellCheck or GitHub CI pass is claimed before publishing this branch.
+
+Mutation checks, one source change at a time:
+
+| mutation | observed test failure |
+| --- | --- |
+| remove `args+=(--model "$model")` | `FAIL: grep -qx -- --model output/args` |
+| restore old `skill_mode.sh <skill>` call / fallback | `FAIL: grep -q Bash(./notify: output/args` |
+| remove rejection of `rh-wrap-fallback:` | `FAIL: expected rejection` on the wrapped-output case |
+
+All three mutations were restored before rerunning the full green suite.
+
+Real local probes used the actual dispatcher, adapters, installed CLIs and existing
+logins in an isolated fixture, with `mode: read-only`, no task credentials, no tools
+requested, and a 90-second ceiling. Both returned exactly
+`AEON_DRYRUN_ROUTING_OK_20260905`:
+
+```text
+dry-run: harness=codex model=gpt-6-astra mode=read-only timeout=90s
+dry-run: harness=codex exit=0 elapsed=11s result_chars=31 reason=ok
+dry-run: harness=claude model=sonnet mode=read-only timeout=90s
+dry-run: harness=claude exit=0 elapsed=41s result_chars=31 reason=ok
+```
+
+Earlier attempts are not hidden: empty requirements first triggered Bash 3.2's
+`keys[@]: unbound variable`; after that correction, requirements-to-JSON conversion
+also needed a newline for an empty list. Both cases have regression coverage. The
+parent execution sandbox rejected the first nested sandbox attempt with exit 71,
+`sandbox-exec: sandbox_apply: Operation not permitted`. An approved execution outside
+that parent sandbox succeeded **with Aeon's read-only wrapper still enabled**.
+
+These probes prove live routing and responses, not game acceptance, self-healing,
+CI authentication or the cause of the previous arena skill's 180-second timeout.

--- a/scripts/dry-run.sh
+++ b/scripts/dry-run.sh
@@ -25,11 +25,11 @@
 #       Fail if any provided real secret value appears in env-file. The guarantee
 #       the whole feature rests on.
 #
-#   run <skill> [var]
+#   run <skill> [var] [--harness claude|codex] [--model <native-id>]
 #       Orchestrate a full dry run: build a synthetic env for the skill's requires,
 #       route ./notify to a capture file (NOTIFY_DRY_RUN), stub git/gh with a fake
-#       token so any push/write fails auth and is discarded, run the skill through
-#       the claude harness under a tight time/turn ceiling, then evaluate. Emits the
+#       token (not a complete remote-write sandbox), run the skill through
+#       shared harness dispatcher under a wall-clock ceiling, then evaluate. Emits the
 #       verdict to $DRYRUN_VERDICT (default output/.dry-run/<skill>.json).
 #
 # Gate toggle: SKILL_DRYRUN repo variable, default on. A fork that hits a false
@@ -42,7 +42,7 @@ ROOT="$(cd "$HERE/.." && pwd)"
 # Keys that must NEVER be synthesized: the model auth the dry run genuinely needs.
 is_model_key() {
   case "$1" in
-    ANTHROPIC_API_KEY|ANTHROPIC_OAUTH_TOKEN|CLAUDE_CODE_OAUTH_TOKEN) return 0 ;;
+    ANTHROPIC_API_KEY|ANTHROPIC_OAUTH_TOKEN|CLAUDE_CODE_OAUTH_TOKEN|OPENAI_API_KEY|CODEX_AUTH) return 0 ;;
     *) return 1 ;;
   esac
 }
@@ -68,6 +68,7 @@ synth_value() {
 
 cmd_synth_env() {
   local csv="${1:-}"
+  [ -n "$csv" ] || return 0  # bash 3.2 treats an empty array as unset under -u
   IFS=', ' read -ra keys <<< "$csv"
   for key in "${keys[@]}"; do
     key="${key%\?}"                     # strip the `?` works-better marker
@@ -141,23 +142,60 @@ cmd_assert_no_real_secrets() {
 }
 
 cmd_run() {
-  local skill="${1:?skill name required}" var="${2:-}"
+  local skill="${1:?skill name required}" var=""; shift
+  [[ "$skill" =~ ^[a-z0-9][a-z0-9-]*$ ]] || { echo 'dry-run: invalid skill name' >&2; return 2; }
+  cd "$ROOT"
+  local verdict="${DRYRUN_VERDICT:-output/.dry-run/${skill}.json}"
+  mkdir -p "$(dirname "$verdict")"
+  reject() { jq -cn --arg reason "$1" '{passed:false,reasons:[$reason]}' | tee "$verdict"; return 1; }
+  # Invalidate any previous receipt before parsing or invoking dependencies.
+  jq -cn '{passed:false,reasons:["dry run not completed"]}' > "$verdict"
+  # Explicit flags win over dry-run env; no implicit model/family fallback.
+  local harness="${DRYRUN_HARNESS:-claude}" model="${DRYRUN_MODEL:-}"
+  if [ $# -gt 0 ] && [[ "$1" != --* ]]; then var="$1"; shift; fi
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --harness|--model)
+        [ $# -ge 2 ] && [ -n "$2" ] || { echo 'dry-run: option needs a value' >&2; return 2; }
+        if [ "$1" = --harness ]; then harness="$2"; else model="$2"; fi
+        shift 2 ;;
+      *) echo 'dry-run: unknown option' >&2; return 2 ;;
+    esac
+  done
+  case "$harness" in claude|codex) ;; *) reject 'unsupported dry-run harness (choose claude or codex)'; return 1 ;; esac
+  if [ -n "$model" ] && ! [[ "$model" =~ ^[a-zA-Z0-9][a-zA-Z0-9._/-]*$ ]]; then
+    reject 'invalid model id'; return 1
+  fi
+  case "$harness:$model" in
+    codex:claude-*|codex:grok-*|codex:openai/*|claude:gpt-*|claude:openai/*)
+      reject 'model does not match harness; use a native model id'; return 1 ;;
+  esac
+  local seconds="${DRYRUN_TIMEOUT:-300}" timer
+  [[ "$seconds" =~ ^[1-9][0-9]*$ ]] || { reject 'invalid dry-run timeout'; return 1; }
+  if command -v timeout >/dev/null 2>&1; then timer=timeout
+  elif command -v gtimeout >/dev/null 2>&1; then timer=gtimeout
+  else reject 'timeout utility missing'; return 1; fi
   if [ "${SKILL_DRYRUN:-1}" = "0" ]; then
     echo "dry-run: SKILL_DRYRUN=0 - gate bypassed for $skill" >&2
-    printf '{"passed":true,"reasons":["dry-run disabled (SKILL_DRYRUN=0)"],"skipped":true}\n'
+    printf '{"passed":true,"reasons":["dry-run disabled (SKILL_DRYRUN=0)"],"skipped":true}\n' | tee "$verdict"
     return 0
   fi
-  [ -f "$ROOT/skills/$skill/SKILL.md" ] || { echo "dry-run: no skills/$skill/SKILL.md" >&2; return 2; }
+  [ -f "$ROOT/skills/$skill/SKILL.md" ] || { reject 'skill file missing'; return 1; }
+  command -v "$harness" >/dev/null 2>&1 || { reject 'selected harness CLI missing'; return 1; }
+  [ -f "$ROOT/harness-adapter/run-harness" ] || { reject 'harness dispatcher missing'; return 1; }
 
+  umask 077
   local work; work="$(mktemp -d)"
-  local envfile="$work/synth.env" capture="$work/notify-capture" verdict="${DRYRUN_VERDICT:-output/.dry-run/${skill}.json}"
+  echo "dry-run: private local evidence directory: $work (do not commit raw output)" >&2
+  local envfile="$work/synth.env" capture="$work/notify-capture"
   mkdir -p "$(dirname "$verdict")" "$capture"
 
   # 1. Synthetic env for everything the skill declares.
   local reqs; reqs="$(bash "$ROOT/scripts/skill_requires.sh" "$skill" 2>/dev/null | paste -sd, - || true)"
   cmd_synth_env "$reqs" > "$envfile"
-  # Also fake the infra tokens a skill inherits, so a rogue push/notify can't reach a
-  # real channel or repo. The real ANTHROPIC/CLAUDE auth is left untouched.
+  # Also fake the default infra tokens. Alternate credential helpers, SSH, local
+  # profiles and undeclared env keys are NOT isolated by this substitution.
+  # Use a disposable checkout and a trusted skill; model auth stays untouched.
   {
     printf 'GITHUB_TOKEN=%s\n' "$(synth_value GITHUB_TOKEN)"
     printf 'GH_TOKEN=%s\n' "$(synth_value GH_TOKEN)"
@@ -172,44 +210,66 @@ cmd_run() {
   # to the env file, so pass the caller's model-auth values in to prove they are
   # absent from the file.
   if ! cmd_assert_no_real_secrets "$envfile" \
-       "${ANTHROPIC_API_KEY:-}" "${ANTHROPIC_OAUTH_TOKEN:-}" "${CLAUDE_CODE_OAUTH_TOKEN:-}"; then
+       "${ANTHROPIC_API_KEY:-}" "${ANTHROPIC_OAUTH_TOKEN:-}" "${CLAUDE_CODE_OAUTH_TOKEN:-}" \
+       "${OPENAI_API_KEY:-}" "${CODEX_AUTH:-}"; then
     jq -cn '{passed:false, reasons:["real secret leaked into synthetic env"]}' | tee "$verdict"
     return 1
   fi
 
-  if ! command -v claude >/dev/null 2>&1; then
-    echo "dry-run: no claude harness present - the live run happens in CI; primitives verified locally" >&2
-    jq -cn '{passed:true, reasons:["no harness present; live execution deferred to CI"], skipped:true}' | tee "$verdict"
-    return 0
-  fi
-
   # Execute the candidate under the synthetic env with notify captured and a tight
   # ceiling, then hand the observed result to `evaluate`.
-  local out="$work/out.txt" rc=0
-  local tools; tools="$(bash "$ROOT/scripts/skill_mode.sh" "$skill" 2>/dev/null || echo 'Read,Bash')"
-  local mode; mode="$(awk -F': *' '/^mode:/{print $2; exit}' "$ROOT/skills/$skill/SKILL.md" | tr -d '"' )"; mode="${mode:-write}"
+  local out="$work/out.json" err="$work/stderr.txt" rc=0 started="$SECONDS"
+  local mode tools
+  mode="$(bash "$ROOT/scripts/skill_mode.sh" mode "$skill")" || { reject 'mode resolution failed'; return 1; }
+  tools="$(bash "$ROOT/scripts/skill_mode.sh" allowed-tools "$mode")" || { reject 'tool resolution failed'; return 1; }
+  if [ "$mode" = read-only ]; then
+    # The dispatcher otherwise degrades to advisory mode when the OS wrapper is
+    # unavailable. A dry-run gate must not silently accept that degradation.
+    . "$ROOT/harness-adapter/lib/sandbox.sh"
+    sandbox_prefix "$work" >/dev/null || { reject 'read-only OS sandbox unavailable'; return 1; }
+  fi
+  local args=("$harness" --mode "$mode" --allowed-tools "$tools" --timeout "$seconds")
+  [ -n "$model" ] && [ "$model" != default ] && args+=(--model "$model")
+  echo "dry-run: harness=$harness model=${model:-default} mode=$mode timeout=${seconds}s" >&2
   (
     # shellcheck source=/dev/null
     set -a; . "$envfile"; set +a
     export NOTIFY_DRY_RUN=1 AEON_PENDING_DIR="$capture"
-    timeout "${DRYRUN_TIMEOUT:-300}" claude -p \
+    printf '%s\n' \
       "You are running a DRY RUN of the skill below with synthetic credentials. Execute it faithfully.
 
 $(cat "$ROOT/skills/$skill/SKILL.md")${var:+
 
-Input: $var}" \
-      --allowedTools "$tools"
-  ) > "$out" 2>&1 || rc=$?
+Input: $var}" | "$timer" "$seconds" bash "$ROOT/harness-adapter/run-harness" "${args[@]}"
+  ) > "$out" 2> "$err" || rc=$?
 
   local out_len writes reqs_json
-  out_len="$(wc -c < "$out" | tr -d ' ')"
+  # Only the actual result counts, not stderr or a non-empty JSON wrapper.
+  out_len=0
+  local protocol_error=false
+  if jq -se 'length == 1 and (.[0] | type == "object" and (.result | type == "string") and (.usage | type == "object") and (.is_error != true))' "$out" >/dev/null 2>&1 \
+     && ! grep -q 'rh-wrap-fallback:' "$err"; then
+    out_len="$(jq -r '.result | gsub("^\\s+|\\s+$"; "") | length' "$out")"
+  else
+    protocol_error=true
+  fi
+  local reason=ok
+  if [ "$rc" = 124 ]; then reason=timeout
+  elif [ "$rc" != 0 ]; then reason=harness-error
+  elif [ "$protocol_error" = true ]; then reason=invalid-envelope
+  elif [ "$out_len" = 0 ]; then reason=empty-result; fi
+  echo "dry-run: harness=$harness exit=$rc elapsed=$((SECONDS-started))s result_chars=$out_len reason=$reason" >&2
   writes="$(cd "$ROOT" && git status --porcelain 2>/dev/null | sed 's/^...//' | jq -R . | jq -sc .)"
-  reqs_json="$(printf '%s' "$reqs" | jq -Rc 'split(",") | map(select(length>0))')"
+  reqs_json="$(printf '%s\n' "$reqs" | jq -Rc 'split(",") | map(select(length>0))')"
 
   cmd_evaluate <(jq -cn --argjson exit "$rc" --argjson output_len "$out_len" \
     --arg mode "$mode" --argjson writes "$writes" --argjson requires "$reqs_json" \
     --argjson secrets_seen '[]' \
     '{exit:$exit, output_len:$output_len, mode:$mode, writes:$writes, requires:$requires, secrets_seen:$secrets_seen}') \
+    | jq --arg harness "$harness" --arg model "$model" --arg reason "$reason" \
+      --argjson rc "$rc" --argjson elapsed "$((SECONDS-started))" --argjson chars "$out_len" \
+      '. + {harness:$harness,requested_model:$model,exit_code:$rc,elapsed_seconds:$elapsed,result_chars:$chars,
+        reason:(if .passed == false and $reason == "ok" then "structural-check-failed" else $reason end)}' \
     | tee "$verdict"
 }
 
@@ -218,5 +278,5 @@ case "${1:-}" in
   evaluate)              shift; cmd_evaluate "$@" ;;
   assert-no-real-secrets) shift; cmd_assert_no_real_secrets "$@" ;;
   run)                   shift; cmd_run "$@" ;;
-  *) echo "usage: dry-run.sh {synth-env <csv>|evaluate <json>|assert-no-real-secrets <file> <vals...>|run <skill> [var]}" >&2; exit 2 ;;
+  *) echo "usage: dry-run.sh {synth-env <csv>|evaluate <json>|assert-no-real-secrets <file> <vals...>|run <skill> [var] [--harness claude|codex] [--model <native-id>]}" >&2; exit 2 ;;
 esac

--- a/scripts/dry-run.sh
+++ b/scripts/dry-run.sh
@@ -188,7 +188,7 @@ cmd_run() {
   local work; work="$(mktemp -d)"
   echo "dry-run: private local evidence directory: $work (do not commit raw output)" >&2
   local envfile="$work/synth.env" capture="$work/notify-capture"
-  mkdir -p "$(dirname "$verdict")" "$capture"
+  mkdir -p "$capture"
 
   # 1. Synthetic env for everything the skill declares.
   local reqs; reqs="$(bash "$ROOT/scripts/skill_requires.sh" "$skill" 2>/dev/null | paste -sd, - || true)"

--- a/scripts/tests/test_dry_run.sh
+++ b/scripts/tests/test_dry_run.sh
@@ -13,6 +13,8 @@ ok() { pass=$((pass+1)); }
 no() { fail=$((fail+1)); printf 'FAIL: %s\n' "$1"; }
 
 # ---- synth-env: synthetic, well-formed, never real ----
+if EMPTY="$(bash "$SCRIPT" synth-env '')" && [ -z "$EMPTY" ]; then ok; else no "empty requires must work on bash 3.2"; fi
+if MODEL_ENV="$(bash "$SCRIPT" synth-env 'OPENAI_API_KEY,CODEX_AUTH')" && [ -z "$MODEL_ENV" ]; then ok; else no "codex model auth must not be synthesized"; fi
 ENVOUT="$(bash "$SCRIPT" synth-env 'SLACK_WEBHOOK_URL, XAI_API_KEY, TELEGRAM_CHAT_ID, HOOK_DEPLOYER_PRIVATE_KEY, ANTHROPIC_API_KEY')"
 echo "$ENVOUT" > "$TMP/env"
 
@@ -56,4 +58,5 @@ ev() { bash "$SCRIPT" evaluate <(printf '%s' "$1") >/dev/null 2>&1; echo $?; }
 [ "$(ev '{"exit":0,"output_len":10,"mode":"write","writes":[],"requires":[],"secrets_seen":["ANTHROPIC_API_KEY"]}')" = 0 ] && ok || no "model key should be exempt"
 
 printf '\ndry-run: %d passed, %d failed\n' "$pass" "$fail"
-[ "$fail" -eq 0 ]
+[ "$fail" -eq 0 ] || exit 1
+bash "$(dirname "$SCRIPT")/tests/test_dry_run_dispatch.sh" || exit 1

--- a/scripts/tests/test_dry_run_dispatch.sh
+++ b/scripts/tests/test_dry_run_dispatch.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Offline boundary tests: real dry-run + mode/requires helpers, stub dispatcher.
+# No model calls, live credentials, notifications, or remote writes.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FIXTURE="$(mktemp -d)"
+trap 'rm -rf "$FIXTURE"' EXIT
+mkdir -p "$FIXTURE"/{scripts/lib,skills/probe,skills/no-auth,harness-adapter/lib,bin}
+cp "$ROOT/scripts/dry-run.sh" "$ROOT/scripts/skill_mode.sh" "$ROOT/scripts/skill_requires.sh" "$FIXTURE/scripts/"
+cp "$ROOT"/scripts/lib/*.sh "$FIXTURE/scripts/lib/"
+cat > "$FIXTURE/skills/probe/SKILL.md" <<'SKILL'
+---
+name: probe
+metadata:
+  mode: read-only
+  requires: [XAI_API_KEY]
+---
+Return the requested marker. Do not call external tools.
+SKILL
+cat > "$FIXTURE/skills/no-auth/SKILL.md" <<'SKILL'
+---
+name: no-auth
+mode: read-only
+requires: []
+---
+Return the requested marker. Do not call external tools.
+SKILL
+cat > "$FIXTURE/harness-adapter/lib/sandbox.sh" <<'STUB'
+sandbox_prefix() { [ "${PROBE_SANDBOX:-available}" = available ]; }
+STUB
+cat > "$FIXTURE/harness-adapter/run-harness" <<'STUB'
+#!/usr/bin/env bash
+set -eu
+printf '%s\n' "$@" > output/args
+cat > output/prompt
+[[ "${XAI_API_KEY:-DRYRUN}" == *DRYRUN* && "$GH_TOKEN" == *DRYRUN* && "$NOTIFY_DRY_RUN" == 1 ]]
+case "${PROBE_REPLY:-ok}" in
+  timeout) sleep 5 ;;
+  error) echo 'synthetic adapter failure' >&2; exit 7 ;;
+  stderr) echo 'diagnostics only' >&2 ;;
+  raw) echo 'not an envelope' ;;
+  empty) echo '{"result":"  ","usage":{}}' ;;
+  is-error) echo '{"result":"error message","usage":{},"is_error":true}' ;;
+  wrapped) echo 'rh-wrap-fallback: synthetic' >&2; echo '{"result":"raw fallback","usage":{}}' ;;
+  *) echo '{"result":"verified fixture marker","usage":{"input_tokens":1,"output_tokens":2}}' ;;
+esac
+STUB
+for cli in claude codex; do
+  printf '#!/bin/sh\nexit 99\n' > "$FIXTURE/bin/$cli"
+  chmod +x "$FIXTURE/bin/$cli"
+done
+# No credential access even if the parent has keys. The stub tests synthetic env.
+export PATH="$FIXTURE/bin:$PATH" DRYRUN_TIMEOUT=2
+unset DRYRUN_HARNESS DRYRUN_MODEL DRYRUN_VERDICT SKILL_DRYRUN XAI_API_KEY
+cd "$FIXTURE"
+git init -q
+git add .
+git -c user.name=fixture -c user.email=fixture@example.invalid commit -qm fixture
+count=0
+run() { bash scripts/dry-run.sh run probe "$@" > output/result.json 2> output/diagnostics; }
+check() { "$@" || { echo "FAIL: $*" >&2; exit 1; }; count=$((count+1)); }
+expect_failure() { if run "$@"; then echo "FAIL: expected rejection (reply=${PROBE_REPLY:-ok}, args=$*)" >&2; exit 1; fi; }
+mkdir -p output
+run
+check jq -e '.passed and .harness == "claude" and .requested_model == ""' output/result.json
+check grep -qx read-only output/args
+check grep -q 'Bash(./notify:' output/args
+if grep -q 'Bash(git:' output/args; then echo 'FAIL: read-only got write tools'; exit 1; fi
+count=$((count+1))
+run 'literal demo input' --harness codex --model gpt-6-astra
+check jq -e '.passed and .harness == "codex" and .requested_model == "gpt-6-astra"' output/result.json
+check grep -qx codex output/args
+check grep -qx -- --model output/args
+check grep -qx gpt-6-astra output/args
+check grep -q 'Input: literal demo input' output/prompt
+DRYRUN_HARNESS=codex DRYRUN_MODEL=gpt-6-astra run
+check jq -e '.passed and .harness == "codex" and .requested_model == "gpt-6-astra"' output/result.json
+DRYRUN_HARNESS=codex DRYRUN_MODEL=gpt-6-astra run --harness claude --model sonnet
+check jq -e '.passed and .harness == "claude" and .requested_model == "sonnet"' output/result.json
+for pair in 'codex claude-sonnet-4' 'claude gpt-6-astra' 'codex openai/gpt-6-astra'; do
+  read -r h m <<< "$pair"
+  expect_failure --harness "$h" --model "$m"
+  check jq -e '.passed == false' output/.dry-run/probe.json
+done
+expect_failure --harness unsupported
+check jq -e '.passed == false' output/.dry-run/probe.json
+run
+expect_failure --unknown
+check jq -e '.passed == false' output/.dry-run/probe.json
+PROBE_SANDBOX=missing expect_failure
+check jq -e '.passed == false and .reasons[0] == "read-only OS sandbox unavailable"' output/.dry-run/probe.json
+for reply in stderr raw empty is-error wrapped error timeout; do
+  PROBE_REPLY="$reply" expect_failure --harness codex
+  check jq -e '.passed == false' output/.dry-run/probe.json
+  case "$reply" in
+    timeout) check jq -e '.reason == "timeout" and .exit_code == 124' output/.dry-run/probe.json ;;
+    error) check jq -e '.reason == "harness-error" and .exit_code == 7' output/.dry-run/probe.json ;;
+    empty) check jq -e '.reason == "empty-result"' output/.dry-run/probe.json ;;
+    *) check jq -e '.reason == "invalid-envelope"' output/.dry-run/probe.json ;;
+  esac
+done
+# Relative verdict paths are rooted in the checkout, even from another cwd.
+(cd /; DRYRUN_VERDICT=output/from-outside.json bash "$FIXTURE/scripts/dry-run.sh" run probe >/dev/null 2>&1)
+check jq -e '.passed' output/from-outside.json
+bash scripts/dry-run.sh run no-auth --harness codex > output/no-auth.json 2> output/no-auth.log
+check jq -e '.passed and .reason == "ok"' output/no-auth.json
+if grep -q 'invalid JSON' output/no-auth.log; then echo 'FAIL: empty requires emitted invalid JSON'; exit 1; fi
+count=$((count+1))
+# Missing CLI must fail, even if a previous invocation passed. Restrict PATH to
+# only the preflight utilities so a globally installed Codex cannot mask this.
+mkdir -p no-cli
+for utility in dirname mkdir jq tee timeout; do
+  ln -s "$(command -v "$utility")" "no-cli/$utility"
+done
+if PATH="$FIXTURE/no-cli" "$BASH" scripts/dry-run.sh run probe --harness codex > output/missing-cli.json 2> output/missing-cli.log; then
+  echo 'FAIL: missing CLI passed'; exit 1
+fi
+check jq -e '.passed == false and .reasons[0] == "selected harness CLI missing"' output/missing-cli.json
+printf 'dry-run dispatch: %d passed\n' "$count"


### PR DESCRIPTION
## what

let local skill dry runs select claude or codex and a native model id through the existing `harness-adapter/run-harness` contract. no new harness, model pin, account configuration or dashboard change. claude remains the default.

## why

while building a small procedural three.js city game (walking, driving, delivery and toy-brick characters) in a supervised codex session, we tried to validate its associated aeon skill locally. that exposed a portability gap: `scripts/dry-run.sh` unconditionally launches `claude -p`, even when the operator wants to test through codex with `gpt-6-astra`.

the game itself is not evidence of an autonomous aeon build. its earlier full skill attempt timed out at 180 seconds; we have not established that timeout's underlying cause. the demonstrated bug is the lack of harness/model selection, independently visible in current upstream source.

parity checked against upstream `048dee9111e311cf9dc54e153876fcbd86e98244`: both pre-fix dry-run source and its existing test are byte-identical to the fork baseline. upstream's last change to the source is `a95f09e7` (#914). an operator selecting codex for a local skill check still gets claude instead, so the gate cannot validate their chosen harness.

## fix

- add `--harness` / `--model`, with `DRYRUN_HARNESS` / `DRYRUN_MODEL` defaults; reject unsupported harnesses and known wrong-family model ids rather than silently switching.
- use the canonical `skill_mode.sh mode <skill>` and `allowed-tools <mode>` interfaces. the old `<skill>` call fell back to `Read,Bash`; nested `metadata.mode` was also missed.
- preserve synthetic task credentials and notification capture; require the read-only os wrapper and a timeout utility.
- reject missing cli, invalid/error envelopes, empty results and raw-output wrapper fallbacks. stderr alone is not useful output.
- record harness, requested model, exit, duration, result length and reason. invalidate stale receipts before invocation.
- handle empty requirements on macos bash 3.2 and encode them as a real empty json list.

the existing gate is not a complete credential sandbox: local profiles, ssh/helpers and undeclared environment credentials remain outside the synthetic-token guarantee. this limitation is documented, not hidden. no safety bypass flags were added.

## verification

on the clean upstream-based branch:

```text
bash scripts/tests/test_dry_run.sh
dry-run: 19 passed, 0 failed
dry-run dispatch: 35 passed
```

the existing `ci-tests.yml` step already invokes `test_dry_run.sh`; it now calls the new offline dispatch suite. bash syntax and `git diff --check` are clean. shellcheck is unavailable locally. github ci results will be linked separately after this opens; not claimed in advance.

three source mutations were rerun on this upstream-based branch, one at a time:

```text
remove model forwarding:
FAIL: grep -qx -- --model output/args
restore the old tool-helper invocation:
FAIL: grep -q Bash(./notify: output/args
remove raw-wrapper rejection:
FAIL: expected rejection (reply=wrapped, args=--harness codex)
```

restored all three source changes and reran the green suite.

real local model probes on the fix, using the actual shared dispatcher and adapters, existing cli logins, an isolated read-only fixture, no requested tools and a 90-second ceiling:

```text
dry-run: harness=codex model=gpt-6-astra mode=read-only timeout=90s
dry-run: harness=codex exit=0 elapsed=11s result_chars=31 reason=ok
dry-run: harness=claude model=sonnet mode=read-only timeout=90s
dry-run: harness=claude exit=0 elapsed=41s result_chars=31 reason=ok
```

both returned exactly `AEON_DRYRUN_ROUTING_OK_20260905`. those are live routing/response receipts, not a comparative speed benchmark or independent server-side model attestation. the first nested-sandbox attempt was rejected with exit 71; approved execution outside the parent sandbox passed with aeon's own read-only wrapper still enabled. the empty-requires failures discovered during those attempts are covered by regression tests.

the separate game currently passes 8/8 unit tests and builds (rerun locally). its saved browser receipt records a completed delivery and zero page errors, but the updated characters measured 28.4 fps in that run, below the 60 fps target. no game source, screenshots, private repo data or self-healing claim is included in this framework patch.

## scope

fresh branch from upstream/main, one isolated commit, four intended files. no `memory/`, disclosure material, `aeon.yml`, credentials, `.mcp.json`, game assets or unrelated fork history.

- [x] core fix; one local dry-run invocation concern
- [x] shared dispatcher and canonical mode helpers reused
- [x] focused tests and mutation checks pass locally
- [x] no `apps/**` changes
