### PR TITLE
fix(aeon): commit a read-only skill's failure log, not just its success

### DIFF
--- a/.github/workflows/aeon.yml
+++ b/.github/workflows/aeon.yml
@@ -1803,7 +1803,12 @@ jobs:
           rm -f "$Q"/*.json
 
       - name: Read-only capability guard
-        if: steps.work.outputs.mode != '' && env.SKILL_MODE == 'read-only'
+        # !cancelled() (same idiom "Send pending notifications" already uses for
+        # #912 R1, not always() — a manually-cancelled job should still skip
+        # this, only a genuine failure shouldn't): a bare `mode != ''` implies
+        # success() and skips this step entirely on a failed Run, so the "no
+        # output captured" branch below was previously unreachable in practice.
+        if: ${{ !cancelled() && steps.work.outputs.mode != '' && env.SKILL_MODE == 'read-only' }}
         run: |
           # read-only skills (mode: read-only) get no Write/Edit/git/gh, so they can't
           # mutate the repo. Three jobs here: (1) record the run-log entry on their
@@ -1814,18 +1819,10 @@ jobs:
           # stub here silently breaks each skill's own dedup/diff baseline, AND
           # trips aeon-doctor's own "wrong heading level" health check, (3) revert
           # any code/config that slipped through a shell redirection. State/memory
-          # and output/ (incl. .chains/) are preserved for the commit step.
-          #
-          # NOTE: this step's `if:` (like "Capture skill output" and "Commit
-          # results" above/below it) has no `always()`, so on a genuine Run
-          # failure the whole step — including the "no output" branch below —
-          # is skipped by GitHub Actions' implicit success() gating, same as
-          # "Commit results" is; a real failure currently gets no guard-authored
-          # log entry at all. Widening that is a separate, wider-blast-radius
-          # change (it touches every skill's failure path, not just read-only
-          # ones) and is intentionally out of scope here — this branch stays as
-          # defensive handling for the cases where the step DOES run without a
-          # real capture (empty/placeholder output).
+          # and output/ (incl. .chains/) are preserved for the commit step below —
+          # on a failed run specifically, "Commit read-only failure log" (next
+          # step) commits just the memory/logs/ entry, since "Commit results"
+          # still requires success() and stays that way (see that step's note).
           SKILL="${{ steps.skill.outputs.name }}"
           RUN_OUTCOME="${{ steps.run.outcome }}"
           TODAY=$(date -u +%Y-%m-%d)
@@ -1848,7 +1845,36 @@ jobs:
           git clean -fd -- $CODE_PATHS 2>/dev/null || true
           echo "read-only guard: logged run + reverted code/config writes for $SKILL"
 
+      - name: Commit read-only failure log
+        # Deliberately its own narrow step rather than widening "Commit
+        # results" to always()/!cancelled(): that step does `git add -A` for
+        # every skill including write-mode ones, and running it unconditionally
+        # would risk committing a write-mode skill's partial/broken mid-edit
+        # state on a genuine failure. Read-only skills can't Write/Edit at all,
+        # so the ONLY thing a failed read-only run could ever need committed is
+        # the memory/logs/ entry "Read-only capability guard" (previous step)
+        # just staged — this step stages that path and nothing else, so by
+        # construction it can't ship code, and it never fires for write-mode
+        # skills regardless (SKILL_MODE == 'read-only' gate).
+        if: ${{ !cancelled() && steps.work.outputs.mode != '' && env.SKILL_MODE == 'read-only' && steps.run.outcome != 'success' }}
+        run: |
+          git config user.name "aeonframework"
+          git config user.email "aeonframework@proton.me"
+          TODAY=$(date -u +%Y-%m-%d)
+          git add "memory/logs/${TODAY}.md"
+          if git diff --staged --quiet; then
+            echo "nothing to commit"
+            exit 0
+          fi
+          git commit -m "chore(${{ steps.skill.outputs.name }}): log read-only failure $(date +%Y-%m-%d)"
+          bash scripts/git-push-retry.sh
+
       - name: Commit results
+        # (Read-only failures are handled above, in "Commit read-only failure
+        # log" — deliberately not by widening this step to always(), since
+        # this step's `git add -A` covers write-mode skills too and running it
+        # unconditionally would risk committing a partial/broken mid-edit state
+        # from a genuinely failed write-mode run.)
         if: steps.work.outputs.mode != ''
         env:
           STATE_BACKEND: ${{ vars.STATE_BACKEND }}
@@ -1903,40 +1929,7 @@ jobs:
           else
             git commit -m "chore($LABEL): auto-commit $(date +%Y-%m-%d)"
           fi
-          for i in 1 2 3 4 5 6 7 8 9 10; do
-            # Pull and rebase onto latest remote
-            if ! git pull --rebase origin main 2>/dev/null; then
-              echo "Rebase conflict on attempt $i, auto-resolving..."
-              while true; do
-                CONFLICTED=$(git diff --name-only --diff-filter=U) || true
-                [ -z "$CONFLICTED" ] && break
-                for f in $CONFLICTED; do
-                  if [[ "$f" == memory/logs/* ]] || [[ "$f" == memory/topics/* ]] || [[ "$f" == memory/MEMORY.md ]] || [[ "$f" == memory/skill-health/* ]] || [[ "$f" == apps/dashboard/outputs/* ]] || [[ "$f" == output/* ]]; then
-                    sed -i '/^<<<<<<< /d; /^=======/d; /^>>>>>>> /d' "$f"
-                    git add "$f"
-                  else
-                    git checkout --theirs "$f"
-                    git add "$f"
-                  fi
-                done
-                if git diff --cached --quiet; then
-                  git rebase --skip || true
-                else
-                  GIT_EDITOR=true git rebase --continue || true
-                fi
-              done
-            fi
-            # Try to push — if it fails, another job beat us, loop and re-pull
-            if git push -u origin HEAD 2>/dev/null; then
-              echo "Pushed successfully on attempt $i"
-              bash scripts/audit.sh "git.push" "$GITHUB_REPOSITORY@$(git rev-parse --abbrev-ref HEAD)" 0 "GH_GLOBAL" || true
-              exit 0
-            fi
-            echo "Push attempt $i failed (ref moved), retrying in ${i}s..."
-            sleep "$(( (RANDOM % 4) + i ))"  # jittered backoff - a deterministic sleep re-collides lockstep writers under push contention
-          done
-          echo "Failed to push after 5 attempts"
-          exit 1
+          bash scripts/git-push-retry.sh
 
       - name: Update cron state
         if: always() && steps.skill.outputs.name != ''

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -54,6 +54,8 @@ jobs:
         run: python3 scripts/tests/test_vuln_scanner_status.py
       - name: read-only guard run-log tests
         run: bash scripts/tests/test_readonly_guard_log.sh
+      - name: read-only failure-commit tests
+        run: bash scripts/tests/test_readonly_failure_commit.sh
       - name: per-skill requires parse tests
         run: bash scripts/tests/test_skill_requires.sh
       - name: run actions summary tests

--- a/scripts/git-push-retry.sh
+++ b/scripts/git-push-retry.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Shared rebase + conflict-resolve + push retry loop for aeon.yml's post-run
+# git steps. Extracted from "Commit results" (unchanged behavior) so
+# "Commit read-only failure log" can reuse the exact same fleet-safe push
+# path instead of a second, drifting copy.
+#
+# Assumes the caller has already `git add`ed and `git commit`ed locally on
+# the current branch — this script only gets that commit onto its remote
+# counterpart under concurrent-writer contention (many skills push often).
+set -uo pipefail
+
+for i in 1 2 3 4 5 6 7 8 9 10; do
+  # Pull and rebase onto latest remote
+  if ! git pull --rebase origin "$(git branch --show-current)" 2>/dev/null; then
+    echo "Rebase conflict on attempt $i, auto-resolving..."
+    while true; do
+      CONFLICTED=$(git diff --name-only --diff-filter=U) || true
+      [ -z "$CONFLICTED" ] && break
+      for f in $CONFLICTED; do
+        if [[ "$f" == memory/logs/* ]] || [[ "$f" == memory/topics/* ]] || [[ "$f" == memory/MEMORY.md ]] || [[ "$f" == memory/skill-health/* ]] || [[ "$f" == apps/dashboard/outputs/* ]] || [[ "$f" == output/* ]]; then
+          sed -i '/^<<<<<<< /d; /^=======/d; /^>>>>>>> /d' "$f"
+          git add "$f"
+        else
+          git checkout --theirs "$f"
+          git add "$f"
+        fi
+      done
+      if git diff --cached --quiet; then
+        git rebase --skip || true
+      else
+        GIT_EDITOR=true git rebase --continue || true
+      fi
+    done
+  fi
+  # Try to push — if it fails, another job beat us, loop and re-pull
+  if git push -u origin HEAD 2>/dev/null; then
+    echo "Pushed successfully on attempt $i"
+    bash scripts/audit.sh "git.push" "${GITHUB_REPOSITORY:-}@$(git rev-parse --abbrev-ref HEAD)" 0 "GH_GLOBAL" || true
+    exit 0
+  fi
+  echo "Push attempt $i failed (ref moved), retrying in ${i}s..."
+  sleep "$(( (RANDOM % 4) + i ))"  # jittered backoff - a deterministic sleep re-collides lockstep writers under push contention
+done
+echo "Failed to push after 10 attempts"
+exit 1

--- a/scripts/tests/test_readonly_failure_commit.sh
+++ b/scripts/tests/test_readonly_failure_commit.sh
@@ -76,7 +76,7 @@ run_step() {
   )
 }
 
-out=$(run_step narrative-tracker 'Run outcome=failure at 2026-09-10T00:00:00Z UTC — no output captured; nothing to log.')
+out=$(run_step narrative-tracker 'Run outcome=failure at 2026-09-10T00:00:00Z UTC - no output captured; nothing to log.')
 echo "$out" | grep -q 'PUSH_RETRY_CALLED' && pass "real failure content staged: commits and calls the shared push-retry script" \
   || bad "should have committed and invoked scripts/git-push-retry.sh"
 

--- a/scripts/tests/test_readonly_failure_commit.sh
+++ b/scripts/tests/test_readonly_failure_commit.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Regression test for the always()/!cancelled() follow-up to the read-only
+# guard fix (#73): a failed read-only skill's run-log entry must actually get
+# committed and pushed, WITHOUT widening "Commit results"' `git add -A` to
+# run on a genuine failure (that step also handles write-mode skills, and
+# running it unconditionally would risk shipping a partial/broken mid-edit
+# state from a real failure — see that step's own inline note).
+set -uo pipefail
+
+WORKFLOW="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/.github/workflows/aeon.yml"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail=0
+pass() { echo "ok   - $1"; }
+bad() { echo "FAIL - $1"; fail=1; }
+
+# --- Part 1: static `if:` condition invariants -----------------------------
+# GitHub Actions `if:` conditions aren't bash — they're evaluated by the
+# runner, not extractable/executable the way a step's `run:` body is. Assert
+# on them directly against the source instead (same spirit as
+# test_workflow_harness_choices.sh's headroom check).
+
+guard_if=$(awk '/^      - name: Read-only capability guard$/{f=1} f && /^        if:/{print; exit}' "$WORKFLOW")
+echo "$guard_if" | grep -q '!cancelled()' && pass "'Read-only capability guard' if: includes !cancelled()" \
+  || bad "'Read-only capability guard' if: missing !cancelled() — failure branch is unreachable again"
+
+commit_ro_if=$(awk '/^      - name: Commit read-only failure log$/{f=1} f && /^        if:/{print; exit}' "$WORKFLOW")
+echo "$commit_ro_if" | grep -q '!cancelled()' && echo "$commit_ro_if" | grep -q "SKILL_MODE == 'read-only'" && echo "$commit_ro_if" | grep -q "steps.run.outcome != 'success'" \
+  && pass "'Commit read-only failure log' if: gated on !cancelled() + read-only + non-success" \
+  || bad "'Commit read-only failure log' if: missing an expected clause"
+
+# The safety invariant this whole design rests on: "Commit results" must NOT
+# gain always()/!cancelled() — it still needs implicit success() so a failed
+# write-mode skill's partial `git add -A` never gets committed.
+commit_results_if=$(awk '/^      - name: Commit results$/{f=1} f && /^        if:/{print; exit}' "$WORKFLOW")
+echo "$commit_results_if" | grep -qE '!cancelled\(\)|always\(\)' \
+  && bad "'Commit results' if: must stay implicit-success() — widening it risks committing a broken write-mode run" \
+  || pass "'Commit results' if: still implicit-success() (unwidened, as designed)"
+
+# --- Part 2: "Commit read-only failure log" run: body, extracted verbatim --
+awk '
+  /^      - name: Commit read-only failure log$/ { on=1 }
+  on && /^          git config user\.name/ { started=1 }
+  on && started { print }
+  on && started && /bash scripts\/git-push-retry\.sh$/ { exit }
+' "$WORKFLOW" | sed 's/^          //' > "$TMP/guard.sh"
+grep -q 'git-push-retry.sh' "$TMP/guard.sh" && grep -q 'log read-only failure' "$TMP/guard.sh" \
+  || { echo "FAIL: extraction anchor drifted — expected content missing from extracted step" >&2; cat "$TMP/guard.sh" >&2; exit 1; }
+
+run_step() {
+  # $1 = steps.skill.outputs.name, $2 = whether memory/logs/<today>.md already
+  # has content staged by "Read-only capability guard" (as it would on a real
+  # failure run, per #73's fallback branch).
+  local skill="$1" precontent="${2:-}"
+  local workdir="$TMP/run-$RANDOM"
+  mkdir -p "$workdir/memory/logs"
+  ( cd "$workdir" && git init -q && git checkout -q -b main )
+  if [ -n "$precontent" ]; then
+    printf '%s' "$precontent" > "$workdir/memory/logs/$(date -u +%Y-%m-%d).md"
+    ( cd "$workdir" && git add memory/logs && git -c user.name=t -c user.email=t@t commit -q -m "seed" )
+    # Simulate the guard's fallback append happening AFTER the seed commit,
+    # same as it would in a real run (guard appends, this step commits it).
+    printf '%s' "$precontent" >> "$workdir/memory/logs/$(date -u +%Y-%m-%d).md"
+  fi
+  mkdir -p "$workdir/scripts"
+  # Stub the shared push script — this test covers THIS step's own logic
+  # (stage the right path, commit message shape, no-op when nothing changed),
+  # not git-push-retry.sh's network/rebase behavior.
+  printf '#!/usr/bin/env bash\necho PUSH_RETRY_CALLED\n' > "$workdir/scripts/git-push-retry.sh"
+  chmod +x "$workdir/scripts/git-push-retry.sh"
+  (
+    cd "$workdir" || exit 1
+    sed "s|\${{ steps\.skill\.outputs\.name }}|$skill|" "$TMP/guard.sh" > step.sh
+    bash step.sh
+  )
+}
+
+out=$(run_step narrative-tracker 'Run outcome=failure at 2026-09-10T00:00:00Z UTC — no output captured; nothing to log.')
+echo "$out" | grep -q 'PUSH_RETRY_CALLED' && pass "real failure content staged: commits and calls the shared push-retry script" \
+  || bad "should have committed and invoked scripts/git-push-retry.sh"
+
+out=$(run_step narrative-tracker '')
+echo "$out" | grep -q 'nothing to commit' && ! echo "$out" | grep -q 'PUSH_RETRY_CALLED' \
+  && pass "no staged content: no-ops without committing or pushing" \
+  || bad "with nothing staged, should no-op before ever calling the push script"
+
+echo "---"
+[ "$fail" -eq 0 ] && echo "ALL PASS" || echo "SOME FAILED"
+exit "$fail"

--- a/scripts/tests/test_readonly_guard_log.sh
+++ b/scripts/tests/test_readonly_guard_log.sh
@@ -12,11 +12,14 @@ TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
 # Extract the guard verbatim from the "Read-only capability guard" step: from
-# the SKILL= assignment up to (excluding) the CODE_PATHS revert logic — same
-# anchored-sed extraction pattern as test_chain_runner_invalid_dispatch.sh.
+# its first `SKILL=` assignment (there are several elsewhere in the workflow
+# for other steps — anchor on the step name first, then take the first match
+# after that) up to (excluding) the CODE_PATHS revert logic — same anchored
+# extraction pattern as test_chain_runner_invalid_dispatch.sh, deliberately
+# NOT keyed to comment wording (which is expected to keep changing).
 awk '
-  /^          # real capture \(empty\/placeholder output\)\.$/ { on=1; next }
-  on && /^          SKILL=/ { print; next }
+  /^      - name: Read-only capability guard$/ { step=1 }
+  step && !on && /^          SKILL=/ { on=1 }
   on && /^          CODE_PATHS=/ { exit }
   on { print }
 ' "$WORKFLOW" | sed 's/^          //' > "$TMP/guard.sh"


### PR DESCRIPTION
## stacked on #1051

Depends on #1051 (the `### <skill>` heading + placeholder fix). This PR's diff will look correct once #1051 merges; review it second.

## what

Follow-up to #1051. Independently confirmed by a second review that the failure path #1051 adds is reachable in theory but not in practice.

## why

`Read-only capability guard` and `Commit results` both have `if:` conditions with no `always()`/`!cancelled()`. GitHub Actions implicitly ANDs a bare `if:` with `success()`, so on a genuine `Run` failure, both steps are skipped entirely — including #1051's own "no output captured" fallback branch. Net effect: a failed read-only skill still leaves **zero** trace in `memory/logs/`.

## fix

Two small, additive pieces, write-mode skills untouched:

1. `Read-only capability guard` → `!cancelled()`. Same idiom already established in this file by `Send pending notifications` (#912 R1) — excludes a cancelled job, includes a genuine failure. Script body unchanged.

2. New step `Commit read-only failure log`, gated `!cancelled() && ... && SKILL_MODE == 'read-only' && steps.run.outcome != 'success'`, stages **only** `memory/logs/<date>.md` and commits+pushes it.

**Why a new step, not widening `Commit results` to `always()`**: `Commit results` does `git add -A` and handles write-mode skills too. Giving it `always()` would risk committing a write-mode skill's partial/broken mid-edit state on a genuine failure. The new step can't do that by construction (one narrow path, never touches `skills/`/`scripts/`/code) and never fires for write-mode skills at all.

Also extracted `Commit results`' rebase/conflict-resolve/push-retry loop into `scripts/git-push-retry.sh` so the new step reuses the same fleet-safe push path.

## tests

`scripts/tests/test_readonly_failure_commit.sh` (new) asserts the `if:` conditions directly — including that `Commit results` stays **unwidened**, the safety property the design rests on — and exercises the new step's `run:` body.

```
ok   - 'Read-only capability guard' if: includes !cancelled()
ok   - 'Commit read-only failure log' if: gated on !cancelled() + read-only + non-success
ok   - 'Commit results' if: still implicit-success() (unwidened, as designed)
ok   - real failure content staged: commits and calls the shared push-retry script
ok   - no staged content: no-ops without committing or pushing
ALL PASS
```

## provenance

Shipped on the Svector-anu/svectors-lab fork (Svector-anu/svectors-lab#74) and **live-verified end-to-end**: forced-failure run [34420947970](https://github.com/Svector-anu/svectors-lab/actions/runs/34420947970) (`token-pick`, grok harness, real 402) → `Run: failure` → `Read-only capability guard: success` → `Commit read-only failure log: success` → `Commit results: skipped` → real commit `ec268d5a` landed on the fork's `main` with a `### token-pick` failure entry. First time in that repo's history a failed read-only run left a trace in `memory/logs/`.