### PR TITLE
fix(egress): stop iron-proxy MITM from redding artifact uploads

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -1103,7 +1103,17 @@ jobs:
       # even if the run failed; the host list is the allowlist oracle P3 builds from.
       - name: Upload egress audit log
         if: always() && vars.EGRESS_AUDIT == '1'
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        env:
+          # This upload talks to Actions-internal artifact infra, not skill egress,
+          # so it must bypass the iron-proxy MITM. NO_PROXY did not fully exclude the
+          # FinalizeArtifact host, so the proxy returned a 403 and reddened otherwise
+          # green runs. Null the proxy for just this step and keep it non-fatal: the
+          # audit log is best-effort P2 observability and must never fail a good run.
+          HTTP_PROXY: ''
+          HTTPS_PROXY: ''
+          NO_PROXY: '*'
         with:
           name: egress-${{ steps.skill.outputs.name }}-${{ github.run_id }}
           path: ${{ runner.temp }}/iron/audit.jsonl
@@ -2111,7 +2121,15 @@ jobs:
 
       - name: Upload audit log
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        env:
+          # Same as the egress audit upload: bypass the iron-proxy MITM for this
+          # Actions-internal artifact upload so a proxied run cannot 403 it, and keep
+          # it non-fatal so a telemetry-upload hiccup never reds a successful run.
+          HTTP_PROXY: ''
+          HTTPS_PROXY: ''
+          NO_PROXY: '*'
         with:
           name: audit-log-${{ github.run_id }}
           path: audit-artifact/audit.jsonl


### PR DESCRIPTION
## Problem

With `EGRESS_AUDIT=1`, the job routes its egress through iron-proxy (MITM) via `HTTP(S)_PROXY`. The `Upload egress audit log` and `Upload audit log` steps run with that sticky proxy env. `upload-artifact` streams the content to blob storage fine (`.blob.core.windows.net` is in `NO_PROXY`), but its `FinalizeArtifact` call still goes through the proxy and returns:

```
##[error]Failed to FinalizeArtifact: Received non-retryable error: Failed request: (403) Forbidden: Error from intermediary with HTTP status code 403 "Forbidden"
```

That reds an otherwise-green skill run. Confirmed on aeon-agent `tweet-digest` run 34254570427 (2026-09-08), which was in **warn/audit mode** (no `EGRESS_MODE` var), so this is the MITM breaking finalize, not an allowlist block.

## Fix

Both `upload-artifact` steps talk to Actions-internal artifact infra, not skill egress, so they should bypass the proxy (the export-env step already states that intent, but `NO_PROXY` did not fully exclude the finalize host). For just those two steps:

- null `HTTP_PROXY`/`HTTPS_PROXY` and set `NO_PROXY=*` so the upload goes direct
- `continue-on-error: true` so a best-effort P2 audit-log upload can never fail a successful run

No change to which skill egress the proxy audits (github.com etc. stay routed through it). Blast radius: 6 instances run with `EGRESS_AUDIT=1` (all but aeon-data) and inherit this via the normal aeon-update sync.

## Verify

- `actionlint -shellcheck= -pyflakes=` clean
- `scripts/tests/test_workflow_harness_choices.sh` passes
