### PR TITLE
fix(chain): distinguish no-action telemetry

### DIFF
--- a/.github/workflows/chain-runner.yml
+++ b/.github/workflows/chain-runner.yml
@@ -432,7 +432,7 @@ jobs:
             echo "CHAIN_STATUS=failed" >> "$GITHUB_ENV"
           elif [ "$CHAIN_NO_ACTION" = "true" ]; then
             echo "Chain '$CHAIN' completed without a review: feature produced no verified PR"
-            echo "CHAIN_STATUS=success" >> "$GITHUB_ENV"
+            echo "CHAIN_STATUS=no-action" >> "$GITHUB_ENV"
           else
             echo "Chain '$CHAIN' completed successfully"
             echo "CHAIN_STATUS=success" >> "$GITHUB_ENV"
@@ -454,13 +454,15 @@ jobs:
           NOW_ISO=$(date -u +%FT%TZ)
           STATUS="${CHAIN_STATUS:-failed}"
 
-          # A rejected malformed dispatch (see the target guards above) never
-          # started a real run — recording it would corrupt the chain's lifetime
-          # success-rate signal skill-health reads. The job itself still fails (this
-          # step running under `if: always()` doesn't change that); only the
-          # reliability bookkeeping is skipped.
-          if [ "$STATUS" = "invalid-dispatch" ]; then
-            echo "Chain '$CHAIN' was rejected before any skill ran (missing/invalid target) — not recording as a functional failure"
+          # Invalid dispatch never started a real run; no-action completed but
+          # produced no verified PR. Neither is functional success or failure,
+          # so exclude both from the lifetime ratio skill-health reads.
+          if [ "$STATUS" = "invalid-dispatch" ] || [ "$STATUS" = "no-action" ]; then
+            if [ "$STATUS" = "invalid-dispatch" ]; then
+              echo "Chain '$CHAIN' was rejected before any skill ran (missing/invalid target) — not recording as a functional failure"
+            else
+              echo "Chain '$CHAIN' completed with no verified PR — not recording as a functional success or failure"
+            fi
             exit 0
           fi
 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -131,6 +131,8 @@ jobs:
         run: bash scripts/tests/test_chain_runner.sh
       - name: chain-runner invalid-dispatch cron-state tests
         run: bash scripts/tests/test_chain_runner_invalid_dispatch.sh
+      - name: chain-runner no-action status tests
+        run: bash scripts/tests/test_chain_runner_no_action.sh
       - name: dev-loop deterministic handoff tests
         run: bash scripts/tests/test_dev_loop_handoff.sh
       - name: dev-loop review contract tests

--- a/scripts/tests/test_chain_runner_no_action.sh
+++ b/scripts/tests/test_chain_runner_no_action.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# A completed dev-loop with no verified PR must be neither a success nor failure
+# in cron-state reliability accounting. Exercise workflow blocks verbatim.
+set -uo pipefail
+
+WORKFLOW="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/.github/workflows/chain-runner.yml"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+awk '
+  /^          # --- Final status ---$/ { on=1; next }
+  on && /^      - name: Update cron state$/ { exit }
+  on { print }
+' "$WORKFLOW" | sed 's/^          //' > "$TMP/status.sh"
+grep -q 'CHAIN_NO_ACTION' "$TMP/status.sh" && grep -q 'CHAIN_STATUS=success' "$TMP/status.sh" \
+  || { echo "FAIL: final-status extraction anchor drifted" >&2; exit 1; }
+
+awk '
+  /^          # env-bound \+ allowlisted, same as the Run chain step\./ { on=1 }
+  on && /^          STATE_FILE="memory\/cron-state\.json"$/ { exit }
+  on { print }
+' "$WORKFLOW" | sed 's/^          //' > "$TMP/guard.sh"
+grep -q 'invalid-dispatch' "$TMP/guard.sh" && grep -q 'no-action' "$TMP/guard.sh" \
+  || { echo "FAIL: cron-state extraction anchor drifted" >&2; exit 1; }
+printf 'echo REACHED_STATE_WRITE\n' >> "$TMP/guard.sh"
+
+run_status() {
+  local failed="$1" no_action="$2" env_file="$TMP/env"
+  : > "$env_file"
+  CHAIN="dev-loop" CHAIN_FAILED="$failed" CHAIN_NO_ACTION="$no_action" \
+    GITHUB_ENV="$env_file" bash "$TMP/status.sh"
+  STATUS_RESULT="$(sed -n 's/^CHAIN_STATUS=//p' "$env_file" | tail -1)"
+}
+
+run_guard() {
+  _INPUT_CHAIN="dev-loop" CHAIN_STATUS="$1" bash "$TMP/guard.sh"
+}
+
+fail=0
+pass() { echo "ok   - $1"; }
+bad() { echo "FAIL - $1"; fail=1; }
+
+run_status false true
+[ "$STATUS_RESULT" = "no-action" ] && pass "no-action emits its own status" \
+  || bad "no-action emitted $STATUS_RESULT"
+out=$(run_guard "$STATUS_RESULT")
+echo "$out" | grep -q 'REACHED_STATE_WRITE' \
+  && bad "no-action reached cron-state write" \
+  || pass "no-action skips cron-state reliability write"
+
+run_status true false
+[ "$STATUS_RESULT" = "failed" ] && pass "failure status is unchanged" \
+  || bad "failure emitted $STATUS_RESULT"
+out=$(run_guard "$STATUS_RESULT")
+echo "$out" | grep -q 'REACHED_STATE_WRITE' \
+  && pass "failure still reaches cron-state write" \
+  || bad "failure did not reach cron-state write"
+
+run_status false false
+[ "$STATUS_RESULT" = "success" ] && pass "success status is unchanged" \
+  || bad "success emitted $STATUS_RESULT"
+out=$(run_guard "$STATUS_RESULT")
+echo "$out" | grep -q 'REACHED_STATE_WRITE' \
+  && pass "success still reaches cron-state write" \
+  || bad "success did not reach cron-state write"
+
+echo "---"
+[ "$fail" -eq 0 ] && echo "ALL PASS" || echo "SOME FAILED"
+exit "$fail"


### PR DESCRIPTION
## bug

A completed dev-loop with no verified feature PR currently emits `CHAIN_STATUS=success`. That makes a no-op indistinguishable from a chain that shipped and passed review, so skill-health can overstate dev-loop reliability.

## fix

- emit `CHAIN_STATUS=no-action` when `CHAIN_NO_ACTION=true`
- exclude `no-action` from cron-state reliability bookkeeping, alongside `invalid-dispatch`
- leave genuine `failed` and reviewed `success` paths unchanged
- add an anchored-extraction regression test and wire it next to the invalid-dispatch test

The Actions run remains visible as a completed run with a distinct status, but it counts as neither a functional success nor a functional failure.

## proof

- post-merge fork proof on `Svector-anu/svectors-lab@4617511a`: both no-action and invalid-dispatch regression tests pass; workflow YAML parses
- upstream port test: pass
- mutation: restoring the old success assignment fails with `no-action emitted success` and `no-action reached cron-state write`
- restored fix: both tests pass and YAML parses
- `git diff --check`: pass
- local lint wrapper could not invoke shellcheck because shellcheck is not installed; upstream CI provides the shellcheck gate

Port of Svector-anu/svectors-lab#75, following the fork-to-upstream pattern used by #1051/#1052.