### PR TITLE
fix(vuln): keep github-trending feed machine-parseable for the scanner

### DIFF
--- a/eyebrowlock.json
+++ b/eyebrowlock.json
@@ -90,10 +90,10 @@
       "files": [
         {
           "path": "SKILL.md",
-          "hash": "737e884def0b5bbda67d0d3cec8ebbde59abab4378c251cc2fcddee10586f8f5"
+          "hash": "4c930a5e7a5e0cbc5602e38a5d57d131f626ddada0cea686d820203150bb806e"
         }
       ],
-      "contentHash": "sha256-786e25aa588dbb5e938612020825b2471f8ef4227f5a9376f240bbeeaa359d58",
+      "contentHash": "sha256-70c1f531e6faefea7a911f5a8458772ef35223946d2269e4cb03c2f9042f89c4",
       "discoveredFrom": "skills/github-trending/SKILL.md"
     },
     {
@@ -117,7 +117,7 @@
       "files": [
         {
           "path": "SKILL.md",
-          "hash": "d518b35f036300881bc862d50e86104f4c90ad9759a78c616c17e794a776475e"
+          "hash": "b7bb683299f312fd4864d43b53260493c29b8a4618972632d2cfe6a438a86c3c"
         },
         {
           "path": "riva.md",
@@ -130,7 +130,7 @@
           "severity": "critical",
           "owasp": "ASK-01",
           "file": "SKILL.md",
-          "line": 130,
+          "line": 138,
           "snippet": "network is open, but `pip install` / `curl | sh` / `tar` are **not** on the in-run",
           "explanation": "downloads and executes remote code via a pipe to a shell"
         },
@@ -139,7 +139,7 @@
           "severity": "critical",
           "owasp": "ASK-01",
           "file": "SKILL.md",
-          "line": 144,
+          "line": 152,
           "snippet": "# open, but `pip install` / `curl | sh` / `tar` are NOT allow-listed — `python3 -m pip`,",
           "explanation": "downloads and executes remote code via a pipe to a shell"
         },
@@ -148,7 +148,7 @@
           "severity": "medium",
           "owasp": "ASK-03",
           "file": "SKILL.md",
-          "line": 385,
+          "line": 393,
           "snippet": "- `exec` / `spawn` / `system` / `eval` sinks + subprocess with string interpolation (RCE)",
           "explanation": "uses a process-execution primitive"
         },
@@ -157,12 +157,12 @@
           "severity": "critical",
           "owasp": "ASK-01",
           "file": "SKILL.md",
-          "line": 1119,
+          "line": 1127,
           "snippet": "1. **Install** — the binaries (`semgrep`, `trufflehog`, `osv-scanner`, `slither`) are **not pre-installed**. Stage the…",
           "explanation": "downloads and executes remote code via a pipe to a shell"
         }
       ],
-      "contentHash": "sha256-7644b3e0890c12324618a5194417007d4216902c7aaff25e6030228004b6f736",
+      "contentHash": "sha256-30e4dd34d44cd10c648cccf99318d6dc50f14ea4f4278ea68fc1a87991b85e3d",
       "discoveredFrom": "skills/vuln-scanner/SKILL.md"
     },
     {

--- a/skills/github-trending/SKILL.md
+++ b/skills/github-trending/SKILL.md
@@ -141,6 +141,8 @@ sources: trending=ok|fail · gh_api=ok|fail · kept N/M
 
 Replace `Xt` with stars today, `Yk` with total stars in thousands, `[TAG]` with DEBUT/ACCELERATING/RETURNING/HOLDOVER.
 
+**Slate-integrity check (before you send).** The workflow captures this notify body verbatim to `output/.chains/github-trending.md`, which `vuln-scanner` reads for `owner/repo` scan targets. So every pick must stay a `[owner/repo](url)` line (a bare `https://github.com/owner/repo` permalink also parses). **Never** collapse the slate into a prose name list (e.g. "picks: OmniRoute, colibri, ...") - a bare repo name with no owner is unparseable and starves the scanner. Before sending, confirm the body carries one `[owner/repo](url)` line per surviving pick.
+
 ### A9. Log and exit
 
 Append to `memory/logs/${today}.md` under a single `### github-trending` heading, with a discriminator line `- branch: github` as the first bullet, followed by:

--- a/skills/vuln-scanner/SKILL.md
+++ b/skills/vuln-scanner/SKILL.md
@@ -85,10 +85,18 @@ If `$TARGET` is set, use it. Otherwise:
 
 ```bash
 # Prefer chained output from github-trending skill
+CANDS=""
 if [ -s output/.chains/github-trending.md ]; then
-  # parse owner/repo lines; pick first that matches criteria below
-  :
-else
+  # Parse owner/repo targets. Accept BOTH the markdown form [owner/repo](url) and a
+  # bare github.com/owner/repo permalink (a feeder degraded under read-only can emit
+  # the latter). A repo name with no owner is NOT a candidate. Pick the first CANDS
+  # entry that matches the criteria below.
+  CANDS=$(grep -oE '\[[^]]+/[^]]+\]\(https?://[^)]+\)|https?://github\.com/[^/ )]+/[^/ )]+' output/.chains/github-trending.md \
+    | sed -E 's#.*github\.com/##; s#\).*##; s#^\[##; s#\].*##' | grep -E '^[^/ ]+/[^/ ]+$' | sort -u)
+fi
+# If the feed was absent OR present-but-unparseable (zero owner/repo lines, e.g. a
+# header-only / prose-only notify body), do NOT stop here - that starves the scan.
+if [ -z "$CANDS" ]; then
   # Shadow runs have no GitHub credentials by design. A bare shadow selector
   # may consume the chained trending output above, but otherwise must fail
   # closed and be retried as shadow:owner/repo.


### PR DESCRIPTION
## Problem

`vuln-scanner` A1 auto-selects its scan target by parsing `output/.chains/github-trending.md` for `owner/repo` lines. That file is the `github-trending` `./notify` body, captured verbatim by the Skill Runner workflow. If a run sends a **header-only** notify that folds the slate into a prose name list, e.g.

> Full curated slate (AI/ML: OmniRoute, colibri, llmfit; ...)

the feed carries **zero** parseable `[owner/repo](url)` lines (bare names have no owner, can't be forked/cloned) and the scanner has nothing to select. Observed live on the `aeon-vuln` instance (2026-09-11): the trending-day feed had 0 parseable targets while the `bigco-repos` feed had 16.

## Fix

- **`github-trending` A8** - slate-integrity check before send: forbid the prose-name-list shortcut, require one `[owner/repo](url)` line per surviving pick (a bare `https://github.com/owner/repo` permalink is also fine).
- **`vuln-scanner` A1** - parse **both** `[owner/repo](url)` and bare `github.com/owner/repo` permalinks; when the feed is present but yields **zero** parseable targets (header-only body), fall through to the existing search fallback instead of stopping. The shadow-kernel fail-closed path is preserved.
- **`eyebrowlock.json`** - scoped re-pin of the two touched artifacts only. The A1 insert shifts `vuln-scanner`'s finding lines +8 (130/144/385/1119 -> 138/152/393/1127); same rule IDs, same severities, no new capability or critical. `github-trending` gains no egress host.

## Verification

- `eyebrow verify` (v0.4.2, the CI-pinned binary) no longer reports either skill as drifted after the re-pin.
- Fresh scan confirms `vuln-scanner` keeps the same 3 criticals + 1 medium (only line numbers moved); no capability expansion.
- `bash -n` clean on the new A1 block; no em/en dashes added.
- Ported from `aeon-vuln` #246 (already merged + verified live: a re-dispatched `github-trending` run regenerated a 16-target parseable slate under the new gate).

## Note (not this PR)

`eyebrow verify` also shows 5 **pre-existing** content drifts on skills this PR does not touch (`remotion`, `deploy-uni-hook`, `competitor-monitor`, `aeon`, `aeon-update`) - the committed lock is stale for them. Left alone to keep this diff scoped; worth a separate `eyebrow scan` refresh.
