### PR TITLE
fix: bind RESEND_API_KEY in validate-skill-secrets step (clear false warning)

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -389,6 +389,7 @@ jobs:
           COINGECKO_API_KEY: ${{ secrets.COINGECKO_API_KEY }}
           ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
           REPLICATE_API_TOKEN: ${{ secrets.REPLICATE_API_TOKEN }}
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
         run: |
           SKILL_FILE="skills/${{ steps.skill.outputs.name }}/SKILL.md"
           [ ! -f "$SKILL_FILE" ] && exit 0


### PR DESCRIPTION
## Problem

Any instance running an email skill (`send-email` / `disclosure-emailer`) logs a
false `##[warning]Secrets not set: RESEND_API_KEY — skill may fail` in the
**Validate skill secrets** step, even when `RESEND_API_KEY` is set and the send
succeeds (the key is injected in-run via the skill's `requires:`, which this step
doesn't observe).

## Cause

The step checks each extracted secret against its **own** `env:` block, which
binds only XAI/COINGECKO/ALCHEMY/REPLICATE. `RESEND_API_KEY` isn't bound there,
so `${!RESEND_API_KEY}` reads empty and it's reported missing.

## Fix

Bind `RESEND_API_KEY` in the step's `env:`, matching the existing pattern.
`RESEND_FROM` / `RESEND_REPLY_TO` end in `_FROM` / `_TO`, which the extract regex
(`_(API_KEY|KEY|TOKEN|SECRET|WEBHOOK_URL)$`) never captures, so they need none.

Verified on aeon-onchain (same patch, PR #39 merged): a real send-email run
(to aaron@aeon.fun) succeeds and the warning is gone.
