### PR TITLE
fix(aeon): read-only guard stub loses every skill's memory/logs baseline

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -1834,7 +1834,7 @@ jobs:
           if [ "$RUN_OUTCOME" = "success" ] && [ -s "$CAPTURED" ] && [ "$(cat "$CAPTURED")" != "_No output captured._" ]; then
             { printf '\n### %s\n' "$SKILL"; cat "$CAPTURED"; printf '\n'; } >> "memory/logs/${TODAY}.md"
           else
-            printf '\n### %s\nRun outcome=%s at %s UTC — no output captured; nothing to log.\n' "$SKILL" "$RUN_OUTCOME" "$(date -u +%FT%TZ)" >> "memory/logs/${TODAY}.md"
+            printf '\n### %s\nRun outcome=%s at %s UTC - no output captured; nothing to log.\n' "$SKILL" "$RUN_OUTCOME" "$(date -u +%FT%TZ)" >> "memory/logs/${TODAY}.md"
           fi
           CODE_PATHS="skills .github apps/mcp-server apps/webhook apps/dashboard/app apps/dashboard/lib apps/dashboard/components scripts docs catalog bin *.md *.json *.yml aeon"
           git checkout -- $CODE_PATHS 2>/dev/null || true

--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -1806,13 +1806,36 @@ jobs:
         if: steps.work.outputs.mode != '' && env.SKILL_MODE == 'read-only'
         run: |
           # read-only skills (mode: read-only) get no Write/Edit/git/gh, so they can't
-          # mutate the repo. Two jobs here: (1) record the run-log entry on their behalf
-          # (they couldn't), (2) revert any code/config that slipped through a shell
-          # redirection. State/memory and output/ (incl. .chains/) are preserved for the commit step.
+          # mutate the repo. Three jobs here: (1) record the run-log entry on their
+          # behalf (they couldn't), (2) reuse the output "Capture skill output"
+          # already staged so that entry carries the skill's real structured output
+          # under the "### <skill>" heading CLAUDE.md's Log contract (and every
+          # read-only skill's own SKILL.md) expects — a content-free/wrong-level
+          # stub here silently breaks each skill's own dedup/diff baseline, AND
+          # trips aeon-doctor's own "wrong heading level" health check, (3) revert
+          # any code/config that slipped through a shell redirection. State/memory
+          # and output/ (incl. .chains/) are preserved for the commit step.
+          #
+          # NOTE: this step's `if:` (like "Capture skill output" and "Commit
+          # results" above/below it) has no `always()`, so on a genuine Run
+          # failure the whole step — including the "no output" branch below —
+          # is skipped by GitHub Actions' implicit success() gating, same as
+          # "Commit results" is; a real failure currently gets no guard-authored
+          # log entry at all. Widening that is a separate, wider-blast-radius
+          # change (it touches every skill's failure path, not just read-only
+          # ones) and is intentionally out of scope here — this branch stays as
+          # defensive handling for the cases where the step DOES run without a
+          # real capture (empty/placeholder output).
           SKILL="${{ steps.skill.outputs.name }}"
+          RUN_OUTCOME="${{ steps.run.outcome }}"
           TODAY=$(date -u +%Y-%m-%d)
           mkdir -p memory/logs
-          printf '\n## %s (read-only)\nRan %s UTC.\n' "$SKILL" "$(date -u +%FT%TZ)" >> "memory/logs/${TODAY}.md"
+          CAPTURED="output/.chains/${SKILL}.md"
+          if [ "$RUN_OUTCOME" = "success" ] && [ -s "$CAPTURED" ] && [ "$(cat "$CAPTURED")" != "_No output captured._" ]; then
+            { printf '\n### %s\n' "$SKILL"; cat "$CAPTURED"; printf '\n'; } >> "memory/logs/${TODAY}.md"
+          else
+            printf '\n### %s\nRun outcome=%s at %s UTC — no output captured; nothing to log.\n' "$SKILL" "$RUN_OUTCOME" "$(date -u +%FT%TZ)" >> "memory/logs/${TODAY}.md"
+          fi
           CODE_PATHS="skills .github apps/mcp-server apps/webhook apps/dashboard/app apps/dashboard/lib apps/dashboard/components scripts docs catalog bin *.md *.json *.yml aeon"
           git checkout -- $CODE_PATHS 2>/dev/null || true
           # Same path set as CODE_PATHS above. `git checkout` only reverts EDITS to

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -52,6 +52,8 @@ jobs:
         run: bash scripts/tests/test_skill_mode.sh
       - name: vuln-scanner status contract tests
         run: python3 scripts/tests/test_vuln_scanner_status.py
+      - name: read-only guard run-log tests
+        run: bash scripts/tests/test_readonly_guard_log.sh
       - name: per-skill requires parse tests
         run: bash scripts/tests/test_skill_requires.sh
       - name: run actions summary tests

--- a/scripts/tests/test_readonly_guard_log.sh
+++ b/scripts/tests/test_readonly_guard_log.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Regression test for aeon.yml's "Read-only capability guard" step: a
+# successful read-only skill's run-log entry must carry its real captured
+# output under a "### <skill>" heading (the shape every read-only SKILL.md's
+# own instructions look for on the next run's dedup/diff), not a
+# content-free stub — while a failed or output-less run must still fall back
+# to the stub so nothing stale gets logged as this run's result.
+set -uo pipefail
+
+WORKFLOW="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/.github/workflows/aeon.yml"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Extract the guard verbatim from the "Read-only capability guard" step: from
+# the SKILL= assignment up to (excluding) the CODE_PATHS revert logic — same
+# anchored-sed extraction pattern as test_chain_runner_invalid_dispatch.sh.
+awk '
+  /^          # real capture \(empty\/placeholder output\)\.$/ { on=1; next }
+  on && /^          SKILL=/ { print; next }
+  on && /^          CODE_PATHS=/ { exit }
+  on { print }
+' "$WORKFLOW" | sed 's/^          //' > "$TMP/guard.sh"
+grep -q 'CAPTURED="output/.chains' "$TMP/guard.sh" && grep -q 'RUN_OUTCOME' "$TMP/guard.sh" \
+  || { echo "FAIL: extraction anchor drifted — expected content missing from extracted guard" >&2; cat "$TMP/guard.sh" >&2; exit 1; }
+
+fail=0
+pass() { echo "ok   - $1"; }
+bad() { echo "FAIL - $1"; fail=1; }
+
+run_guard() {
+  # $1 = steps.skill.outputs.name, $2 = steps.run.outcome
+  local skill="$1" outcome="$2"
+  local workdir="$TMP/run-$RANDOM"
+  mkdir -p "$workdir/memory/logs" "$workdir/output/.chains"
+  if [ -n "${3:-}" ]; then printf '%s' "$3" > "$workdir/output/.chains/${skill}.md"; fi
+  (
+    cd "$workdir" || exit 1
+    sed "s|\${{ steps.skill.outputs.name }}|$skill|; s|\${{ steps.run.outcome }}|$outcome|" "$TMP/guard.sh" > guard.sh
+    bash guard.sh
+  )
+  cat "$workdir/memory/logs/$(date -u +%Y-%m-%d).md" 2>/dev/null
+}
+
+# Successful run with real captured output → the log entry carries the real
+# content under a "### <skill>" heading (3-hash — what narrative-tracker,
+# github-trending, token-pick, etc.'s own SKILL.md all instruct diffing
+# against), not the old content-free "## <skill> (read-only)" stub.
+out=$(run_guard narrative-tracker success '*Narrative Tracker — 2026-09-08*
+TRANSITIONS
+• NEW: ZCAT/privacy')
+echo "$out" | grep -q '^### narrative-tracker$' && pass "success: writes a 3-hash '### <skill>' heading" \
+  || bad "success: missing '### narrative-tracker' heading"
+echo "$out" | grep -q 'NEW: ZCAT/privacy' && pass "success: real captured output lands in the log" \
+  || bad "success: captured output missing from the log entry"
+
+# Failed run → falls back to the stub, but STILL under the same "### <skill>"
+# heading level (CLAUDE.md's Log contract + aeon-doctor's own health check both
+# expect every skill's entry at this level, regardless of outcome) — no
+# stale/wrong content masquerading as this run's real output either.
+out=$(run_guard narrative-tracker failure '')
+echo "$out" | grep -q '^### narrative-tracker$' && pass "failure: still uses the '### <skill>' heading" \
+  || bad "failure: heading level must match the success case (CLAUDE.md Log contract)"
+echo "$out" | grep -q 'outcome=failure' && pass "failure: stub records the real outcome" \
+  || bad "failure: stub should record outcome=failure"
+
+# Successful run but nothing was captured (empty/missing output/.chains file)
+# → also falls back to the stub rather than logging an empty heading.
+out=$(run_guard narrative-tracker success '')
+echo "$out" | grep -q '^### narrative-tracker$' && echo "$out" | grep -q 'no output captured' \
+  && pass "success-but-empty: falls back to the stub" \
+  || bad "success-but-empty: should fall back to the stub, not log an empty '### ' heading"
+
+# Successful run, but "Capture skill output" only wrote its own placeholder
+# ("_No output captured._" — the literal string it emits when there was
+# neither a pending notification nor a non-empty /tmp/skill-result.txt) →
+# must NOT be treated as real content (it's non-empty, so a bare -s check
+# would wrongly accept it and pollute the skill's own dedup baseline).
+out=$(run_guard narrative-tracker success '_No output captured._')
+echo "$out" | grep -q '_No output captured\._' && bad "placeholder: must not be logged as if it were real content" \
+  || pass "placeholder: '_No output captured._' is treated as empty, not real output"
+
+echo "---"
+[ "$fail" -eq 0 ] && echo "ALL PASS" || echo "SOME FAILED"
+exit "$fail"


### PR DESCRIPTION
## what

The `Read-only capability guard` step (introduced in #548) logs only a content-free two-line stub for `mode: read-only` skills, since a read-only skill can't write `memory/logs/` itself:

```
## <skill> (read-only)
Ran <timestamp> UTC.
```

But every read-only skill's own `SKILL.md` (and `CLAUDE.md`'s Log contract) instructs it to log its structured output under a `### <skill>` heading, and to read that heading back on the next run for dedup / diff / transition detection. That heading has never been written. All `mode: read-only` skills — `narrative-tracker`, `github-trending`, `token-pick`, `monitor-polymarket`, `investigation-report`, `seo-audit`, `posthog-errors`, `you-web-search`, `tx-explain`, `competitor-monitor`, `aeon-doctor` — have been silently losing their day-to-day baseline on every run since read-only mode shipped.

`narrative-tracker` is where this first surfaced: incompatible day-to-day maps on the same calendar date, a "no prior 3-day baseline" claim on runs where prior entries clearly existed.

## fix

`Capture skill output` (an earlier step in the same job) already stages each successful run's real output at `output/.chains/<skill>.md`. Reuse it: on a successful run with non-placeholder captured output, append it to `memory/logs/<date>.md` under `### <skill>`. Fall back to a stub — now also `### <skill>` level (matching `CLAUDE.md`'s Log contract and not tripping `aeon-doctor`'s own "wrong heading level" check) — on failure or empty output.

Also rejects the literal `_No output captured._` placeholder that `Capture skill output` emits when nothing was staged: it's non-empty, so a bare `[ -s ]` check would log it as if it were real content and pollute the skill's next-run dedup.

20-line diff to one step, no skill files touched.

## tests

`scripts/tests/test_readonly_guard_log.sh` (new) — extracts the guard verbatim from `aeon.yml` (same anchored-sed pattern as `test_chain_runner_invalid_dispatch.sh`), covers all paths (success with content, failure, success-but-empty, placeholder). Wired into `ci-tests.yml`.

```
ok   - success: writes a 3-hash '### <skill>' heading
ok   - success: real captured output lands in the log
ok   - failure: still uses the '### <skill>' heading
ok   - failure: stub records the real outcome
ok   - success-but-empty: falls back to the stub
ok   - placeholder: '_No output captured._' is treated as empty, not real output
ALL PASS
```

## provenance

Shipped and running on the Svector-anu/svectors-lab fork (Svector-anu/svectors-lab#73), live-verified with a real forced-failure run.