### PR TITLE
fix(tests): make vuln-scanner status test tolerant of the timeout-aware block

### DIFF
--- a/scripts/tests/test_vuln_scanner_status.py
+++ b/scripts/tests/test_vuln_scanner_status.py
@@ -24,7 +24,15 @@ class ScannerStatusContract(unittest.TestCase):
                     self.assertEqual(rows[-1], f"trufflehog-git={expected}")
 
     def test_filesystem_clean_empty_stream_is_ok(self):
-        row = next(line for line in SKILL.splitlines() if line.startswith('echo "trufflehog='))
+        # The filesystem trufflehog status is the RC-driven ok/fail echo. It now lives
+        # inside a timeout-aware if/else (the `=124` guard mirrors the git block), so it
+        # is indented and sits alongside a sibling `trufflehog=timeout` line - select it
+        # by its ok/fail expression and strip the indentation before running it.
+        row = next(
+            line.strip()
+            for line in SKILL.splitlines()
+            if line.strip().startswith('echo "trufflehog=') and "&& echo ok" in line
+        )
         with tempfile.TemporaryDirectory() as directory:
             for rc, expected in [(0, "ok"), (1, "fail")]:
                 subprocess.run(["bash", "-c", f"TRUFFLEHOG_RC={rc}\n" + row.replace("/tmp/vuln-scan", directory)], check=True)


### PR DESCRIPTION
## What

`ci-tests` has been red on `main` since #1055. That PR wrapped the filesystem trufflehog status echo in a timeout-aware `if [ "${TRUFFLEHOG_RC:-1}" = 124 ]; then ... else ... fi` block (the `=124` guard mirrors the existing git-history block), which:
- indented the RC-driven `echo "trufflehog=..."` line by two spaces, and
- added a sibling `echo "trufflehog=timeout"` line.

`test_filesystem_clean_empty_stream_is_ok` extracted that line with `line.startswith('echo "trufflehog=')` at column 0, so it now raises `StopIteration`. Because `ci-tests` is path-filtered (`scripts/**`, `bin/**`, `aeon.yml`, `harness-adapter/**`), #1055 merged without running it and left `main` red; every later PR touching those paths surfaces the failure.

## Fix

Select the RC-driven ok/fail echo by its expression (`&& echo ok`) and strip the indentation before executing it, so the contract test tracks the restructured shape instead of assuming a flat column-0 line. No change to the skill's behavior.

Full `scripts/tests/` suite passes locally (76 tests); the target file 5/5.
